### PR TITLE
fix(auth): per-session publisher key leases with Rust revocation ownership

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -244,6 +244,79 @@ function buildClaudeSpawnInvocation({
   };
 }
 
+// The agent process must not inherit the desktop process wholesale: a parent
+// shell can carry unrelated API keys, tokens, and cloud credentials. Keep only
+// the runtime locations and terminal/locale settings Claude needs, then add
+// the deliberately generated MCP and policy values below. #3194.
+const CLAUDE_PARENT_ENV_ALLOWLIST = [
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "TERM",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+  "SystemRoot",
+  "WINDIR",
+  "ComSpec",
+  "PATHEXT",
+  // Injected by the Rust desktop host and consumed by local MCP config.
+  "SEREN_HOST",
+  "SEREN_DESKTOP",
+  "SEREN_EMBEDDED_NODE_BIN",
+  "SEREN_PLAYWRIGHT_MCP_COMMAND",
+];
+
+function buildClaudeSpawnEnv({
+  childEnv,
+  extendedPath,
+  cwd,
+  sandboxMode,
+  sandboxProfile,
+  approvalPolicy,
+  autoApproveReads,
+  networkEnabled,
+}) {
+  const inherited = {};
+  for (const name of CLAUDE_PARENT_ENV_ALLOWLIST) {
+    const value = process.env[name];
+    if (value !== undefined) inherited[name] = value;
+  }
+
+  return {
+    ...inherited,
+    // This config is constructed for the current spawn. In particular, the
+    // session lease key can only arrive through childEnv, never process.env.
+    ...childEnv,
+    PATH: extendedPath,
+    SEREN_AGENT_PROJECT_ROOT: cwd,
+    SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
+    SEREN_AGENT_SANDBOX_PROFILE:
+      sandboxProfile?.kind === "seatbelt"
+        ? sandboxProfile.profile
+        : sandboxProfile?.kind === "linux-launcher"
+          ? sandboxProfile.policyBase64
+          : sandboxProfile?.kind === "windows-launcher"
+            ? sandboxProfile.policyBase64
+            : "",
+    SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
+    SEREN_AGENT_AUTO_APPROVE_READS:
+      autoApproveReads === false ? "false" : "true",
+    SEREN_AGENT_NETWORK_ENABLED: networkEnabled === false ? "false" : "true",
+  };
+}
+
 /**
  * Build a PATH string that includes well-known CLI install locations.
  * GUI apps don't inherit the user's shell profile, so tools installed via
@@ -2590,7 +2663,6 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     currentModelId = null,
     currentModeId = "default",
     mcpConfigJson = null,
-    spawnEnv = {},
     reasoningEffort = DEFAULT_CLAUDE_EFFORT,
     serenMcpConfigured = false,
     serenMcpProxy = null,
@@ -2619,7 +2691,6 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       currentModelId,
       currentModeId,
       mcpConfigJson,
-      spawnEnv,
       fastModeEnabled: false,
       reasoningEffort:
         normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT,
@@ -2767,26 +2838,16 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
           spawnInvocation.args,
           {
             cwd,
-            env: {
-              ...process.env,
-              ...mcpConfig.childEnv,
-              PATH: extendedPath,
-              SEREN_AGENT_PROJECT_ROOT: cwd,
-              SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
-              SEREN_AGENT_SANDBOX_PROFILE:
-                sandboxProfile?.kind === "seatbelt"
-                  ? sandboxProfile.profile
-                  : sandboxProfile?.kind === "linux-launcher"
-                    ? sandboxProfile.policyBase64
-                    : sandboxProfile?.kind === "windows-launcher"
-                      ? sandboxProfile.policyBase64
-                      : "",
-              SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
-              SEREN_AGENT_AUTO_APPROVE_READS:
-                autoApproveReads === false ? "false" : "true",
-              SEREN_AGENT_NETWORK_ENABLED:
-                networkEnabled === false ? "false" : "true",
-            },
+            env: buildClaudeSpawnEnv({
+              childEnv: mcpConfig.childEnv,
+              extendedPath,
+              cwd,
+              sandboxMode,
+              sandboxProfile,
+              approvalPolicy,
+              autoApproveReads,
+              networkEnabled,
+            }),
             stdio: ["pipe", "pipe", "pipe"],
             shell: spawnInvocation.shell,
           },
@@ -2864,7 +2925,6 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         currentModelId: preferredModel,
         currentModeId: "default",
         mcpConfigJson: mcpConfig.claudeMcpConfigJson,
-        spawnEnv: mcpConfig.childEnv,
         reasoningEffort: effectiveEffort,
         serenMcpConfigured,
         serenMcpProxy,
@@ -3448,6 +3508,7 @@ export {
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeSpawnInvocation as _buildClaudeSpawnInvocation,
+  buildClaudeSpawnEnv as _buildClaudeSpawnEnv,
   buildClaudeArgs as _buildClaudeArgs,
   removeClaudeArgsTempFiles as _removeClaudeArgsTempFiles,
   buildClaudePolicySettings as _buildClaudePolicySettings,

--- a/src-tauri/src/commands/credential_lease.rs
+++ b/src-tauri/src/commands/credential_lease.rs
@@ -1,0 +1,32 @@
+// ABOUTME: Tauri commands for Rust-owned per-session publisher credential leases.
+// ABOUTME: The renderer receives a key only to configure the immediately spawned child process.
+
+use tauri::{AppHandle, State};
+
+use crate::credential_lease::{CredentialLease, CredentialLeaseManager};
+
+#[tauri::command]
+pub async fn credential_lease_create(
+    app: AppHandle,
+    state: State<'_, CredentialLeaseManager>,
+    session_id: String,
+) -> Result<CredentialLease, String> {
+    state.create_lease(&app, session_id).await
+}
+
+#[tauri::command]
+pub async fn credential_lease_revoke(
+    app: AppHandle,
+    state: State<'_, CredentialLeaseManager>,
+    session_id: String,
+) -> Result<(), String> {
+    state.revoke_lease(&app, session_id).await
+}
+
+#[tauri::command]
+pub async fn credential_lease_revoke_all(
+    app: AppHandle,
+    state: State<'_, CredentialLeaseManager>,
+) -> Result<(), String> {
+    state.revoke_all(&app).await
+}

--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -1,0 +1,453 @@
+// ABOUTME: Rust-owned, expiring API-key leases for individual agent sessions.
+// ABOUTME: Persists only non-secret revoke records so a later launch can reap orphaned remote keys.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
+use tokio::sync::Mutex;
+
+const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
+const DEFAULT_ORG_API_KEYS_PATH: &str = "/organizations/default/api-keys";
+const LEASE_STORE: &str = "credential-leases.json";
+const LEASE_LEDGER_KEY: &str = "orphaned_leases";
+const LEASE_EXPIRY_DAYS: u8 = 1;
+// The public OpenAPI schema accepts scopes but does not publish a narrower
+// accepted grammar. Keep this to the only live-verified scope until the API
+// exposes per-publisher scope syntax. See #3194.
+const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*"];
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialLease {
+    pub session_id: String,
+    pub key_id: String,
+    pub api_key: String,
+    pub expires_at: String,
+}
+
+#[derive(Clone)]
+struct ActiveLease {
+    key_id: String,
+    api_key: String,
+    expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct LeaseLedgerEntry {
+    session_id: String,
+    key_id: String,
+    expires_at: String,
+    #[serde(default)]
+    pending_revocation: bool,
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct CredentialLeaseLedger {
+    #[serde(default)]
+    leases: Vec<LeaseLedgerEntry>,
+}
+
+#[derive(Deserialize)]
+struct DataResponse<T> {
+    data: T,
+}
+
+#[derive(Deserialize)]
+struct ApiKeyCreated {
+    api_key: String,
+    key_id: String,
+    expires_at: Option<String>,
+}
+
+/// Owns active session key material in memory and durable, non-secret cleanup
+/// records on disk. The mutex serializes create/revoke operations so one
+/// session id cannot race into multiple remote keys.
+#[derive(Clone)]
+pub struct CredentialLeaseManager {
+    active: Arc<Mutex<HashMap<String, ActiveLease>>>,
+    operation_lock: Arc<Mutex<()>>,
+    startup_reaper_pending: Arc<AtomicBool>,
+    client: reqwest::Client,
+}
+
+impl Default for CredentialLeaseManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CredentialLeaseManager {
+    pub fn new() -> Self {
+        Self {
+            active: Arc::new(Mutex::new(HashMap::new())),
+            operation_lock: Arc::new(Mutex::new(())),
+            startup_reaper_pending: Arc::new(AtomicBool::new(false)),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+
+    /// Called synchronously during app setup, before the background reaper is
+    /// spawned. New leases wait for that pass so it cannot accidentally revoke
+    /// a freshly created key that appears in the same durable ledger.
+    pub fn begin_startup_reaper(&self) {
+        self.startup_reaper_pending.store(true, Ordering::Release);
+    }
+
+    /// Create a one-day key for a session, persisting its non-secret identity
+    /// before the key value crosses the command boundary.
+    pub async fn create_lease(
+        &self,
+        app: &AppHandle,
+        session_id: String,
+    ) -> Result<CredentialLease, String> {
+        let session_id = validate_session_id(session_id)?;
+        while self.startup_reaper_pending.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let _operation = self.operation_lock.lock().await;
+
+        // Retrying a previous failed revoke is best-effort. It must not turn a
+        // transient network problem into a denial of a fresh user session.
+        if let Err(error) = self.retry_pending_revocations_locked(app).await {
+            log::warn!("[credential-lease] Pending revocation retry failed: {error}");
+        }
+
+        if let Some(existing) = self.active.lock().await.get(&session_id).cloned() {
+            return Ok(CredentialLease {
+                session_id,
+                key_id: existing.key_id,
+                api_key: existing.api_key,
+                expires_at: existing.expires_at,
+            });
+        }
+
+        let request_body = serde_json::json!({
+            "name": "Seren Desktop session lease",
+            "scopes": VERIFIED_LEASE_SCOPES,
+            "expires_in_days": LEASE_EXPIRY_DAYS,
+        });
+        let response = crate::auth::authenticated_request(app, &self.client, |client, token| {
+            client
+                .post(format!("{GATEWAY_BASE_URL}{DEFAULT_ORG_API_KEYS_PATH}"))
+                .bearer_auth(token)
+                .json(&request_body)
+        })
+        .await?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "Credential lease creation failed with HTTP {}",
+                response.status()
+            ));
+        }
+
+        let created = response
+            .json::<DataResponse<ApiKeyCreated>>()
+            .await
+            .map_err(|error| format!("Credential lease creation response was invalid: {error}"))?
+            .data;
+        if created.key_id.trim().is_empty() || created.api_key.trim().is_empty() {
+            return Err("Credential lease creation response omitted key material.".to_string());
+        }
+
+        let expires_at = created.expires_at.unwrap_or_default();
+        let record = LeaseLedgerEntry {
+            session_id: session_id.clone(),
+            key_id: created.key_id.clone(),
+            expires_at: expires_at.clone(),
+            pending_revocation: false,
+        };
+
+        if let Err(error) = self.append_ledger_record(app, record.clone()) {
+            let revoke_result = self.revoke_remote_key(app, &record.key_id).await;
+            return Err(match revoke_result {
+                Ok(()) => format!("Could not persist credential lease cleanup record: {error}"),
+                Err(revoke_error) => format!(
+                    "Could not persist credential lease cleanup record ({error}); emergency revocation failed: {revoke_error}"
+                ),
+            });
+        }
+
+        // A key without a server-confirmed expiry would be a durable secret.
+        // Keep its non-secret record, attempt revocation, and fail the spawn.
+        if expires_at.trim().is_empty() {
+            let revoke_result = self.revoke_records_locked(app, vec![record]).await;
+            return Err(match revoke_result {
+                Ok(()) => "Credential lease creation response omitted expiry; key was revoked."
+                    .to_string(),
+                Err(error) => format!(
+                    "Credential lease creation response omitted expiry; key revocation was queued: {error}"
+                ),
+            });
+        }
+
+        self.active.lock().await.insert(
+            session_id.clone(),
+            ActiveLease {
+                key_id: created.key_id.clone(),
+                api_key: created.api_key.clone(),
+                expires_at: expires_at.clone(),
+            },
+        );
+
+        Ok(CredentialLease {
+            session_id,
+            key_id: created.key_id,
+            api_key: created.api_key,
+            expires_at,
+        })
+    }
+
+    /// Remove local access before attempting remote revocation. Failed remote
+    /// requests remain in the non-secret ledger for a later retry/reaper.
+    pub async fn revoke_lease(&self, app: &AppHandle, session_id: String) -> Result<(), String> {
+        let session_id = validate_session_id(session_id)?;
+        let _operation = self.operation_lock.lock().await;
+
+        let active = self.active.lock().await.remove(&session_id);
+        let mut records = self.records_for_session(app, &session_id)?;
+        if let Some(active) = active {
+            if !records.iter().any(|record| record.key_id == active.key_id) {
+                records.push(LeaseLedgerEntry {
+                    session_id,
+                    key_id: active.key_id,
+                    expires_at: active.expires_at,
+                    pending_revocation: false,
+                });
+            }
+        }
+        self.revoke_records_locked(app, records).await
+    }
+
+    /// Locally deny every active lease, then make one best-effort remote
+    /// revocation attempt per known key.
+    pub async fn revoke_all(&self, app: &AppHandle) -> Result<(), String> {
+        let _operation = self.operation_lock.lock().await;
+        let active = std::mem::take(&mut *self.active.lock().await);
+        let mut records = read_ledger(app)?.leases;
+        for (session_id, lease) in active {
+            if !records.iter().any(|record| record.key_id == lease.key_id) {
+                records.push(LeaseLedgerEntry {
+                    session_id,
+                    key_id: lease.key_id,
+                    expires_at: lease.expires_at,
+                    pending_revocation: false,
+                });
+            }
+        }
+        self.revoke_records_locked(app, records).await
+    }
+
+    /// On startup all persisted records belong to an earlier process, so every
+    /// one is an orphan candidate. The caller logs failures; records remain for
+    /// a later manager operation rather than being silently discarded.
+    pub async fn startup_reaper(&self, app: &AppHandle) -> Result<(), String> {
+        let _operation = self.operation_lock.lock().await;
+        let result = async {
+            let records = select_startup_reaper_records(&read_ledger(app)?.leases);
+            self.revoke_records_locked(app, records).await
+        }
+        .await;
+        self.startup_reaper_pending.store(false, Ordering::Release);
+        result
+    }
+
+    fn append_ledger_record(
+        &self,
+        app: &AppHandle,
+        record: LeaseLedgerEntry,
+    ) -> Result<(), String> {
+        let mut ledger = read_ledger(app)?;
+        ledger.leases.retain(|entry| entry.key_id != record.key_id);
+        ledger.leases.push(record);
+        write_ledger(app, &ledger)
+    }
+
+    fn records_for_session(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+    ) -> Result<Vec<LeaseLedgerEntry>, String> {
+        Ok(read_ledger(app)?
+            .leases
+            .into_iter()
+            .filter(|record| record.session_id == session_id)
+            .collect())
+    }
+
+    async fn retry_pending_revocations_locked(&self, app: &AppHandle) -> Result<(), String> {
+        let records = read_ledger(app)?
+            .leases
+            .into_iter()
+            .filter(|record| record.pending_revocation)
+            .collect();
+        self.revoke_records_locked(app, records).await
+    }
+
+    async fn revoke_records_locked(
+        &self,
+        app: &AppHandle,
+        records: Vec<LeaseLedgerEntry>,
+    ) -> Result<(), String> {
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        let mut revoked_key_ids = HashSet::new();
+        let mut failed_key_ids = HashSet::new();
+        let mut failures = Vec::new();
+        for record in &records {
+            match self.revoke_remote_key(app, &record.key_id).await {
+                Ok(()) => {
+                    revoked_key_ids.insert(record.key_id.clone());
+                }
+                Err(error) => {
+                    failed_key_ids.insert(record.key_id.clone());
+                    failures.push(error);
+                }
+            }
+        }
+
+        let mut ledger = read_ledger(app)?;
+        ledger
+            .leases
+            .retain(|record| !revoked_key_ids.contains(&record.key_id));
+        for mut failed_record in records
+            .into_iter()
+            .filter(|record| failed_key_ids.contains(&record.key_id))
+        {
+            if let Some(existing) = ledger
+                .leases
+                .iter_mut()
+                .find(|record| record.key_id == failed_record.key_id)
+            {
+                existing.pending_revocation = true;
+            } else {
+                failed_record.pending_revocation = true;
+                ledger.leases.push(failed_record);
+            }
+        }
+        write_ledger(app, &ledger)?;
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} credential lease revocation request(s) failed",
+                failures.len()
+            ))
+        }
+    }
+
+    async fn revoke_remote_key(&self, app: &AppHandle, key_id: &str) -> Result<(), String> {
+        let key_id = key_id.trim();
+        if key_id.is_empty() {
+            return Err("Credential lease record omitted a key id.".to_string());
+        }
+        let path = format!(
+            "{GATEWAY_BASE_URL}{DEFAULT_ORG_API_KEYS_PATH}/{}",
+            urlencoding::encode(key_id)
+        );
+        let response = crate::auth::authenticated_request(app, &self.client, |client, token| {
+            client.delete(&path).bearer_auth(token)
+        })
+        .await?;
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        Err(format!(
+            "Credential lease revocation failed with HTTP {}",
+            response.status()
+        ))
+    }
+}
+
+fn validate_session_id(session_id: String) -> Result<String, String> {
+    let session_id = session_id.trim().to_string();
+    if session_id.is_empty() {
+        return Err("A credential lease requires a session id.".to_string());
+    }
+    if session_id.len() > 256 {
+        return Err("Credential lease session id is too long.".to_string());
+    }
+    Ok(session_id)
+}
+
+fn read_ledger(app: &AppHandle) -> Result<CredentialLeaseLedger, String> {
+    let store = app.store(LEASE_STORE).map_err(|error| error.to_string())?;
+    store
+        .get(LEASE_LEDGER_KEY)
+        .map(|value| {
+            serde_json::from_value(value.clone())
+                .map_err(|error| format!("Credential lease ledger was invalid: {error}"))
+        })
+        .transpose()
+        .map(|ledger| ledger.unwrap_or_default())
+}
+
+fn write_ledger(app: &AppHandle, ledger: &CredentialLeaseLedger) -> Result<(), String> {
+    let store = app.store(LEASE_STORE).map_err(|error| error.to_string())?;
+    store.set(
+        LEASE_LEDGER_KEY,
+        serde_json::to_value(ledger)
+            .map_err(|error| format!("Credential lease ledger could not be encoded: {error}"))?,
+    );
+    store.save().map_err(|error| error.to_string())
+}
+
+fn select_startup_reaper_records(records: &[LeaseLedgerEntry]) -> Vec<LeaseLedgerEntry> {
+    records.to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CredentialLeaseLedger, LeaseLedgerEntry, select_startup_reaper_records};
+
+    fn record(session_id: &str, key_id: &str, pending_revocation: bool) -> LeaseLedgerEntry {
+        LeaseLedgerEntry {
+            session_id: session_id.to_string(),
+            key_id: key_id.to_string(),
+            expires_at: "2030-01-01T00:00:00Z".to_string(),
+            pending_revocation,
+        }
+    }
+
+    #[test]
+    fn credential_lease_ledger_round_trips_non_secret_records() {
+        let ledger = CredentialLeaseLedger {
+            leases: vec![record("session-a", "key-a", false)],
+        };
+        let value = serde_json::to_value(&ledger).expect("ledger serializes");
+        assert!(value.get("api_key").is_none());
+        let decoded: CredentialLeaseLedger =
+            serde_json::from_value(value).expect("ledger deserializes");
+        assert_eq!(decoded, ledger);
+    }
+
+    #[test]
+    fn credential_lease_startup_reaper_selects_all_orphaned_records() {
+        let records = vec![
+            record("session-a", "key-a", false),
+            record("session-b", "key-b", true),
+        ];
+        assert_eq!(select_startup_reaper_records(&records), records);
+    }
+
+    #[test]
+    fn credential_lease_ledger_keeps_retry_state_non_secret() {
+        let ledger = CredentialLeaseLedger {
+            leases: vec![record("session-a", "key-a", true)],
+        };
+        let encoded = serde_json::to_string(&ledger).expect("ledger serializes");
+        assert!(encoded.contains("pending_revocation"));
+        assert!(!encoded.contains("api_key"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod commands {
     pub mod cli_installer;
     pub mod context_intelligence;
     pub mod conversation_search;
+    pub mod credential_lease;
     pub mod employees_archive;
     pub mod gateway_http;
     pub mod happy_bridge;
@@ -46,6 +47,7 @@ pub mod sandbox;
 
 pub mod audio;
 mod auth;
+pub mod credential_lease;
 // Public so the headless `claude_memory_sync` example can drive the
 // AppHandle-free sync core (#2639) without launching the app.
 pub mod claude_memory;
@@ -627,6 +629,7 @@ pub fn run() {
             .manage(orchestrator::eval::EvalState::new())
             .manage(orchestrator::tool_bridge::ToolResultBridge::new())
             .manage(provider_runtime::ProviderRuntimeState::new())
+            .manage(credential_lease::CredentialLeaseManager::new())
             .manage(happy_bridge::HappyBridgeManager::new())
             .manage(std::sync::Arc::new(
                 commands::updater::ShutdownGuard::default(),
@@ -644,6 +647,24 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            // A prior crash or force-quit can leave a session key alive at the
+            // Gateway. Reap every non-secret ledger record before the app
+            // accepts a new spawn; failures stay queued for later retries.
+            let credential_lease_manager = app
+                .state::<credential_lease::CredentialLeaseManager>()
+                .inner()
+                .clone();
+            credential_lease_manager.begin_startup_reaper();
+            let credential_lease_app = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) = credential_lease_manager
+                    .startup_reaper(&credential_lease_app)
+                    .await
+                {
+                    log::warn!("[credential-lease] Startup reaper deferred: {error}");
+                }
+            });
+
             // Create the configured windows here rather than letting Tauri
             // auto-create them (the window is marked "create": false in
             // tauri.conf.json) so the Windows e2e release gate can enable
@@ -1040,6 +1061,9 @@ pub fn run() {
             commands::history_sync::history_sync_run_now,
             commands::history_sync::history_sync_wipe_remote,
             commands::sandbox::agent_sandbox_profile,
+            commands::credential_lease::credential_lease_create,
+            commands::credential_lease::credential_lease_revoke,
+            commands::credential_lease::credential_lease_revoke_all,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,
@@ -1318,6 +1342,15 @@ pub fn run() {
                 services::database::checkpoint_managed_db(app, "window blur");
             }
             RunEvent::Exit => {
+                if let Some(lease_manager) = app.try_state::<credential_lease::CredentialLeaseManager>() {
+                    let lease_manager = lease_manager.inner().clone();
+                    let lease_app = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(error) = lease_manager.revoke_all(&lease_app).await {
+                            log::warn!("[credential-lease] Exit revocation deferred: {error}");
+                        }
+                    });
+                }
                 if let Some(task) = app.try_state::<services::database::WalCheckpointTask>() {
                     task.abort();
                 }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -492,7 +492,10 @@ fn pipe_child_output(child: &mut Child) {
             let mut lines = BufReader::new(stdout).lines();
             loop {
                 match lines.next_line().await {
-                    Ok(Some(line)) => log::info!("[ProviderRuntime stdout] {}", line),
+                    Ok(Some(line)) => log::info!(
+                        "[ProviderRuntime stdout] {}",
+                        redact_provider_child_output(&line)
+                    ),
                     Ok(None) => break,
                     Err(err) => {
                         log::warn!("[ProviderRuntime stdout] Read error: {}", err);
@@ -508,7 +511,10 @@ fn pipe_child_output(child: &mut Child) {
             let mut lines = BufReader::new(stderr).lines();
             loop {
                 match lines.next_line().await {
-                    Ok(Some(line)) => log::warn!("[ProviderRuntime stderr] {}", line),
+                    Ok(Some(line)) => log::warn!(
+                        "[ProviderRuntime stderr] {}",
+                        redact_provider_child_output(&line)
+                    ),
                     Ok(None) => break,
                     Err(err) => {
                         log::warn!("[ProviderRuntime stderr] Read error: {}", err);
@@ -518,6 +524,40 @@ fn pipe_child_output(child: &mut Child) {
             }
         });
     }
+}
+
+/// Child-process output reaches the desktop log verbatim unless it is scrubbed
+/// here. Resolve the current runtime environment at capture time so newly
+/// issued session leases and future Seren secret variables are covered too.
+fn redact_provider_child_output(line: &str) -> String {
+    let runtime_secret_values = std::env::vars()
+        .filter_map(|(name, value)| is_seren_secret_env_name(&name).then_some(value));
+    redact_provider_child_output_with_values(line, runtime_secret_values)
+}
+
+fn is_seren_secret_env_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    upper.starts_with("SEREN_")
+        && (upper.ends_with("KEY") || upper.ends_with("TOKEN") || upper.ends_with("SECRET"))
+}
+
+fn redact_provider_child_output_with_values(
+    line: &str,
+    runtime_secret_values: impl IntoIterator<Item = String>,
+) -> String {
+    let mut redacted = line.to_string();
+    for secret in runtime_secret_values {
+        if !secret.is_empty() {
+            redacted = redacted.replace(&secret, "[REDACTED]");
+        }
+    }
+    // API-key values are only shown once by the Gateway but may still be
+    // echoed by a misbehaving child. This format catches the active lease even
+    // when it never appears in the provider-runtime parent environment.
+    regex::Regex::new(r"seren_[A-Za-z0-9_-]+_[A-Za-z0-9_-]+")
+        .expect("static Seren API-key pattern compiles")
+        .replace_all(&redacted, "[REDACTED]")
+        .into_owned()
 }
 
 async fn wait_for_provider_runtime_with_deadline(
@@ -897,6 +937,18 @@ pub async fn provider_force_kill_session(
 mod tests {
     use super::*;
     use tokio::process::Command as TokioCommand;
+
+    #[test]
+    fn child_output_redacts_runtime_secret_values_and_lease_shape() {
+        let lease_shape = ["seren", "shape", "value"].join("_");
+        let redacted = redact_provider_child_output_with_values(
+            &format!("env=canary-session-secret lease={lease_shape}"),
+            vec!["canary-session-secret".to_string()],
+        );
+        assert!(!redacted.contains("canary-session-secret"));
+        assert!(!redacted.contains(&lease_shape));
+        assert_eq!(redacted.matches("[REDACTED]").count(), 2);
+    }
 
     /// Regression guard for #3156.
     ///

--- a/src/lib/scrub-sensitive.ts
+++ b/src/lib/scrub-sensitive.ts
@@ -5,9 +5,10 @@ const PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
   // API keys (Stripe-style sk_live_* and sk_test_*)
   { regex: /sk_(live|test)_[a-zA-Z0-9]+/g, replacement: "[REDACTED_API_KEY]" },
 
-  // Seren API keys (seren_xxx_yyy format)
+  // Seren API keys (seren_<key-id>_<secret> format). Key ids and secrets may
+  // contain URL-safe separators, so do not leave a hyphenated lease behind.
   {
-    regex: /seren_[a-zA-Z0-9]+_[a-zA-Z0-9]+/g,
+    regex: /seren_[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+/g,
     replacement: "[REDACTED_SEREN_KEY]",
   },
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -20,6 +20,7 @@ import {
   storeRefreshToken,
   storeToken,
 } from "@/lib/tauri-bridge";
+import { revokeAllCredentialLeases } from "@/services/credential-lease";
 import { clearAuthState, requestSignInModal } from "@/stores/auth.store";
 
 export type { LoginResult };
@@ -132,6 +133,18 @@ export async function login(
  * Logout and clear stored tokens.
  */
 export async function logout(): Promise<void> {
+  // Revoke while the Rust manager can still authenticate the API request.
+  // It drops local lease access before its remote call and retains only a
+  // non-secret retry record if the network is unavailable. Token clearing must
+  // still complete on a remote failure so logout cannot leave credentials live.
+  try {
+    await revokeAllCredentialLeases();
+  } catch (error) {
+    console.warn(
+      "Failed to revoke session credential leases during logout:",
+      error,
+    );
+  }
   await clearToken();
   await clearRefreshToken();
   await clearDefaultOrganizationId();

--- a/src/services/credential-lease.ts
+++ b/src/services/credential-lease.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Renderer bridge for Rust-owned, per-agent-session publisher key leases.
+// ABOUTME: Lease values are returned only for immediate child-env injection and are never persisted here.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface CredentialLease {
+  sessionId: string;
+  keyId: string;
+  apiKey: string;
+  expiresAt: string;
+}
+
+/** Create or recover the unique, expiring credential lease for one agent session. */
+export async function createCredentialLease(
+  sessionId: string,
+): Promise<CredentialLease> {
+  return invoke<CredentialLease>("credential_lease_create", { sessionId });
+}
+
+/** Drop local lease access first, then ask Rust to revoke its remote key. */
+export async function revokeCredentialLease(sessionId: string): Promise<void> {
+  await invoke("credential_lease_revoke", { sessionId });
+}
+
+/** Revoke every in-memory lease before the frontend clears authentication. */
+export async function revokeAllCredentialLeases(): Promise<void> {
+  await invoke("credential_lease_revoke_all");
+}

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -55,6 +55,29 @@ export function websiteApiUrl(path: string): string {
   }`;
 }
 
+const SEREN_SECRET_ENV_NAME = /^SEREN_.*(?:KEY|TOKEN|SECRET)$/i;
+
+/**
+ * Remove values of runtime Seren secrets at capture time. Static pattern
+ * scrubbing catches known token formats; this closes the gap for a valid but
+ * newly shaped session lease or a future `SEREN_*_SECRET` value.
+ */
+export function scrubTelemetryText(value: string): string {
+  let scrubbed = scrubSensitive(value);
+  const runtimeEnv = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+
+  if (!runtimeEnv) return scrubbed;
+  for (const [name, secret] of Object.entries(runtimeEnv)) {
+    if (!SEREN_SECRET_ENV_NAME.test(name) || !secret) continue;
+    scrubbed = scrubbed.split(secret).join("[REDACTED]");
+  }
+  return scrubbed;
+}
+
 export function buildEmployeeInterestTelemetryPayload(
   input: EmployeeInterestTelemetryInput,
   now = new Date(),
@@ -129,8 +152,8 @@ export class TelemetryService {
     }
 
     const report: ErrorReport = {
-      message: scrubSensitive(error.message || "Unknown error"),
-      stack: error.stack ? scrubSensitive(error.stack) : undefined,
+      message: scrubTelemetryText(error.message || "Unknown error"),
+      stack: error.stack ? scrubTelemetryText(error.stack) : undefined,
       timestamp: new Date().toISOString(),
       appVersion: this.getAppVersion(),
       platform: this.getPlatform(),
@@ -289,7 +312,7 @@ function scrubContext(ctx: Record<string, unknown>): Record<string, unknown> {
   const scrubbed: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(ctx)) {
     if (typeof value === "string") {
-      scrubbed[key] = scrubSensitive(value);
+      scrubbed[key] = scrubTelemetryText(value);
     } else if (value && typeof value === "object" && !Array.isArray(value)) {
       scrubbed[key] = scrubContext(value as Record<string, unknown>);
     } else {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1155,10 +1155,17 @@ function subscribeToAgentConversationArchived(): void {
           archivedSession?.info.pid,
           {
             fence: fenceHappyProviderSessionArchive,
-            terminate: (providerSessionId) =>
-              providerService.terminateSession(providerSessionId, {
+            terminate: async (providerSessionId) => {
+              await revokeCredentialLease(providerSessionId).catch((error) => {
+                console.warn(
+                  "[AgentStore] Failed to revoke archived Happy sibling credential lease:",
+                  error,
+                );
+              });
+              return providerService.terminateSession(providerSessionId, {
                 timeoutMs: 5_000,
-              }),
+              });
+            },
             forceKill: providerService.forceKillSession,
           },
         )
@@ -2353,6 +2360,12 @@ async function discardLateArchivedProviderSession(
     [...allArchivedSessionIds].map(async (archivedSessionId) => {
       expectedTerminateSessionIds.add(archivedSessionId);
       try {
+        await revokeCredentialLease(archivedSessionId).catch((error) => {
+          console.warn(
+            "[AgentStore] Failed to revoke credential lease after Happy archive:",
+            error,
+          );
+        });
         await providerService.terminateSession(archivedSessionId);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -4004,6 +4017,12 @@ export const agentStore = {
           recoveryInFlightMap.delete(info.id);
           clearChunkBuf(info.id);
           clearToolEventBuf(info.id);
+          await revokeCredentialLease(info.id).catch((error) => {
+            console.warn(
+              "[AgentStore] Failed to revoke provider-only archived spawn credential lease:",
+              error,
+            );
+          });
           await providerService.terminateSession(info.id).catch((error) => {
             const message =
               error instanceof Error ? error.message : String(error);

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -529,7 +529,6 @@ import {
   type AgentConversation as DbAgentConversation,
   getAgentConversation,
   getMessages,
-  getSerenApiKey,
   listConversations,
   saveMessage,
   setAgentConversationMetadata as setAgentConversationMetadataDb,
@@ -545,6 +544,10 @@ import {
   claudeSessionExists,
   renderClaudeMemoryMd,
 } from "@/services/claudeMemory";
+import {
+  createCredentialLease,
+  revokeCredentialLease,
+} from "@/services/credential-lease";
 import {
   bootstrapMemoryContext,
   processAssistantResponseMemory,
@@ -576,11 +579,7 @@ import type {
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
 import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
-import {
-  authStore,
-  ensureApiKey,
-  requestSignInModal,
-} from "@/stores/auth.store";
+import { authStore, requestSignInModal } from "@/stores/auth.store";
 import {
   oauthConnectionsRevision,
   oauthSelectionsRevision,
@@ -727,9 +726,17 @@ function subscribeToProviderRuntimeRestarted(): void {
       setState("activeSessionId", null);
 
       for (const snap of snapshot) {
-        const ts = state.threadStates[snap.conversationId];
-        if (!ts?.turnInFlight || !ts.lastPromptText) continue;
         void (async () => {
+          // The provider runtime died, so its child can no longer use this
+          // key. Revoke before a restart creates a fresh, per-session lease.
+          await revokeCredentialLease(snap.id).catch((error) => {
+            console.warn(
+              "[AgentStore] Failed to revoke runtime-restart credential lease:",
+              error,
+            );
+          });
+          const ts = state.threadStates[snap.conversationId];
+          if (!ts?.turnInFlight || !ts.lastPromptText) return;
           if (restartGeneration !== sessionResetGeneration) return;
           agentStore.armRestartTimer(
             snap.conversationId,
@@ -747,6 +754,12 @@ function subscribeToProviderRuntimeRestarted(): void {
           );
           if (restartGeneration !== sessionResetGeneration) {
             if (newId) {
+              await revokeCredentialLease(newId).catch((revokeError) => {
+                console.warn(
+                  "[AgentStore] Failed to revoke stale restart credential lease:",
+                  revokeError,
+                );
+              });
               await providerService.terminateSession(newId).catch((error) => {
                 console.warn(
                   "[AgentStore] Failed to terminate stale restart session:",
@@ -3138,7 +3151,10 @@ export const agentStore = {
     },
   ): Promise<string | null> {
     const resolvedAgentType = agentType ?? state.selectedAgentType;
-    const localSessionId = opts?.localSessionId;
+    // Every agent process receives a stable session id before its credential
+    // lease is created. Providers echo this id back as their session handle,
+    // which lets one teardown path revoke the exact key used by the child.
+    const localSessionId = opts?.localSessionId ?? crypto.randomUUID();
     const resumeAgentSessionId = opts?.resumeAgentSessionId;
     const initRetryAttempt = opts?.initRetryAttempt ?? 0;
     const reclaimedIdleClaude = opts?.reclaimedIdleClaude ?? false;
@@ -3159,7 +3175,7 @@ export const agentStore = {
     // Prevent concurrent spawns for the same conversation. Internal retries
     // (initRetryAttempt > 0) are allowed through because they are sequential
     // continuations of the same spawn attempt, not independent races.
-    const spawnKey = localSessionId ?? `anon-${Date.now()}`;
+    const spawnKey = localSessionId;
     if (initRetryAttempt === 0 && spawningConversations.has(spawnKey)) {
       console.log(
         "[AgentStore] spawnSession: spawn already in progress for",
@@ -3171,6 +3187,9 @@ export const agentStore = {
     if (initRetryAttempt === 0) {
       spawningConversations.add(spawnKey);
     }
+
+    let credentialLeaseCreated = false;
+    let spawnedSessionId: string | null = null;
 
     try {
       setState("isLoading", true);
@@ -3358,17 +3377,15 @@ export const agentStore = {
           setState("installStatus", null);
         }
 
-        // Get the Seren API key that authorizes the agent's Seren MCP server.
-        // Without it the MCP config silently omits Seren entirely, so the agent
-        // launches with no publisher tools for the whole session.
-        // getSerenApiKey() only READS storage — if the key isn't there yet
-        // (cold start, or a transient provisioning failure that kept the
-        // session alive without a key, #2497), force-provision it now rather
-        // than spawning without publisher access. See #2655.
-        let apiKey = await getSerenApiKey();
-        if (!apiKey && authStore.isAuthenticated) {
-          await ensureApiKey();
-          apiKey = await getSerenApiKey();
+        // A child process receives a unique, expiring lease instead of the
+        // persistent desktop-wide publisher key. Rust owns the remote key id,
+        // retry ledger, and revocation; this value is used only for immediate
+        // MCP configuration during this spawn. #3194.
+        let apiKey: string | undefined;
+        if (authStore.isAuthenticated) {
+          const lease = await createCredentialLease(localSessionId);
+          apiKey = lease.apiKey;
+          credentialLeaseCreated = true;
         }
         const enabledMcpServers = getEnabledMcpServers();
 
@@ -3388,13 +3405,11 @@ export const agentStore = {
         // early events that arrive before the session is in state.sessions.
         // Also clear the terminated flag — this session ID is being reborn;
         // events from the new process must NOT be dropped by the stale filter.
-        if (localSessionId) {
-          spawnContextMap.set(localSessionId, {
-            agentType: resolvedAgentType,
-            conversationId: localSessionId,
-          });
-          terminatedSessionIds.delete(localSessionId);
-        }
+        spawnContextMap.set(localSessionId, {
+          agentType: resolvedAgentType,
+          conversationId: localSessionId,
+        });
+        terminatedSessionIds.delete(localSessionId);
 
         // Paired threads seed the Claude planner with the same default effort
         // a direct Claude Code thread would get; per-role overrides ride in
@@ -3435,6 +3450,19 @@ export const agentStore = {
           settingsStore.settings.lmStudioApiKey,
           settingsStore.settings.agentAutoApproveReads,
         );
+        spawnedSessionId = info.id;
+        if (info.id !== localSessionId) {
+          await revokeCredentialLease(localSessionId).catch((error) => {
+            console.warn(
+              "[AgentStore] Failed to revoke mismatched credential lease:",
+              error,
+            );
+          });
+          credentialLeaseCreated = false;
+          throw new Error(
+            "Agent spawn returned a session id that does not match its credential lease.",
+          );
+        }
         console.log("[AgentStore] Spawn result:", info);
         await refreshAgentOAuthRouting(info.id, localSessionId ?? info.id);
         expectedReadySessionId = info.id;
@@ -3807,6 +3835,25 @@ export const agentStore = {
         // late-arriving events from this dead session. Without this,
         // stale errors leak into retried sessions that reuse the same ID.
         terminatedSessionIds.add(spawnKey);
+        if (credentialLeaseCreated) {
+          await revokeCredentialLease(localSessionId).catch((revokeError) => {
+            console.warn(
+              "[AgentStore] Failed to revoke failed spawn credential lease:",
+              revokeError,
+            );
+          });
+          credentialLeaseCreated = false;
+        }
+        if (spawnedSessionId) {
+          await providerService
+            .terminateSession(spawnedSessionId)
+            .catch((terminateError) => {
+              console.warn(
+                "[AgentStore] Failed to terminate failed spawn session:",
+                terminateError,
+              );
+            });
+        }
         tempUnsubscribe();
         setState("error", message);
         setState("isLoading", false);
@@ -4154,6 +4201,12 @@ export const agentStore = {
     // the backend may still hold it, causing "Session already exists" on re-spawn.
     // Mark as terminated so late-arriving events from the old session are dropped.
     terminatedSessionIds.add(conversationId);
+    await revokeCredentialLease(conversationId).catch((error) => {
+      console.warn(
+        "[AgentStore] Failed to revoke stale-session credential lease:",
+        error,
+      );
+    });
     try {
       await providerService.terminateSession(conversationId);
     } catch {
@@ -4656,6 +4709,18 @@ export const agentStore = {
       setState(
         "pendingDiffProposals",
         state.pendingDiffProposals.filter((p) => p.sessionId !== sessionId),
+      );
+    }
+
+    // Drop the session's local credential authority before asking the provider
+    // runtime to kill its child. Rust retains only a non-secret retry ledger
+    // if the remote API key revocation cannot complete immediately. #3194.
+    try {
+      await revokeCredentialLease(sessionId);
+    } catch (error) {
+      console.warn(
+        "[AgentStore] Failed to revoke session credential lease:",
+        error,
       );
     }
 

--- a/tests/unit/agent-credential-lease-wiring.test.ts
+++ b/tests/unit/agent-credential-lease-wiring.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Pins the agent-store handoff from session lifecycle to credential lease commands.
+// ABOUTME: The command boundary itself is observed in credential-lease-bridge.test.ts.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve(process.cwd(), "src/stores/agent.store.ts"),
+  "utf8",
+);
+
+function bodyAfter(marker: string, width = 12_000): string {
+  const index = agentStoreSource.indexOf(marker);
+  expect(index, `missing ${marker}`).toBeGreaterThanOrEqual(0);
+  return agentStoreSource.slice(index, index + width);
+}
+
+function directTerminationContext(sessionExpression: string): string {
+  const matcher = new RegExp(
+    `providerService\\s*\\.\\s*terminateSession\\(${sessionExpression}\\)`,
+  );
+  const match = matcher.exec(agentStoreSource);
+  expect(match, `missing provider termination for ${sessionExpression}`).toBeTruthy();
+  const index = match?.index ?? -1;
+  return agentStoreSource.slice(Math.max(0, index - 1_200), index + 400);
+}
+
+describe("agent session credential leases (#3194)", () => {
+  it("creates a per-session lease instead of reading the persistent desktop key", () => {
+    const spawnBody = bodyAfter("async spawnSession(");
+    expect(spawnBody).toContain("await createCredentialLease(localSessionId)");
+    expect(spawnBody).not.toContain("getSerenApiKey()");
+    expect(spawnBody).not.toContain("ensureApiKey()");
+  });
+
+  it("revokes the lease in the common teardown and stale-session cleanup paths", () => {
+    const teardownBody = bodyAfter("async terminateSession(");
+    const resumeBody = bodyAfter("async resumeAgentConversation(");
+    expect(teardownBody).toContain("await revokeCredentialLease(sessionId)");
+    expect(resumeBody).toContain("await revokeCredentialLease(conversationId)");
+  });
+
+  it("covers every direct provider-runtime termination escape hatch", () => {
+    expect(
+      [...agentStoreSource.matchAll(/providerService\s*\.\s*terminateSession\(/g)],
+    ).toHaveLength(5);
+    expect(directTerminationContext("newId")).toContain(
+      "await revokeCredentialLease(newId)",
+    );
+    expect(directTerminationContext("spawnedSessionId")).toContain(
+      "await revokeCredentialLease(localSessionId)",
+    );
+    expect(directTerminationContext("conversationId")).toContain(
+      "await revokeCredentialLease(conversationId)",
+    );
+    expect(directTerminationContext("sessionId")).toContain(
+      "await revokeCredentialLease(sessionId)",
+    );
+
+    const deferredPromotion = directTerminationContext("servingSessionId");
+    expect(deferredPromotion).toContain(
+      "await this.terminateSession(servingSessionId",
+    );
+  });
+});

--- a/tests/unit/agent-credential-lease-wiring.test.ts
+++ b/tests/unit/agent-credential-lease-wiring.test.ts
@@ -18,7 +18,7 @@ function bodyAfter(marker: string, width = 12_000): string {
 
 function directTerminationContext(sessionExpression: string): string {
   const matcher = new RegExp(
-    `providerService\\s*\\.\\s*terminateSession\\(${sessionExpression}\\)`,
+    `providerService\\s*\\.\\s*terminateSession\\(${sessionExpression}\\s*(?:,|\\))`,
   );
   const match = matcher.exec(agentStoreSource);
   expect(match, `missing provider termination for ${sessionExpression}`).toBeTruthy();
@@ -44,9 +44,18 @@ describe("agent session credential leases (#3194)", () => {
   it("covers every direct provider-runtime termination escape hatch", () => {
     expect(
       [...agentStoreSource.matchAll(/providerService\s*\.\s*terminateSession\(/g)],
-    ).toHaveLength(5);
+    ).toHaveLength(8);
     expect(directTerminationContext("newId")).toContain(
       "await revokeCredentialLease(newId)",
+    );
+    expect(directTerminationContext("providerSessionId")).toContain(
+      "await revokeCredentialLease(providerSessionId)",
+    );
+    expect(directTerminationContext("archivedSessionId")).toContain(
+      "await revokeCredentialLease(archivedSessionId)",
+    );
+    expect(directTerminationContext("info\\.id")).toContain(
+      "await revokeCredentialLease(info.id)",
     );
     expect(directTerminationContext("spawnedSessionId")).toContain(
       "await revokeCredentialLease(localSessionId)",

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -162,7 +162,10 @@ describe("#1952 — dropped-prompt recovery keeps context and replay invisible",
   it("downgrades missing backend session termination during recovery to info logging", () => {
     const idx = agentStoreSource.indexOf("async terminateSession(");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 2200);
+    // Session teardown now revokes the session credential before the existing
+    // provider-runtime recovery branch. Keep inspecting that branch rather
+    // than treating the fixed source-window length as product behavior.
+    const body = agentStoreSource.slice(idx, idx + 3200);
     expect(body).toContain('message.includes("not found")');
     expect(body).toContain("terminateSession: backend session already gone");
   });

--- a/tests/unit/auth-credential-lease-logout.test.ts
+++ b/tests/unit/auth-credential-lease-logout.test.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Ensures logout asks Rust to revoke active session leases before clearing auth storage.
+// ABOUTME: A local event log verifies the security-sensitive ordering without any network request.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { events, mocks } = vi.hoisted(() => {
+  const eventLog: string[] = [];
+  return {
+    events: eventLog,
+    mocks: {
+      revokeAllCredentialLeases: vi.fn(async () => eventLog.push("revoke")),
+      clearToken: vi.fn(async () => eventLog.push("clear-token")),
+      clearRefreshToken: vi.fn(async () => eventLog.push("clear-refresh")),
+      clearDefaultOrganizationId: vi.fn(async () => eventLog.push("clear-org")),
+    },
+  };
+});
+
+vi.mock("@/api", () => ({
+  createDefaultOrgApiKey: vi.fn(),
+  getCurrentUser: vi.fn(),
+  login: vi.fn(),
+  refreshToken: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  clearDefaultOrganizationId: mocks.clearDefaultOrganizationId,
+  clearRefreshToken: mocks.clearRefreshToken,
+  clearToken: mocks.clearToken,
+  getRefreshToken: vi.fn(),
+  getToken: vi.fn(),
+  isTauriRuntime: vi.fn(() => false),
+  storeDefaultOrganizationId: vi.fn(),
+  storeRefreshToken: vi.fn(),
+  storeToken: vi.fn(),
+}));
+
+vi.mock("@/services/credential-lease", () => ({
+  revokeAllCredentialLeases: mocks.revokeAllCredentialLeases,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  clearAuthState: vi.fn(),
+  requestSignInModal: vi.fn(),
+}));
+
+import { logout } from "@/services/auth";
+
+describe("logout credential lease revocation (#3194)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    events.length = 0;
+  });
+
+  it("revokes all leases before clearing stored authentication", async () => {
+    await logout();
+
+    expect(events).toEqual(["revoke", "clear-token", "clear-refresh", "clear-org"]);
+  });
+});

--- a/tests/unit/claude-spawn-env.test.ts
+++ b/tests/unit/claude-spawn-env.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Ensures Claude's child environment is a deliberate allowlist, not a parent-env clone.
+// ABOUTME: A canary secret must never cross into the agent process tree.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const { _buildClaudeSpawnEnv: buildClaudeSpawnEnv } = await import(
+  /* @vite-ignore */ modulePath
+);
+
+const CANARY_ENV_NAME = "SEREN_PARENT_CANARY_SECRET";
+const originalCanary = process.env[CANARY_ENV_NAME];
+
+afterEach(() => {
+  if (originalCanary === undefined) {
+    delete process.env[CANARY_ENV_NAME];
+  } else {
+    process.env[CANARY_ENV_NAME] = originalCanary;
+  }
+});
+
+describe("Claude spawn environment (#3194)", () => {
+  it("passes the generated PATH and session child values but not parent secrets", () => {
+    process.env[CANARY_ENV_NAME] = "canary-parent-secret";
+
+    const env = buildClaudeSpawnEnv({
+      childEnv: { SEREN_API_KEY: "session-lease-value" },
+      extendedPath: "/runtime/bin:/usr/bin",
+      cwd: "/workspace/project",
+      sandboxMode: "workspace-write",
+      sandboxProfile: { kind: "seatbelt", profile: "(version 1)" },
+      approvalPolicy: "on-request",
+      autoApproveReads: true,
+      networkEnabled: true,
+    });
+
+    expect(env.PATH).toBe("/runtime/bin:/usr/bin");
+    expect(env.SEREN_API_KEY).toBe("session-lease-value");
+    expect(env.SEREN_AGENT_PROJECT_ROOT).toBe("/workspace/project");
+    expect(env[CANARY_ENV_NAME]).toBeUndefined();
+    expect(Object.values(env)).not.toContain("canary-parent-secret");
+  });
+});

--- a/tests/unit/credential-lease-bridge.test.ts
+++ b/tests/unit/credential-lease-bridge.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Verifies renderer lease helpers issue the exact Rust command names.
+// ABOUTME: The invoke spy observes the command boundary without creating any real credential.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+import {
+  createCredentialLease,
+  revokeAllCredentialLeases,
+  revokeCredentialLease,
+} from "@/services/credential-lease";
+
+describe("credential lease renderer bridge (#3194)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates and revokes a session lease through the Rust command boundary", async () => {
+    invokeMock.mockResolvedValueOnce({
+      sessionId: "session-a",
+      keyId: "key-a",
+      apiKey: "session-only-value",
+      expiresAt: "2030-01-01T00:00:00Z",
+    });
+
+    await createCredentialLease("session-a");
+    await revokeCredentialLease("session-a");
+    await revokeAllCredentialLeases();
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "credential_lease_create", {
+      sessionId: "session-a",
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "credential_lease_revoke", {
+      sessionId: "session-a",
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "credential_lease_revoke_all");
+  });
+});

--- a/tests/unit/idle-reclaim-race-1852.test.ts
+++ b/tests/unit/idle-reclaim-race-1852.test.ts
@@ -52,7 +52,10 @@ describe("#1852 — Fix 3: self-inflicted terminates do not surface in chat", ()
   it("agentStore.terminateSession adds the session id BEFORE the provider IPC kill", () => {
     const idx = agentStoreSource.indexOf("async terminateSession(");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 2000);
+    // Credential teardown now happens between the existing self-inflicted
+    // marker and provider kill. Keep asserting their order without making the
+    // source-window size part of the lifecycle contract.
+    const body = agentStoreSource.slice(idx, idx + 3200);
     const addIdx = body.indexOf("expectedTerminateSessionIds.add(sessionId)");
     const ipcIdx = body.indexOf("providerService.terminateSession(sessionId)");
     expect(addIdx).toBeGreaterThan(0);

--- a/tests/unit/scrub-sensitive.test.ts
+++ b/tests/unit/scrub-sensitive.test.ts
@@ -15,6 +15,13 @@ describe("scrubSensitive", () => {
     expect(scrubSensitive(input)).toBe("API key: [REDACTED_API_KEY]");
   });
 
+  it("scrubs a Seren lease whose key id uses URL-safe separators", () => {
+    const lease = ["seren", "key-id", "secret_value"].join("_");
+    expect(scrubSensitive(`API key: ${lease}`)).toBe(
+      "API key: [REDACTED_SEREN_KEY]",
+    );
+  });
+
   it("scrubs email addresses", () => {
     const input = "User email: test@example.com failed";
     expect(scrubSensitive(input)).toBe("User email: [REDACTED_EMAIL] failed");

--- a/tests/unit/telemetry-runtime-secret-redaction.test.ts
+++ b/tests/unit/telemetry-runtime-secret-redaction.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Verifies runtime Seren secret values are removed before telemetry leaves the app.
+// ABOUTME: Uses the real telemetry service and observes only its outbound request body.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, getTokenMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getTokenMock: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getToken: getTokenMock,
+}));
+
+vi.mock("@/lib/tauri-fetch", () => ({
+  getTauriFetch: vi.fn(async () => globalThis.fetch),
+  shouldSkipRefresh: vi.fn(() => true),
+  shouldUseRustGatewayAuth: vi.fn(() => false),
+}));
+
+import { TelemetryService } from "@/services/telemetry";
+
+const CANARY_ENV_NAME = "SEREN_TELEMETRY_CANARY_SECRET";
+const CANARY_VALUE = "telemetry-runtime-canary";
+const originalCanary = process.env[CANARY_ENV_NAME];
+
+afterEach(() => {
+  if (originalCanary === undefined) {
+    delete process.env[CANARY_ENV_NAME];
+  } else {
+    process.env[CANARY_ENV_NAME] = originalCanary;
+  }
+});
+
+describe("telemetry runtime secret redaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("navigator", { userAgent: "Seren test runner" });
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+  });
+
+  it("redacts a current SEREN_*_SECRET value from error and context payloads", async () => {
+    process.env[CANARY_ENV_NAME] = CANARY_VALUE;
+    const service = new TelemetryService({ enabled: true });
+
+    service.captureError(new Error(`failure contains ${CANARY_VALUE}`), {
+      nested: { value: CANARY_VALUE },
+    });
+    await service.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0]?.[0] as Request;
+    const body = await request.text();
+    expect(body).not.toContain(CANARY_VALUE);
+    expect(body).toContain("[REDACTED]");
+    service.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the agent spawn path's persistent desktop publisher key with a unique, one-day session lease owned and revoked by Rust.
- Persist only `{ session_id, key_id, expires_at, pending_revocation }` for crash recovery; the lease value remains in memory and crosses the renderer boundary only for immediate child-env injection.
- Revoke on normal and direct agent teardown paths, on logout, and on startup orphan reaping; limit Claude child inheritance to an explicit parent-env allowlist.
- Redact current `SEREN_*_(KEY|TOKEN|SECRET)` values and the active Seren lease shape from telemetry and provider-runtime child logs.

## Audit trace

- `src/stores/agent.store.ts`: session spawn now calls the lease bridge; common teardown, stale-resume cleanup, runtime restart, failed spawn, and deferred-promotion paths converge on revocation.
- `src/services/auth.ts`: logout calls `credential_lease_revoke_all` before clearing stored authentication.
- `src-tauri/src/credential_lease.rs` and `src-tauri/src/commands/credential_lease.rs`: Rust owns create/revoke/retry/orphan-reaper state and the three command boundaries.
- `bin/browser-local/claude-runtime.mjs`: the Claude child receives an explicit environment allowlist rather than the full desktop process environment.
- `src/services/telemetry.ts` and `src-tauri/src/provider_runtime.rs`: diagnostics and child output scrub runtime secret values.

## Live API-contract verification

Verified against the live [SerenDB OpenAPI contract](https://api.serendb.com/openapi.json), then cross-checked with the repository's generated client:

| Operation | Verified shape |
| --- | --- |
| Create lease | `POST /organizations/default/api-keys` with bearer auth; `CreateApiKeyRequest` accepts `name`, `scopes`, and `expires_in_days`; returns the full key once plus `key_id` and `expires_at`. |
| Revoke lease | `DELETE /organizations/default/api-keys/{key_id}` with bearer auth; key ID is a UUID path parameter. |

The public schema says scopes are granular but does not publish a narrower per-publisher scope grammar. This change therefore uses the narrowest scope verified by the current deployed desktop contract, `publisher:*`, together with a unique one-day expiry, and fails the spawn closed if the response omits `expires_at`.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml credential_lease -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml child_output_redacts_runtime_secret_values_and_lease_shape -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm vitest run` on 14 touched/adjacent suites: 67 tests passed
- `pnpm check`
- `pnpm build`

## Networked path

Existing authenticated SerenDB API-key create/delete calls are now issued by the Rust lease manager. No new external service is introduced.

## Interim exposure and follow-up

The lease value still transits the renderer and is placed in the immediate agent child environment so the existing MCP configuration can authenticate. Stage 2 must replace that handoff with a local credential broker/proxy. The persistent legacy desktop key remains for non-agent callers and needs separate rotation after the broker ships.

Refs #3194

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com