### PR TITLE
fix(happy): preserve active sessions across bridge restarts

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -866,6 +866,7 @@ export function createAcpRuntime({
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      pid: session.process?.pid ?? null,
     }));
   }
 

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -3129,6 +3129,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      pid: session.process?.pid ?? null,
     }));
   }
 

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -1713,6 +1713,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      pid: null,
     }));
   }
 

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -1516,6 +1516,7 @@ export function createPairedRuntime({ emit, inner }) {
       createdAt: paired.createdAt,
       agentSessionId: compositeAgentSessionId(paired),
       timeoutSecs: paired.timeoutSecs,
+      pid: null,
     }));
   }
 

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -2013,6 +2013,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         currentModelId: session.currentModelId,
         currentModeId: session.currentModeId,
         pendingPermissions: listPendingPermissions(session),
+        pid: session.process?.pid ?? null,
       })),
       ...(await claudeRuntime.listSessions()),
       ...(await geminiRuntime.listSessions()),

--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -54,7 +54,7 @@ function startInputReader() {
 
 // Caps the wait for the closes below so a socket that never completes its
 // handshake still exits well inside the supervisor's STOP_GRACE_PERIOD.
-const CLOSE_TIMEOUT_MS = 2000;
+const CLOSE_TIMEOUT_MS = 4000;
 
 async function shutdown(exitCode = 0) {
   if (shuttingDown) return;
@@ -63,8 +63,14 @@ async function shutdown(exitCode = 0) {
   // Windows with an assertion in uv_async_send. The loop cannot be left to
   // drain on its own instead, because a child's piped stdout and stderr keep
   // it alive indefinitely.
+  const closeBridgeComponents = (async () => {
+    // Keep the provider RPC socket open until Happy has unwound any in-flight
+    // remote spawn; that cleanup may still need provider terminate/list calls.
+    await Promise.allSettled([happyLayer?.close()]);
+    await Promise.allSettled([client?.close()]);
+  })();
   await Promise.race([
-    Promise.allSettled([client?.close(), happyLayer?.close()]),
+    closeBridgeComponents,
     new Promise((resolve) => setTimeout(resolve, CLOSE_TIMEOUT_MS)),
   ]);
   supervisorChannel?.close();

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -19,10 +19,10 @@ import {
   validatePermissionResponse,
   validateSpawnRoot,
 } from "./validate.mjs";
+import { createHappySessionKeyStore } from "./session-key-store.mjs";
 
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
-const SUMMARY_CACHE_TTL_MS = 1000;
 const SESSION_KEEP_ALIVE_MS = 2000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
 const BUSY_SESSION_STATUSES = new Set(["prompting", "busy", "running"]);
@@ -44,6 +44,7 @@ const NARROW_ALLOW_OPTION_IDS = new Set([
   "approve",
 ]);
 const NARROW_ALLOW_KINDS = new Set(["allow_once", "allow-once"]);
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function encodeBase64(bytes) {
   return Buffer.from(bytes).toString("base64");
@@ -488,23 +489,98 @@ export async function getOrCreateUsableHappySession({
   tag,
   metadata,
   state,
+  encryptionKey,
+  expectedSessionId,
+  allowLegacyReplacement = false,
   debugLog = () => {},
-  replacementTag = () => `seren-recovery-${randomUUID()}`,
+  replacementTag,
+  persistReplacementTag = async () => {},
+  persistReady = async () => {},
 }) {
-  const initial = await api.getOrCreateSession({ tag, metadata, state });
-  if (!initial || isUsableHappySession(initial)) return initial ?? null;
+  const options = encryptionKey ? { tag, metadata, state, encryptionKey } : { tag, metadata, state };
+  const initial = await api.getOrCreateSession(options);
+  if (!initial) return null;
+  if (isUsableHappySession(initial)) {
+    if (expectedSessionId && initial.id !== expectedSessionId) {
+      debugLog("Happy session binding resolved to a different relay row");
+      if (!(await api.deactivateSession(initial.id))) {
+        debugLog("failed to retire unexpected Happy relay row");
+      }
+      return null;
+    }
+    try {
+      await persistReady(initial.id);
+    } catch (error) {
+      if (!(await api.deactivateSession(initial.id))) {
+        debugLog("failed to retire Happy relay row after persistence failure");
+      }
+      throw error;
+    }
+    return initial;
+  }
 
-  // Data-key sessions cannot decrypt a relay record created by an earlier
-  // bridge process because Happy 1.2.0 keeps that session key only in memory.
-  // A one-time tag forces a fresh encrypted record instead of passing null
-  // metadata into ApiSessionClient, whose constructor dereferences `.path`.
-  debugLog("replacing Happy session with unreadable metadata");
+  // Older data-key bridge builds generated an in-memory random key for this
+  // stable tag. Only a new pending binding may migrate it: a ready binding that
+  // becomes unreadable is corruption and must fail closed rather than fork.
+  if (!allowLegacyReplacement || typeof initial.id !== "string") return null;
+  debugLog("retiring Happy session with unreadable metadata");
+  if (!(await api.deactivateSession(initial.id))) {
+    debugLog("failed to retire Happy session with unreadable metadata");
+    return null;
+  }
+  if (typeof replacementTag !== "string" || replacementTag.length === 0) return null;
+  // Persist the recovery tag before its POST. If the process exits after the
+  // relay creates the row, the next process retries the same tag and key.
+  await persistReplacementTag(replacementTag);
   const replacement = await api.getOrCreateSession({
-    tag: replacementTag(),
+    ...options,
+    tag: replacementTag,
     metadata,
     state,
   });
-  return isUsableHappySession(replacement) ? replacement : null;
+  if (!isUsableHappySession(replacement)) return null;
+  try {
+    await persistReady(replacement.id);
+  } catch (error) {
+    if (!(await api.deactivateSession(replacement.id))) {
+      debugLog("failed to retire replacement Happy row after persistence failure");
+    }
+    throw error;
+  }
+  return replacement;
+}
+
+export function disposeHappySessionEntry({ api, entry, debugLog = () => {} }) {
+  if (entry.disposal) return entry.disposal;
+  entry.liveness?.stop();
+  entry.disposal = (async () => {
+    try {
+      entry.client.sendSessionDeath();
+    } catch {
+      debugLog("failed to signal Happy session end");
+    }
+    const deactivate = (async () => {
+      try {
+        const retired = await api.deactivateSession(entry.happySessionId);
+        if (!retired) {
+          debugLog("failed to deactivate Happy session");
+        }
+        return retired;
+      } catch {
+        debugLog("failed to deactivate Happy session");
+        return false;
+      }
+    })();
+    // The HTTP fallback and outbox/socket close are independent. Starting both
+    // keeps worst-case teardown within the supervisor's bounded grace period.
+    const [deactivateResult, closeResult] = await Promise.allSettled([
+      deactivate,
+      entry.client.close(),
+    ]);
+    if (closeResult.status === "rejected") debugLog("failed to close Happy session client");
+    return deactivateResult.status === "fulfilled" && deactivateResult.value;
+  })();
+  return entry.disposal;
 }
 
 export function createHappyLayer({
@@ -513,10 +589,12 @@ export function createHappyLayer({
   source,
   debugLog = () => {},
   onShutdownRequest = async () => {},
+  sessionKeyStore: providedSessionKeyStore = null,
 }) {
   configuration.serverUrl = config.relayUrl;
   let identity = config.machineIdentity;
   let api = null;
+  let sessionKeyStore = null;
   let machineClient = null;
   let pairingPromise = null;
   let pairingAuthorizationPromise = null;
@@ -524,6 +602,8 @@ export function createHappyLayer({
   let latestPairingPayload = null;
   let pairingCancelled = false;
   let closing = false;
+  let identityResetting = false;
+  let identityResetPromise = null;
   let sourceSubscription = null;
   let supervisorSubscription = null;
   let advertisedRoots = [];
@@ -534,6 +614,8 @@ export function createHappyLayer({
   const sessions = new Map();
   const sessionCreationPromises = new Map();
   const sessionDisposals = new Set();
+  const spawnOperations = new Set();
+  const layerOperations = new Set();
   const remotelyArchivedSessions = new Set();
   const terminatedSessions = createTerminatedSessionTracker();
   const pendingRequests = Object.create(null);
@@ -542,15 +624,340 @@ export function createHappyLayer({
   const assistantMessageCoalescer = createAssistantMessageCoalescer();
 
   const sessionSummaries = new Map();
-  let summariesFetchedAt = 0;
+  let summariesRefreshPromise = null;
 
   function debug(message) {
     debugLog(message);
   }
 
+  function initializeSessionKeyStore() {
+    const storeKey =
+      identity?.encryption?.type === "dataKey"
+        ? identity.encryption.machineKey
+        : identity?.encryption?.type === "legacy"
+          ? identity.encryption.secret
+          : identity?.secret;
+    if (!storeKey) {
+      sessionKeyStore = null;
+      return;
+    }
+    if (providedSessionKeyStore) {
+      sessionKeyStore = providedSessionKeyStore;
+      return;
+    }
+    const directory = process.env.HAPPY_HOME_DIR;
+    if (typeof directory !== "string" || directory.length === 0) {
+      throw new Error("Happy session key storage directory is unavailable");
+    }
+    sessionKeyStore = createHappySessionKeyStore({
+      directory,
+      machineKey: decodeByteValue(storeKey),
+    });
+  }
+
+  async function forgetSessionBinding(sessionId) {
+    if (!sessionKeyStore) return;
+    try {
+      await sessionKeyStore.delete(sessionId);
+    } catch {
+      debug("failed to remove Happy session binding");
+    }
+  }
+
+  async function persistedSessionBindings() {
+    if (!sessionKeyStore) return [];
+    return sessionKeyStore.list();
+  }
+
+  async function persistedSessionBinding(sessionId) {
+    const bindings = await persistedSessionBindings();
+    return bindings.find((binding) => binding.sessionId === sessionId) ?? null;
+  }
+
+  async function providerSessionIsArchived(sessionId) {
+    const result = await supervisorChannel.call("provider_session_archive_lookup", {
+      providerSessionId: sessionId,
+    });
+    return result?.archived === true;
+  }
+
+  async function markSessionBindingRetiring(
+    sessionId,
+    happySessionId,
+    providerRetired = false,
+    blockRevival = false,
+    conversationId,
+    agentSessionId,
+  ) {
+    if (!sessionKeyStore) return null;
+    try {
+      return await sessionKeyStore.markRetiring(
+        sessionId,
+        happySessionId,
+        providerRetired,
+        blockRevival,
+        conversationId,
+        agentSessionId,
+      );
+    } catch {
+      debug("failed to persist retiring Happy session binding");
+      return null;
+    }
+  }
+
+  async function resolveRetiringRelayId(sessionId, binding) {
+    if (typeof binding?.happySessionId === "string") return binding.happySessionId;
+    if (!api || !binding) return null;
+    let session;
+    try {
+      session = await api.getOrCreateSession({
+        tag: binding.relayTag,
+        metadata: {
+          path: os.homedir(),
+          host: config.machineName,
+          name: "Retiring Seren session",
+          lifecycleState: "archived",
+        },
+        state: { controlledByUser: true },
+        encryptionKey: binding.key,
+      });
+    } catch {
+      debug("failed to resolve retiring Happy session binding");
+      return null;
+    }
+    if (typeof session?.id !== "string" || session.id.length === 0) return null;
+    const persisted = await markSessionBindingRetiring(sessionId, session.id);
+    return persisted ? session.id : null;
+  }
+
+  async function retirePersistedSession({
+    sessionId,
+    binding,
+    entry = null,
+    terminateProvider = false,
+    providerAlreadyRetired = false,
+    blockRevival = false,
+    desktopAlreadyFenced = false,
+    agentSessionId,
+  }) {
+    let retiringBinding = binding;
+    const shouldArchiveConversation = blockRevival || binding?.blockRevival === true;
+    let conversationId = binding?.conversationId;
+    let archiveProviderOnly = false;
+    const ownerAgentSessionId =
+      agentSessionId ?? entry?.summary?.agentSessionId ?? binding?.agentSessionId;
+    if (sessionKeyStore) {
+      // Persist the user's archive intent before either the owner lookup or an
+      // external teardown. A crash or transient DB failure can then resume the
+      // whole retirement on the next bridge start.
+      retiringBinding = await markSessionBindingRetiring(
+        sessionId,
+        entry?.happySessionId ?? binding?.happySessionId,
+        providerAlreadyRetired || binding?.providerRetired === true,
+        shouldArchiveConversation,
+        conversationId,
+        ownerAgentSessionId,
+      );
+      if (!retiringBinding) return false;
+    }
+    if (
+      shouldArchiveConversation &&
+      !desktopAlreadyFenced &&
+      typeof conversationId !== "string"
+    ) {
+      try {
+        const owner = await supervisorChannel.call("conversation_owner_lookup", {
+          providerSessionId: sessionId,
+          agentSessionId: ownerAgentSessionId ?? null,
+        });
+        if (typeof owner?.conversationId === "string" && owner.conversationId.length > 0) {
+          conversationId = owner.conversationId;
+        } else if (
+          owner &&
+          typeof owner === "object" &&
+          !("conversationId" in owner)
+        ) {
+          // Predictive standbys and not-yet-persisted remote spawns have no
+          // desktop conversation row. The supervisor still fences the exact
+          // provider session in the frontend before it is terminated.
+          archiveProviderOnly = true;
+        } else {
+          debug("failed to resolve desktop conversation for retired Happy session");
+          return false;
+        }
+      } catch {
+        debug("failed to resolve desktop conversation for retired Happy session");
+        return false;
+      }
+      if (sessionKeyStore && !archiveProviderOnly) {
+        // Persist the resolved owner before SQLite is changed. This exact id is
+        // required after provider-session compaction and on a crash retry.
+        retiringBinding = await markSessionBindingRetiring(
+          sessionId,
+          entry?.happySessionId ?? retiringBinding?.happySessionId,
+          retiringBinding?.providerRetired === true,
+          true,
+          conversationId,
+          ownerAgentSessionId,
+        );
+        if (!retiringBinding) return false;
+      }
+    }
+
+    let providerRetired =
+      providerAlreadyRetired || retiringBinding?.providerRetired === true;
+    if (shouldArchiveConversation && !desktopAlreadyFenced) {
+      try {
+        if (archiveProviderOnly) {
+          await supervisorChannel.call("provider_session_archive", {
+            providerSessionId: sessionId,
+          });
+        } else {
+          await supervisorChannel.call("conversation_archive", {
+            conversationId,
+            providerSessionId: sessionId,
+          });
+        }
+      } catch {
+        debug("failed to fence desktop state for retired Happy session");
+        return false;
+      }
+    }
+    if (terminateProvider) {
+      try {
+        await source.terminate(sessionId);
+        providerRetired = true;
+        if (sessionKeyStore) {
+          retiringBinding = await markSessionBindingRetiring(
+            sessionId,
+            entry?.happySessionId ?? retiringBinding?.happySessionId,
+            true,
+            shouldArchiveConversation,
+            conversationId,
+            ownerAgentSessionId,
+          );
+          if (!retiringBinding) return false;
+        }
+      } catch {
+        debug("failed to terminate provider for retiring Happy session");
+      }
+    }
+
+    let relayRetired = false;
+    if (entry) {
+      relayRetired = await disposeHappySessionEntry({ api, entry, debugLog: debug });
+    } else {
+      const happySessionId = await resolveRetiringRelayId(sessionId, retiringBinding);
+      if (happySessionId) {
+        try {
+          relayRetired = await api.deactivateSession(happySessionId);
+        } catch {
+          relayRetired = false;
+        }
+        if (!relayRetired) debug("failed to deactivate persisted Happy session");
+      }
+    }
+
+    if (providerRetired && relayRetired) {
+      await forgetSessionBinding(sessionId);
+      if (shouldArchiveConversation) {
+        remotelyArchivedSessions.add(sessionId);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  async function retireProviderSessionFromDesktop(sessionId) {
+    remotelyArchivedSessions.add(sessionId);
+    terminatedSessions.mark(sessionId);
+    const entry = sessions.get(sessionId) ?? null;
+    if (entry) {
+      sessions.delete(sessionId);
+      liveSessions.delete(sessionId);
+      promptQueue.clear(sessionId);
+      turnCorrelator.clear(sessionId);
+      assistantMessageCoalescer.clear(sessionId);
+      delete pendingRequests[sessionId];
+      sessionCreationPromises.delete(sessionId);
+      entry.liveness.stop();
+    }
+    const binding = entry ? null : await persistedSessionBinding(sessionId);
+    if (!entry && !binding) {
+      await source
+        .terminate(sessionId)
+        .catch(() => debug("failed to terminate provider without a Happy binding"));
+      return;
+    }
+    await retirePersistedSession({
+      sessionId,
+      ...(entry ? { entry } : { binding }),
+      terminateProvider: true,
+      blockRevival: true,
+      desktopAlreadyFenced: true,
+      agentSessionId: entry?.summary?.agentSessionId ?? binding?.agentSessionId,
+    });
+  }
+
+  async function reconcilePersistedSessions(listed) {
+    const bindings = await persistedSessionBindings();
+    const listedIds = new Set(listed.map((summary) => summary.sessionId));
+    const blocked = new Set();
+    const archivedIds = new Set(
+      (
+        await Promise.all(
+          bindings.map(async (binding) =>
+            (await providerSessionIsArchived(binding.sessionId)) ? binding.sessionId : null,
+          ),
+        )
+      ).filter(Boolean),
+    );
+    const retirements = bindings
+      // Provider restoration happens after the bridge starts during a full app
+      // launch, so absence from this first snapshot is not proof of termination.
+      // Only an intent durably recorded before teardown is safe to replay.
+      .filter((binding) => binding.state === "retiring" || archivedIds.has(binding.sessionId))
+      .map(async (binding) => {
+        blocked.add(binding.sessionId);
+        const desktopAlreadyFenced = archivedIds.has(binding.sessionId);
+        const retired = await retirePersistedSession({
+          sessionId: binding.sessionId,
+          binding,
+          terminateProvider: listedIds.has(binding.sessionId),
+          providerAlreadyRetired:
+            (binding.blockRevival === true || desktopAlreadyFenced) &&
+            !listedIds.has(binding.sessionId),
+          blockRevival: desktopAlreadyFenced,
+          desktopAlreadyFenced,
+        });
+        if (retired) terminatedSessions.mark(binding.sessionId);
+      });
+    await Promise.allSettled(retirements);
+    return blocked;
+  }
+
   function trackSessionDisposal(disposal) {
     sessionDisposals.add(disposal);
-    void disposal.finally(() => sessionDisposals.delete(disposal));
+    void disposal.then(
+      () => sessionDisposals.delete(disposal),
+      () => sessionDisposals.delete(disposal),
+    );
+  }
+
+  function trackLayerOperation(operation, failureMessage) {
+    const handled = Promise.resolve(operation).catch(() => debug(failureMessage));
+    layerOperations.add(handled);
+    void handled.then(
+      () => layerOperations.delete(handled),
+      () => layerOperations.delete(handled),
+    );
+    return handled;
+  }
+
+  async function drainOperations(operations) {
+    while (operations.size > 0) {
+      await Promise.allSettled([...operations]);
+    }
   }
 
   const promptQueue = createDeferredPromptQueue({
@@ -566,24 +973,32 @@ export function createHappyLayer({
   });
 
   // Listing every session once per streamed event issued one provider RPC per
-  // assistant delta. Summaries are stable for the fields consumed here
-  // (agentType, cwd), so they are cached and only re-listed for a session the
-  // cache has never seen, at most once per interval.
+  // assistant delta. The scope/provider fields are cached; provider status
+  // events merge a newly assigned native agentSessionId below.
   async function refreshSessionSummaries() {
-    const listed = await source.listSessions();
-    sessionSummaries.clear();
-    for (const summary of listed) sessionSummaries.set(summary.sessionId, summary);
-    summariesFetchedAt = Date.now();
-    return listed;
+    if (summariesRefreshPromise) return summariesRefreshPromise;
+    summariesRefreshPromise = (async () => {
+      const listed = await source.listSessions();
+      sessionSummaries.clear();
+      for (const summary of listed) {
+        sessionSummaries.set(summary.sessionId, summary);
+        const entry = sessions.get(summary.sessionId);
+        if (entry) entry.summary = summary;
+      }
+      return listed;
+    })();
+    try {
+      return await summariesRefreshPromise;
+    } finally {
+      summariesRefreshPromise = null;
+    }
   }
 
   async function sessionSummary(sessionId) {
-    if (
-      !sessionSummaries.has(sessionId) &&
-      Date.now() - summariesFetchedAt > SUMMARY_CACHE_TTL_MS
-    ) {
-      await refreshSessionSummaries();
-    }
+    // A full app launch starts this bridge before frontend agent restoration.
+    // Never negative-cache the initial empty list: the first provider event is
+    // often the only signal that its restored session is now available.
+    if (!sessionSummaries.has(sessionId)) await refreshSessionSummaries();
     return sessionSummaries.get(sessionId) ?? null;
   }
 
@@ -606,9 +1021,7 @@ export function createHappyLayer({
       assistantMessageCoalescer.clear(sessionId);
       delete pendingRequests[sessionId];
       sessionCreationPromises.delete(sessionId);
-      entry.liveness.stop();
-      await entry.client
-        .close()
+      await disposeHappySessionEntry({ api, entry, debugLog: debug })
         .catch(() => debug("failed to close Happy session leaving scope"));
     }
   }
@@ -658,10 +1071,12 @@ export function createHappyLayer({
       remotelyArchivedSessions.add(sessionId);
       entry.liveness.stop();
       const disposal = (async () => {
-        await source
-          .terminate(sessionId)
-          .catch(() => debug("failed to terminate Happy session archived remotely"));
-        await client.close().catch(() => debug("failed to close archived Happy session"));
+        await retirePersistedSession({
+          sessionId,
+          entry,
+          terminateProvider: true,
+          blockRevival: true,
+        });
       })();
       trackSessionDisposal(disposal);
     });
@@ -748,49 +1163,188 @@ export function createHappyLayer({
     return { ok: true };
   }
 
-  async function createSessionEntry(sessionId, summary, existingSession = null) {
-    if (closing) throw new Error("Happy layer is closing");
+  async function createSessionEntry(sessionId, summary) {
+    if (closing || identityResetting) throw new Error("Happy layer is closing");
     const existing = sessions.get(sessionId);
     if (existing) return existing;
     if (!api || !identity) throw new Error("Happy API is not registered");
+    if (await providerSessionIsArchived(sessionId)) {
+      remotelyArchivedSessions.add(sessionId);
+      terminatedSessions.mark(sessionId);
+      await source
+        .terminate(sessionId)
+        .catch(() => debug("failed to terminate archived provider before relay creation"));
+      return null;
+    }
+    const sessionApi = api;
     const machineId = identity.machineId ?? "seren-desktop";
     const metadata = sessionMetadata(config, summary, machineId);
-    const session =
-      existingSession ??
-      (await getOrCreateUsableHappySession({
-        api,
-        tag: `seren-${sessionId}`,
-        metadata,
-        state: { controlledByUser: true },
-        debugLog: debug,
-      }));
+    const legacyTag = `seren-${sessionId}`;
+    const binding = sessionKeyStore
+      ? await sessionKeyStore.getOrCreate(sessionId, legacyTag)
+      : null;
+    if (binding?.state === "retiring") {
+      await retirePersistedSession({
+        sessionId,
+        binding,
+        terminateProvider: true,
+      });
+      terminatedSessions.mark(sessionId);
+      debug("retired provider restored after its Happy session was removed");
+      return null;
+    }
+    if (
+      binding?.state === "pending" &&
+      binding.relayTag === legacyTag &&
+      UUID_PATTERN.test(sessionId)
+    ) {
+      // Before stable ids, a Happy-created desktop conversation retained the
+      // original relay id in its DB metadata but its relay tag used a temporary
+      // `spawn-*` id. Its data key cannot be recovered; at least retire that
+      // known row before creating the one-time decryptable replacement.
+      const recorded = await supervisorChannel.call("conversation_happy_session_lookup", {
+        conversationId: sessionId,
+      });
+      const previousHappySessionId = recorded?.happySessionId;
+      if (
+        typeof previousHappySessionId === "string" &&
+        previousHappySessionId.length > 0 &&
+        !(await sessionApi.deactivateSession(previousHappySessionId))
+      ) {
+        throw new Error("Previous Happy relay row could not be retired");
+      }
+    }
+    const resumedBinding = binding?.state === "ready";
+    const session = await getOrCreateUsableHappySession({
+      api: sessionApi,
+      tag: binding?.relayTag ?? legacyTag,
+      metadata,
+      state: { controlledByUser: true },
+      encryptionKey: binding?.key,
+      expectedSessionId: binding?.state === "ready" ? binding.happySessionId : undefined,
+      allowLegacyReplacement: binding?.state === "pending" && binding.relayTag === legacyTag,
+      debugLog: debug,
+      replacementTag: `seren-v2-${randomUUID()}`,
+      persistReplacementTag: async (relayTag) => {
+        await sessionKeyStore?.replacePendingTag(sessionId, relayTag);
+      },
+      persistReady: async (happySessionId) => {
+        await sessionKeyStore?.markReady(sessionId, happySessionId);
+      },
+    });
     // The relay lookup can outlive bridge shutdown. Do not create a socket or
     // heartbeat after close() has already drained the tracked entries.
-    if (closing) throw new Error("Happy layer is closing");
+    if (closing || identityResetting) {
+      if (isUsableHappySession(session)) await sessionApi.deactivateSession(session.id);
+      throw new Error("Happy layer is closing");
+    }
     if (!isUsableHappySession(session)) {
       throw new Error("Happy relay did not return a usable session");
     }
-    const client = api.sessionSyncClient(session);
+    if (
+      session.metadata.lifecycleState === "archiveRequested" ||
+      session.metadata.lifecycleState === "archived"
+    ) {
+      remotelyArchivedSessions.add(sessionId);
+      terminatedSessions.mark(sessionId);
+      await retirePersistedSession({
+        sessionId,
+        binding: { ...(binding ?? {}), state: "ready", happySessionId: session.id },
+        terminateProvider: true,
+        blockRevival: true,
+        agentSessionId: summary?.agentSessionId,
+      });
+      return null;
+    }
+
+    // A terminal/archive event can overtake the relay lookup while this entry
+    // is still unregistered. Re-check the lifecycle fence before constructing
+    // a socket or heartbeat so that event cannot return while leaving a hidden
+    // live entry behind.
+    const creationWasTerminated = terminatedSessions.has(sessionId);
+    const creationWasArchived = remotelyArchivedSessions.has(sessionId);
+    if (creationWasTerminated || creationWasArchived) {
+      const retiringBinding = await persistedSessionBinding(sessionId);
+      if (retiringBinding) {
+        await retirePersistedSession({
+          sessionId,
+          binding: retiringBinding,
+          terminateProvider: creationWasArchived && !creationWasTerminated,
+          providerAlreadyRetired: creationWasTerminated,
+          blockRevival: creationWasArchived,
+          agentSessionId: summary?.agentSessionId,
+        });
+      } else {
+        if (creationWasArchived && !creationWasTerminated) {
+          await source
+            .terminate(sessionId)
+            .catch(() => debug("failed to terminate archived provider during relay creation"));
+        }
+        await sessionApi
+          .deactivateSession(session.id)
+          .catch(() => debug("failed to deactivate superseded Happy relay row"));
+      }
+      return null;
+    }
+    if (!isSessionInScope(summary)) {
+      await sessionApi
+        .deactivateSession(session.id)
+        .catch(() => debug("failed to deactivate Happy session after roots changed"));
+      debug("discarded Happy session after its root left scope during relay creation");
+      return null;
+    }
+
+    let client;
+    const resumeFromSeq =
+      resumedBinding || session.seq > 0
+        ? typeof session.seq === "number"
+          ? session.seq
+          : 0
+        : 0;
+    try {
+      // The SDK applies this cursor before opening its socket, so the initial
+      // fetch and a concurrent N+1 socket update cannot replay older prompts.
+      client = sessionApi.sessionSyncClient(session, { resumeFromSeq });
+    } catch (error) {
+      await sessionApi.deactivateSession(session.id);
+      throw error;
+    }
+    // Do not rewrite lifecycle metadata when resuming. A mobile archive can
+    // land after the GET snapshot; an optimistic update retry would otherwise
+    // overwrite that newer archiveRequested value back to running.
     const thinking = BUSY_SESSION_STATUSES.has(summary?.status);
-    const entry = {
-      sessionId,
-      happySessionId: session.id,
-      summary,
-      session,
-      client,
-      liveness: createSessionLiveness(client, thinking),
-    };
-    sessions.set(sessionId, entry);
-    liveSessions.add(sessionId);
-    promptQueue.setBusy(sessionId, thinking);
-    rememberPendingPermissions(sessionId, summary?.pendingPermissions);
-    registerInbound(entry);
-    client.sendSessionEvent({ type: "switch", mode: "remote" });
-    return entry;
+    let entry;
+    try {
+      entry = {
+        sessionId,
+        happySessionId: session.id,
+        summary,
+        session,
+        client,
+        liveness: createSessionLiveness(client, thinking),
+      };
+      sessions.set(sessionId, entry);
+      liveSessions.add(sessionId);
+      promptQueue.setBusy(sessionId, thinking);
+      rememberPendingPermissions(sessionId, summary?.pendingPermissions);
+      registerInbound(entry);
+      client.sendSessionEvent({ type: "switch", mode: "remote" });
+      return entry;
+    } catch (error) {
+      sessions.delete(sessionId);
+      liveSessions.delete(sessionId);
+      promptQueue.clear(sessionId);
+      turnCorrelator.clear(sessionId);
+      assistantMessageCoalescer.clear(sessionId);
+      delete pendingRequests[sessionId];
+      entry?.liveness?.stop();
+      await Promise.allSettled([sessionApi.deactivateSession(session.id), client.close()]);
+      throw error;
+    }
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
-    if (closing) return null;
+    if (closing || identityResetting) return null;
     if (remotelyArchivedSessions.has(sessionId)) return null;
     const tracked = resolveTrackedSession({ sessions, terminatedSessions, sessionId });
     if (tracked.entry) return tracked.entry;
@@ -812,7 +1366,9 @@ export function createHappyLayer({
     try {
       return await creation;
     } finally {
-      sessionCreationPromises.delete(sessionId);
+      if (sessionCreationPromises.get(sessionId) === creation) {
+        sessionCreationPromises.delete(sessionId);
+      }
     }
   }
 
@@ -820,14 +1376,73 @@ export function createHappyLayer({
     // An entry only exists if it passed the scope check when it was created, so
     // a tracked session stays tracked; an unknown one is gated here, before any
     // bookkeeping, so out-of-scope sessions accumulate no state either.
-    const summary =
+    const terminal =
+      event.kind === "status" && ["error", "terminated"].includes(event.payload?.status);
+    if (remotelyArchivedSessions.has(event.sessionId)) {
+      let retiringBinding = null;
+      try {
+        retiringBinding = await persistedSessionBinding(event.sessionId);
+      } catch {
+        debug("failed to read archived Happy session binding");
+      }
+      if (retiringBinding?.state === "retiring") {
+        await retirePersistedSession({
+          sessionId: event.sessionId,
+          binding: retiringBinding,
+          terminateProvider: !terminal,
+          providerAlreadyRetired: terminal,
+        });
+      } else if (!terminal) {
+        await source.terminate(event.sessionId).catch(() =>
+          debug("failed to terminate a late restored archived provider"),
+        );
+      }
+      return;
+    }
+    let summary =
       (await sessionSummary(event.sessionId)) ?? sessions.get(event.sessionId)?.summary ?? null;
+    const observedAgentSessionId = event.payload?.agentSessionId;
+    if (
+      summary &&
+      typeof observedAgentSessionId === "string" &&
+      observedAgentSessionId.length > 0
+    ) {
+      summary = { ...summary, agentSessionId: observedAgentSessionId };
+      sessionSummaries.set(event.sessionId, summary);
+      const trackedEntry = sessions.get(event.sessionId);
+      if (trackedEntry) trackedEntry.summary = summary;
+    }
+    if (terminal && !sessions.has(event.sessionId)) {
+      liveSessions.delete(event.sessionId);
+      promptQueue.clear(event.sessionId);
+      delete pendingRequests[event.sessionId];
+      terminatedSessions.mark(event.sessionId);
+      const binding = await persistedSessionBinding(event.sessionId);
+      if (binding) {
+        await retirePersistedSession({
+          sessionId: event.sessionId,
+          binding,
+          providerAlreadyRetired: true,
+        });
+      }
+      return;
+    }
+    if (!sessions.has(event.sessionId)) {
+      const retiringBinding = await persistedSessionBinding(event.sessionId);
+      if (retiringBinding?.state === "retiring") {
+        await retirePersistedSession({
+          sessionId: event.sessionId,
+          binding: retiringBinding,
+          terminateProvider: true,
+        });
+        terminatedSessions.mark(event.sessionId);
+        return;
+      }
+    }
     if (!sessions.has(event.sessionId) && !isSessionInScope(summary)) {
       debug("dropped event for session outside advertised roots");
       return;
     }
-    const terminal =
-      event.kind === "status" && ["error", "terminated"].includes(event.payload?.status);
     const providerStatus = event.kind === "status" ? event.payload?.status : null;
     const providerThinking = BUSY_SESSION_STATUSES.has(providerStatus);
     const providerReady =
@@ -849,7 +1464,6 @@ export function createHappyLayer({
       terminatedSessions.forget(event.sessionId);
     }
     rememberPermission(event);
-    if (terminal && !sessions.has(event.sessionId)) return;
     const entry = await findOrCreateSession(event.sessionId, summary);
     if (!entry) return;
     if (providerThinking) {
@@ -871,6 +1485,12 @@ export function createHappyLayer({
         sessionId: event.sessionId,
         entry,
         send: async () => {},
+        dispose: (terminalEntry) =>
+          retirePersistedSession({
+            sessionId: event.sessionId,
+            entry: terminalEntry,
+            providerAlreadyRetired: true,
+          }),
       }).catch(() => debug("failed to close Happy session"));
     }
     if (event.kind === "permission-request" && api) {
@@ -889,7 +1509,10 @@ export function createHappyLayer({
     }));
   }
 
-  async function handleSpawn(options) {
+  async function performSpawn(options) {
+    if (closing || identityResetting) {
+      return { type: "error", errorMessage: "Happy session bridge is stopping" };
+    }
     const validation = validateSpawnRoot(options?.directory, advertisedRoots);
     if (!validation.ok) {
       debug("refused spawn outside advertised roots");
@@ -900,62 +1523,194 @@ export function createHappyLayer({
       debug("refused spawn for unknown agent type");
       return { type: "error", errorMessage: "Requested agent is not available" };
     }
-    const pendingSessionId = `spawn-${randomUUID()}`;
-    const pending = await createSessionEntry(pendingSessionId, {
-      sessionId: pendingSessionId,
-      agentType,
-      cwd: validation.root,
-      title: `${agentType} Agent`,
-      status: "initializing",
-    });
-    // Everything past this point can reject, and the pending entry already holds
-    // an open sync client and a relay-side session. Unwind it on failure so a
-    // repeated failing spawn cannot accumulate open sockets.
+    // Preallocate the final desktop/provider id before creating the relay row.
+    // Deriving the row key from a throwaway pending id would make a remotely
+    // spawned session unrecoverable under its persisted id after restart.
+    const pendingSessionId = randomUUID();
+    let pending = null;
+    let conversationCreated = false;
+    let providerSpawnAttempted = false;
+    let providerConfirmedAbsent = false;
+    let pendingProviderRetired = false;
+    let unexpectedProviderSessionId = null;
     try {
+      // Entry creation itself persists the key/tag and can create the relay
+      // row. Keep it inside the unwind scope so a client-construction failure
+      // cannot strand a ready binding that startup would keep forever.
+      pending = await createSessionEntry(pendingSessionId, {
+        sessionId: pendingSessionId,
+        agentType,
+        cwd: validation.root,
+        title: `${agentType} Agent`,
+        status: "initializing",
+      });
+      if (!pending) throw new Error("Happy session closed before provider spawn");
       const conversation = await supervisorChannel.call("conversation_create", {
+        conversationId: pendingSessionId,
         agentType,
         cwd: validation.root,
         title: `${agentType} Agent`,
         happySessionId: pending.happySessionId,
       });
-      if (closing || sessions.get(pendingSessionId) !== pending) {
-        return { type: "error", errorMessage: "Happy session closed before provider spawn" };
+      conversationCreated = true;
+      if (conversation.conversationId !== pendingSessionId) {
+        throw new Error("conversation id did not match the preallocated session id");
       }
-      const spawned = await source.spawn({
-        agentType,
-        cwd: validation.root,
-        localSessionId: conversation.conversationId,
-        approvalPolicy: defaultApprovalPolicy(agentType),
-      });
+      if (closing || identityResetting || sessions.get(pendingSessionId) !== pending) {
+        throw new Error("Happy session closed before provider spawn");
+      }
+      providerSpawnAttempted = true;
+      let spawned;
+      try {
+        spawned = await source.spawn({
+          agentType,
+          cwd: validation.root,
+          localSessionId: conversation.conversationId,
+          approvalPolicy: defaultApprovalPolicy(agentType),
+        });
+      } catch (error) {
+        providerConfirmedAbsent = error?.providerRequestRejected === true;
+        throw error;
+      }
       if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
-      if (closing || sessions.get(pendingSessionId) !== pending) {
-        await source
-          .terminate(spawned.sessionId)
-          .catch(() => debug("failed to terminate provider spawned after Happy session closed"));
-        return { type: "error", errorMessage: "Happy session closed during provider spawn" };
+      if (closing || identityResetting || sessions.get(pendingSessionId) !== pending) {
+        try {
+          await source.terminate(spawned.sessionId);
+          pendingProviderRetired = spawned.sessionId === pendingSessionId;
+          providerConfirmedAbsent = spawned.sessionId !== pendingSessionId;
+        } catch {
+          if (spawned.sessionId !== pendingSessionId) {
+            unexpectedProviderSessionId = spawned.sessionId;
+            providerConfirmedAbsent = true;
+          }
+          debug("failed to terminate provider spawned after Happy session closed");
+        }
+        throw new Error("Happy session closed during provider spawn");
       }
-      sessions.delete(pendingSessionId);
-      turnCorrelator.clear(pendingSessionId);
-      assistantMessageCoalescer.clear(pendingSessionId);
-      pending.sessionId = spawned.sessionId;
+      if (spawned.sessionId !== pendingSessionId) {
+        providerConfirmedAbsent = true;
+        try {
+          await source.terminate(spawned.sessionId);
+        } catch {
+          unexpectedProviderSessionId = spawned.sessionId;
+          debug("failed to terminate provider with mismatched session id");
+        }
+        throw new Error("provider did not preserve the preallocated session id");
+      }
       pending.summary = spawned;
-      sessions.set(spawned.sessionId, pending);
-      liveSessions.delete(pendingSessionId);
-      liveSessions.add(spawned.sessionId);
-      pendingRequests[spawned.sessionId] = pendingRequests[pendingSessionId] ?? Object.create(null);
-      delete pendingRequests[pendingSessionId];
+      liveSessions.add(pendingSessionId);
       // Seed the cache so the first streamed event resolves this session's
       // provider without re-listing.
-      sessionSummaries.set(spawned.sessionId, spawned);
+      sessionSummaries.set(pendingSessionId, spawned);
       return { type: "success", sessionId: pending.happySessionId };
     } catch (error) {
-      await discardPendingSpawn(pendingSessionId, pending);
+      if (unexpectedProviderSessionId) {
+        await source
+          .terminate(unexpectedProviderSessionId)
+          .catch(() => debug("failed to retry mismatched provider termination"));
+      }
+      await discardPendingSpawn(pendingSessionId, pending, {
+        providerNeverStarted: !providerSpawnAttempted || providerConfirmedAbsent,
+        providerAlreadyRetired: pendingProviderRetired,
+      });
+      if (conversationCreated) {
+        await supervisorChannel
+          .call("conversation_delete", { conversationId: pendingSessionId })
+          .catch(() => debug("failed to roll back abandoned Happy conversation"));
+      }
       debug("failed to spawn Happy session");
       return {
         type: "error",
         errorMessage: error instanceof Error ? error.message : "spawn failed",
       };
     }
+  }
+
+  function handleSpawn(options) {
+    const operation = performSpawn(options);
+    spawnOperations.add(operation);
+    void operation.then(
+      () => spawnOperations.delete(operation),
+      () => spawnOperations.delete(operation),
+    );
+    return operation;
+  }
+
+  async function retireIdentitySessions() {
+    if (identityResetPromise) return identityResetPromise;
+    identityResetting = true;
+    sourceSubscription?.();
+    sourceSubscription = null;
+    identityResetPromise = (async () => {
+      await Promise.allSettled([...spawnOperations]);
+      await Promise.allSettled([...sessionCreationPromises.values()]);
+      if (!api) return false;
+
+      let bindings;
+      try {
+        bindings = await persistedSessionBindings();
+      } catch {
+        debug("failed to read Happy session bindings for identity reset");
+        return false;
+      }
+
+      const relaySessionIds = new Set(
+        [...sessions.values()].map((entry) => entry.happySessionId),
+      );
+      const resolvedBindings = await Promise.all(
+        bindings.map(async (binding) => {
+          if (typeof binding.happySessionId === "string") {
+            return binding.happySessionId;
+          }
+          try {
+            const resolved = await api.getOrCreateSession({
+              tag: binding.relayTag,
+              metadata: {
+                path: os.homedir(),
+                host: config.machineName,
+                name: "Retiring Seren session",
+                lifecycleState: "archived",
+              },
+              state: { controlledByUser: true },
+              encryptionKey: binding.key,
+            });
+            return typeof resolved?.id === "string" && resolved.id.length > 0
+              ? resolved.id
+              : null;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (resolvedBindings.some((happySessionId) => happySessionId === null)) {
+        debug("failed to resolve Happy session during identity reset");
+        return false;
+      }
+      for (const happySessionId of resolvedBindings) relaySessionIds.add(happySessionId);
+
+      for (const entry of sessions.values()) entry.liveness.stop();
+      const results = await Promise.all(
+        [...relaySessionIds].map(async (happySessionId) => {
+          try {
+            return await api.deactivateSession(happySessionId);
+          } catch {
+            return false;
+          }
+        }),
+      );
+      if (results.some((retired) => !retired)) {
+        debug("failed to retire every Happy session before identity reset");
+        return false;
+      }
+
+      // The relay rows are now confirmed inactive. Do not wait for SDK outbox
+      // flushing here: Rust stops this child immediately after the reset ack,
+      // and a slow socket close must not make an otherwise complete reset time
+      // out and revive the old identity.
+      sessions.clear();
+      return true;
+    })();
+    return identityResetPromise;
   }
 
   // Registered once, from `start()`, and torn down in `close()`. A single
@@ -968,14 +1723,41 @@ export function createHappyLayer({
     return supervisorChannel.onNotification((method, params) => {
       if (method === "roots_update") {
         advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
-        void (async () => {
-          await dropSessionsOutOfScope();
-          await updateCapabilities();
-        })().catch(() => debug("failed to apply Happy roots update"));
+        void trackLayerOperation(
+          (async () => {
+            await dropSessionsOutOfScope();
+            await updateCapabilities();
+          })(),
+          "failed to apply Happy roots update",
+        );
         return;
       }
       if (method === "cancel_pairing") {
         cancelPairing();
+        return;
+      }
+      if (method === "identity_reset") {
+        const requestId = params?.requestId;
+        if (typeof requestId !== "string" || requestId.length > 64) return;
+        void trackLayerOperation(
+          retireIdentitySessions()
+            .then((success) => {
+              supervisorChannel.notify("identity_reset_result", { requestId, success });
+            })
+            .catch(() => {
+              supervisorChannel.notify("identity_reset_result", { requestId, success: false });
+            }),
+          "failed to reset Happy identity",
+        );
+        return;
+      }
+      if (method === "provider_session_retire") {
+        const sessionId = params?.providerSessionId;
+        if (typeof sessionId !== "string" || !UUID_PATTERN.test(sessionId)) return;
+        void trackLayerOperation(
+          retireProviderSessionFromDesktop(sessionId),
+          "failed to retire provider session fenced by desktop",
+        );
         return;
       }
       if (method === "shutdown") {
@@ -987,16 +1769,28 @@ export function createHappyLayer({
     });
   }
 
-  async function discardPendingSpawn(pendingSessionId, pending) {
-    if (sessions.get(pendingSessionId) !== pending) return;
-    sessions.delete(pendingSessionId);
-    liveSessions.delete(pendingSessionId);
-    turnCorrelator.clear(pendingSessionId);
-    assistantMessageCoalescer.clear(pendingSessionId);
-    delete pendingRequests[pendingSessionId];
-    sessionCreationPromises.delete(pendingSessionId);
-    pending.liveness.stop();
-    await pending.client.close().catch(() => debug("failed to close abandoned Happy session"));
+  async function discardPendingSpawn(
+    pendingSessionId,
+    pending,
+    { providerNeverStarted = false, providerAlreadyRetired = false } = {},
+  ) {
+    if (pending && sessions.get(pendingSessionId) === pending) {
+      sessions.delete(pendingSessionId);
+      liveSessions.delete(pendingSessionId);
+      turnCorrelator.clear(pendingSessionId);
+      assistantMessageCoalescer.clear(pendingSessionId);
+      delete pendingRequests[pendingSessionId];
+      sessionCreationPromises.delete(pendingSessionId);
+    }
+    const binding = pending ? null : await persistedSessionBinding(pendingSessionId);
+    if (!pending && !binding) return;
+    const providerIsRetired = providerNeverStarted || providerAlreadyRetired;
+    await retirePersistedSession({
+      sessionId: pendingSessionId,
+      ...(pending ? { entry: pending } : { binding }),
+      terminateProvider: !providerIsRetired,
+      providerAlreadyRetired: providerIsRetired,
+    });
   }
 
   function setupMachineHandlers() {
@@ -1016,6 +1810,7 @@ export function createHappyLayer({
 
   async function registerMachine() {
     if (!identity) return false;
+    initializeSessionKeyStore();
     const credentials = credentialsFromIdentity(identity);
     api = await ApiClient.create(credentials);
     const machineId = identity.machineId ?? randomUUID();
@@ -1123,13 +1918,18 @@ export function createHappyLayer({
     return startupStatusGate.complete(async () => {
       await updateCapabilities();
       const listed = await refreshSessionSummaries();
+      const blockedSessionIds = await reconcilePersistedSessions(listed);
       for (const summary of listed) {
+        if (blockedSessionIds.has(summary.sessionId)) continue;
         if (!isSessionInScope(summary)) continue;
         await createSessionEntry(summary.sessionId, summary);
       }
       sourceSubscription?.();
       sourceSubscription = source.subscribe((event) => {
-        void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
+        void trackLayerOperation(
+          publishEvent(event),
+          "failed to publish Happy session event",
+        );
       });
     });
   }
@@ -1153,17 +1953,24 @@ export function createHappyLayer({
       assistantMessageCoalescer.close();
       cancelPairing();
       await pairingAuthorizationPromise;
+      // A remote spawn may already own a persisted relay row while provider
+      // creation is still in flight. The Rust supervisor bounds shutdown; wait
+      // here so performSpawn can durably unwind before this process exits.
+      await drainOperations(spawnOperations);
+      await drainOperations(layerOperations);
+      await Promise.allSettled([...sessionCreationPromises.values()]);
       // Awaited rather than fire-and-forget: the caller exits the process once
       // this resolves, and tearing the event loop down while these closes are
       // still in flight aborts the process on Windows.
       await Promise.allSettled(
-        [...sessions.values()].map((entry) => {
-          entry.liveness.stop();
-          return entry.client.close().catch(() => debug("failed to close Happy session"));
-        }),
+        [...sessions.values()].map((entry) =>
+          disposeHappySessionEntry({ api, entry, debugLog: debug }).catch(() =>
+            debug("failed to close Happy session"),
+          ),
+        ),
       );
       sessions.clear();
-      await Promise.allSettled([...sessionDisposals]);
+      await drainOperations(sessionDisposals);
       sessionDisposals.clear();
       remotelyArchivedSessions.clear();
       terminatedSessions.clear();
@@ -1174,9 +1981,8 @@ export function createHappyLayer({
   };
 }
 
-export async function completeTerminalSession({ sessions, sessionId, entry, send }) {
+export async function completeTerminalSession({ sessions, sessionId, entry, send, dispose }) {
   await send(entry);
   sessions.delete(sessionId);
-  entry.liveness?.stop();
-  await entry.client.close();
+  await (dispose ? dispose(entry) : entry.client.close());
 }

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -121,7 +121,12 @@ class ProviderRuntimeClient {
     this.pending.delete(message.id);
     clearTimeout(pending.timer);
     if (message.error) {
-      pending.reject(new Error(message.error.message ?? "provider runtime RPC failed"));
+      const error = new Error(message.error.message ?? "provider runtime RPC failed");
+      // The local runtime only returns an RPC error after its spawn handler has
+      // cleaned up the failed session. Keep this distinct from a socket loss or
+      // timeout, where creation may have succeeded and must be reconciled.
+      error.providerRequestRejected = true;
+      pending.reject(error);
     } else {
       pending.resolve(message.result);
     }

--- a/bin/happy-bridge/session-key-store.mjs
+++ b/bin/happy-bridge/session-key-store.mjs
@@ -1,0 +1,611 @@
+// ABOUTME: Persists Happy session data keys without exposing session identifiers at rest.
+// ABOUTME: Uses a pairing-key-derived KEK, authenticated encryption, and atomic serialized writes.
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  hkdfSync,
+  randomBytes,
+} from "node:crypto";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
+import path from "node:path";
+
+export const HAPPY_SESSION_KEY_STORE_FILENAME = "happy-session-keys.v1.json";
+
+const STORE_VERSION = 1;
+const PAYLOAD_VERSION = 1;
+const SESSION_KEY_BYTES = 32;
+const SALT_BYTES = 32;
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const MAX_SESSION_ID_BYTES = 512;
+const MAX_RELAY_TAG_BYTES = 1_024;
+const MAX_RELAY_SESSION_ID_BYTES = 512;
+const MAX_ENTRIES = 1_024;
+const MAX_PLAINTEXT_BYTES = 700_000;
+const MAX_STORE_FILE_BYTES = 1_048_576;
+const KEK_CONTEXT = Buffer.from("seren-desktop/happy-session-key-store/kek/v1", "utf8");
+const FILE_AAD = Buffer.from("seren-desktop/happy-session-key-store/file/v1", "utf8");
+const operationQueues = new Map();
+
+export class HappySessionKeyStoreError extends Error {
+  constructor(cause) {
+    super("Happy session key store could not be authenticated", { cause });
+    this.name = "HappySessionKeyStoreError";
+    this.code = "ERR_HAPPY_SESSION_KEY_STORE_INVALID";
+  }
+}
+
+function invalidStore(cause) {
+  return cause instanceof HappySessionKeyStoreError
+    ? cause
+    : new HappySessionKeyStoreError(cause);
+}
+
+function copyMachineKey(machineKey) {
+  if (!(machineKey instanceof Uint8Array) || machineKey.byteLength !== SESSION_KEY_BYTES) {
+    throw new TypeError("Happy pairing machine key must be a 32-byte Uint8Array");
+  }
+  return Buffer.from(machineKey);
+}
+
+function resolveStorePath(directory) {
+  if (
+    typeof directory !== "string" ||
+    directory.length === 0 ||
+    directory.includes("\0") ||
+    Buffer.byteLength(directory, "utf8") > 4_096
+  ) {
+    throw new TypeError("Happy session key store directory is invalid");
+  }
+  return path.join(path.resolve(directory), HAPPY_SESSION_KEY_STORE_FILENAME);
+}
+
+function validateSessionId(sessionId) {
+  const byteLength = typeof sessionId === "string" ? Buffer.byteLength(sessionId, "utf8") : 0;
+  if (byteLength === 0 || byteLength > MAX_SESSION_ID_BYTES || sessionId.includes("\0")) {
+    throw new TypeError(`Happy session id must be between 1 and ${MAX_SESSION_ID_BYTES} bytes`);
+  }
+  return sessionId;
+}
+
+function validateRelayTag(relayTag) {
+  const byteLength = typeof relayTag === "string" ? Buffer.byteLength(relayTag, "utf8") : 0;
+  if (byteLength === 0 || byteLength > MAX_RELAY_TAG_BYTES || relayTag.includes("\0")) {
+    throw new TypeError(`Happy relay tag must be between 1 and ${MAX_RELAY_TAG_BYTES} bytes`);
+  }
+  return relayTag;
+}
+
+function validateRelaySessionId(sessionId) {
+  const byteLength = typeof sessionId === "string" ? Buffer.byteLength(sessionId, "utf8") : 0;
+  if (
+    byteLength === 0 ||
+    byteLength > MAX_RELAY_SESSION_ID_BYTES ||
+    sessionId.includes("\0")
+  ) {
+    throw new TypeError(
+      `Happy relay session id must be between 1 and ${MAX_RELAY_SESSION_ID_BYTES} bytes`,
+    );
+  }
+  return sessionId;
+}
+
+function validateAgentSessionId(sessionId) {
+  const byteLength = typeof sessionId === "string" ? Buffer.byteLength(sessionId, "utf8") : 0;
+  if (byteLength === 0 || byteLength > MAX_SESSION_ID_BYTES || sessionId.includes("\0")) {
+    throw new TypeError(
+      `Happy agent session id must be between 1 and ${MAX_SESSION_ID_BYTES} bytes`,
+    );
+  }
+  return sessionId;
+}
+
+function copyBinding(binding) {
+  return {
+    state: binding.state,
+    relayTag: binding.relayTag,
+    key: new Uint8Array(binding.key),
+    ...(binding.state === "retiring"
+      ? {
+          blockRevival: binding.blockRevival,
+          providerRetired: binding.providerRetired,
+          ...(typeof binding.conversationId === "string"
+            ? { conversationId: binding.conversationId }
+            : {}),
+          ...(typeof binding.agentSessionId === "string"
+            ? { agentSessionId: binding.agentSessionId }
+            : {}),
+        }
+      : {}),
+    ...(typeof binding.happySessionId === "string"
+      ? { happySessionId: binding.happySessionId }
+      : {}),
+  };
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeCanonicalBase64(value, expectedBytes) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_STORE_FILE_BYTES ||
+    value.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(value)
+  ) {
+    throw invalidStore();
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (
+    (expectedBytes !== undefined && decoded.byteLength !== expectedBytes) ||
+    decoded.toString("base64") !== value
+  ) {
+    throw invalidStore();
+  }
+  return decoded;
+}
+
+function deriveKek(machineKey, salt) {
+  return Buffer.from(hkdfSync("sha256", machineKey, salt, KEK_CONTEXT, SESSION_KEY_BYTES));
+}
+
+function parsePayload(plaintext) {
+  if (plaintext.byteLength === 0 || plaintext.byteLength > MAX_PLAINTEXT_BYTES) {
+    throw invalidStore();
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(plaintext.toString("utf8"));
+  } catch (error) {
+    throw invalidStore(error);
+  }
+  if (
+    !isRecord(payload) ||
+    payload.version !== PAYLOAD_VERSION ||
+    !Array.isArray(payload.entries) ||
+    payload.entries.length > MAX_ENTRIES
+  ) {
+    throw invalidStore();
+  }
+
+  const entries = new Map();
+  try {
+    for (const entry of payload.entries) {
+      if (!isRecord(entry)) throw invalidStore();
+      const hasHappySessionId = Object.hasOwn(entry, "happySessionId");
+      const hasConversationId = Object.hasOwn(entry, "conversationId");
+      const hasAgentSessionId = Object.hasOwn(entry, "agentSessionId");
+      const expectedKeys =
+        entry.state === "retiring"
+          ? [
+              ...(hasAgentSessionId ? ["agentSessionId"] : []),
+              "blockRevival",
+              "key",
+              "providerRetired",
+              "relayTag",
+              "sessionId",
+              "state",
+              ...(hasConversationId ? ["conversationId"] : []),
+              ...(hasHappySessionId ? ["happySessionId"] : []),
+            ].sort()
+          : hasHappySessionId
+            ? ["happySessionId", "key", "relayTag", "sessionId", "state"]
+            : ["key", "relayTag", "sessionId", "state"];
+      if (Object.keys(entry).sort().join("\0") !== expectedKeys.join("\0")) {
+        throw invalidStore();
+      }
+      const sessionId = validateSessionId(entry.sessionId);
+      if (entries.has(sessionId)) throw invalidStore();
+      const state = entry.state;
+      if (
+        state !== "pending" &&
+        state !== "ready" &&
+        state !== "retiring"
+      ) {
+        throw invalidStore();
+      }
+      if (
+        (state === "ready" && !hasHappySessionId) ||
+        (state === "pending" && hasHappySessionId) ||
+        (state !== "retiring" && (hasConversationId || hasAgentSessionId))
+      ) {
+        throw invalidStore();
+      }
+      if (
+        state === "retiring" &&
+        (typeof entry.providerRetired !== "boolean" || typeof entry.blockRevival !== "boolean")
+      ) {
+        throw invalidStore();
+      }
+      const binding = {
+        state,
+        relayTag: validateRelayTag(entry.relayTag),
+        key: decodeCanonicalBase64(entry.key, SESSION_KEY_BYTES),
+        ...(state === "retiring"
+          ? {
+              blockRevival: entry.blockRevival,
+              providerRetired: entry.providerRetired,
+              ...(hasConversationId
+                ? { conversationId: validateSessionId(entry.conversationId) }
+                : {}),
+              ...(hasAgentSessionId
+                ? { agentSessionId: validateAgentSessionId(entry.agentSessionId) }
+                : {}),
+            }
+          : {}),
+      };
+      if (hasHappySessionId) {
+        binding.happySessionId = validateRelaySessionId(entry.happySessionId);
+      }
+      entries.set(sessionId, binding);
+    }
+  } catch (error) {
+    throw invalidStore(error);
+  }
+  return entries;
+}
+
+function decryptDocument(document, machineKey) {
+  try {
+    if (
+      !isRecord(document) ||
+      document.version !== STORE_VERSION ||
+      !isRecord(document.kdf) ||
+      document.kdf.name !== "HKDF-SHA256" ||
+      !isRecord(document.aead) ||
+      document.aead.name !== "AES-256-GCM"
+    ) {
+      throw invalidStore();
+    }
+
+    const salt = decodeCanonicalBase64(document.kdf.salt, SALT_BYTES);
+    const iv = decodeCanonicalBase64(document.aead.iv, IV_BYTES);
+    const tag = decodeCanonicalBase64(document.aead.tag, AUTH_TAG_BYTES);
+    const ciphertext = decodeCanonicalBase64(document.aead.ciphertext);
+    const kek = deriveKek(machineKey, salt);
+    let plaintext;
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", kek, iv, {
+        authTagLength: AUTH_TAG_BYTES,
+      });
+      decipher.setAAD(FILE_AAD);
+      decipher.setAuthTag(tag);
+      plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    } finally {
+      kek.fill(0);
+    }
+
+    try {
+      return parsePayload(plaintext);
+    } finally {
+      plaintext.fill(0);
+    }
+  } catch (error) {
+    throw invalidStore(error);
+  }
+}
+
+function encryptEntries(entries, machineKey) {
+  if (entries.size > MAX_ENTRIES) {
+    throw new RangeError(`Happy session key store supports at most ${MAX_ENTRIES} entries`);
+  }
+  const plaintext = Buffer.from(
+    JSON.stringify({
+      version: PAYLOAD_VERSION,
+      entries: [...entries].map(([sessionId, binding]) => ({
+        sessionId,
+        state: binding.state,
+        relayTag: binding.relayTag,
+        key: binding.key.toString("base64"),
+        ...(binding.state === "retiring"
+          ? {
+              blockRevival: binding.blockRevival,
+              providerRetired: binding.providerRetired,
+              ...(typeof binding.conversationId === "string"
+                ? { conversationId: binding.conversationId }
+                : {}),
+              ...(typeof binding.agentSessionId === "string"
+                ? { agentSessionId: binding.agentSessionId }
+                : {}),
+            }
+          : {}),
+        ...(typeof binding.happySessionId === "string"
+          ? { happySessionId: binding.happySessionId }
+          : {}),
+      })),
+    }),
+    "utf8",
+  );
+  if (plaintext.byteLength > MAX_PLAINTEXT_BYTES) {
+    plaintext.fill(0);
+    throw new RangeError("Happy session key store payload is too large");
+  }
+
+  const salt = randomBytes(SALT_BYTES);
+  const iv = randomBytes(IV_BYTES);
+  const kek = deriveKek(machineKey, salt);
+  let ciphertext;
+  let tag;
+  try {
+    const cipher = createCipheriv("aes-256-gcm", kek, iv, {
+      authTagLength: AUTH_TAG_BYTES,
+    });
+    cipher.setAAD(FILE_AAD);
+    ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    tag = cipher.getAuthTag();
+  } finally {
+    plaintext.fill(0);
+    kek.fill(0);
+  }
+
+  const serialized = JSON.stringify({
+    version: STORE_VERSION,
+    kdf: { name: "HKDF-SHA256", salt: salt.toString("base64") },
+    aead: {
+      name: "AES-256-GCM",
+      iv: iv.toString("base64"),
+      tag: tag.toString("base64"),
+      ciphertext: ciphertext.toString("base64"),
+    },
+  });
+  if (Buffer.byteLength(serialized, "utf8") > MAX_STORE_FILE_BYTES) {
+    throw new RangeError("Happy session key store file is too large");
+  }
+  return serialized;
+}
+
+async function loadEntries(filePath, machineKey) {
+  let handle;
+  try {
+    handle = await open(filePath, "r");
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+
+  try {
+    const metadata = await handle.stat();
+    if (
+      !metadata.isFile() ||
+      metadata.size === 0 ||
+      metadata.size > MAX_STORE_FILE_BYTES ||
+      (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)
+    ) {
+      throw invalidStore();
+    }
+    // Read no more than the size we validated, plus one byte to detect a
+    // concurrent append. FileHandle.readFile() could otherwise allocate an
+    // attacker-controlled amount if the file grows between stat and read.
+    const bytes = Buffer.alloc(metadata.size + 1);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const { bytesRead } = await handle.read(bytes, offset, bytes.byteLength - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset === 0 || offset !== metadata.size) {
+      throw invalidStore();
+    }
+
+    let document;
+    try {
+      document = JSON.parse(bytes.subarray(0, offset).toString("utf8"));
+    } catch (error) {
+      throw invalidStore(error);
+    }
+    return decryptDocument(document, machineKey);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeEntries(filePath, entries, machineKey) {
+  const serialized = encryptEntries(entries, machineKey);
+  const directory = path.dirname(filePath);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = path.join(
+    directory,
+    `.${HAPPY_SESSION_KEY_STORE_FILENAME}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`,
+  );
+  let handle;
+  let renamed = false;
+  try {
+    handle = await open(temporaryPath, "wx", 0o600);
+    await handle.chmod(0o600);
+    await handle.writeFile(serialized, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryPath, filePath);
+    renamed = true;
+    await syncDirectory(directory);
+  } finally {
+    await handle?.close().catch(() => {});
+    if (!renamed) await unlink(temporaryPath).catch(() => {});
+  }
+}
+
+async function syncDirectory(directory) {
+  if (process.platform === "win32") return;
+  const directoryHandle = await open(directory, "r");
+  try {
+    await directoryHandle.sync();
+  } finally {
+    await directoryHandle.close();
+  }
+}
+
+async function removeStore(filePath) {
+  try {
+    await unlink(filePath);
+    await syncDirectory(path.dirname(filePath));
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function serializeForPath(filePath, operation) {
+  const previous = operationQueues.get(filePath) ?? Promise.resolve();
+  const result = previous.then(operation);
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  operationQueues.set(filePath, settled);
+  void settled.then(() => {
+    if (operationQueues.get(filePath) === settled) operationQueues.delete(filePath);
+  });
+  return result;
+}
+
+export function createHappySessionKeyStore({ directory, machineKey }) {
+  const filePath = resolveStorePath(directory);
+  const pairingMachineKey = copyMachineKey(machineKey);
+
+  return Object.freeze({
+    filePath,
+
+    async list() {
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        return entries
+          ? [...entries].map(([sessionId, binding]) => ({
+              sessionId,
+              ...copyBinding(binding),
+            }))
+          : [];
+      });
+    },
+
+    async getOrCreate(sessionId, initialRelayTag) {
+      validateSessionId(sessionId);
+      validateRelayTag(initialRelayTag);
+      return serializeForPath(filePath, async () => {
+        const entries = (await loadEntries(filePath, pairingMachineKey)) ?? new Map();
+        const existing = entries.get(sessionId);
+        if (existing) return copyBinding(existing);
+        if (entries.size >= MAX_ENTRIES) {
+          throw new RangeError(`Happy session key store supports at most ${MAX_ENTRIES} entries`);
+        }
+        const binding = {
+          state: "pending",
+          relayTag: initialRelayTag,
+          key: randomBytes(SESSION_KEY_BYTES),
+        };
+        entries.set(sessionId, binding);
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async replacePendingTag(sessionId, relayTag) {
+      validateSessionId(sessionId);
+      validateRelayTag(relayTag);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (binding.state !== "pending") {
+          throw new Error("A non-pending Happy session binding cannot change relay tags");
+        }
+        binding.relayTag = relayTag;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async markReady(sessionId, happySessionId) {
+      validateSessionId(sessionId);
+      validateRelaySessionId(happySessionId);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (binding.state === "retiring") {
+          throw new Error("A retiring Happy session binding cannot become ready");
+        }
+        if (binding.state === "ready") {
+          if (binding.happySessionId !== happySessionId) {
+            throw new Error("Happy session binding resolved to a different relay row");
+          }
+          return copyBinding(binding);
+        }
+        binding.state = "ready";
+        binding.happySessionId = happySessionId;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async markRetiring(
+      sessionId,
+      happySessionId,
+      providerRetired = false,
+      blockRevival = false,
+      conversationId,
+      agentSessionId,
+    ) {
+      validateSessionId(sessionId);
+      if (happySessionId !== undefined) validateRelaySessionId(happySessionId);
+      if (typeof providerRetired !== "boolean") {
+        throw new TypeError("Happy provider retirement state must be a boolean");
+      }
+      if (typeof blockRevival !== "boolean") {
+        throw new TypeError("Happy revival-block state must be a boolean");
+      }
+      if (conversationId !== undefined) validateSessionId(conversationId);
+      if (agentSessionId !== undefined) validateAgentSessionId(agentSessionId);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (
+          typeof binding.happySessionId === "string" &&
+          happySessionId !== undefined &&
+          binding.happySessionId !== happySessionId
+        ) {
+          throw new Error("Happy session binding resolved to a different relay row");
+        }
+        if (
+          typeof binding.conversationId === "string" &&
+          conversationId !== undefined &&
+          binding.conversationId !== conversationId
+        ) {
+          throw new Error("Happy session binding resolved to a different conversation");
+        }
+        if (
+          typeof binding.agentSessionId === "string" &&
+          agentSessionId !== undefined &&
+          binding.agentSessionId !== agentSessionId
+        ) {
+          throw new Error("Happy session binding resolved to a different agent session");
+        }
+        binding.state = "retiring";
+        binding.providerRetired = binding.providerRetired === true || providerRetired;
+        binding.blockRevival = binding.blockRevival === true || blockRevival;
+        if (happySessionId !== undefined) binding.happySessionId = happySessionId;
+        if (conversationId !== undefined) binding.conversationId = conversationId;
+        if (agentSessionId !== undefined) binding.agentSessionId = agentSessionId;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async delete(sessionId) {
+      validateSessionId(sessionId);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        if (!entries || !entries.delete(sessionId)) return false;
+        if (entries.size === 0) await removeStore(filePath);
+        else await writeEntries(filePath, entries, pairingMachineKey);
+        return true;
+      });
+    },
+  });
+}

--- a/patches/happy@1.2.0.patch
+++ b/patches/happy@1.2.0.patch
@@ -1,16 +1,72 @@
+diff --git a/dist/lib.d.cts b/dist/lib.d.cts
+index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed55f6cd1a4 100644
+--- a/dist/lib.d.cts
++++ b/dist/lib.d.cts
+@@ -772,6 +772,7 @@ declare class ApiClient {
+         tag: string;
+         metadata: Metadata;
+         state: AgentState | null;
++        encryptionKey?: Uint8Array;
+     }): Promise<Session | null>;
+     /**
+      * Register or update machine with the server
+@@ -782,7 +783,9 @@ declare class ApiClient {
+         metadata: MachineMetadata;
+         daemonState?: DaemonState;
+     }): Promise<Machine>;
+-    sessionSyncClient(session: Session): ApiSessionClient;
++    sessionSyncClient(session: Session, options?: {
++        resumeFromSeq?: number;
++    }): ApiSessionClient;
+     machineSyncClient(machine: Machine): ApiMachineClient;
+     push(): PushNotificationClient;
+     /**
+diff --git a/dist/lib.d.mts b/dist/lib.d.mts
+index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed55f6cd1a4 100644
+--- a/dist/lib.d.mts
++++ b/dist/lib.d.mts
+@@ -772,6 +772,7 @@ declare class ApiClient {
+         tag: string;
+         metadata: Metadata;
+         state: AgentState | null;
++        encryptionKey?: Uint8Array;
+     }): Promise<Session | null>;
+     /**
+      * Register or update machine with the server
+@@ -782,7 +783,9 @@ declare class ApiClient {
+         metadata: MachineMetadata;
+         daemonState?: DaemonState;
+     }): Promise<Machine>;
+-    sessionSyncClient(session: Session): ApiSessionClient;
++    sessionSyncClient(session: Session, options?: {
++        resumeFromSeq?: number;
++    }): ApiSessionClient;
+     machineSyncClient(machine: Machine): ApiMachineClient;
+     push(): PushNotificationClient;
+     /**
 diff --git a/dist/types-CV0guBiJ.mjs b/dist/types-CV0guBiJ.mjs
-index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e6bc11c91 100644
+index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5a76443b7 100644
 --- a/dist/types-CV0guBiJ.mjs
 +++ b/dist/types-CV0guBiJ.mjs
-@@ -2142,6 +2142,7 @@ class ApiSessionClient extends EventEmitter {
+@@ -2142,10 +2142,16 @@ class ApiSessionClient extends EventEmitter {
    };
    lastSeq = 0;
    pendingOutbox = [];
 +  outboundMessageLocalIds = /* @__PURE__ */ new Set();
    sendSync;
    receiveSync;
-   constructor(token, session) {
-@@ -2206,18 +2207,22 @@ class ApiSessionClient extends EventEmitter {
+-  constructor(token, session) {
++  constructor(token, session, options = {}) {
+     super();
++    const resumeFromSeq = options.resumeFromSeq ?? 0;
++    if (!Number.isSafeInteger(resumeFromSeq) || resumeFromSeq < 0) {
++      throw new Error("Session resume sequence must be a non-negative safe integer");
++    }
++    this.lastSeq = resumeFromSeq;
+     this.token = token;
+     this.sessionId = session.id;
+     this.metadata = session.metadata;
+@@ -2206,18 +2212,22 @@ class ApiSessionClient extends EventEmitter {
            return;
          }
          if (data.body.t === "new-message") {
@@ -37,7 +93,7 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e
          } else if (data.body.t === "update-session") {
            if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
              this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
-@@ -2454,7 +2459,17 @@ class ApiSessionClient extends EventEmitter {
+@@ -2454,7 +2464,17 @@ class ApiSessionClient extends EventEmitter {
          if (message.seq > maxSeq) {
            maxSeq = message.seq;
          }
@@ -56,7 +112,7 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e
          if (message.content?.t !== "encrypted") {
            continue;
          }
-@@ -2487,10 +2502,13 @@ class ApiSessionClient extends EventEmitter {
+@@ -2487,10 +2507,13 @@ class ApiSessionClient extends EventEmitter {
    static MAX_OUTBOX_BATCH_SIZE = 50;
    async flushOutbox() {
      while (this.pendingOutbox.length > 0) {
@@ -73,7 +129,7 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e
          `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
          {
            messages: batch
-@@ -2500,17 +2518,16 @@ class ApiSessionClient extends EventEmitter {
+@@ -2500,17 +2523,16 @@ class ApiSessionClient extends EventEmitter {
            timeout: 6e4
          }
        );
@@ -94,35 +150,67 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e
      });
      if (invalidate) {
        this.sendSync.invalidate();
-@@ -2777,6 +2794,15 @@ class ApiSessionClient extends EventEmitter {
+@@ -2777,6 +2799,14 @@ class ApiSessionClient extends EventEmitter {
    }
    async close() {
      logger.debug("[API] socket.close() called");
-+    // Drain anything still queued before stopping the sync. stop() latches a
-+    // flag that makes the pending flush return without running, so closing
-+    // first discarded the tail of every turn — the final assistant text never
-+    // reached the relay.
++    // Join the existing single-flight sender before stopping it. Calling
++    // flushOutbox() directly here can overlap an in-flight drain, causing both
++    // callers to POST and splice the same batch while the relay is delayed.
 +    try {
-+      await this.flushOutbox();
++      await this.sendSync.invalidateAndAwait();
 +    } catch (error) {
 +      logger.debug("[API] Failed to flush outbox during close", { error });
 +    }
      this.sendSync.stop();
      this.receiveSync.stop();
      if (this.reconnectInterval) {
+@@ -5229,7 +5259,10 @@ class ApiClient {
+     let encryptionKey;
+     let encryptionVariant;
+     if (this.credential.encryption.type === "dataKey") {
+-      encryptionKey = getRandomBytes(32);
++      encryptionKey = opts.encryptionKey ? new Uint8Array(opts.encryptionKey) : getRandomBytes(32);
++      if (encryptionKey.length !== 32) {
++        throw new Error("Session encryption key must be 32 bytes");
++      }
+       encryptionVariant = "dataKey";
+       let encryptedDataKey = libsodiumEncryptForPublicKey(encryptionKey, this.credential.encryption.publicKey);
+       dataEncryptionKey = new Uint8Array(encryptedDataKey.length + 1);
+@@ -5419,8 +5452,8 @@ class ApiClient {
+       throw error;
+     }
+   }
+-  sessionSyncClient(session) {
+-    return new ApiSessionClient(this.credential.token, session);
++  sessionSyncClient(session, options) {
++    return new ApiSessionClient(this.credential.token, session, options);
+   }
+   machineSyncClient(machine) {
+     return new ApiMachineClient(this.credential.token, machine);
 diff --git a/dist/types-D0KwHfY9.cjs b/dist/types-D0KwHfY9.cjs
-index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c53fb7ac7d 100644
+index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac111682af27 100644
 --- a/dist/types-D0KwHfY9.cjs
 +++ b/dist/types-D0KwHfY9.cjs
-@@ -2145,6 +2145,7 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2145,10 +2145,16 @@ class ApiSessionClient extends node_events.EventEmitter {
    };
    lastSeq = 0;
    pendingOutbox = [];
 +  outboundMessageLocalIds = /* @__PURE__ */ new Set();
    sendSync;
    receiveSync;
-   constructor(token, session) {
-@@ -2209,18 +2210,22 @@ class ApiSessionClient extends node_events.EventEmitter {
+-  constructor(token, session) {
++  constructor(token, session, options = {}) {
+     super();
++    const resumeFromSeq = options.resumeFromSeq ?? 0;
++    if (!Number.isSafeInteger(resumeFromSeq) || resumeFromSeq < 0) {
++      throw new Error("Session resume sequence must be a non-negative safe integer");
++    }
++    this.lastSeq = resumeFromSeq;
+     this.token = token;
+     this.sessionId = session.id;
+     this.metadata = session.metadata;
+@@ -2209,18 +2215,22 @@ class ApiSessionClient extends node_events.EventEmitter {
            return;
          }
          if (data.body.t === "new-message") {
@@ -149,7 +237,7 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c5
          } else if (data.body.t === "update-session") {
            if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
              this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
-@@ -2457,7 +2462,17 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2457,7 +2467,17 @@ class ApiSessionClient extends node_events.EventEmitter {
          if (message.seq > maxSeq) {
            maxSeq = message.seq;
          }
@@ -168,7 +256,7 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c5
          if (message.content?.t !== "encrypted") {
            continue;
          }
-@@ -2490,10 +2505,13 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2490,10 +2510,13 @@ class ApiSessionClient extends node_events.EventEmitter {
    static MAX_OUTBOX_BATCH_SIZE = 50;
    async flushOutbox() {
      while (this.pendingOutbox.length > 0) {
@@ -185,7 +273,7 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c5
          `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
          {
            messages: batch
-@@ -2503,17 +2521,16 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2503,17 +2526,16 @@ class ApiSessionClient extends node_events.EventEmitter {
            timeout: 6e4
          }
        );
@@ -206,19 +294,41 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c5
      });
      if (invalidate) {
        this.sendSync.invalidate();
-@@ -2780,6 +2797,15 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2780,6 +2802,14 @@ class ApiSessionClient extends node_events.EventEmitter {
    }
    async close() {
      logger.debug("[API] socket.close() called");
-+    // Drain anything still queued before stopping the sync. stop() latches a
-+    // flag that makes the pending flush return without running, so closing
-+    // first discarded the tail of every turn — the final assistant text never
-+    // reached the relay.
++    // Join the existing single-flight sender before stopping it. Calling
++    // flushOutbox() directly here can overlap an in-flight drain, causing both
++    // callers to POST and splice the same batch while the relay is delayed.
 +    try {
-+      await this.flushOutbox();
++      await this.sendSync.invalidateAndAwait();
 +    } catch (error) {
 +      logger.debug("[API] Failed to flush outbox during close", { error });
 +    }
      this.sendSync.stop();
      this.receiveSync.stop();
      if (this.reconnectInterval) {
+@@ -5232,7 +5262,10 @@ class ApiClient {
+     let encryptionKey;
+     let encryptionVariant;
+     if (this.credential.encryption.type === "dataKey") {
+-      encryptionKey = getRandomBytes(32);
++      encryptionKey = opts.encryptionKey ? new Uint8Array(opts.encryptionKey) : getRandomBytes(32);
++      if (encryptionKey.length !== 32) {
++        throw new Error("Session encryption key must be 32 bytes");
++      }
+       encryptionVariant = "dataKey";
+       let encryptedDataKey = libsodiumEncryptForPublicKey(encryptionKey, this.credential.encryption.publicKey);
+       dataEncryptionKey = new Uint8Array(encryptedDataKey.length + 1);
+@@ -5422,8 +5455,8 @@ class ApiClient {
+       throw error;
+     }
+   }
+-  sessionSyncClient(session) {
+-    return new ApiSessionClient(this.credential.token, session);
++  sessionSyncClient(session, options) {
++    return new ApiSessionClient(this.credential.token, session, options);
+   }
+   machineSyncClient(machine) {
+     return new ApiMachineClient(this.credential.token, machine);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  happy@1.2.0: 9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771
+  happy@1.2.0: bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e
 
 importers:
 
@@ -79,7 +79,7 @@ importers:
         version: 2.10.1
       happy:
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
+        version: 1.2.0(patch_hash=bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -10140,7 +10140,7 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  happy@1.2.0(patch_hash=9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
+  happy@1.2.0(patch_hash=bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk': 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2,15 +2,16 @@
 // ABOUTME: Handles CRUD operations for conversations and messages in SQLite.
 
 use crate::commands::provider_runtime::DERIVED_KIND_CASE_SQL;
+use crate::happy_bridge::HappyBridgeManager;
 use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use crate::services::database::{
     DbPool, PersistedMessage, enqueue_sync_tombstone, init_db, mark_sync_upsert,
     save_message_record,
 };
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 
 fn load_indexable_message_meta(
     conn: &Connection,
@@ -102,7 +103,7 @@ pub(crate) fn delete_conversation_records(
     conn: &Connection,
     conversation_ids: &[String],
 ) -> rusqlite::Result<usize> {
-    let tx = conn.unchecked_transaction()?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let mut deleted = 0;
     for id in conversation_ids {
         let mut event_stmt =
@@ -594,7 +595,7 @@ pub(crate) async fn create_agent_conversation_record(
         .or_else(|| agent_cwd.as_deref().and_then(normalize_project_root));
     let project_id = normalized_project_root.clone();
 
-    let convo = AgentConversation {
+    let mut convo = AgentConversation {
         id: id.clone(),
         title: title.clone(),
         created_at,
@@ -609,9 +610,22 @@ pub(crate) async fn create_agent_conversation_record(
         is_archived: false,
     };
 
-    run_db(app, move |conn| {
-        conn.execute(
-            "INSERT INTO conversations (
+    let persisted_convo = convo.clone();
+    let is_archived = run_db(app, move |conn| {
+        upsert_agent_conversation_in_db(conn, &persisted_convo)
+    })
+    .await?;
+    convo.is_archived = is_archived;
+
+    Ok(convo)
+}
+
+fn upsert_agent_conversation_in_db(
+    conn: &Connection,
+    convo: &AgentConversation,
+) -> rusqlite::Result<bool> {
+    conn.execute(
+        "INSERT INTO conversations (
                 id,
                 title,
                 created_at,
@@ -623,33 +637,58 @@ pub(crate) async fn create_agent_conversation_record(
                 agent_metadata,
                 project_id,
                 project_root
-            ) VALUES (?1, ?2, ?3, 0, 'agent', ?4, ?5, ?6, ?7, ?8, ?9)
+            ) VALUES (
+                ?1,
+                ?2,
+                ?3,
+                COALESCE((
+                    SELECT is_archived
+                    FROM happy_provider_session_lifecycle
+                    WHERE provider_session_id = ?1
+                ), 0),
+                'agent',
+                ?4,
+                ?5,
+                ?6,
+                ?7,
+                ?8,
+                ?9
+            )
              ON CONFLICT(id) DO UPDATE SET
-                is_archived = 0,
                 agent_type = excluded.agent_type,
                 agent_session_id = COALESCE(excluded.agent_session_id, conversations.agent_session_id),
                 agent_cwd = COALESCE(conversations.agent_cwd, excluded.agent_cwd),
                 agent_metadata = COALESCE(excluded.agent_metadata, conversations.agent_metadata),
                 project_id = COALESCE(conversations.project_id, excluded.project_id),
                 project_root = COALESCE(conversations.project_root, excluded.project_root)",
-            params![
-                id,
-                title,
-                created_at,
-                agent_type,
-                agent_session_id,
-                agent_cwd,
-                agent_metadata,
-                project_id,
-                normalized_project_root
-            ],
-        )?;
-        mark_sync_upsert(conn, "conversations", &id)?;
-        Ok(())
-    })
-    .await?;
-
-    Ok(convo)
+        params![
+            convo.id,
+            convo.title,
+            convo.created_at,
+            convo.agent_type,
+            convo.agent_session_id,
+            convo.agent_cwd,
+            convo.agent_metadata,
+            convo.project_id,
+            convo.project_root,
+        ],
+    )?;
+    conn.execute(
+        "UPDATE happy_provider_session_lifecycle
+         SET conversation_id = COALESCE(conversation_id, ?1),
+             updated_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+         WHERE provider_session_id = ?1",
+        params![convo.id],
+    )?;
+    // Idempotent create/resume calls may arrive after another actor archives
+    // the row. They can refresh agent metadata, but only an explicit restore
+    // operation may make an archived conversation active again.
+    mark_sync_upsert(conn, "conversations", &convo.id)?;
+    conn.query_row(
+        "SELECT is_archived FROM conversations WHERE id = ?1",
+        params![convo.id],
+        |row| row.get(0),
+    )
 }
 
 pub(crate) async fn lookup_agent_conversation_by_happy_session(
@@ -657,15 +696,18 @@ pub(crate) async fn lookup_agent_conversation_by_happy_session(
     happy_session_id: String,
 ) -> Result<Option<AgentConversation>, String> {
     run_db(app, move |conn| {
-        let mut stmt = conn.prepare(
-            "SELECT id, title, created_at, agent_type, agent_session_id,
-                    agent_cwd, agent_model_id, agent_permission_mode,
-                    agent_metadata, project_id, project_root, is_archived
-             FROM conversations
-             WHERE kind = 'agent'
-               AND json_extract(agent_metadata, '$.happy_session_id') = ?1
+        let sql = format!(
+            "SELECT c.id, c.title, c.created_at, c.agent_type, c.agent_session_id,
+                    c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
+                    c.agent_metadata, c.project_id, c.project_root, c.is_archived
+             FROM conversations c
+             LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+             WHERE ({case}) = 'agent'
+               AND json_extract(c.agent_metadata, '$.happy_session_id') = ?1
              LIMIT 1",
-        )?;
+            case = DERIVED_KIND_CASE_SQL,
+        );
+        let mut stmt = conn.prepare(&sql)?;
 
         let conversation = stmt.query_row(params![happy_session_id], |row| {
             Ok(AgentConversation {
@@ -691,6 +733,286 @@ pub(crate) async fn lookup_agent_conversation_by_happy_session(
         }
     })
     .await
+}
+
+pub(crate) async fn lookup_happy_session_id_by_conversation(
+    app: AppHandle,
+    conversation_id: String,
+) -> Result<Option<String>, String> {
+    run_db(app, move |conn| {
+        lookup_happy_session_id_by_conversation_in_db(conn, &conversation_id)
+    })
+    .await
+}
+
+fn lookup_happy_session_id_by_conversation_in_db(
+    conn: &Connection,
+    conversation_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    let sql = format!(
+        "SELECT c.agent_metadata
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1 AND ({case}) = 'agent'
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let metadata = conn
+        .query_row(&sql, params![conversation_id], |row| {
+            row.get::<_, Option<String>>(0)
+        })
+        .optional()?
+        .flatten();
+    Ok(metadata.and_then(|raw| {
+        serde_json::from_str::<serde_json::Value>(&raw)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("happy_session_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+    }))
+}
+
+fn lookup_agent_conversation_owner_in_db(
+    conn: &Connection,
+    provider_session_id: &str,
+    agent_session_id: Option<&str>,
+) -> rusqlite::Result<(Option<String>, bool)> {
+    let lifecycle_sql = format!(
+        "SELECT c.id
+         FROM happy_provider_session_lifecycle hpsl
+         JOIN conversations c ON c.id = hpsl.conversation_id
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE hpsl.provider_session_id = ?1
+           AND ({case}) = 'agent'
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    if let Some(owner) = conn
+        .query_row(&lifecycle_sql, params![provider_session_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()?
+    {
+        return Ok((Some(owner), false));
+    }
+
+    let direct_sql = format!(
+        "SELECT c.id
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1 AND ({case}) = 'agent'
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    if let Some(owner) = conn
+        .query_row(&direct_sql, params![provider_session_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()?
+    {
+        return Ok((Some(owner), false));
+    }
+
+    let Some(agent_session_id) = agent_session_id else {
+        return Ok((None, false));
+    };
+    let fallback_sql = format!(
+        "SELECT c.id
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.agent_session_id = ?1 AND ({case}) = 'agent'
+         LIMIT 2",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let mut statement = conn.prepare(&fallback_sql)?;
+    let owners = statement
+        .query_map(params![agent_session_id], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((owners.first().cloned(), owners.len() > 1))
+}
+
+fn claim_happy_provider_session_owner_in_db(
+    conn: &Connection,
+    conversation_id: &str,
+    provider_session_id: &str,
+    agent_session_id: Option<&str>,
+) -> rusqlite::Result<bool> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let sql = format!(
+        "SELECT 1
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1 AND ({case}) = 'agent'
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    if tx
+        .query_row(&sql, params![conversation_id], |_| Ok(()))
+        .optional()?
+        .is_none()
+    {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
+
+    tx.execute(
+        "INSERT INTO happy_provider_session_lifecycle
+            (provider_session_id, conversation_id, is_archived, updated_at)
+         VALUES (?1, ?2, 0, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+         ON CONFLICT(provider_session_id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            updated_at = excluded.updated_at",
+        params![provider_session_id, conversation_id],
+    )?;
+    let archived = tx.query_row(
+        "SELECT hpsl.is_archived OR c.is_archived
+         FROM happy_provider_session_lifecycle hpsl
+         JOIN conversations c ON c.id = hpsl.conversation_id
+         WHERE hpsl.provider_session_id = ?1",
+        params![provider_session_id],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if archived {
+        tx.execute(
+            "UPDATE happy_provider_session_lifecycle
+             SET is_archived = 1
+             WHERE provider_session_id = ?1",
+            params![provider_session_id],
+        )?;
+        archive_agent_conversation_in_db(&tx, conversation_id)?;
+    } else if let Some(agent_session_id) = agent_session_id {
+        if !set_agent_conversation_session_id_in_db(&tx, conversation_id, agent_session_id)? {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
+    }
+    tx.commit()?;
+    Ok(archived)
+}
+
+/// Persist an exact provider-session archive fence without emitting another
+/// frontend archive event. The Happy event listener uses this for sibling
+/// sessions before attempting process teardown, so a transient provider RPC
+/// failure cannot let the sibling reattach or promote later.
+#[tauri::command]
+pub async fn fence_happy_provider_session_archive(
+    app: AppHandle,
+    provider_session_id: String,
+) -> Result<(), String> {
+    uuid::Uuid::parse_str(&provider_session_id)
+        .map_err(|_| "providerSessionId must be a UUID".to_string())?;
+    let persisted_provider_session_id = provider_session_id.clone();
+    run_db(app.clone(), move |conn| {
+        archive_happy_provider_session_in_db(conn, &persisted_provider_session_id).map(|_| ())
+    })
+    .await?;
+
+    // The SQLite row is the crash-safe source of truth. Also notify the live
+    // bridge so it can mark its encrypted relay binding retiring immediately;
+    // startup reconciliation consults the SQLite fence if this write races a
+    // bridge crash.
+    if let Some(manager) = app.try_state::<HappyBridgeManager>()
+        && manager.process_exists().await
+        && let Err(error) = manager.retire_provider_session(&provider_session_id).await
+    {
+        log::warn!("[HappyBridge] Failed to notify live bridge of provider retirement: {error}");
+    }
+    Ok(())
+}
+
+fn archive_happy_provider_session_in_db(
+    conn: &Connection,
+    provider_session_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO happy_provider_session_lifecycle
+            (provider_session_id, conversation_id, is_archived, updated_at)
+         VALUES (?1, NULL, 1, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+         ON CONFLICT(provider_session_id) DO UPDATE SET
+            is_archived = 1,
+            updated_at = excluded.updated_at",
+        params![provider_session_id],
+    )?;
+
+    let (mut owner, _) = lookup_agent_conversation_owner_in_db(&tx, provider_session_id, None)?;
+    if owner.is_none() {
+        let direct_sql = format!(
+            "SELECT c.id
+             FROM conversations c
+             LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+             WHERE c.id = ?1 AND ({case}) = 'agent'
+             LIMIT 1",
+            case = DERIVED_KIND_CASE_SQL,
+        );
+        owner = tx
+            .query_row(&direct_sql, params![provider_session_id], |row| {
+                row.get::<_, String>(0)
+            })
+            .optional()?;
+    }
+    let Some(conversation_id) = owner else {
+        tx.commit()?;
+        return Ok(None);
+    };
+    tx.execute(
+        "UPDATE happy_provider_session_lifecycle
+         SET conversation_id = ?2
+         WHERE provider_session_id = ?1",
+        params![provider_session_id, conversation_id],
+    )?;
+    let archived = archive_agent_conversation_in_db(&tx, &conversation_id)?;
+    tx.commit()?;
+    if archived {
+        Ok(Some(conversation_id))
+    } else {
+        Ok(None)
+    }
+}
+
+fn is_happy_provider_session_archived_in_db(
+    conn: &Connection,
+    provider_session_id: &str,
+) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT is_archived
+         FROM happy_provider_session_lifecycle
+         WHERE provider_session_id = ?1",
+        params![provider_session_id],
+        |row| row.get::<_, bool>(0),
+    )
+    .optional()
+    .map(|archived| archived.unwrap_or(false))
+}
+
+pub(crate) async fn is_happy_provider_session_archived(
+    app: AppHandle,
+    provider_session_id: String,
+) -> Result<bool, String> {
+    run_db(app, move |conn| {
+        is_happy_provider_session_archived_in_db(conn, &provider_session_id)
+    })
+    .await
+}
+
+pub(crate) async fn lookup_agent_conversation_owner(
+    app: AppHandle,
+    provider_session_id: String,
+    agent_session_id: Option<String>,
+) -> Result<Option<String>, String> {
+    let (owner, ambiguous) = run_db(app, move |conn| {
+        lookup_agent_conversation_owner_in_db(
+            conn,
+            &provider_session_id,
+            agent_session_id.as_deref(),
+        )
+    })
+    .await?;
+    if ambiguous {
+        return Err("provider session maps to multiple agent conversations".to_string());
+    }
+    Ok(owner)
 }
 
 #[tauri::command]
@@ -749,14 +1071,85 @@ pub async fn set_agent_conversation_session_id(
     agent_session_id: String,
 ) -> Result<(), String> {
     run_db(app, move |conn| {
-        conn.execute(
-            "UPDATE conversations SET agent_session_id = ?1 WHERE id = ?2 AND kind = 'agent'",
-            params![agent_session_id, id],
-        )?;
-        mark_sync_upsert(conn, "conversations", &id)?;
+        if !set_agent_conversation_session_id_in_db(conn, &id, &agent_session_id)? {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
         Ok(())
     })
     .await
+}
+
+fn set_agent_conversation_session_id_in_db(
+    conn: &Connection,
+    id: &str,
+    agent_session_id: &str,
+) -> rusqlite::Result<bool> {
+    let sql = format!(
+        "SELECT 1
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1
+           AND ({case}) = 'agent'
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let is_agent = conn
+        .query_row(&sql, params![id], |_| Ok(()))
+        .optional()?
+        .is_some();
+    if !is_agent {
+        return Ok(false);
+    }
+    if conn.execute(
+        "UPDATE conversations SET agent_session_id = ?1 WHERE id = ?2",
+        params![agent_session_id, id],
+    )? != 1
+    {
+        return Ok(false);
+    }
+    mark_sync_upsert(conn, "conversations", id)?;
+    Ok(true)
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HappyProviderSessionOwnerClaim {
+    archived: bool,
+}
+
+#[tauri::command]
+pub async fn claim_happy_provider_session_owner(
+    app: AppHandle,
+    conversation_id: String,
+    provider_session_id: String,
+    agent_session_id: Option<String>,
+) -> Result<HappyProviderSessionOwnerClaim, String> {
+    uuid::Uuid::parse_str(&conversation_id)
+        .map_err(|_| "conversation_id must be a UUID".to_string())?;
+    uuid::Uuid::parse_str(&provider_session_id)
+        .map_err(|_| "provider_session_id must be a UUID".to_string())?;
+    let index_id = conversation_id.clone();
+    let target_provider_session_id = provider_session_id.clone();
+    let archived = run_db(app.clone(), move |conn| {
+        claim_happy_provider_session_owner_in_db(
+            conn,
+            &conversation_id,
+            &provider_session_id,
+            agent_session_id.as_deref(),
+        )
+    })
+    .await?;
+    if archived {
+        refresh_conversation_index_meta_best_effort(
+            app.clone(),
+            index_id.clone(),
+            None,
+            Some(true),
+        )
+        .await;
+        emit_happy_provider_archive_event(&app, Some(&index_id), &target_provider_session_id);
+    }
+    Ok(HappyProviderSessionOwnerClaim { archived })
 }
 
 #[tauri::command]
@@ -927,18 +1320,134 @@ pub async fn set_agent_conversation_metadata(
 
 #[tauri::command]
 pub async fn archive_agent_conversation(app: AppHandle, id: String) -> Result<(), String> {
-    let index_id = id.clone();
-    run_db(app.clone(), move |conn| {
-        conn.execute(
-            "UPDATE conversations SET is_archived = 1 WHERE id = ?1 AND kind = 'agent'",
-            params![id],
-        )?;
-        mark_sync_upsert(conn, "conversations", &id)?;
-        Ok(())
+    archive_agent_conversation_with_origin(app, id, AgentArchiveOrigin::Desktop, None).await
+}
+
+pub(crate) async fn archive_agent_conversation_from_happy(
+    app: AppHandle,
+    id: String,
+    provider_session_id: String,
+) -> Result<(), String> {
+    archive_agent_conversation_with_origin(
+        app,
+        id,
+        AgentArchiveOrigin::Happy,
+        Some(provider_session_id),
+    )
+    .await
+}
+
+pub(crate) async fn archive_happy_provider_session_from_happy(
+    app: AppHandle,
+    provider_session_id: String,
+) -> Result<Option<String>, String> {
+    let target_provider_session_id = provider_session_id.clone();
+    let conversation_id = run_db(app.clone(), move |conn| {
+        archive_happy_provider_session_in_db(conn, &provider_session_id)
     })
     .await?;
-    refresh_conversation_index_meta_best_effort(app, index_id, None, Some(true)).await;
+    if let Some(conversation_id) = conversation_id.as_deref() {
+        refresh_conversation_index_meta_best_effort(
+            app.clone(),
+            conversation_id.to_string(),
+            None,
+            Some(true),
+        )
+        .await;
+    }
+    emit_happy_provider_archive_event(
+        &app,
+        conversation_id.as_deref(),
+        &target_provider_session_id,
+    );
+    Ok(conversation_id)
+}
+
+#[derive(Clone, Copy)]
+enum AgentArchiveOrigin {
+    Desktop,
+    Happy,
+}
+
+async fn archive_agent_conversation_with_origin(
+    app: AppHandle,
+    id: String,
+    origin: AgentArchiveOrigin,
+    provider_session_id: Option<String>,
+) -> Result<(), String> {
+    let index_id = id.clone();
+    let archived = run_db(app.clone(), move |conn| {
+        archive_agent_conversation_in_db(conn, &id)
+    })
+    .await?;
+    if !archived {
+        return Err("agent conversation was not found".to_string());
+    }
+    refresh_conversation_index_meta_best_effort(app.clone(), index_id.clone(), None, Some(true))
+        .await;
+    emit_happy_archive_event(&app, origin, &index_id, provider_session_id.as_deref());
     Ok(())
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HappyConversationArchivedEvent<'a> {
+    conversation_id: Option<&'a str>,
+    target_provider_session_id: &'a str,
+}
+
+pub(crate) fn emit_happy_provider_archive_event<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    conversation_id: Option<&str>,
+    target_provider_session_id: &str,
+) {
+    let _ = app.emit(
+        "happy-bridge://conversation-archived",
+        HappyConversationArchivedEvent {
+            conversation_id,
+            target_provider_session_id,
+        },
+    );
+}
+
+fn emit_happy_archive_event<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    origin: AgentArchiveOrigin,
+    conversation_id: &str,
+    provider_session_id: Option<&str>,
+) {
+    if let (AgentArchiveOrigin::Happy, Some(target_provider_session_id)) =
+        (origin, provider_session_id)
+    {
+        emit_happy_provider_archive_event(app, Some(conversation_id), target_provider_session_id);
+    }
+}
+
+fn archive_agent_conversation_in_db(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
+    let sql = format!(
+        "SELECT ({case}) = 'agent'
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let is_agent = conn
+        .query_row(&sql, params![id], |row| row.get::<_, bool>(0))
+        .optional()?
+        .unwrap_or(false);
+    if !is_agent {
+        return Ok(false);
+    }
+    let changed = conn.execute(
+        "UPDATE conversations SET is_archived = 1 WHERE id = ?1",
+        params![id],
+    )?;
+    if changed != 1 {
+        return Ok(false);
+    }
+    mark_sync_upsert(conn, "conversations", id)?;
+    Ok(true)
 }
 
 // ============================================================================
@@ -1132,14 +1641,286 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::DERIVED_KIND_CASE_SQL;
+    use super::{
+        AgentArchiveOrigin, AgentConversation, DERIVED_KIND_CASE_SQL,
+        archive_agent_conversation_in_db, archive_happy_provider_session_in_db,
+        claim_happy_provider_session_owner_in_db, emit_happy_archive_event,
+        emit_happy_provider_archive_event, is_happy_provider_session_archived_in_db,
+        lookup_agent_conversation_owner_in_db, lookup_happy_session_id_by_conversation_in_db,
+        set_agent_conversation_session_id_in_db, upsert_agent_conversation_in_db,
+    };
     use crate::services::database::setup_schema;
     use rusqlite::{Connection, params};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tauri::Listener;
 
     fn open() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         setup_schema(&conn).unwrap();
         conn
+    }
+
+    #[test]
+    fn happy_archive_resolves_promoted_owner_and_derived_agent_rows() {
+        let conn = open();
+        conn.execute(
+            "INSERT INTO conversations
+                (id, title, created_at, kind, agent_session_id, agent_metadata)
+             VALUES (?1, 'Promoted agent', 1000, 'chat', ?2, ?3)",
+            params![
+                "owning-conversation",
+                "native-agent-session",
+                r#"{"happy_session_id":"relay-session"}"#,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO provider_session_runtime
+                (thread_id, provider, status, updated_at)
+             VALUES (?1, 'codex', 'active', 2000)",
+            params!["owning-conversation"],
+        )
+        .unwrap();
+
+        let (owner, ambiguous) = lookup_agent_conversation_owner_in_db(
+            &conn,
+            "different-runtime-session",
+            Some("native-agent-session"),
+        )
+        .unwrap();
+        assert_eq!(owner.as_deref(), Some("owning-conversation"));
+        assert!(!ambiguous);
+        assert_eq!(
+            lookup_happy_session_id_by_conversation_in_db(&conn, "owning-conversation")
+                .unwrap()
+                .as_deref(),
+            Some("relay-session"),
+        );
+        assert!(archive_agent_conversation_in_db(&conn, "owning-conversation").unwrap());
+        assert_eq!(
+            conn.query_row(
+                "SELECT is_archived FROM conversations WHERE id = ?1",
+                params!["owning-conversation"],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1,
+        );
+        assert!(!archive_agent_conversation_in_db(&conn, "missing-conversation").unwrap());
+    }
+
+    #[test]
+    fn native_session_id_updates_a_derived_agent_row() {
+        let conn = open();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind)
+             VALUES ('derived-agent', 'Derived agent', 1000, 'chat')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO provider_session_runtime
+                (thread_id, provider, status, updated_at)
+             VALUES ('derived-agent', 'codex', 'active', 2000)",
+            [],
+        )
+        .unwrap();
+
+        assert!(
+            set_agent_conversation_session_id_in_db(&conn, "derived-agent", "native-session",)
+                .unwrap(),
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT agent_session_id FROM conversations WHERE id = 'derived-agent'",
+                [],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .unwrap()
+            .as_deref(),
+            Some("native-session"),
+        );
+    }
+
+    #[test]
+    fn provider_archive_fence_survives_late_create_and_promotion_claims() {
+        let conn = open();
+
+        assert_eq!(
+            archive_happy_provider_session_in_db(&conn, "late-create").unwrap(),
+            None,
+        );
+        assert!(is_happy_provider_session_archived_in_db(&conn, "late-create").unwrap());
+        assert!(!is_happy_provider_session_archived_in_db(&conn, "not-archived").unwrap());
+        let late = AgentConversation {
+            id: "late-create".to_string(),
+            title: "Late create".to_string(),
+            created_at: 1000,
+            agent_type: "codex".to_string(),
+            agent_session_id: None,
+            agent_cwd: None,
+            agent_model_id: None,
+            agent_permission_mode: None,
+            agent_metadata: None,
+            project_id: None,
+            project_root: None,
+            is_archived: false,
+        };
+        assert!(upsert_agent_conversation_in_db(&conn, &late).unwrap());
+
+        let promoted = AgentConversation {
+            id: "promoted-owner".to_string(),
+            title: "Promoted owner".to_string(),
+            ..late.clone()
+        };
+        assert!(!upsert_agent_conversation_in_db(&conn, &promoted).unwrap());
+        assert_eq!(
+            archive_happy_provider_session_in_db(&conn, "promoted-provider").unwrap(),
+            None,
+        );
+        assert!(
+            claim_happy_provider_session_owner_in_db(
+                &conn,
+                "promoted-owner",
+                "promoted-provider",
+                Some("native-promoted"),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            lookup_agent_conversation_owner_in_db(&conn, "promoted-provider", None,).unwrap(),
+            (Some("promoted-owner".to_string()), false),
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT is_archived FROM conversations WHERE id = 'promoted-owner'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1,
+        );
+
+        let mapped = AgentConversation {
+            id: "mapped-owner".to_string(),
+            title: "Mapped owner".to_string(),
+            ..late.clone()
+        };
+        assert!(!upsert_agent_conversation_in_db(&conn, &mapped).unwrap());
+        assert!(
+            !claim_happy_provider_session_owner_in_db(
+                &conn,
+                "mapped-owner",
+                "mapped-provider",
+                None,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            archive_happy_provider_session_in_db(&conn, "mapped-provider").unwrap(),
+            Some("mapped-owner".to_string()),
+        );
+
+        let already_archived = AgentConversation {
+            id: "already-archived-owner".to_string(),
+            title: "Already archived owner".to_string(),
+            ..late
+        };
+        assert!(!upsert_agent_conversation_in_db(&conn, &already_archived).unwrap());
+        assert!(archive_agent_conversation_in_db(&conn, "already-archived-owner").unwrap());
+        assert!(
+            claim_happy_provider_session_owner_in_db(
+                &conn,
+                "already-archived-owner",
+                "late-provider-claim",
+                None,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn only_happy_origin_emits_frontend_archive_invalidation() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+        let received = Arc::new(AtomicUsize::new(0));
+        let received_by_listener = Arc::clone(&received);
+        let received_payload = Arc::new(Mutex::new(None));
+        let received_payload_by_listener = Arc::clone(&received_payload);
+        app.handle()
+            .listen("happy-bridge://conversation-archived", move |event| {
+                received_by_listener.fetch_add(1, Ordering::SeqCst);
+                *received_payload_by_listener.lock().unwrap() =
+                    serde_json::from_str::<serde_json::Value>(event.payload()).ok();
+            });
+
+        emit_happy_archive_event(
+            app.handle(),
+            AgentArchiveOrigin::Desktop,
+            "desktop-conversation",
+            None,
+        );
+        assert_eq!(received.load(Ordering::SeqCst), 0);
+        emit_happy_archive_event(
+            app.handle(),
+            AgentArchiveOrigin::Happy,
+            "happy-conversation",
+            Some("happy-provider-session"),
+        );
+        assert_eq!(received.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *received_payload.lock().unwrap(),
+            Some(serde_json::json!({
+                "conversationId": "happy-conversation",
+                "targetProviderSessionId": "happy-provider-session",
+            })),
+        );
+
+        emit_happy_provider_archive_event(app.handle(), None, "unowned-provider-session");
+        assert_eq!(received.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            *received_payload.lock().unwrap(),
+            Some(serde_json::json!({
+                "conversationId": null,
+                "targetProviderSessionId": "unowned-provider-session",
+            })),
+        );
+    }
+
+    #[test]
+    fn late_agent_upsert_preserves_an_archived_row() {
+        let conn = open();
+        let mut conversation = AgentConversation {
+            id: "late-resume".to_string(),
+            title: "Synthetic agent".to_string(),
+            created_at: 1000,
+            agent_type: "codex".to_string(),
+            agent_session_id: None,
+            agent_cwd: Some("/synthetic/project".to_string()),
+            agent_model_id: None,
+            agent_permission_mode: None,
+            agent_metadata: None,
+            project_id: Some("/synthetic/project".to_string()),
+            project_root: Some("/synthetic/project".to_string()),
+            is_archived: false,
+        };
+
+        assert!(!upsert_agent_conversation_in_db(&conn, &conversation).unwrap());
+        assert!(archive_agent_conversation_in_db(&conn, &conversation.id).unwrap());
+
+        conversation.agent_session_id = Some("late-provider-session".to_string());
+        assert!(upsert_agent_conversation_in_db(&conn, &conversation).unwrap());
+        assert_eq!(
+            conn.query_row(
+                "SELECT is_archived, agent_session_id FROM conversations WHERE id = ?1",
+                params![conversation.id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .unwrap(),
+            (1, Some("late-provider-session".to_string())),
+        );
     }
 
     /// Mirror of the production `list_conversations` SQL so tests can

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -151,16 +151,14 @@ pub async fn happy_bridge_cancel_pairing(
     state.cancel_pairing().await
 }
 
-/// Stops the bridge before clearing the credential. The running process holds
-/// the identity in memory, so deleting only the keychain entry would leave a
-/// live, still-paired bridge behind.
+/// Retires every relay session using the old identity, then clears its encrypted
+/// bindings and pairing credential as one serialized reset operation.
 #[tauri::command]
 pub async fn happy_bridge_reset_identity(
     app: AppHandle,
     state: State<'_, HappyBridgeManager>,
 ) -> Result<(), String> {
-    state.stop(&app).await?;
-    state.delete_pairing_credential(&app)
+    state.reset_identity(&app).await
 }
 
 pub async fn auto_start_if_enabled(app: AppHandle) {

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
@@ -18,11 +18,19 @@ const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
 const SUPERVISOR_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
+// Identity retirement first waits for any in-flight provider spawn/session
+// creation, then may need one final relay lookup and deactivation. Keep the
+// Rust deadline above that combined worst case so a completed reset is not
+// mistaken for a failure and followed by revival of the old identity.
+const IDENTITY_RESET_TIMEOUT: Duration = Duration::from_secs(180);
+const BRIDGE_READY_TIMEOUT: Duration = Duration::from_secs(15);
 const KILL_LOCK_ATTEMPTS: u32 = 20;
 const KILL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
 const STATUS_EVENT: &str = "happy-bridge://status";
 const PAIRING_EVENT: &str = "happy-bridge://pairing";
 const CREDENTIAL_ACCOUNT: &str = "happy-bridge-pairing-credential";
+const SESSION_KEY_STORE_FILENAME: &str = "happy-session-keys.v1.json";
+const SESSION_KEY_STORE_RESET_FILENAME: &str = "happy-session-keys.v1.reset-pending";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -59,23 +67,31 @@ struct ProviderRuntimeConnection {
 struct HappyBridgeProcess {
     child: Child,
     _stdin: Arc<Mutex<ChildStdin>>,
+    generation: u64,
     spawned_at: Instant,
     restart_budget_rearmed: bool,
 }
 
 pub struct HappyBridgeManager {
+    lifecycle: Mutex<()>,
     process: Arc<Mutex<Option<HappyBridgeProcess>>>,
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
-    // These mutexes are always acquired independently; never hold one while awaiting the other.
+    // Restart accounting is independent of the output/credential gates below.
+    // Credential mutation is always acquired before the output gate.
     restart_attempts: Arc<Mutex<u32>>,
     stopping: Arc<AtomicBool>,
     pairing_payload: Arc<Mutex<Option<String>>>,
+    identity_reset_result: Mutex<Option<(String, bool)>>,
+    process_generation: AtomicU64,
+    output_gate: Mutex<()>,
+    credential_mutation: Mutex<()>,
 }
 
 impl HappyBridgeManager {
     pub fn new() -> Self {
         Self {
+            lifecycle: Mutex::new(()),
             process: Arc::new(Mutex::new(None)),
             monitor_handle: Mutex::new(None),
             status: Arc::new(Mutex::new(HappyBridgeStatus {
@@ -85,10 +101,53 @@ impl HappyBridgeManager {
             restart_attempts: Arc::new(Mutex::new(0)),
             stopping: Arc::new(AtomicBool::new(false)),
             pairing_payload: Arc::new(Mutex::new(None)),
+            identity_reset_result: Mutex::new(None),
+            process_generation: AtomicU64::new(0),
+            output_gate: Mutex::new(()),
+            credential_mutation: Mutex::new(()),
+        }
+    }
+
+    fn is_process_generation_current(&self, generation: u64) -> bool {
+        self.process_generation.load(Ordering::Acquire) == generation
+    }
+
+    fn require_current_process_generation(&self, generation: u64) -> Result<(), String> {
+        self.is_process_generation_current(generation)
+            .then_some(())
+            .ok_or_else(|| "stale Happy bridge process".to_string())
+    }
+
+    fn require_process_write_allowed(&self, generation: u64) -> Result<(), String> {
+        if self.stopping.load(Ordering::Acquire) {
+            return Err("Happy bridge is stopping".to_string());
+        }
+        self.require_current_process_generation(generation)
+    }
+
+    async fn advance_process_generation(&self) -> u64 {
+        // Notification handlers hold this gate while checking their generation
+        // and updating Rust state, so advancing here is a hard boundary: no
+        // notification from the previous child can commit after this returns.
+        let _output = self.output_gate.lock().await;
+        self.process_generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1)
+    }
+
+    async fn invalidate_process_generation_if_current(&self, generation: u64) {
+        let _output = self.output_gate.lock().await;
+        if self.is_process_generation_current(generation) {
+            self.process_generation.fetch_add(1, Ordering::AcqRel);
         }
     }
 
     pub async fn start(&self, app: &AppHandle) -> Result<(), String> {
+        let _lifecycle = self.lifecycle.lock().await;
+        self.start_inner(app).await
+    }
+
+    async fn start_inner(&self, app: &AppHandle) -> Result<(), String> {
         {
             let mut guard = self.process.lock().await;
             if let Some(process) = guard.as_mut() {
@@ -117,14 +176,40 @@ impl HappyBridgeManager {
         Ok(())
     }
 
+    async fn restart_from_monitor(&self, app: &AppHandle) -> Result<(), String> {
+        let _lifecycle = self.lifecycle.lock().await;
+        if self.stopping.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        {
+            let mut guard = self.process.lock().await;
+            if let Some(process) = guard.as_mut()
+                && process
+                    .child
+                    .try_wait()
+                    .map_err(|error| format!("Failed checking Happy bridge: {error}"))?
+                    .is_none()
+            {
+                return Ok(());
+            }
+            *guard = None;
+        }
+        self.start_process(app).await
+    }
+
     async fn start_process(&self, app: &AppHandle) -> Result<(), String> {
+        let generation = self.advance_process_generation().await;
         let provider_runtime = app
             .state::<crate::provider_runtime::ProviderRuntimeState>()
             .ensure_started(app)
             .await?;
         let node_binary = resolve_node_binary(app);
         let bridge_entry = find_happy_bridge_mjs()?;
-        let machine_identity = self.load_pairing_credential(app)?.map(|credential| {
+        let pairing_credential = self.load_pairing_credential(app)?;
+        if let Some(directory) = happy_home_dir(app) {
+            reconcile_session_key_store_reset(&directory, pairing_credential.is_some())?;
+        }
+        let machine_identity = pairing_credential.map(|credential| {
             serde_json::from_str(&credential).unwrap_or_else(|_| Value::String(credential))
         });
         // Reuse the existing conversation reader as the source of recent project roots.
@@ -219,7 +304,7 @@ impl HappyBridgeManager {
         )
         .await
         .map_err(|error| format!("Failed to advertise Happy project folders: {error}"))?;
-        pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone());
+        pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone(), generation);
         let mut guard = self.process.lock().await;
         // `stop()` can take the process slot while a start is still in flight.
         // Storing the child now would leave a live bridge accepting inbound
@@ -232,6 +317,7 @@ impl HappyBridgeManager {
         *guard = Some(HappyBridgeProcess {
             child,
             _stdin: stdin,
+            generation,
             spawned_at: Instant::now(),
             restart_budget_rearmed: false,
         });
@@ -254,16 +340,28 @@ impl HappyBridgeManager {
     }
 
     pub async fn stop<R: tauri::Runtime>(&self, app: &AppHandle<R>) -> Result<(), String> {
+        let _lifecycle = self.lifecycle.lock().await;
+        self.stop_inner(app).await
+    }
+
+    async fn stop_inner<R: tauri::Runtime>(&self, app: &AppHandle<R>) -> Result<(), String> {
         self.stopping.store(true, Ordering::Release);
         if let Some(handle) = self.monitor_handle.lock().await.take() {
             handle.abort();
         }
 
         let process = self.process.lock().await.take();
-        if let Some(mut process) = process {
+        let terminate_result = if let Some(mut process) = process {
             let stdin = Arc::clone(&process._stdin);
-            terminate_child(&mut process.child, Some(&stdin)).await?;
-        }
+            terminate_child(&mut process.child, Some(&stdin)).await
+        } else {
+            Ok(())
+        };
+        // Keep this exact child generation current while its graceful close
+        // drains correlated cleanup RPCs. The lifecycle lock prevents a
+        // replacement child from starting until termination completes.
+        self.advance_process_generation().await;
+        terminate_result?;
         // A pairing payload is only usable while the process that minted it is
         // alive, because the matching secret key lives in that process. Drop it
         // so a restart cannot hand back a code whose secret half is gone.
@@ -285,6 +383,152 @@ impl HappyBridgeManager {
             .is_some()
     }
 
+    async fn wait_until_running(&self) -> Result<(), String> {
+        let deadline = tokio::time::Instant::now() + BRIDGE_READY_TIMEOUT;
+        loop {
+            let status = self.status().await;
+            match status.state {
+                HappyBridgeState::Running => return Ok(()),
+                HappyBridgeState::Error => {
+                    return Err(status
+                        .detail
+                        .unwrap_or_else(|| "Happy bridge failed to start".to_string()));
+                }
+                HappyBridgeState::Stopped | HappyBridgeState::Starting => {}
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err("Happy bridge did not become ready for identity reset".to_string());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn request_identity_retirement(&self) -> Result<(), String> {
+        let stdin = {
+            let guard = self.process.lock().await;
+            let Some(process) = guard.as_ref() else {
+                return Err("Happy bridge is not running".to_string());
+            };
+            Arc::clone(&process._stdin)
+        };
+        let request_id = uuid::Uuid::new_v4().to_string();
+        *self.identity_reset_result.lock().await = None;
+        notify_supervisor(
+            &stdin,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "identity_reset",
+                "params": { "requestId": request_id },
+            }),
+        )
+        .await?;
+
+        let deadline = tokio::time::Instant::now() + IDENTITY_RESET_TIMEOUT;
+        loop {
+            if let Some(success) = matching_identity_reset_result(
+                self.identity_reset_result.lock().await.take(),
+                &request_id,
+            ) {
+                return if success {
+                    Ok(())
+                } else {
+                    Err(
+                        "Happy could not retire every remote session; check the network and retry"
+                            .to_string(),
+                    )
+                };
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(
+                    "Happy session retirement timed out; check the network and retry".to_string(),
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn record_identity_reset_result(
+        &self,
+        generation: u64,
+        request_id: String,
+        success: bool,
+    ) {
+        let _output = self.output_gate.lock().await;
+        if !self.is_process_generation_current(generation) {
+            return;
+        }
+        *self.identity_reset_result.lock().await = Some((request_id, success));
+    }
+
+    async fn restore_after_failed_reset(
+        &self,
+        app: &AppHandle,
+        was_running: bool,
+        reset_error: String,
+    ) -> Result<(), String> {
+        let stop_error = self.stop_inner(app).await.err();
+        let restart_error = if was_running {
+            self.start_inner(app).await.err()
+        } else {
+            None
+        };
+        let failures = [stop_error, restart_error]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if failures.is_empty() {
+            Err(reset_error)
+        } else {
+            Err(format!(
+                "{reset_error}; bridge recovery failed: {}",
+                failures.join("; ")
+            ))
+        }
+    }
+
+    pub async fn reset_identity(&self, app: &AppHandle) -> Result<(), String> {
+        let _lifecycle = self.lifecycle.lock().await;
+        // Keep the credential check, remote retirement, child stop and keychain
+        // deletion in one mutation transaction. A store already in progress
+        // finishes before this check; a later store is rejected until stop has
+        // invalidated its child generation.
+        let _credential_mutation = self.credential_mutation.lock().await;
+        if self.load_pairing_credential(app)?.is_none() {
+            self.stop_inner(app).await?;
+            return self.delete_pairing_identity_transaction(app);
+        }
+        let was_running = self.process_exists().await;
+        if !was_running {
+            self.start_inner(app).await?;
+        }
+        if let Err(error) = self.wait_until_running().await {
+            return self
+                .restore_after_failed_reset(app, was_running, error)
+                .await;
+        }
+
+        // Prevent the monitor from replacing the old-identity process while its
+        // sessions are being retired and the credential transaction is pending.
+        self.stopping.store(true, Ordering::Release);
+        if let Err(error) = self.request_identity_retirement().await {
+            return self
+                .restore_after_failed_reset(app, was_running, error)
+                .await;
+        }
+        if let Err(error) = self.stop_inner(app).await {
+            return self
+                .restore_after_failed_reset(app, was_running, error)
+                .await;
+        }
+        if let Err(error) = self.delete_pairing_identity_transaction(app) {
+            if was_running {
+                let _ = self.start_inner(app).await;
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
     pub async fn update_roots(&self, roots: Vec<String>) -> Result<(), String> {
         // The stdin handle is cloned out and the process lock released before
         // writing. A bridge that is alive but not draining stdin blocks the
@@ -303,6 +547,25 @@ impl HappyBridgeManager {
                 "jsonrpc": "2.0",
                 "method": "roots_update",
                 "params": { "roots": roots },
+            }),
+        )
+        .await
+    }
+
+    pub async fn retire_provider_session(&self, provider_session_id: &str) -> Result<(), String> {
+        let stdin = {
+            let guard = self.process.lock().await;
+            let Some(process) = guard.as_ref() else {
+                return Err("Happy bridge is not running".to_string());
+            };
+            Arc::clone(&process._stdin)
+        };
+        notify_supervisor(
+            &stdin,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "provider_session_retire",
+                "params": { "providerSessionId": provider_session_id },
             }),
         )
         .await
@@ -340,12 +603,17 @@ impl HappyBridgeManager {
         }
     }
 
-    async fn record_status_report(
+    async fn record_status_report<R: tauri::Runtime>(
         &self,
-        app: &AppHandle,
+        app: &AppHandle<R>,
+        generation: u64,
         state: Option<String>,
         detail: Option<String>,
     ) {
+        let _output = self.output_gate.lock().await;
+        if !self.is_process_generation_current(generation) {
+            return;
+        }
         // The restart budget is refunded only by sustained uptime (see
         // `should_rearm`). A connection report says startup succeeded once, not
         // that the process is durable, so refunding here would let a bridge that
@@ -360,9 +628,36 @@ impl HappyBridgeManager {
         let _ = app.emit(STATUS_EVENT, status.clone());
     }
 
-    async fn record_pairing_payload<R: tauri::Runtime>(&self, app: &AppHandle<R>, payload: String) {
+    async fn record_pairing_payload<R: tauri::Runtime>(
+        &self,
+        app: &AppHandle<R>,
+        generation: u64,
+        payload: String,
+    ) {
+        let _output = self.output_gate.lock().await;
+        if !self.is_process_generation_current(generation) {
+            return;
+        }
         *self.pairing_payload.lock().await = Some(payload.clone());
         let _ = app.emit(PAIRING_EVENT, payload);
+    }
+
+    async fn store_pairing_credential_for_generation(
+        &self,
+        app: &AppHandle,
+        generation: u64,
+        credential: &str,
+    ) -> Result<(), String> {
+        self.require_process_write_allowed(generation)?;
+        // Do not await this lock from the stdout dispatcher. During reset the
+        // same dispatcher must remain free to consume identity_reset_result.
+        let _credential_mutation = self
+            .credential_mutation
+            .try_lock()
+            .map_err(|_| "pairing credential reset is in progress".to_string())?;
+        let _output = self.output_gate.lock().await;
+        self.require_process_write_allowed(generation)?;
+        self.store_pairing_credential(app, credential)
     }
 
     /// Store the opaque credential received during pairing in the OS credential
@@ -406,6 +701,14 @@ impl HappyBridgeManager {
         Ok(())
     }
 
+    fn delete_pairing_identity_transaction(&self, app: &AppHandle) -> Result<(), String> {
+        let directory = happy_home_dir(app)
+            .ok_or_else(|| "failed to resolve Happy session key store directory".to_string())?;
+        let credential_present = self.load_pairing_credential(app)?.is_some();
+        reconcile_session_key_store_reset(&directory, credential_present)?;
+        reset_session_key_store_transaction(&directory, || self.delete_pairing_credential(app))
+    }
+
     async fn set_status<R: tauri::Runtime>(
         &self,
         app: &AppHandle<R>,
@@ -418,6 +721,7 @@ impl HappyBridgeManager {
     }
 
     pub fn kill_sync(&self) {
+        self.process_generation.fetch_add(1, Ordering::AcqRel);
         if let Ok(mut guard) = self.monitor_handle.try_lock() {
             if let Some(handle) = guard.take() {
                 handle.abort();
@@ -489,14 +793,14 @@ async fn monitor_process(
 ) {
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let (exited, should_rearm) = {
+        let (exited, should_rearm, exited_generation) = {
             let mut guard = process.lock().await;
             match guard.as_mut() {
                 None => {
                     if stopping.load(Ordering::Acquire) {
                         return;
                     }
-                    (true, false)
+                    (true, false, None)
                 }
                 Some(process) => match process.child.try_wait() {
                     Ok(None) => {
@@ -508,19 +812,25 @@ async fn monitor_process(
                         if rearm {
                             process.restart_budget_rearmed = true;
                         }
-                        (false, rearm)
+                        (false, rearm, None)
                     }
                     Ok(Some(_)) => {
+                        let generation = process.generation;
                         *guard = None;
-                        (true, false)
+                        (true, false, Some(generation))
                     }
                     Err(error) => {
                         log::warn!("[HappyBridge] Failed checking process status: {error}");
-                        (false, false)
+                        (false, false, None)
                     }
                 },
             }
         };
+        if let Some(generation) = exited_generation {
+            app.state::<HappyBridgeManager>()
+                .invalidate_process_generation_if_current(generation)
+                .await;
+        }
         if should_rearm {
             *restart_attempts.lock().await = 0;
         }
@@ -561,7 +871,7 @@ async fn monitor_process(
         tokio::time::sleep(delay).await;
 
         let manager = app.state::<HappyBridgeManager>();
-        if let Err(error) = manager.start_process(&app).await {
+        if let Err(error) = manager.restart_from_monitor(&app).await {
             if attempt >= MAX_RESTART_ATTEMPTS {
                 let failed = HappyBridgeStatus {
                     state: HappyBridgeState::Error,
@@ -630,6 +940,13 @@ fn report_state(state: Option<&str>) -> Option<HappyBridgeState> {
     }
 }
 
+fn matching_identity_reset_result(
+    result: Option<(String, bool)>,
+    expected_request_id: &str,
+) -> Option<bool> {
+    result.and_then(|(request_id, success)| (request_id == expected_request_id).then_some(success))
+}
+
 fn should_rearm(spawned_at: Instant, already_rearmed: bool, now: Instant) -> bool {
     !already_rearmed && now.duration_since(spawned_at) >= Duration::from_secs(60)
 }
@@ -642,6 +959,95 @@ fn happy_home_dir(app: &AppHandle) -> Option<PathBuf> {
         .app_data_dir()
         .ok()
         .map(|dir| dir.join("happy-bridge"))
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &std::path::Path) -> Result<(), String> {
+    std::fs::File::open(directory)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| format!("failed to sync Happy session-key directory: {error}"))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_directory: &std::path::Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn stage_session_key_store_reset(directory: &std::path::Path) -> Result<bool, String> {
+    let store = directory.join(SESSION_KEY_STORE_FILENAME);
+    let staged = directory.join(SESSION_KEY_STORE_RESET_FILENAME);
+    if staged.exists() {
+        return Err("Happy session-key reset is already pending".to_string());
+    }
+    if !store.exists() {
+        return Ok(false);
+    }
+    std::fs::rename(&store, &staged)
+        .map_err(|error| format!("failed to stage Happy session keys for reset: {error}"))?;
+    sync_directory(directory)?;
+    Ok(true)
+}
+
+fn restore_staged_session_key_store(directory: &std::path::Path) -> Result<(), String> {
+    let store = directory.join(SESSION_KEY_STORE_FILENAME);
+    let staged = directory.join(SESSION_KEY_STORE_RESET_FILENAME);
+    if store.exists() {
+        return Err("Happy session-key store already exists while restoring reset".to_string());
+    }
+    std::fs::rename(&staged, &store)
+        .map_err(|error| format!("failed to restore Happy session keys: {error}"))?;
+    sync_directory(directory)
+}
+
+fn finish_session_key_store_reset(directory: &std::path::Path) -> Result<(), String> {
+    let staged = directory.join(SESSION_KEY_STORE_RESET_FILENAME);
+    match std::fs::remove_file(&staged) {
+        Ok(()) => sync_directory(directory),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "failed to remove reset Happy session keys: {error}"
+        )),
+    }
+}
+
+fn reconcile_session_key_store_reset(
+    directory: &std::path::Path,
+    credential_present: bool,
+) -> Result<(), String> {
+    let staged = directory.join(SESSION_KEY_STORE_RESET_FILENAME);
+    if !staged.exists() {
+        return Ok(());
+    }
+    if credential_present {
+        restore_staged_session_key_store(directory)
+    } else {
+        finish_session_key_store_reset(directory)
+    }
+}
+
+fn reset_session_key_store_transaction<F>(
+    directory: &std::path::Path,
+    delete_credential: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let staged = stage_session_key_store_reset(directory)?;
+    if let Err(error) = delete_credential() {
+        if staged {
+            restore_staged_session_key_store(directory).map_err(|restore_error| {
+                format!("{error}; failed to restore Happy session keys: {restore_error}")
+            })?;
+        }
+        return Err(error);
+    }
+    if staged && let Err(error) = finish_session_key_store_reset(directory) {
+        // The credential is already gone and every relay row was confirmed
+        // inactive. Leaving the encrypted tombstone is safe; startup sees
+        // there is no old credential and retries this unlink.
+        log::warn!("[HappyBridge] Failed to remove reset session-key tombstone: {error}");
+    }
+    Ok(())
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
@@ -770,7 +1176,15 @@ fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
 
     if !matches!(
         method,
-        "conversation_create" | "conversation_lookup" | "identity_store"
+        "conversation_create"
+            | "conversation_archive"
+            | "conversation_delete"
+            | "conversation_happy_session_lookup"
+            | "conversation_lookup"
+            | "conversation_owner_lookup"
+            | "provider_session_archive"
+            | "provider_session_archive_lookup"
+            | "identity_store"
     ) {
         return Err(error_response(id, -32601, "unknown supervisor method"));
     }
@@ -791,12 +1205,20 @@ fn required_string(params: &Value, key: &str) -> Result<String, String> {
         .ok_or_else(|| format!("{key} is required"))
 }
 
+fn required_uuid(params: &Value, key: &str) -> Result<String, String> {
+    let value = required_string(params, key)?;
+    uuid::Uuid::parse_str(&value).map_err(|_| format!("{key} must be a UUID"))?;
+    Ok(value)
+}
+
 async fn dispatch_supervisor_request(
     app: &AppHandle,
     request: SupervisorRequest,
+    generation: u64,
 ) -> Result<Value, String> {
     match request.method.as_str() {
         "conversation_create" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
             let agent_type = required_string(&request.params, "agentType")?;
             let cwd = required_string(&request.params, "cwd")?;
             let title = required_string(&request.params, "title")?;
@@ -813,7 +1235,7 @@ async fn dispatch_supervisor_request(
             .map_err(|error| error.to_string())?;
             let conversation = crate::commands::chat::create_agent_conversation_record(
                 app.clone(),
-                uuid::Uuid::new_v4().to_string(),
+                conversation_id,
                 title,
                 agent_type,
                 Some(cwd.clone()),
@@ -841,6 +1263,71 @@ async fn dispatch_supervisor_request(
                 None => json!({}),
             })
         }
+        "conversation_happy_session_lookup" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
+            let happy_session_id = crate::commands::chat::lookup_happy_session_id_by_conversation(
+                app.clone(),
+                conversation_id,
+            )
+            .await?;
+            Ok(match happy_session_id {
+                Some(happy_session_id) => json!({ "happySessionId": happy_session_id }),
+                None => json!({}),
+            })
+        }
+        "conversation_owner_lookup" => {
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
+            let agent_session_id = request
+                .params
+                .get("agentSessionId")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned);
+            let conversation_id = crate::commands::chat::lookup_agent_conversation_owner(
+                app.clone(),
+                provider_session_id,
+                agent_session_id,
+            )
+            .await?;
+            Ok(match conversation_id {
+                Some(conversation_id) => json!({ "conversationId": conversation_id }),
+                None => json!({}),
+            })
+        }
+        "provider_session_archive" => {
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
+            crate::commands::chat::archive_happy_provider_session_from_happy(
+                app.clone(),
+                provider_session_id,
+            )
+            .await?;
+            Ok(json!({ "archived": true }))
+        }
+        "provider_session_archive_lookup" => {
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
+            let archived = crate::commands::chat::is_happy_provider_session_archived(
+                app.clone(),
+                provider_session_id,
+            )
+            .await?;
+            Ok(json!({ "archived": archived }))
+        }
+        "conversation_archive" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
+            crate::commands::chat::archive_agent_conversation_from_happy(
+                app.clone(),
+                conversation_id,
+                provider_session_id,
+            )
+            .await?;
+            Ok(json!({ "archived": true }))
+        }
+        "conversation_delete" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
+            crate::commands::chat::delete_conversation(app.clone(), conversation_id).await?;
+            Ok(json!({ "deleted": true }))
+        }
         "identity_store" => {
             let identity = request
                 .params
@@ -851,21 +1338,30 @@ async fn dispatch_supervisor_request(
                 .map(ToOwned::to_owned)
                 .unwrap_or_else(|| identity.to_string());
             app.state::<HappyBridgeManager>()
-                .store_pairing_credential(app, &credential)?;
+                .store_pairing_credential_for_generation(app, generation, &credential)
+                .await?;
             Ok(json!({ "stored": true }))
         }
         _ => Err("unknown supervisor method".to_string()),
     }
 }
 
-async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex<ChildStdin>>) {
+async fn dispatch_supervisor_line(
+    app: &AppHandle,
+    line: &str,
+    stdin: &Arc<Mutex<ChildStdin>>,
+    generation: u64,
+) {
+    let manager = app.state::<HappyBridgeManager>();
+    if !manager.is_process_generation_current(generation) {
+        return;
+    }
     if let Ok(value) = serde_json::from_str::<Value>(line) {
         if let Some(object) = value.as_object()
             && object.get("id").is_none()
             && let Some(method) = object.get("method").and_then(Value::as_str)
         {
             let params = object.get("params").cloned().unwrap_or_else(|| json!({}));
-            let manager = app.state::<HappyBridgeManager>();
             match method {
                 "status_report" => {
                     let state = params
@@ -876,12 +1372,28 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
                         .get("detail")
                         .and_then(Value::as_str)
                         .map(ToOwned::to_owned);
-                    manager.record_status_report(app, state, detail).await;
+                    manager
+                        .record_status_report(app, generation, state, detail)
+                        .await;
                 }
                 "pairing_payload" => {
                     if let Some(payload) = params.get("payload").and_then(Value::as_str) {
                         manager
-                            .record_pairing_payload(app, payload.to_string())
+                            .record_pairing_payload(app, generation, payload.to_string())
+                            .await;
+                    }
+                }
+                "identity_reset_result" => {
+                    if let (Some(request_id), Some(success)) = (
+                        params.get("requestId").and_then(Value::as_str),
+                        params.get("success").and_then(Value::as_bool),
+                    ) {
+                        manager
+                            .record_identity_reset_result(
+                                generation,
+                                request_id.to_string(),
+                                success,
+                            )
                             .await;
                     }
                 }
@@ -895,7 +1407,7 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
         Err(response) => response,
         Ok(request) => {
             let id = request.id.clone();
-            match dispatch_supervisor_request(app, request).await {
+            match dispatch_supervisor_request(app, request, generation).await {
                 Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
                 Err(error) => error_response(id, -32000, &error),
             }
@@ -1037,7 +1549,12 @@ where
     }
 }
 
-fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: AppHandle) {
+fn pipe_bridge_output(
+    child: &mut Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    app: AppHandle,
+    generation: u64,
+) {
     if let Some(stdout) = child.stdout.take() {
         let stdout_stdin = Arc::clone(&stdin);
         tauri::async_runtime::spawn(async move {
@@ -1045,7 +1562,7 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
             loop {
                 match read_bounded_line(&mut reader).await {
                     Ok(Some(BoundedLine::Complete(line))) => {
-                        dispatch_supervisor_line(&app, &line, &stdout_stdin).await;
+                        dispatch_supervisor_line(&app, &line, &stdout_stdin, generation).await;
                     }
                     Ok(Some(BoundedLine::Oversized)) => {
                         write_supervisor_response(
@@ -1069,9 +1586,10 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
                     Err(error) => {
                         log::warn!("[HappyBridge] Supervisor channel read failed: {error}");
                         app.state::<HappyBridgeManager>()
-                            .set_status(
+                            .record_status_report(
                                 &app,
-                                HappyBridgeState::Error,
+                                generation,
+                                Some("error".to_string()),
                                 Some("supervisor channel closed".to_string()),
                             )
                             .await;
@@ -1099,12 +1617,16 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 mod tests {
     use super::{
         BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES,
-        discovered_project_roots, error_response, is_advertised_root, next_restart_attempt,
-        notify_supervisor, parse_supervisor_line, read_bounded_line, report_state, restart_allowed,
-        restart_delay, should_rearm,
+        SESSION_KEY_STORE_FILENAME, SESSION_KEY_STORE_RESET_FILENAME, discovered_project_roots,
+        error_response, is_advertised_root, matching_identity_reset_result, next_restart_attempt,
+        notify_supervisor, parse_supervisor_line, read_bounded_line,
+        reconcile_session_key_store_reset, report_state, required_uuid,
+        reset_session_key_store_transaction, restart_allowed, restart_delay, should_rearm,
+        stage_session_key_store_reset,
     };
     use crate::commands::happy_bridge::{ADVERTISED_ROOTS_KEY, SETTINGS_STORE};
     use serde_json::Value;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use tauri_plugin_store::StoreExt;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, duplex};
@@ -1124,6 +1646,79 @@ mod tests {
         app
     }
 
+    #[test]
+    fn remote_conversation_ids_must_be_preallocated_uuids() {
+        let valid = serde_json::json!({
+            "conversationId": "00000000-0000-4000-8000-000000000123"
+        });
+        assert_eq!(
+            required_uuid(&valid, "conversationId").unwrap(),
+            "00000000-0000-4000-8000-000000000123"
+        );
+        assert_eq!(
+            required_uuid(
+                &serde_json::json!({ "conversationId": "not-a-uuid" }),
+                "conversationId"
+            )
+            .unwrap_err(),
+            "conversationId must be a UUID"
+        );
+    }
+
+    #[test]
+    fn identity_reset_ack_must_match_the_pending_request() {
+        assert_eq!(
+            matching_identity_reset_result(Some(("expected".to_string(), true)), "expected"),
+            Some(true)
+        );
+        assert_eq!(
+            matching_identity_reset_result(Some(("stale".to_string(), true)), "expected"),
+            None
+        );
+    }
+
+    #[test]
+    fn identity_reset_stages_and_restores_session_keys_transactionally() {
+        let directory = tempfile::tempdir().unwrap();
+        let binding_store = directory.path().join(SESSION_KEY_STORE_FILENAME);
+        let staged = directory.path().join(SESSION_KEY_STORE_RESET_FILENAME);
+        let unrelated = directory.path().join("unrelated.json");
+        std::fs::write(&binding_store, "synthetic encrypted payload").unwrap();
+        std::fs::write(&unrelated, "keep").unwrap();
+
+        let error = reset_session_key_store_transaction(directory.path(), || {
+            Err("synthetic credential deletion failure".to_string())
+        })
+        .unwrap_err();
+        assert_eq!(error, "synthetic credential deletion failure");
+        // A keychain-deletion failure leaves the old credential installed, so
+        // the transaction must restore its only decryptable session-key store.
+        assert!(binding_store.exists());
+        assert!(!staged.exists());
+
+        reset_session_key_store_transaction(directory.path(), || Ok(())).unwrap();
+        assert!(!binding_store.exists());
+        assert!(!staged.exists());
+        assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn startup_reconciles_an_interrupted_identity_reset_from_credential_state() {
+        let with_credential = tempfile::tempdir().unwrap();
+        let store = with_credential.path().join(SESSION_KEY_STORE_FILENAME);
+        std::fs::write(&store, "synthetic encrypted payload").unwrap();
+        stage_session_key_store_reset(with_credential.path()).unwrap();
+        reconcile_session_key_store_reset(with_credential.path(), true).unwrap();
+        assert!(store.exists());
+
+        let without_credential = tempfile::tempdir().unwrap();
+        let store = without_credential.path().join(SESSION_KEY_STORE_FILENAME);
+        std::fs::write(&store, "synthetic encrypted payload").unwrap();
+        stage_session_key_store_reset(without_credential.path()).unwrap();
+        reconcile_session_key_store_reset(without_credential.path(), false).unwrap();
+        assert!(!store.exists());
+    }
+
     #[tokio::test]
     async fn stopping_discards_the_pairing_payload_of_the_dead_process() {
         // Regression: the payload outlived the process that minted it, so
@@ -1131,9 +1726,14 @@ mod tests {
         // secret key had died with the previous bridge and pairing never completed.
         let app = mock_app_with_roots(None);
         let manager = super::HappyBridgeManager::new();
+        let generation = manager.advance_process_generation().await;
 
         manager
-            .record_pairing_payload(app.handle(), "payload-from-bridge-a".to_string())
+            .record_pairing_payload(
+                app.handle(),
+                generation,
+                "payload-from-bridge-a".to_string(),
+            )
             .await;
         assert!(
             manager.pairing_payload.lock().await.is_some(),
@@ -1147,6 +1747,92 @@ mod tests {
         assert!(
             manager.pairing_payload.lock().await.is_none(),
             "a payload minted by a stopped bridge must not be handed out"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_child_output_cannot_mutate_bridge_or_credentials() {
+        let app = mock_app_with_roots(None);
+        let manager = super::HappyBridgeManager::new();
+        let stale_generation = manager.advance_process_generation().await;
+        let current_generation = manager.advance_process_generation().await;
+
+        manager
+            .record_status_report(
+                app.handle(),
+                current_generation,
+                Some("connected".to_string()),
+                Some("Connected".to_string()),
+            )
+            .await;
+        manager
+            .record_status_report(
+                app.handle(),
+                stale_generation,
+                Some("error".to_string()),
+                Some("stale child".to_string()),
+            )
+            .await;
+        assert!(matches!(
+            manager.status().await.state,
+            HappyBridgeState::Running
+        ));
+
+        manager
+            .record_pairing_payload(
+                app.handle(),
+                current_generation,
+                "current-payload".to_string(),
+            )
+            .await;
+        manager
+            .record_pairing_payload(app.handle(), stale_generation, "stale-payload".to_string())
+            .await;
+        assert_eq!(
+            manager.pairing_payload.lock().await.as_deref(),
+            Some("current-payload")
+        );
+
+        manager
+            .record_identity_reset_result(current_generation, "current".to_string(), true)
+            .await;
+        manager
+            .record_identity_reset_result(stale_generation, "stale".to_string(), false)
+            .await;
+        assert_eq!(
+            manager.identity_reset_result.lock().await.as_ref(),
+            Some(&("current".to_string(), true))
+        );
+
+        assert_eq!(
+            manager
+                .require_current_process_generation(stale_generation)
+                .unwrap_err(),
+            "stale Happy bridge process"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_writes_are_rejected_while_stopping_and_after_generation_advance() {
+        let manager = super::HappyBridgeManager::new();
+        let generation = manager.advance_process_generation().await;
+        assert!(manager.require_process_write_allowed(generation).is_ok());
+
+        manager.stopping.store(true, Ordering::Release);
+        assert_eq!(
+            manager
+                .require_process_write_allowed(generation)
+                .expect_err("stopping rejects identity writes"),
+            "Happy bridge is stopping",
+        );
+
+        manager.stopping.store(false, Ordering::Release);
+        manager.advance_process_generation().await;
+        assert_eq!(
+            manager
+                .require_process_write_allowed(generation)
+                .expect_err("stale generations stay rejected"),
+            "stale Happy bridge process",
         );
     }
 
@@ -1172,9 +1858,7 @@ mod tests {
         let nested = consented.path().join("nested");
         std::fs::create_dir(&nested).expect("nested dir");
 
-        let app = mock_app_with_roots(Some(vec![
-            consented.path().to_string_lossy().to_string(),
-        ]));
+        let app = mock_app_with_roots(Some(vec![consented.path().to_string_lossy().to_string()]));
 
         let sibling_path = sibling.path().to_string_lossy().to_string();
         assert!(
@@ -1273,8 +1957,14 @@ mod tests {
 
     #[test]
     fn bridge_error_status_is_preserved_as_error() {
-        assert!(matches!(report_state(Some("error")), Some(HappyBridgeState::Error)));
-        assert!(matches!(report_state(Some("connected")), Some(HappyBridgeState::Running)));
+        assert!(matches!(
+            report_state(Some("error")),
+            Some(HappyBridgeState::Error)
+        ));
+        assert!(matches!(
+            report_state(Some("connected")),
+            Some(HappyBridgeState::Running)
+        ));
         assert!(report_state(Some("starting")).is_none());
     }
 
@@ -1305,6 +1995,51 @@ mod tests {
         .expect_err("unknown method must fail");
         assert_eq!(response["error"]["code"], -32601);
         assert_eq!(response["id"], 7);
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_happy_session_lookup() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":7,"method":"conversation_happy_session_lookup","params":{"conversationId":"00000000-0000-4000-8000-000000000123"}}"#,
+        )
+        .expect("lookup method is allowlisted");
+        assert_eq!(request.method, "conversation_happy_session_lookup");
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_conversation_owner_lookup() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":9,"method":"conversation_owner_lookup","params":{"providerSessionId":"00000000-0000-4000-8000-000000000123"}}"#,
+        )
+        .expect("owner lookup method is allowlisted");
+        assert_eq!(request.method, "conversation_owner_lookup");
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_conversation_archive() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":8,"method":"conversation_archive","params":{"conversationId":"00000000-0000-4000-8000-000000000123","providerSessionId":"00000000-0000-4000-8000-000000000124"}}"#,
+        )
+        .expect("archive method is allowlisted");
+        assert_eq!(request.method, "conversation_archive");
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_provider_session_archive() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":10,"method":"provider_session_archive","params":{"providerSessionId":"00000000-0000-4000-8000-000000000123"}}"#,
+        )
+        .expect("provider-only archive method is allowlisted");
+        assert_eq!(request.method, "provider_session_archive");
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_provider_session_archive_lookup() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":11,"method":"provider_session_archive_lookup","params":{"providerSessionId":"00000000-0000-4000-8000-000000000123"}}"#,
+        )
+        .expect("provider archive lookup method is allowlisted");
+        assert_eq!(request.method, "provider_session_archive_lookup");
     }
 
     #[test]
@@ -1354,7 +2089,10 @@ mod tests {
         let (reader, mut writer) = duplex(1024);
         let writer_task = tokio::spawn(async move {
             writer.write_all(&[0xff, 0xfe]).await.unwrap();
-            writer.write_all(b"\n{\"jsonrpc\":\"2.0\"}\n").await.unwrap();
+            writer
+                .write_all(b"\n{\"jsonrpc\":\"2.0\"}\n")
+                .await
+                .unwrap();
         });
         let mut reader = BufReader::new(reader);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1093,6 +1093,8 @@ pub fn run() {
             commands::chat::create_agent_conversation,
             commands::chat::get_agent_conversation,
             commands::chat::set_agent_conversation_session_id,
+            commands::chat::claim_happy_provider_session_owner,
+            commands::chat::fence_happy_provider_session_archive,
             commands::chat::set_agent_conversation_title,
             commands::chat::set_agent_conversation_model_id,
             commands::chat::set_agent_conversation_permission_mode,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1252,7 +1252,24 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     migrate_orphan_messages(conn)?;
 
     setup_provider_runtime_schema(conn)?;
+    setup_happy_provider_session_lifecycle_schema(conn)?;
 
+    Ok(())
+}
+
+/// Durable archive fence for provider sessions that may not have a
+/// conversation row yet (fresh spawns and predictive standbys).
+fn setup_happy_provider_session_lifecycle_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS happy_provider_session_lifecycle (
+            provider_session_id TEXT PRIMARY KEY,
+            conversation_id TEXT,
+            is_archived INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_happy_provider_session_lifecycle_conversation
+         ON happy_provider_session_lifecycle(conversation_id);",
+    )?;
     Ok(())
 }
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -827,7 +827,7 @@ export async function updateConversation(
 }
 
 /**
- * Create (or re-open) an agent conversation.
+ * Create or refresh an agent conversation without changing archive state.
  */
 export async function createAgentConversation(
   id: string,
@@ -880,6 +880,37 @@ export async function setAgentConversationSessionId(
     throw new Error("Conversation operations require Tauri runtime");
   }
   await invoke("set_agent_conversation_session_id", { id, agentSessionId });
+}
+
+export async function claimHappyProviderSessionOwner(
+  conversationId: string,
+  providerSessionId: string,
+  agentSessionId?: string,
+): Promise<{ archived: boolean }> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  return await invoke<{ archived: boolean }>(
+    "claim_happy_provider_session_owner",
+    {
+      conversationId,
+      providerSessionId,
+      agentSessionId: agentSessionId ?? null,
+    },
+  );
+}
+
+export async function fenceHappyProviderSessionArchive(
+  providerSessionId: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  await invoke("fence_happy_provider_session_archive", {
+    providerSessionId,
+  });
 }
 
 /**

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -600,8 +600,11 @@ export async function cancelPrompt(sessionId: string): Promise<void> {
 /**
  * Terminate an agent runtime session.
  */
-export async function terminateSession(sessionId: string): Promise<void> {
-  return invokeProvider("provider_terminate", { sessionId });
+export async function terminateSession(
+  sessionId: string,
+  options?: { timeoutMs?: number | null },
+): Promise<void> {
+  return invokeProvider("provider_terminate", { sessionId }, options);
 }
 
 /**

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -64,6 +64,53 @@ const reattachingConversations = new Map<string, Promise<boolean>>();
  *  into new/live sessions. Cleared when the global subscriber is torn down. */
 const terminatedSessionIds = new Set<string>();
 
+/**
+ * Monotonic fence for Happy-origin archives. Async list/spawn/reattach work
+ * captures an epoch before it starts and may only commit while that epoch is
+ * still current and the conversation is not tombstoned.
+ */
+export class HappyArchiveFence {
+  private readonly entries = new Map<
+    string,
+    { generation: number; archived: boolean }
+  >();
+
+  capture(conversationId: string): number {
+    return this.entries.get(conversationId)?.generation ?? 0;
+  }
+
+  archive(conversationId: string): number {
+    const current = this.entries.get(conversationId);
+    if (current?.archived) return current.generation;
+    const generation = (current?.generation ?? 0) + 1;
+    this.entries.set(conversationId, { generation, archived: true });
+    return generation;
+  }
+
+  isArchived(conversationId: string): boolean {
+    return this.entries.get(conversationId)?.archived === true;
+  }
+
+  allows(conversationId: string, capturedGeneration: number): boolean {
+    const current = this.entries.get(conversationId);
+    return (
+      (current?.generation ?? 0) === capturedGeneration &&
+      current?.archived !== true
+    );
+  }
+
+  filterVisible<T extends { id: string }>(rows: T[]): T[] {
+    return rows.filter((row) => !this.isArchived(row.id));
+  }
+}
+
+const happyArchiveFence = new HappyArchiveFence();
+
+/** Exact provider sessions archived before a conversation owner was durable.
+ * Kept separate from conversation fences so an unowned standby cannot evict
+ * its healthy serving sibling. */
+const happyProviderArchiveTombstones = new Set<string>();
+
 /** Session IDs that the agent store just terminated programmatically. The
  *  runtime emits "Session terminated before request completed." (and other
  *  death-string `provider://error` events) when in-flight control requests
@@ -134,12 +181,51 @@ const SUMMARY_PRIMARY_MODEL = "anthropic/claude-sonnet-4";
 // deterministic local summary. #2111.
 const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"];
 
+/** Owner-aware global cap for predictive compaction. An archived run can
+ * release its own slot immediately, but a stale completion from that run must
+ * never release a newer thread's slot. */
+export class PredictiveCompactMutex {
+  private owner: { sessionId: string; generation: number } | null = null;
+  private nextGeneration = 0;
+
+  tryAcquire(
+    sessionId: string,
+  ): Readonly<{ sessionId: string; generation: number }> | null {
+    if (this.owner !== null) return null;
+    this.nextGeneration += 1;
+    this.owner = { sessionId, generation: this.nextGeneration };
+    return this.owner;
+  }
+
+  release(lease: Readonly<{ sessionId: string; generation: number }>): boolean {
+    if (
+      this.owner?.sessionId !== lease.sessionId ||
+      this.owner.generation !== lease.generation
+    ) {
+      return false;
+    }
+    this.owner = null;
+    return true;
+  }
+
+  releaseCurrentForAny(sessionIds: Iterable<string>): boolean {
+    if (!this.owner) return false;
+    for (const sessionId of sessionIds) {
+      if (this.owner.sessionId === sessionId) {
+        this.owner = null;
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
  * Prevents 3x Sonnet 4 calls and 3x Node subprocesses when multiple threads
  * cross the threshold in the same promptComplete tick. #1631.
  */
-let predictiveCompactBusy = false;
+const predictiveCompactMutex = new PredictiveCompactMutex();
 
 /**
  * Per-thread restart-timer handles. Cleared when the turn produces its
@@ -524,9 +610,11 @@ import {
   reportError,
 } from "@/lib/support/hook";
 import {
+  claimHappyProviderSessionOwner,
   clearConversationHistory,
   createAgentConversation,
   type AgentConversation as DbAgentConversation,
+  fenceHappyProviderSessionArchive,
   getAgentConversation,
   getMessages,
   getSerenApiKey,
@@ -594,6 +682,10 @@ let providerRuntimeReadyListener: Promise<UnlistenFn> | null = null;
  *  initialize() calls don't stack listeners. #1631. */
 let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
 
+/** Set once we've subscribed to remote Happy archive notifications so the
+ *  sidebar and serving pointers cannot outlive the archived DB row. */
+let agentConversationArchivedListener: Promise<UnlistenFn> | null = null;
+
 /** Set once we've subscribed to `provider://cli-scan-rejected` so repeated
  *  initialize() calls don't stack listeners. #1646. */
 let cliScanRejectedUnsub: (() => void) | null = null;
@@ -639,6 +731,10 @@ function disposeAgentStoreSideChannelListeners(): void {
   const restartedListener = providerRuntimeRestartedListener;
   providerRuntimeRestartedListener = null;
   disposeTauriListener(restartedListener, "provider-runtime restarted");
+
+  const archivedListener = agentConversationArchivedListener;
+  agentConversationArchivedListener = null;
+  disposeTauriListener(archivedListener, "agent-conversation archived");
 
   cliScanRejectedUnsub?.();
   cliScanRejectedUnsub = null;
@@ -782,6 +878,322 @@ function subscribeToProviderRuntimeRestarted(): void {
       }
     },
   );
+}
+
+/**
+ * Invalidate the frontend immediately after Rust archives an agent
+ * conversation. A conversation may own more than one runtime session while a
+ * predictive-compaction standby is warming, so every matching session must be
+ * removed and tombstoned before a late runtime event can reach the UI.
+ */
+export function planHappyArchiveInvalidation(
+  sessions: Record<
+    string,
+    {
+      conversationId: string;
+      role: "serving" | "standby";
+      archiveOwnerConversationId?: string;
+      standbySessionId?: string | null;
+    }
+  >,
+  activeSessionId: string | null,
+  conversationId: string,
+): { archivedSessionIds: string[]; nextActiveSessionId: string | null } {
+  const archivedSessionIdSet = new Set(
+    Object.entries(sessions)
+      .filter(
+        ([, session]) =>
+          session.conversationId === conversationId ||
+          session.archiveOwnerConversationId === conversationId,
+      )
+      .map(([sessionId]) => sessionId),
+  );
+  // Include a registered warm standby even if it predates the explicit owner
+  // field. The serving pointer is the durable sibling relationship until
+  // promotion copies the persisted conversation id onto the standby.
+  for (const sessionId of [...archivedSessionIdSet]) {
+    const standbySessionId = sessions[sessionId]?.standbySessionId;
+    if (standbySessionId && sessions[standbySessionId]) {
+      archivedSessionIdSet.add(standbySessionId);
+    }
+  }
+  const archivedSessionIds = [...archivedSessionIdSet];
+  const nextActiveSessionId =
+    activeSessionId && archivedSessionIdSet.has(activeSessionId)
+      ? (Object.entries(sessions).find(
+          ([sessionId, session]) =>
+            !archivedSessionIdSet.has(sessionId) && session.role === "serving",
+        )?.[0] ?? null)
+      : activeSessionId;
+  return { archivedSessionIds, nextActiveSessionId };
+}
+
+/**
+ * Release the app-wide predictive-compaction mutex only when the archived
+ * conversation owns the in-flight warmup. Clearing it for an unrelated
+ * archive could allow a second compaction to start concurrently.
+ */
+export interface HappyArchivedSiblingRetirementResult {
+  fenced: boolean;
+  retired: boolean;
+  forceKilled: boolean;
+  lastError?: unknown;
+}
+
+/**
+ * Retire a sibling of the Happy row archived on mobile. The durable local
+ * fence is attempted before process teardown, and the PID-guarded Rust kill is
+ * the immediate fallback when the provider runtime cannot service termination.
+ */
+export async function retireHappyArchivedSiblingProvider(
+  sessionId: string,
+  pid: number | null | undefined,
+  operations: {
+    fence: (sessionId: string) => Promise<void>;
+    terminate: (sessionId: string) => Promise<void>;
+    forceKill: (pid: number) => Promise<boolean>;
+  },
+): Promise<HappyArchivedSiblingRetirementResult> {
+  let fenced = false;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2 && !fenced; attempt += 1) {
+    try {
+      await operations.fence(sessionId);
+      fenced = true;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  try {
+    await operations.terminate(sessionId);
+    return { fenced, retired: true, forceKilled: false, lastError };
+  } catch (error) {
+    lastError = error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("not found")) {
+      return { fenced, retired: true, forceKilled: false, lastError };
+    }
+  }
+
+  if (pid != null) {
+    try {
+      const forceKilled = await operations.forceKill(pid);
+      if (forceKilled) {
+        return { fenced, retired: true, forceKilled: true, lastError };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  return { fenced, retired: false, forceKilled: false, lastError };
+}
+
+export function planHappyProviderArchiveInvalidation(
+  sessions: Record<
+    string,
+    {
+      role: "serving" | "standby";
+      standbySessionId?: string | null;
+    }
+  >,
+  activeSessionId: string | null,
+  targetProviderSessionId: string,
+): {
+  archivedSessionIds: string[];
+  linkedServingSessionIds: string[];
+  nextActiveSessionId: string | null;
+} {
+  const linkedServingSessionIds = Object.entries(sessions)
+    .filter(
+      ([sessionId, session]) =>
+        sessionId !== targetProviderSessionId &&
+        session.role === "serving" &&
+        session.standbySessionId === targetProviderSessionId,
+    )
+    .map(([sessionId]) => sessionId);
+  const nextActiveSessionId =
+    activeSessionId === targetProviderSessionId
+      ? (Object.entries(sessions).find(
+          ([sessionId, session]) =>
+            sessionId !== targetProviderSessionId && session.role === "serving",
+        )?.[0] ?? null)
+      : activeSessionId;
+  return {
+    archivedSessionIds: [targetProviderSessionId],
+    linkedServingSessionIds,
+    nextActiveSessionId,
+  };
+}
+
+function subscribeToAgentConversationArchived(): void {
+  if (agentConversationArchivedListener) return;
+  agentConversationArchivedListener = listen<
+    | string
+    | {
+        conversationId: string | null;
+        targetProviderSessionId: string;
+      }
+  >("happy-bridge://conversation-archived", (event) => {
+    const payload = event.payload;
+    const conversationId =
+      typeof payload === "string" ? payload : payload?.conversationId;
+    const targetProviderSessionId =
+      typeof payload === "object" &&
+      payload !== null &&
+      typeof payload.targetProviderSessionId === "string"
+        ? payload.targetProviderSessionId
+        : null;
+    if (targetProviderSessionId) {
+      happyProviderArchiveTombstones.add(targetProviderSessionId);
+    }
+    if (
+      (typeof conversationId !== "string" || conversationId.length === 0) &&
+      targetProviderSessionId
+    ) {
+      const {
+        archivedSessionIds,
+        linkedServingSessionIds,
+        nextActiveSessionId,
+      } = planHappyProviderArchiveInvalidation(
+        state.sessions,
+        state.activeSessionId,
+        targetProviderSessionId,
+      );
+      terminatedSessionIds.add(targetProviderSessionId);
+      sessionReadyPromises.get(targetProviderSessionId)?.resolve();
+      sessionReadyPromises.delete(targetProviderSessionId);
+      pendingSessionEvents.delete(targetProviderSessionId);
+      spawnContextMap.delete(targetProviderSessionId);
+      recoveryInFlightMap.delete(targetProviderSessionId);
+      clearChunkBuf(targetProviderSessionId);
+      clearToolEventBuf(targetProviderSessionId);
+
+      setState("pendingPermissions", (items) =>
+        items.filter((item) => item.sessionId !== targetProviderSessionId),
+      );
+      setState("pendingDiffProposals", (items) =>
+        items.filter((item) => item.sessionId !== targetProviderSessionId),
+      );
+      setState(
+        produce((draft) => {
+          for (const sessionId of archivedSessionIds) {
+            delete draft.sessions[sessionId];
+          }
+          for (const sessionId of linkedServingSessionIds) {
+            const serving = draft.sessions[sessionId];
+            if (!serving) continue;
+            serving.standbySessionId = null;
+            serving.predictiveCompactInFlight = false;
+          }
+        }),
+      );
+      if (linkedServingSessionIds.length > 0) {
+        predictiveCompactMutex.releaseCurrentForAny(linkedServingSessionIds);
+        for (const servingSessionId of linkedServingSessionIds) {
+          agentStore.drainAfterPredictiveAbort(servingSessionId);
+        }
+      }
+      if (state.activeSessionId !== nextActiveSessionId) {
+        setState("activeSessionId", nextActiveSessionId);
+      }
+      return;
+    }
+    if (typeof conversationId !== "string" || conversationId.length === 0) {
+      return;
+    }
+
+    // Fence first: async refresh/resume work that started before this event
+    // must observe the tombstone before it can commit any late result.
+    happyArchiveFence.archive(conversationId);
+
+    setState("recentAgentConversations", (rows) =>
+      rows.filter((row) => row.id !== conversationId),
+    );
+
+    const { archivedSessionIds, nextActiveSessionId } =
+      planHappyArchiveInvalidation(
+        state.sessions,
+        state.activeSessionId,
+        conversationId,
+      );
+    const archivedSessionIdSet = new Set(archivedSessionIds);
+    for (const sessionId of archivedSessionIds) {
+      const archivedSession = state.sessions[sessionId];
+      terminatedSessionIds.add(sessionId);
+      sessionReadyPromises.get(sessionId)?.resolve();
+      sessionReadyPromises.delete(sessionId);
+      pendingSessionEvents.delete(sessionId);
+      spawnContextMap.delete(sessionId);
+      recoveryInFlightMap.delete(sessionId);
+      clearChunkBuf(sessionId);
+      clearToolEventBuf(sessionId);
+      // Happy retires the provider that originated this archive. Reap every
+      // other planned sibling explicitly, including a standby that was
+      // promoted to serving while the old provider was winding down. Keep
+      // the legacy-string fallback narrow for rolling upgrades.
+      const shouldTerminateSibling = targetProviderSessionId
+        ? sessionId !== targetProviderSessionId
+        : archivedSession?.role === "standby";
+      if (shouldTerminateSibling) {
+        expectedTerminateSessionIds.add(sessionId);
+        void retireHappyArchivedSiblingProvider(
+          sessionId,
+          archivedSession?.info.pid,
+          {
+            fence: fenceHappyProviderSessionArchive,
+            terminate: (providerSessionId) =>
+              providerService.terminateSession(providerSessionId, {
+                timeoutMs: 5_000,
+              }),
+            forceKill: providerService.forceKillSession,
+          },
+        )
+          .then((result) => {
+            if (!result.fenced) {
+              console.error(
+                "[AgentStore] Failed to persist archived Happy sibling fence:",
+                result.lastError,
+              );
+            }
+            if (!result.retired) {
+              console.error(
+                "[AgentStore] Failed to retire archived Happy sibling:",
+                result.lastError,
+              );
+            }
+          })
+          .finally(() => expectedTerminateSessionIds.delete(sessionId));
+      }
+    }
+    const restartTimer = restartTimers.get(conversationId);
+    if (restartTimer) clearTimeout(restartTimer);
+    restartTimers.delete(conversationId);
+    pairedConfigPersisted.delete(conversationId);
+
+    setState("pendingPermissions", (items) =>
+      items.filter((item) => !archivedSessionIdSet.has(item.sessionId)),
+    );
+    setState("pendingDiffProposals", (items) =>
+      items.filter((item) => !archivedSessionIdSet.has(item.sessionId)),
+    );
+
+    setState(
+      produce((draft) => {
+        for (const sessionId of archivedSessionIds) {
+          delete draft.sessions[sessionId];
+        }
+        delete draft.threadStates[conversationId];
+        delete draft.persistedMessages[conversationId];
+      }),
+    );
+
+    predictiveCompactMutex.releaseCurrentForAny(archivedSessionIds);
+
+    if (state.activeSessionId !== nextActiveSessionId) {
+      setState("activeSessionId", nextActiveSessionId);
+    }
+  });
 }
 
 function subscribeToClaudeMemoryIntercepts(): void {
@@ -1090,6 +1502,9 @@ export interface ActiveSession {
   cwd: string;
   /** Local persisted conversation id (SQLite). */
   conversationId: string;
+  /** Persisted owner used to fence an invisible predictive standby before
+   * promotion copies that owner's conversationId onto the standby. */
+  archiveOwnerConversationId?: string;
   /** Remote agent runtime session id (e.g., Codex thread id). */
   agentSessionId?: string;
   /** Session configuration options reported by the agent runtime. */
@@ -1869,6 +2284,78 @@ const [state, setState] = createStore<AgentState>({
   agentModeEnabled: false,
 });
 
+/** Kill a provider that completed after its owning Happy conversation was
+ * archived. This path can run before the session was ever registered in the
+ * Solid store, so it must call the provider directly rather than delegate to
+ * terminateSession (which intentionally no-ops for unknown session IDs). */
+async function discardLateArchivedProviderSession(
+  sessionId: string,
+  conversationId: string,
+): Promise<void> {
+  const { archivedSessionIds, nextActiveSessionId } =
+    planHappyArchiveInvalidation(
+      state.sessions,
+      state.activeSessionId,
+      conversationId,
+    );
+  const allArchivedSessionIds = new Set([...archivedSessionIds, sessionId]);
+
+  terminatedSessionIds.add(sessionId);
+  terminatedSessionIds.add(conversationId);
+  for (const archivedSessionId of allArchivedSessionIds) {
+    terminatedSessionIds.add(archivedSessionId);
+    sessionReadyPromises.get(archivedSessionId)?.resolve();
+    sessionReadyPromises.delete(archivedSessionId);
+    pendingSessionEvents.delete(archivedSessionId);
+    spawnContextMap.delete(archivedSessionId);
+    recoveryInFlightMap.delete(archivedSessionId);
+    clearChunkBuf(archivedSessionId);
+    clearToolEventBuf(archivedSessionId);
+  }
+  spawnContextMap.delete(conversationId);
+
+  setState("recentAgentConversations", (rows) =>
+    rows.filter((row) => row.id !== conversationId),
+  );
+  setState("pendingPermissions", (items) =>
+    items.filter((item) => !allArchivedSessionIds.has(item.sessionId)),
+  );
+  setState("pendingDiffProposals", (items) =>
+    items.filter((item) => !allArchivedSessionIds.has(item.sessionId)),
+  );
+  setState(
+    produce((draft) => {
+      for (const archivedSessionId of allArchivedSessionIds) {
+        delete draft.sessions[archivedSessionId];
+      }
+      delete draft.threadStates[conversationId];
+      delete draft.persistedMessages[conversationId];
+    }),
+  );
+  if (state.activeSessionId !== nextActiveSessionId) {
+    setState("activeSessionId", nextActiveSessionId);
+  }
+
+  await Promise.all(
+    [...allArchivedSessionIds].map(async (archivedSessionId) => {
+      expectedTerminateSessionIds.add(archivedSessionId);
+      try {
+        await providerService.terminateSession(archivedSessionId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("not found")) {
+          console.warn(
+            "[AgentStore] Failed to terminate provider after Happy archive:",
+            error,
+          );
+        }
+      } finally {
+        expectedTerminateSessionIds.delete(archivedSessionId);
+      }
+    }),
+  );
+}
+
 const agentOAuthRoutingRefreshes = new Map<string, Promise<boolean>>();
 const agentOAuthRoutingAvailability = new Map<string, boolean>();
 const agentOAuthRoutingDelivery = new Map<string, boolean>();
@@ -2106,6 +2593,7 @@ function disposeAgentStoreRuntimeBindings(): void {
   sessionReadyPromises.clear();
   recoveryInFlightMap.clear();
   terminatedSessionIds.clear();
+  happyProviderArchiveTombstones.clear();
   spawnContextMap.clear();
   for (const timer of chunkFlushTimers.values()) {
     clearTimeout(timer);
@@ -2946,6 +3434,7 @@ export const agentStore = {
     // to applyAgents just overwrite availableAgents with the same data.
     subscribeToProviderRuntimeReady();
     subscribeToProviderRuntimeRestarted();
+    subscribeToAgentConversationArchived();
     // Surface CLI-updater scan rejections per #1646. Default-on, runs once
     // at app init, idempotent (the runtime emits the event at most once
     // per launch per CLI). System notification + state record so the user
@@ -2992,7 +3481,10 @@ export const agentStore = {
         projectRoot: cwd,
         limit,
       });
-      setState("recentAgentConversations", rows.map(unifiedRowToAgent));
+      setState(
+        "recentAgentConversations",
+        happyArchiveFence.filterVisible(rows.map(unifiedRowToAgent)),
+      );
     } catch (error) {
       console.error("Failed to load agent conversation history:", error);
     }
@@ -3017,6 +3509,7 @@ export const agentStore = {
    * agent-kind on a cross-category switch.
    */
   upsertAgentConversationFromDb(row: DbAgentConversation) {
+    if (happyArchiveFence.isArchived(row.id)) return;
     setState("recentAgentConversations", (rows) => {
       const without = rows.filter((r) => r.id !== row.id);
       return [row, ...without];
@@ -3037,7 +3530,9 @@ export const agentStore = {
         providerService.listRemoteSessions(resolvedAgentType, cwd),
         listConversations({ kind: "agent", limit: 200 }),
       ]);
-      const localRows = rawLocalRows.map(unifiedRowToAgent);
+      const localRows = happyArchiveFence.filterVisible(
+        rawLocalRows.map(unifiedRowToAgent),
+      );
 
       setState("recentAgentConversations", localRows);
       const titleOverrides = new Map(
@@ -3135,11 +3630,27 @@ export const agentStore = {
       /** Warm-standby spawns are invisible to the UI — no session-selector
        *  entry, events buffered not rendered, does not steal active focus. */
       role?: "serving" | "standby";
+      /** Persisted serving conversation that owns a predictive standby. */
+      archiveOwnerConversationId?: string;
     },
   ): Promise<string | null> {
     const resolvedAgentType = agentType ?? state.selectedAgentType;
     const localSessionId = opts?.localSessionId;
     const resumeAgentSessionId = opts?.resumeAgentSessionId;
+    const happyArchiveOwnerConversationId =
+      opts?.archiveOwnerConversationId ?? localSessionId;
+    const happyArchiveGeneration = happyArchiveOwnerConversationId
+      ? happyArchiveFence.capture(happyArchiveOwnerConversationId)
+      : null;
+    if (
+      happyArchiveOwnerConversationId &&
+      !happyArchiveFence.allows(
+        happyArchiveOwnerConversationId,
+        happyArchiveGeneration ?? 0,
+      )
+    ) {
+      return null;
+    }
     const initRetryAttempt = opts?.initRetryAttempt ?? 0;
     const reclaimedIdleClaude = opts?.reclaimedIdleClaude ?? false;
     const conversationTitle =
@@ -3436,8 +3947,68 @@ export const agentStore = {
           settingsStore.settings.agentAutoApproveReads,
         );
         console.log("[AgentStore] Spawn result:", info);
-        await refreshAgentOAuthRouting(info.id, localSessionId ?? info.id);
         expectedReadySessionId = info.id;
+        const guardedConversationId =
+          happyArchiveOwnerConversationId ?? info.id;
+        const happyArchiveAllowsCommit = () =>
+          !happyProviderArchiveTombstones.has(info.id) &&
+          !happyArchiveFence.isArchived(info.id) &&
+          (!happyArchiveOwnerConversationId ||
+            happyArchiveFence.allows(
+              happyArchiveOwnerConversationId,
+              happyArchiveGeneration ?? 0,
+            ));
+        const abortArchivedSpawn = async (): Promise<null> => {
+          await discardLateArchivedProviderSession(
+            info.id,
+            guardedConversationId,
+          );
+          setState("isLoading", false);
+          tempUnsubscribe();
+          return null;
+        };
+        const abortProviderArchivedSpawn = async (): Promise<null> => {
+          terminatedSessionIds.add(info.id);
+          sessionReadyPromises.get(info.id)?.resolve();
+          sessionReadyPromises.delete(info.id);
+          pendingSessionEvents.delete(info.id);
+          spawnContextMap.delete(info.id);
+          recoveryInFlightMap.delete(info.id);
+          clearChunkBuf(info.id);
+          clearToolEventBuf(info.id);
+          await providerService.terminateSession(info.id).catch((error) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            if (!message.includes("not found")) {
+              console.warn(
+                "[AgentStore] Failed to terminate provider-only archived spawn:",
+                error,
+              );
+            }
+          });
+          if (state.sessions[info.id]) {
+            setState(
+              produce((draft) => {
+                delete draft.sessions[info.id];
+              }),
+            );
+          }
+          setState("isLoading", false);
+          tempUnsubscribe();
+          return null;
+        };
+        const abortHappyArchivedSpawn = () =>
+          happyProviderArchiveTombstones.has(info.id)
+            ? abortProviderArchivedSpawn()
+            : abortArchivedSpawn();
+
+        if (!happyArchiveAllowsCommit()) {
+          return abortHappyArchivedSpawn();
+        }
+        await refreshAgentOAuthRouting(info.id, guardedConversationId);
+        if (!happyArchiveAllowsCommit()) {
+          return abortHappyArchivedSpawn();
+        }
 
         // The new session is alive — immediately clear the terminated flag so
         // early events (configOptionsUpdate, sessionStatus with models/modes)
@@ -3454,9 +4025,10 @@ export const agentStore = {
         // abort/cancel the standby is terminated and nothing is persisted.
         // Without this guard, every warm-up left an orphaned thread row that
         // re-surfaced as an idle agent thread in the sidebar after restart.
+        let persistedConversation: DbAgentConversation | null = null;
         if (opts?.role !== "standby") {
           try {
-            await createAgentConversation(
+            persistedConversation = await createAgentConversation(
               info.id,
               conversationTitle,
               resolvedAgentType,
@@ -3475,6 +4047,14 @@ export const agentStore = {
             console.warn("Failed to persist agent conversation", error);
           }
         }
+        if (persistedConversation?.is_archived) {
+          happyArchiveFence.archive(info.id);
+          happyArchiveFence.archive(guardedConversationId);
+          return abortHappyArchivedSpawn();
+        }
+        if (!happyArchiveAllowsCommit()) {
+          return abortHappyArchivedSpawn();
+        }
 
         // Create session state
         const hasRestoredMessages =
@@ -3489,6 +4069,9 @@ export const agentStore = {
               opts.initialModelId,
             )
           : null;
+        if (!happyArchiveAllowsCommit()) {
+          return abortHappyArchivedSpawn();
+        }
         const session: ActiveSession = {
           info,
           // Only explicit titles belong in live state. Fresh conversations omit
@@ -3502,6 +4085,7 @@ export const agentStore = {
           pendingUserMessage: "",
           cwd,
           conversationId: info.id,
+          archiveOwnerConversationId: opts?.archiveOwnerConversationId,
           // When we already have a pending local bootstrap snapshot, skip the
           // provider's replay to avoid duplicates until that bootstrap state is
           // cleared and provider history becomes authoritative.
@@ -3625,6 +4209,9 @@ export const agentStore = {
         }
 
         if (initFailure) {
+          if (!happyArchiveAllowsCommit()) {
+            return abortHappyArchivedSpawn();
+          }
           if (
             resolvedAgentType === "claude-code" &&
             initRetryAttempt < MAX_CLAUDE_INIT_RETRIES &&
@@ -3687,6 +4274,9 @@ export const agentStore = {
         // Worker can fail fast and remove the session before timeout handling.
         // Treat that as an initialization failure instead of returning a dead id.
         if (!state.sessions[info.id]) {
+          if (!happyArchiveAllowsCommit()) {
+            return abortHappyArchivedSpawn();
+          }
           const exitedMsg = "Agent session exited during initialization.";
           if (
             resolvedAgentType === "claude-code" &&
@@ -3783,6 +4373,9 @@ export const agentStore = {
           }
         }
 
+        if (!happyArchiveAllowsCommit()) {
+          return abortHappyArchivedSpawn();
+        }
         return info.id;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -3924,6 +4517,10 @@ export const agentStore = {
     if (inFlight) {
       return inFlight;
     }
+    const happyArchiveGeneration = happyArchiveFence.capture(conversationId);
+    if (!happyArchiveFence.allows(conversationId, happyArchiveGeneration)) {
+      return false;
+    }
 
     const attempt = (async () => {
       let liveInfo: AgentSessionInfo | undefined;
@@ -3985,6 +4582,15 @@ export const agentStore = {
       // global event subscription. Re-install it so events from the live
       // session (incl. background task completions) are routed again.
       await this.ensureAgentEventSubscription();
+      await refreshAgentOAuthRouting(liveInfo.id, conversationId);
+
+      if (convo?.is_archived) {
+        happyArchiveFence.archive(conversationId);
+      }
+      if (!happyArchiveFence.allows(conversationId, happyArchiveGeneration)) {
+        await discardLateArchivedProviderSession(liveInfo.id, conversationId);
+        return false;
+      }
 
       // This id is alive again — clear any stale terminated marker so the global
       // subscriber does not drop its events.
@@ -4031,7 +4637,6 @@ export const agentStore = {
       };
       setState("sessions", conversationId, session);
       setState("activeSessionId", conversationId);
-      await refreshAgentOAuthRouting(liveInfo.id, conversationId);
 
       if (rehydratedPendingPermissions.length > 0) {
         const seenRequestIds = new Set(
@@ -4102,6 +4707,9 @@ export const agentStore = {
     conversationId: string,
     cwd?: string,
   ): Promise<string | null> {
+    if (happyArchiveFence.isArchived(conversationId)) {
+      return null;
+    }
     // If already running, just focus it. Use the conversationId-aware helper
     // — state.sessions is keyed by sessionId, and after a predictive-compaction
     // promotion the running session id no longer matches the conversation. #1682.
@@ -4148,6 +4756,9 @@ export const agentStore = {
         err,
       );
     }
+    if (happyArchiveFence.isArchived(conversationId)) {
+      return null;
+    }
 
     // Pre-emptively clean up any stale backend session with this conversation id.
     // If the frontend lost track of a session (e.g. after a crash or auth error),
@@ -4165,6 +4776,10 @@ export const agentStore = {
       convo = await getAgentConversation(conversationId);
     } catch (error) {
       console.error("Failed to read agent conversation:", error);
+    }
+    if (convo?.is_archived) {
+      happyArchiveFence.archive(conversationId);
+      return null;
     }
     if (!convo) {
       setState("error", "Agent conversation not found");
@@ -4965,7 +5580,7 @@ export const agentStore = {
     // (#1631); flipping isCompacting on the serving session there makes
     // the drain block at the bottom of promptComplete skip indefinitely
     // and queued prompts get stuck (#1673). Predictive mode has its own
-    // gates (`predictiveCompactInFlight` per-session, `predictiveCompactBusy`
+    // gates (`predictiveCompactInFlight` per-session, owner-aware global mutex
     // module-level) — only the reactive branch should set isCompacting.
     if (mode === "reactive") {
       setState("sessions", sessionId, "isCompacting", true);
@@ -5149,7 +5764,7 @@ export const agentStore = {
         // No teardown, no UI side-effects — the next user submit promotes it.
         // isCompacting is intentionally NOT set on the serving session here
         // (#1673); concurrency is gated by `predictiveCompactInFlight` and
-        // the module-level `predictiveCompactBusy` mutex.
+        // the module-level predictive-compaction mutex.
 
         // #1713 / #1829: synthetic-transcript pre-warm. When enabled, build
         // a synthetic JSONL on disk that splices the structured summary in
@@ -5166,6 +5781,7 @@ export const agentStore = {
               );
             const syntheticStandbyId = await this.spawnSession(cwd, agentType, {
               role: "standby",
+              archiveOwnerConversationId: conversationId,
               resumeAgentSessionId: syntheticAgentSessionId,
               initialModelId: session.currentModelId,
             });
@@ -5189,8 +5805,6 @@ export const agentStore = {
             // The synthetic JSONL already contains the real prior turn pair.
             // Mark seed-complete immediately so promotion does not stall.
             setState("sessions", syntheticStandbyId, "seedCompleted", true);
-            predictiveCompactBusy = false;
-            setState("sessions", sessionId, "predictiveCompactInFlight", false);
             // No promptComplete event fires for this standby (no seed turn),
             // so the drain that previously lived in the promptComplete
             // handler must be triggered explicitly. #1749 / #1829.
@@ -5220,6 +5834,7 @@ export const agentStore = {
         // user's actual prompt. #1829.
         const standbyId = await this.spawnSession(cwd, agentType, {
           role: "standby",
+          archiveOwnerConversationId: conversationId,
           initialModelId: session.currentModelId,
         });
         if (!standbyId) {
@@ -5246,8 +5861,6 @@ export const agentStore = {
         // No seed turn — mark seed-complete directly so promotion's gate
         // (waitForStandbySeed) clears immediately on the next user submit.
         setState("sessions", standbyId, "seedCompleted", true);
-        predictiveCompactBusy = false;
-        setState("sessions", sessionId, "predictiveCompactInFlight", false);
         // Drain the #1749 race-guard queue explicitly — no promptComplete
         // fires for this standby because we never sent a seed turn. #1829.
         drainStandbyQueueIfPending(standbyId, this.sendPrompt.bind(this));
@@ -5590,10 +6203,9 @@ export const agentStore = {
    * Warm a standby session in the background. Serving session keeps running;
    * the standby is seeded with the compaction summary so the next submit can
    * swap invisibly. Idempotent per-session and globally bounded via
-   * `predictiveCompactBusy`. #1631.
+   * owner-aware global mutex. #1631.
    */
   async kickPredictiveCompact(sessionId: string): Promise<void> {
-    if (predictiveCompactBusy) return;
     const session = state.sessions[sessionId];
     if (!session || session.predictiveCompactInFlight) return;
 
@@ -5607,8 +6219,10 @@ export const agentStore = {
       return;
     }
 
-    predictiveCompactBusy = true;
+    const predictiveCompactLease = predictiveCompactMutex.tryAcquire(sessionId);
+    if (!predictiveCompactLease) return;
     setState("sessions", sessionId, "predictiveCompactInFlight", true);
+    let shouldDrainAfterAbort = false;
     try {
       const result = await this.compactAgentConversation(
         sessionId,
@@ -5621,19 +6235,24 @@ export const agentStore = {
           "[AgentStore] kickPredictiveCompact: non-success outcome",
           result.outcome,
         );
-        predictiveCompactBusy = false;
-        setState("sessions", sessionId, "predictiveCompactInFlight", false);
-        this.drainAfterPredictiveAbort(sessionId);
+        shouldDrainAfterAbort = true;
       }
-      // On success, the standby's promptComplete handler clears both flags.
     } catch (err) {
       console.warn(
         "[AgentStore] kickPredictiveCompact failed (non-fatal):",
         err,
       );
-      predictiveCompactBusy = false;
-      setState("sessions", sessionId, "predictiveCompactInFlight", false);
-      this.drainAfterPredictiveAbort(sessionId);
+      shouldDrainAfterAbort = true;
+    } finally {
+      // Only the current generation may clear the per-session flag or drain
+      // its queue. An archived generation may finish after the same serving
+      // id has already acquired a newer lease.
+      if (predictiveCompactMutex.release(predictiveCompactLease)) {
+        if (state.sessions[sessionId]) {
+          setState("sessions", sessionId, "predictiveCompactInFlight", false);
+        }
+        if (shouldDrainAfterAbort) this.drainAfterPredictiveAbort(sessionId);
+      }
     }
   },
 
@@ -5671,18 +6290,59 @@ export const agentStore = {
     prompt: string,
     context?: Array<Record<string, string>>,
     options?: { displayContent?: string; docNames?: string[] },
-  ): Promise<void> {
+  ): Promise<boolean> {
     const serving = state.sessions[servingSessionId];
     const standbyId = serving?.standbySessionId;
     if (!serving || !standbyId) {
       // Fall through — caller will dispatch to serving.
-      return;
+      return false;
     }
     const standby = state.sessions[standbyId];
     if (!standby) {
-      return;
+      return false;
     }
     const conversationId = serving.conversationId;
+
+    // Make the provider-to-conversation ownership durable before exposing the
+    // standby as serving. If mobile archive won the race, Rust atomically
+    // archives the conversation and reports that result instead of allowing a
+    // promoted provider to resurrect it on the next refresh.
+    try {
+      const claim = await claimHappyProviderSessionOwner(
+        conversationId,
+        standbyId,
+        standby.agentSessionId,
+      );
+      if (claim.archived) {
+        happyProviderArchiveTombstones.add(standbyId);
+        happyArchiveFence.archive(conversationId);
+        return false;
+      }
+    } catch (error) {
+      console.warn(
+        "[AgentStore] Failed to persist standby ownership; keeping the serving session:",
+        error,
+      );
+      await this.terminateSession(standbyId).catch(() => {});
+      if (state.sessions[servingSessionId]) {
+        setState("sessions", servingSessionId, "standbySessionId", null);
+        setState(
+          "sessions",
+          servingSessionId,
+          "predictiveCompactInFlight",
+          false,
+        );
+      }
+      return false;
+    }
+    if (
+      happyProviderArchiveTombstones.has(standbyId) ||
+      happyArchiveFence.isArchived(conversationId) ||
+      !state.sessions[standbyId] ||
+      state.sessions[servingSessionId]?.standbySessionId !== standbyId
+    ) {
+      return false;
+    }
 
     // Transfer the UI transcript to the promoted session so scroll-up is
     // preserved across the swap. The standby session was invisible until now.
@@ -5696,6 +6356,7 @@ export const agentStore = {
     );
     // Inherit persisted conversationId so SQLite keeps a single thread.
     setState("sessions", standbyId, "conversationId", conversationId);
+    setState("sessions", standbyId, "archiveOwnerConversationId", undefined);
     setState("sessions", standbyId, "role", "serving");
     setState("sessions", standbyId, "seedCompleted", undefined);
     // Transfer queued prompts. The #1749 enqueue-during-spawn-race guard in
@@ -5735,6 +6396,7 @@ export const agentStore = {
         console.warn("[AgentStore] Deferred provider terminate failed:", error);
       }
     }
+    return true;
   },
 
   /**
@@ -5922,13 +6584,19 @@ export const agentStore = {
         console.info(
           `[AgentStore] Promoting standby ${session.standbySessionId} for serving ${sessionId}`,
         );
-        await this.promoteStandbyAndDispatch(
+        const promoted = await this.promoteStandbyAndDispatch(
           sessionId,
           prompt,
           context,
           options,
         );
-        return;
+        if (
+          promoted ||
+          happyProviderArchiveTombstones.has(standby.info.id) ||
+          happyArchiveFence.isArchived(session.conversationId)
+        ) {
+          return;
+        }
       }
       if (standby) {
         // Standby not ready yet. When the serving session is at or above the
@@ -5959,13 +6627,19 @@ export const agentStore = {
             console.info(
               `[AgentStore] Promoting just-seeded standby ${session.standbySessionId}`,
             );
-            await this.promoteStandbyAndDispatch(
+            const promoted = await this.promoteStandbyAndDispatch(
               sessionId,
               prompt,
               context,
               options,
             );
-            return;
+            if (
+              promoted ||
+              happyProviderArchiveTombstones.has(standby.info.id) ||
+              happyArchiveFence.isArchived(session.conversationId)
+            ) {
+              return;
+            }
           }
           console.info(
             `[AgentStore] Standby did not seed within ${STANDBY_SEED_WAIT_MS}ms — falling through to serving`,
@@ -5974,10 +6648,14 @@ export const agentStore = {
         console.info(
           "[AgentStore] Standby not ready at submit; cancelling warm-up",
         );
-        await this.terminateSession(session.standbySessionId).catch(() => {});
+        const cancelledStandbyId = session.standbySessionId;
+        // Relinquish this predictive generation before the termination await.
+        // Releasing by session id afterward could clear a newer generation if
+        // archive/restart work reacquired the mutex while termination waited.
         setState("sessions", sessionId, "standbySessionId", null);
-        predictiveCompactBusy = false;
+        predictiveCompactMutex.releaseCurrentForAny([sessionId]);
         setState("sessions", sessionId, "predictiveCompactInFlight", false);
+        await this.terminateSession(cancelledStandbyId).catch(() => {});
       }
     }
 
@@ -6866,7 +7544,6 @@ export const agentStore = {
             "status",
             "ready" as SessionStatus,
           );
-          predictiveCompactBusy = false;
           // Find the serving session via its standbySessionId backref. The
           // serving's conversationId is the persisted thread id (e.g.
           // 3fa906a4…), but the standby is spawned with conversationId =
@@ -7115,7 +7792,7 @@ export const agentStore = {
                 //
                 // #1716: route through `kickPredictiveCompact` rather than
                 // calling `compactAgentConversation` directly. The helper
-                // flips `predictiveCompactBusy` and `predictiveCompactInFlight`
+                // acquires the global mutex and flips `predictiveCompactInFlight`
                 // synchronously before the first await, so the 70% predictive
                 // block below short-circuits on the same `promptComplete`.
                 // Calling `compactAgentConversation` directly bypassed both

--- a/tests/unit/agent-conversation-archive-invalidation.test.ts
+++ b/tests/unit/agent-conversation-archive-invalidation.test.ts
@@ -1,0 +1,266 @@
+// ABOUTME: Regression coverage for Happy-triggered agent archive invalidation.
+// ABOUTME: Ensures an archived conversation cannot remain selectable or receive late runtime events.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  HappyArchiveFence,
+  planHappyArchiveInvalidation,
+  planHappyProviderArchiveInvalidation,
+  retireHappyArchivedSiblingProvider,
+} from "@/stores/agent.store";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf8",
+);
+
+describe("Happy conversation archive invalidation", () => {
+  it("fences stale async commits and filters delayed refresh results", async () => {
+    const fence = new HappyArchiveFence();
+    const generation = fence.capture("archived-conversation");
+    const delayedRows = Promise.resolve([
+      { id: "archived-conversation" },
+      { id: "remaining-conversation" },
+    ]);
+
+    expect(fence.allows("archived-conversation", generation)).toBe(true);
+    const archiveGeneration = fence.archive("archived-conversation");
+    expect(fence.archive("archived-conversation")).toBe(archiveGeneration);
+    expect(fence.allows("archived-conversation", generation)).toBe(false);
+    expect(fence.filterVisible(await delayedRows)).toEqual([
+      { id: "remaining-conversation" },
+    ]);
+  });
+
+  it("plans eviction of serving and standby sessions and selects another live conversation", () => {
+    const plan = planHappyArchiveInvalidation(
+      {
+        serving: {
+          conversationId: "archived-conversation",
+          role: "serving",
+          standbySessionId: "standby",
+        },
+        standby: {
+          conversationId: "standby-runtime-id",
+          role: "standby",
+        },
+        remaining: { conversationId: "remaining-conversation", role: "serving" },
+      },
+      "serving",
+      "archived-conversation",
+    );
+
+    expect(plan).toEqual({
+      archivedSessionIds: ["serving", "standby"],
+      nextActiveSessionId: "remaining",
+    });
+    expect(
+      planHappyArchiveInvalidation(
+        {
+          standby: {
+            conversationId: "standby-runtime-id",
+            archiveOwnerConversationId: "archived-conversation",
+            role: "standby",
+          },
+        },
+        null,
+        "archived-conversation",
+      ),
+    ).toEqual({ archivedSessionIds: ["standby"], nextActiveSessionId: null });
+    expect(
+      planHappyArchiveInvalidation(
+        {
+          promoted: {
+            conversationId: "archived-conversation",
+            role: "serving",
+          },
+        },
+        "promoted",
+        "archived-conversation",
+      ),
+    ).toEqual({ archivedSessionIds: ["promoted"], nextActiveSessionId: null });
+    expect(
+      planHappyArchiveInvalidation(
+        { remaining: { conversationId: "remaining-conversation", role: "serving" } },
+        "remaining",
+        "archived-conversation",
+      ),
+    ).toEqual({ archivedSessionIds: [], nextActiveSessionId: "remaining" });
+  });
+
+  it("evicts only an unowned provider and releases its serving back-reference", () => {
+    expect(
+      planHappyProviderArchiveInvalidation(
+        {
+          serving: {
+            role: "serving",
+            standbySessionId: "unowned-standby",
+          },
+          "unowned-standby": { role: "standby" },
+          remaining: { role: "serving" },
+        },
+        "unowned-standby",
+        "unowned-standby",
+      ),
+    ).toEqual({
+      archivedSessionIds: ["unowned-standby"],
+      linkedServingSessionIds: ["serving"],
+      nextActiveSessionId: "serving",
+    });
+  });
+
+  it("durably fences before considering a sibling retired", async () => {
+    const calls: string[] = [];
+    let fenceAttempts = 0;
+    const result = await retireHappyArchivedSiblingProvider(
+      "archived-sibling",
+      1234,
+      {
+        fence: async () => {
+          calls.push("fence");
+          fenceAttempts += 1;
+          if (fenceAttempts === 1) throw new Error("temporary database error");
+        },
+        terminate: async () => {
+          calls.push("terminate");
+        },
+        forceKill: async () => {
+          calls.push("force-kill");
+          return true;
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      fenced: true,
+      retired: true,
+      forceKilled: false,
+    });
+    expect(calls).toEqual(["fence", "fence", "terminate"]);
+  });
+
+  it("uses the PID-guarded force-kill as soon as sibling termination fails", async () => {
+    const forceKilledPids: number[] = [];
+    const result = await retireHappyArchivedSiblingProvider(
+      "archived-sibling",
+      4321,
+      {
+        fence: async () => {},
+        terminate: async () => {
+          throw new Error("provider runtime disconnected");
+        },
+        forceKill: async (pid) => {
+          forceKilledPids.push(pid);
+          return true;
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      fenced: true,
+      retired: true,
+      forceKilled: true,
+    });
+    expect(forceKilledPids).toEqual([4321]);
+  });
+
+  it("evicts the cached thread through a Happy-only disposable side-channel listener", () => {
+    const listenerStart = agentStoreSource.indexOf(
+      "function subscribeToAgentConversationArchived()",
+    );
+    expect(listenerStart).toBeGreaterThan(0);
+    const listenerEnd = agentStoreSource.indexOf(
+      "function subscribeToClaudeMemoryIntercepts()",
+      listenerStart,
+    );
+    const listenerBody = agentStoreSource.slice(
+      listenerStart,
+      listenerEnd > listenerStart ? listenerEnd : listenerStart + 9000,
+    );
+
+    expect(listenerBody).toContain('"happy-bridge://conversation-archived"');
+    expect(listenerBody).toContain("happyArchiveFence.archive(conversationId)");
+    expect(listenerBody).toContain("row.id !== conversationId");
+    expect(listenerBody).toContain("terminatedSessionIds.add(sessionId)");
+    expect(listenerBody).toContain("payload.targetProviderSessionId");
+    expect(listenerBody).toContain("planHappyProviderArchiveInvalidation(");
+    expect(listenerBody).toContain("serving.standbySessionId = null");
+    expect(listenerBody).toContain("serving.predictiveCompactInFlight = false");
+    expect(listenerBody).toContain(
+      "predictiveCompactMutex.releaseCurrentForAny(",
+    );
+    expect(listenerBody).toContain("sessionId !== targetProviderSessionId");
+    expect(listenerBody).toContain("retireHappyArchivedSiblingProvider(");
+    expect(listenerBody).toContain("fenceHappyProviderSessionArchive");
+    expect(listenerBody).toContain("timeoutMs: 5_000");
+    expect(listenerBody).toContain("forceKill: providerService.forceKillSession");
+    expect(listenerBody).toContain("clearChunkBuf(sessionId)");
+    expect(listenerBody).toContain("restartTimers.delete(conversationId)");
+    expect(listenerBody).toContain('setState("pendingPermissions"');
+    expect(listenerBody).toContain("delete draft.sessions[sessionId]");
+    expect(listenerBody).toContain("delete draft.threadStates[conversationId]");
+    expect(listenerBody).toContain("planHappyArchiveInvalidation(");
+    expect(listenerBody).toContain('setState("activeSessionId", nextActiveSessionId)');
+
+    expect(agentStoreSource).toContain(
+      "subscribeToAgentConversationArchived();",
+    );
+    const disposeStart = agentStoreSource.indexOf(
+      "function disposeAgentStoreSideChannelListeners()",
+    );
+    const disposeBody = agentStoreSource.slice(disposeStart, disposeStart + 900);
+    expect(disposeBody).toContain(
+      "agentConversationArchivedListener = null;",
+    );
+    expect(disposeBody).toContain(
+      'disposeTauriListener(archivedListener, "agent-conversation archived")',
+    );
+  });
+
+  it("guards late spawn and reattach commits and terminates their providers", () => {
+    const spawnStart = agentStoreSource.indexOf("async spawnSession(");
+    const spawnEnd = agentStoreSource.indexOf(
+      "async ensureAgentEventSubscription()",
+      spawnStart,
+    );
+    const spawnBody = agentStoreSource.slice(spawnStart, spawnEnd);
+    expect(spawnBody).toContain("happyArchiveAllowsCommit");
+    expect(spawnBody).toContain("happyArchiveOwnerConversationId");
+    expect(spawnBody).toContain("persistedConversation?.is_archived");
+    expect(spawnBody).toContain("discardLateArchivedProviderSession(");
+    expect(spawnBody.indexOf("happyArchiveAllowsCommit()")).toBeLessThan(
+      spawnBody.indexOf('setState("sessions", info.id, session)'),
+    );
+
+    const reattachStart = agentStoreSource.indexOf(
+      "async reattachLiveSession(",
+    );
+    const reattachEnd = agentStoreSource.indexOf(
+      "async resumeAgentConversation(",
+      reattachStart,
+    );
+    const reattachBody = agentStoreSource.slice(reattachStart, reattachEnd);
+    expect(reattachBody).toContain("happyArchiveFence.allows(");
+    expect(reattachBody).toContain("convo?.is_archived");
+    expect(reattachBody).toContain("discardLateArchivedProviderSession(");
+
+    const refreshStart = agentStoreSource.indexOf(
+      "async refreshRecentAgentConversations(",
+    );
+    const refreshEnd = agentStoreSource.indexOf(
+      "async loadMoreRemoteSessions(",
+      refreshStart,
+    );
+    const refreshBody = agentStoreSource.slice(refreshStart, refreshEnd);
+    expect(refreshBody.match(/happyArchiveFence\.filterVisible\(/g)).toHaveLength(
+      2,
+    );
+    expect(
+      agentStoreSource.match(
+        /role: "standby",\n\s+archiveOwnerConversationId: conversationId,/g,
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { PredictiveCompactMutex } from "@/stores/agent.store";
 
 const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
@@ -17,10 +18,19 @@ describe("#1631 — predictive compaction threshold & concurrency", () => {
     );
   });
 
-  it("declares a module-level predictiveCompactBusy flag", () => {
-    expect(agentStoreSource).toMatch(
-      /let predictiveCompactBusy\s*=\s*false/,
-    );
+  it("does not let an archived run release a newer thread's mutex", () => {
+    const mutex = new PredictiveCompactMutex();
+    const archivedLease = mutex.tryAcquire("same-session");
+    expect(archivedLease).not.toBeNull();
+    if (!archivedLease) throw new Error("expected archived lease");
+    expect(mutex.releaseCurrentForAny(["same-session"])).toBe(true);
+    const newerLease = mutex.tryAcquire("same-session");
+    expect(newerLease).not.toBeNull();
+    if (!newerLease) throw new Error("expected newer lease");
+    expect(mutex.release(archivedLease)).toBe(false);
+    expect(mutex.tryAcquire("third-run")).toBeNull();
+    expect(mutex.release(newerLease)).toBe(true);
+    expect(mutex.tryAcquire("third-run")).not.toBeNull();
   });
 
   it("gates the trigger in promptComplete on all four invariants", () => {
@@ -45,15 +55,20 @@ describe("#1631 — compactAgentConversation accepts mode", () => {
 });
 
 describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
-  it("kickPredictiveCompact symbol exists and is idempotent via busy flag", () => {
+  it("kickPredictiveCompact symbol exists and is idempotent via the mutex", () => {
     expect(agentStoreSource).toContain("async kickPredictiveCompact(");
-    expect(agentStoreSource).toContain("if (predictiveCompactBusy) return");
+    expect(agentStoreSource).toContain(
+      "predictiveCompactMutex.tryAcquire(sessionId)",
+    );
+    expect(agentStoreSource).toContain(
+      "predictiveCompactMutex.release(predictiveCompactLease)",
+    );
   });
 
-  it("#1716 — sets predictiveCompactBusy + predictiveCompactInFlight synchronously before the first await", () => {
+  it("#1716 — acquires the mutex + sets predictiveCompactInFlight synchronously before the first await", () => {
     // The duplicate-spawn race (#1716) was: the 85% auto-compact branch
     // called compactAgentConversation directly, so the global mutex
-    // (`predictiveCompactBusy`) and per-session flag
+    // (the owner-aware mutex) and per-session flag
     // (`predictiveCompactInFlight`) stayed false until well after the
     // first `await` (the Sonnet-4 summary call). The 70% predictive block
     // that ran on the same `promptComplete` event then saw clean guards
@@ -68,13 +83,15 @@ describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
     const fnEnd = agentStoreSource.indexOf("\n  },", fnStart);
     const fnBody = agentStoreSource.slice(fnStart, fnEnd);
 
-    const busyFlipIdx = fnBody.indexOf("predictiveCompactBusy = true");
+    const mutexAcquireIdx = fnBody.indexOf(
+      "predictiveCompactMutex.tryAcquire(sessionId)",
+    );
     const inFlightFlipIdx = fnBody.indexOf(
       'setState("sessions", sessionId, "predictiveCompactInFlight", true)',
     );
     const firstAwaitIdx = fnBody.indexOf("await ");
 
-    expect(busyFlipIdx, "predictiveCompactBusy must be flipped true").toBeGreaterThan(
+    expect(mutexAcquireIdx, "predictive mutex must be acquired").toBeGreaterThan(
       0,
     );
     expect(
@@ -83,8 +100,8 @@ describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
     ).toBeGreaterThan(0);
     expect(firstAwaitIdx, "first await must exist").toBeGreaterThan(0);
     expect(
-      busyFlipIdx,
-      "predictiveCompactBusy must flip BEFORE the first await",
+      mutexAcquireIdx,
+      "predictive mutex must be acquired BEFORE the first await",
     ).toBeLessThan(firstAwaitIdx);
     expect(
       inFlightFlipIdx,
@@ -123,6 +140,27 @@ describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
   it("sendPrompt checks for a ready standby and promotes when present", () => {
     expect(agentStoreSource).toContain("standby.seedCompleted === true");
     expect(agentStoreSource).toContain("await this.promoteStandbyAndDispatch(");
+  });
+
+  it("releases a cancelled warm-up generation before awaiting termination", () => {
+    const cancelStart = agentStoreSource.indexOf(
+      "Standby not ready at submit; cancelling warm-up",
+    );
+    expect(cancelStart).toBeGreaterThan(0);
+    const cancelBody = agentStoreSource.slice(cancelStart, cancelStart + 1200);
+    const release = cancelBody.indexOf(
+      "predictiveCompactMutex.releaseCurrentForAny([sessionId])",
+    );
+    const flagClear = cancelBody.indexOf(
+      'setState("sessions", sessionId, "predictiveCompactInFlight", false)',
+    );
+    const terminate = cancelBody.indexOf(
+      "await this.terminateSession(cancelledStandbyId)",
+    );
+
+    expect(release).toBeGreaterThan(0);
+    expect(flagClear).toBeGreaterThan(release);
+    expect(terminate).toBeGreaterThan(flagClear);
   });
 });
 

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -116,13 +116,19 @@ describe("#1623 — sendPrompt defensive guard against compaction race", () => {
     expect(sendPromptStart, "sendPrompt must exist").toBeGreaterThan(0);
     // The guard must live BEFORE the session.info.status === "error" branch
     // because a compacting session still has an otherwise-valid status.
-    // Window widened to accommodate the predictive-swap block added in #1631
-    // and the predictive-compact-race guard added in #1749, both before the
-    // compacting guard. The invariant we care about is that the compacting
-    // guard still fires BEFORE the `status === "error"` branch.
+    // Bound this to the method rather than a fixed character count: archive
+    // and predictive-swap guards can legitimately grow ahead of this branch.
+    const sendPromptEnd = agentStoreSource.indexOf(
+      "\n  async cancelPrompt(",
+      sendPromptStart,
+    );
+    expect(
+      sendPromptEnd,
+      "sendPrompt must have a method boundary",
+    ).toBeGreaterThan(sendPromptStart);
     const sendPromptWindow = agentStoreSource.slice(
       sendPromptStart,
-      sendPromptStart + 7000,
+      sendPromptEnd,
     );
     expect(sendPromptWindow).toContain("session?.isCompacting");
     expect(sendPromptWindow).toContain("this.enqueuePrompt(sessionId, prompt)");

--- a/tests/unit/happy-provider-notification-buffer.test.ts
+++ b/tests/unit/happy-provider-notification-buffer.test.ts
@@ -37,7 +37,9 @@ afterEach(async () => {
  * Answers the handshake and every later RPC, and hands the live socket back so
  * the test can push notifications the way the provider runtime does.
  */
-async function startProviderRuntime(): Promise<{
+async function startProviderRuntime(
+  { rejectMethods = new Set<string>() }: { rejectMethods?: Set<string> } = {},
+): Promise<{
   port: number;
   socket: Promise<{ send(data: string): void }>;
 }> {
@@ -50,6 +52,16 @@ async function startProviderRuntime(): Promise<{
       connection.on("message", (raw) => {
         const message = JSON.parse(String(raw));
         if (message.id === undefined || message.id === null) return;
+        if (rejectMethods.has(message.method)) {
+          connection.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              error: { code: -32000, message: "synthetic provider rejection" },
+            }),
+          );
+          return;
+        }
         connection.send(
           JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }),
         );
@@ -70,6 +82,19 @@ function connectedClient(port: number): BridgeClient {
 }
 
 describe("Happy provider notification buffering (#3150)", () => {
+  it("distinguishes a confirmed provider rejection from an ambiguous disconnect", async () => {
+    const runtime = await startProviderRuntime({
+      rejectMethods: new Set(["provider_spawn"]),
+    });
+    const client = connectedClient(runtime.port);
+    await client.connect();
+
+    await expect(client.call("provider_spawn")).rejects.toMatchObject({
+      message: "synthetic provider rejection",
+      providerRequestRejected: true,
+    });
+  });
+
   it("delivers a turn completion that arrived before registration subscribed", async () => {
     // A bridge restart during a live turn seeds the session busy from the
     // list-time snapshot, then spends several relay round trips before

--- a/tests/unit/happy-relay-sync-patch.test.ts
+++ b/tests/unit/happy-relay-sync-patch.test.ts
@@ -21,6 +21,26 @@ function installedClientSources(): Array<{ name: string; source: string }> {
   }));
 }
 
+type InvalidateSyncConstructor = new (command: () => Promise<void>) => {
+  invalidate: () => void;
+  invalidateAndAwait: () => Promise<void>;
+  stop: () => void;
+};
+
+function loadInstalledInvalidateSync(source: string): InvalidateSyncConstructor {
+  const classStart = source.indexOf("class InvalidateSync {");
+  const classEnd = source.indexOf("\n\nfunction isRecord", classStart);
+  if (classStart < 0 || classEnd < 0) {
+    throw new Error("Happy InvalidateSync implementation not found");
+  }
+  const classSource = source.slice(classStart, classEnd);
+  const evaluate = new Function(
+    "backoff",
+    `${classSource}\nreturn InvalidateSync;`,
+  ) as (backoff: (command: () => Promise<void>) => Promise<void>) => InvalidateSyncConstructor;
+  return evaluate(async (command) => command());
+}
+
 describe("happy relay sync patch", () => {
   const sources = installedClientSources();
 
@@ -30,6 +50,33 @@ describe("happy relay sync patch", () => {
     const version = declared.dependencies.happy;
     // A bump without regenerating the patch silently reverts every fix below.
     expect(workspace).toContain(`happy@${version}: patches/happy@${version}.patch`);
+  });
+
+  it("lets the bridge supply a stable data-key session encryption key", () => {
+    for (const { source } of sources) {
+      const createStart = source.indexOf("async getOrCreateSession(opts)");
+      const createEnd = source.indexOf("async getOrCreateMachine(opts)", createStart);
+      const createBody = source.slice(createStart, createEnd);
+      expect(createBody).toContain(
+        "opts.encryptionKey ? new Uint8Array(opts.encryptionKey) : getRandomBytes(32)",
+      );
+      expect(createBody).toContain('throw new Error("Session encryption key must be 32 bytes")');
+    }
+  });
+
+  it("sets a validated resume cursor before the session socket connects", () => {
+    for (const { source } of sources) {
+      const constructorStart = source.indexOf("constructor(token, session, options = {})");
+      const socketConnect = source.indexOf("this.socket.connect();", constructorStart);
+      const cursorAssignment = source.indexOf("this.lastSeq = resumeFromSeq;", constructorStart);
+      expect(constructorStart).toBeGreaterThan(-1);
+      expect(cursorAssignment).toBeGreaterThan(constructorStart);
+      expect(cursorAssignment).toBeLessThan(socketConnect);
+      expect(source).toContain(
+        'throw new Error("Session resume sequence must be a non-negative safe integer")',
+      );
+      expect(source).toContain("sessionSyncClient(session, options)");
+    }
   });
 
   it("skips relay messages the socket handler already routed", () => {
@@ -88,17 +135,57 @@ describe("happy relay sync patch", () => {
     }
   });
 
-  it("flushes the outbox before stopping the send sync on close", () => {
+  it("joins the single-flight outbox drain before stopping send sync on close", () => {
     for (const { source } of sources) {
       const closeIndex = source.indexOf("[API] socket.close() called");
       expect(closeIndex).toBeGreaterThan(-1);
       const closeBody = source.slice(closeIndex, closeIndex + 600);
-      const flushIndex = closeBody.indexOf("await this.flushOutbox()");
+      const flushIndex = closeBody.indexOf("await this.sendSync.invalidateAndAwait()");
       const stopIndex = closeBody.indexOf("this.sendSync.stop()");
       expect(flushIndex).toBeGreaterThan(-1);
-      // stop() latches a flag that makes a pending flush a no-op, so ordering is
-      // the whole fix: flush must complete first or the turn's tail is dropped.
       expect(flushIndex).toBeLessThan(stopIndex);
+      expect(closeBody).not.toContain("await this.flushOutbox()");
+    }
+  });
+
+  it("serializes close behind a delayed relay drain without losing or duplicating messages", async () => {
+    for (const { source } of sources) {
+      const InvalidateSync = loadInstalledInvalidateSync(source);
+      const outbox = ["first"];
+      const postedBatches: string[][] = [];
+      let activeDrains = 0;
+      let maxActiveDrains = 0;
+      let releaseFirstPost: (() => void) | undefined;
+      const firstPostBlocked = new Promise<void>((resolve) => {
+        releaseFirstPost = resolve;
+      });
+
+      const sync = new InvalidateSync(async () => {
+        activeDrains += 1;
+        maxActiveDrains = Math.max(maxActiveDrains, activeDrains);
+        try {
+          const batch = outbox.slice();
+          if (batch.length === 0) return;
+          postedBatches.push(batch);
+          if (postedBatches.length === 1) {
+            await firstPostBlocked;
+          }
+          outbox.splice(0, batch.length);
+        } finally {
+          activeDrains -= 1;
+        }
+      });
+
+      sync.invalidate();
+      outbox.push("second");
+      const closeDrain = sync.invalidateAndAwait();
+      releaseFirstPost?.();
+      await closeDrain;
+      sync.stop();
+
+      expect(postedBatches).toEqual([["first"], ["second"]]);
+      expect(maxActiveDrains).toBe(1);
+      expect(outbox).toEqual([]);
     }
   });
 

--- a/tests/unit/happy-sdk-session-resume.test.ts
+++ b/tests/unit/happy-sdk-session-resume.test.ts
@@ -1,0 +1,104 @@
+// ABOUTME: Exercises the installed Happy SDK patch through its public API.
+// ABOUTME: Proves stable data keys and resume cursors survive package patching/install.
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { ApiClient, configuration } from "happy/lib";
+import nacl from "tweetnacl";
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+const originalServerUrl = configuration.serverUrl;
+
+afterEach(async () => {
+  configuration.serverUrl = originalServerUrl;
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
+
+function readJson(request: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function startSyntheticRelay() {
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    if (request.method !== "POST" || request.url !== "/v1/sessions") {
+      response.writeHead(404).end();
+      return;
+    }
+    void readJson(request).then((body) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          session: {
+            id: "synthetic-stable-relay-row",
+            seq: 7,
+            metadata: body.metadata,
+            metadataVersion: 1,
+            agentState: body.agentState,
+            agentStateVersion: 1,
+          },
+        }),
+      );
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("installed Happy session resume patch", () => {
+  it("reopens with the supplied key and applies the cursor before socket startup", async () => {
+    configuration.serverUrl = await startSyntheticRelay();
+    const keyPair = nacl.box.keyPair();
+    const api = await ApiClient.create({
+      token: "synthetic-token",
+      encryption: {
+        type: "dataKey",
+        publicKey: keyPair.publicKey,
+        machineKey: new Uint8Array(32).fill(4),
+      },
+    });
+    const encryptionKey = new Uint8Array(32).fill(9);
+    const options = {
+      tag: "synthetic-stable-tag",
+      metadata: { path: "/synthetic/project", host: "synthetic-host" },
+      state: null,
+      encryptionKey,
+    };
+
+    const first = await api.getOrCreateSession(options);
+    const reopened = await api.getOrCreateSession(options);
+    expect(Buffer.from(first!.encryptionKey)).toEqual(Buffer.from(encryptionKey));
+    expect(Buffer.from(reopened!.encryptionKey)).toEqual(Buffer.from(encryptionKey));
+    expect(reopened!.metadata).toEqual(options.metadata);
+
+    const client = api.sessionSyncClient(reopened!, { resumeFromSeq: 7 });
+    expect((client as unknown as { lastSeq: number }).lastSeq).toBe(7);
+    expect(() => api.sessionSyncClient(reopened!, { resumeFromSeq: -1 })).toThrow(
+      /non-negative safe integer/,
+    );
+    await client.close();
+  });
+});

--- a/tests/unit/happy-session-key-store.test.ts
+++ b/tests/unit/happy-session-key-store.test.ts
@@ -1,0 +1,220 @@
+// ABOUTME: Guards encrypted, restart-stable persistence for Happy session data keys.
+// ABOUTME: Verifies CRUD serialization, disk privacy, permissions, and fail-closed reads.
+
+import { access, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge key store is plain ESM without declarations.
+import {
+  createHappySessionKeyStore,
+  HAPPY_SESSION_KEY_STORE_FILENAME,
+} from "../../bin/happy-bridge/session-key-store.mjs";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(path.join(tmpdir(), "seren-happy-session-keys-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("Happy session key store", () => {
+  it("persists independent random keys without exposing ids or key material on disk", async () => {
+    const directory = await temporaryDirectory();
+    const machineKey = Buffer.alloc(32, 0x31);
+    const sessionId = "synthetic-session-id-that-must-not-appear-on-disk";
+    const otherSessionId = "second-synthetic-session";
+    const store = createHappySessionKeyStore({ directory, machineKey });
+
+    const first = await store.getOrCreate(sessionId, "seren-synthetic-session");
+    const repeated = await store.getOrCreate(sessionId, "ignored-on-reopen");
+    const other = await store.getOrCreate(otherSessionId, "seren-second-session");
+
+    expect(first).toMatchObject({ state: "pending", relayTag: "seren-synthetic-session" });
+    expect(first.key).toBeInstanceOf(Uint8Array);
+    expect(first.key).toHaveLength(32);
+    expect(Buffer.from(repeated.key)).toEqual(Buffer.from(first.key));
+    expect(Buffer.from(other.key)).not.toEqual(Buffer.from(first.key));
+
+    const persisted = await readFile(store.filePath, "utf8");
+    expect(persisted).not.toContain(sessionId);
+    expect(persisted).not.toContain(otherSessionId);
+    expect(persisted).not.toContain("seren-synthetic-session");
+    expect(persisted).not.toContain(Buffer.from(first.key).toString("base64"));
+    expect(persisted).not.toContain(Buffer.from(first.key).toString("hex"));
+    expect(JSON.parse(persisted)).toMatchObject({
+      version: 1,
+      kdf: { name: "HKDF-SHA256" },
+      aead: { name: "AES-256-GCM" },
+    });
+    expect(await readdir(directory)).toEqual([HAPPY_SESSION_KEY_STORE_FILENAME]);
+    if (process.platform !== "win32") {
+      expect((await stat(store.filePath)).mode & 0o777).toBe(0o600);
+    }
+
+    const reopened = createHappySessionKeyStore({ directory, machineKey });
+    const ready = await reopened.markReady(sessionId, "synthetic-relay-row");
+    expect(ready).toMatchObject({
+      state: "ready",
+      relayTag: "seren-synthetic-session",
+      happySessionId: "synthetic-relay-row",
+    });
+    expect(Buffer.from(ready.key)).toEqual(Buffer.from(first.key));
+    await expect(reopened.replacePendingTag(sessionId, "replacement")).rejects.toThrow(
+      /cannot change relay tags/,
+    );
+    const reopenedReady = await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+      sessionId,
+      "ignored-after-ready",
+    );
+    expect(reopenedReady).toMatchObject({
+      state: "ready",
+      relayTag: "seren-synthetic-session",
+      happySessionId: "synthetic-relay-row",
+    });
+    expect(Buffer.from(reopenedReady.key)).toEqual(Buffer.from(first.key));
+    await expect(reopened.markReady(sessionId, "different-relay-row")).rejects.toThrow(
+      /different relay row/,
+    );
+    const retiring = await reopened.markRetiring(sessionId, "synthetic-relay-row");
+    expect(retiring).toMatchObject({
+      state: "retiring",
+      happySessionId: "synthetic-relay-row",
+      providerRetired: false,
+      blockRevival: false,
+    });
+    const providerRetired = await reopened.markRetiring(
+      sessionId,
+      "synthetic-relay-row",
+      true,
+      true,
+      "synthetic-conversation",
+      "synthetic-agent-session",
+    );
+    expect(providerRetired.providerRetired).toBe(true);
+    expect(providerRetired.blockRevival).toBe(true);
+    expect(providerRetired.conversationId).toBe("synthetic-conversation");
+    expect(providerRetired.agentSessionId).toBe("synthetic-agent-session");
+    const retiringDocument = await readFile(store.filePath, "utf8");
+    expect(retiringDocument).not.toContain("synthetic-conversation");
+    expect(retiringDocument).not.toContain("synthetic-agent-session");
+    const reopenedRetiring = await createHappySessionKeyStore({
+      directory,
+      machineKey,
+    }).list();
+    expect(reopenedRetiring).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId,
+          state: "retiring",
+          providerRetired: true,
+          blockRevival: true,
+          conversationId: "synthetic-conversation",
+          agentSessionId: "synthetic-agent-session",
+        }),
+      ]),
+    );
+    await expect(reopened.markReady(sessionId, "synthetic-relay-row")).rejects.toThrow(
+      /cannot become ready/,
+    );
+    expect(await reopened.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId, state: "retiring", providerRetired: true }),
+      ]),
+    );
+  });
+
+  it("serializes concurrent writers and removes the file with the last binding", async () => {
+    const directory = await temporaryDirectory();
+    const machineKey = Buffer.alloc(32, 0x42);
+    const firstStore = createHappySessionKeyStore({ directory, machineKey });
+    const secondStore = createHappySessionKeyStore({ directory, machineKey });
+    const sessionIds = Array.from({ length: 24 }, (_, index) => `concurrent-session-${index}`);
+
+    const created = await Promise.all(
+      sessionIds.map((sessionId, index) =>
+        (index % 2 === 0 ? firstStore : secondStore).getOrCreate(
+          sessionId,
+          `seren-${sessionId}`,
+        ),
+      ),
+    );
+    const reopened = createHappySessionKeyStore({ directory, machineKey });
+    for (const [index, sessionId] of sessionIds.entries()) {
+      const binding = await reopened.getOrCreate(sessionId, `ignored-${sessionId}`);
+      expect(Buffer.from(binding.key)).toEqual(Buffer.from(created[index].key));
+    }
+
+    expect(await reopened.delete(sessionIds[1])).toBe(true);
+    const recreated = await reopened.getOrCreate(sessionIds[1], `seren-${sessionIds[1]}`);
+    expect(Buffer.from(recreated.key)).not.toEqual(Buffer.from(created[1].key));
+    for (const sessionId of sessionIds) expect(await reopened.delete(sessionId)).toBe(true);
+    await expect(access(reopened.filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await reopened.delete(sessionIds[0])).toBe(false);
+  });
+
+  it("fails closed without replacing a store encrypted by another key or corrupted on disk", async () => {
+    const directory = await temporaryDirectory();
+    const store = createHappySessionKeyStore({
+      directory,
+      machineKey: Buffer.alloc(32, 0x53),
+    });
+    await store.getOrCreate("protected-synthetic-session", "seren-protected-session");
+    const original = await readFile(store.filePath, "utf8");
+    const wrongKeyStore = createHappySessionKeyStore({
+      directory,
+      machineKey: Buffer.alloc(32, 0x54),
+    });
+
+    await expect(
+      wrongKeyStore.getOrCreate("another-session", "seren-another-session"),
+    ).rejects.toMatchObject({
+      code: "ERR_HAPPY_SESSION_KEY_STORE_INVALID",
+    });
+    expect(await readFile(store.filePath, "utf8")).toBe(original);
+
+    const document = JSON.parse(original);
+    const ciphertext = Buffer.from(document.aead.ciphertext, "base64");
+    ciphertext[0] ^= 0x01;
+    document.aead.ciphertext = ciphertext.toString("base64");
+    await writeFile(store.filePath, JSON.stringify(document), { mode: 0o600 });
+
+    await expect(
+      store.getOrCreate("protected-synthetic-session", "seren-protected-session"),
+    ).rejects.toMatchObject({
+      code: "ERR_HAPPY_SESSION_KEY_STORE_INVALID",
+    });
+  });
+
+  it("rejects invalid inputs and oversized store files", async () => {
+    const directory = await temporaryDirectory();
+    expect(() =>
+      createHappySessionKeyStore({ directory, machineKey: Buffer.alloc(31) }),
+    ).toThrow(/32-byte/);
+
+    const store = createHappySessionKeyStore({ directory, machineKey: Buffer.alloc(32, 0x65) });
+    await expect(store.getOrCreate("", "valid-tag")).rejects.toThrow(/between 1 and 512 bytes/);
+    await expect(store.getOrCreate("x".repeat(513), "valid-tag")).rejects.toThrow(
+      /between 1 and 512 bytes/,
+    );
+    await expect(store.getOrCreate("valid-session", "")).rejects.toThrow(
+      /relay tag must be between/,
+    );
+    await writeFile(
+      path.join(directory, HAPPY_SESSION_KEY_STORE_FILENAME),
+      Buffer.alloc(1_048_577),
+      { mode: 0o600 },
+    );
+    await expect(store.getOrCreate("bounded-read", "seren-bounded-read")).rejects.toMatchObject({
+      code: "ERR_HAPPY_SESSION_KEY_STORE_INVALID",
+    });
+  });
+});

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -25,24 +25,136 @@ afterEach(() => {
 
 function createClient() {
   const eventHandlers = new Map<string, () => void>();
+  const rpcHandlers = new Map<
+    string,
+    (payload: Record<string, unknown>) => unknown
+  >();
   return {
     close: vi.fn(async () => {}),
     emit(event: string) {
       eventHandlers.get(event)?.();
     },
     keepAlive: vi.fn(),
+    lastSeq: 0,
+    invokeRpc(name: string, payload: Record<string, unknown>) {
+      const handler = rpcHandlers.get(name);
+      if (!handler) throw new Error(`Happy RPC handler ${name} is not registered`);
+      return handler(payload);
+    },
     on: vi.fn((event: string, handler: () => void) => {
       eventHandlers.set(event, handler);
     }),
     onUserMessage: vi.fn(),
-    rpcHandlerManager: { registerHandler: vi.fn() },
+    rpcHandlerManager: {
+      registerHandler: vi.fn(
+        (name: string, handler: (payload: Record<string, unknown>) => unknown) => {
+          rpcHandlers.set(name, handler);
+        },
+      ),
+    },
     sendAgentMessage: vi.fn(),
+    sendSessionDeath: vi.fn(),
     sendSessionEvent: vi.fn(),
     sendSessionProtocolMessage: vi.fn(),
+    suppressNextArchiveSignal: vi.fn(),
+    updateMetadata: vi.fn(),
   };
 }
 
-function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<Record<string, unknown>> } = {}) {
+function createMemorySessionKeyStore() {
+  type Binding = {
+    state: "pending" | "ready" | "retiring";
+    relayTag: string;
+    key: Uint8Array;
+    happySessionId?: string;
+    providerRetired?: boolean;
+    blockRevival?: boolean;
+    conversationId?: string;
+    agentSessionId?: string;
+  };
+  const bindings = new Map<string, Binding>();
+  let generation = 0;
+  const copy = (binding: Binding) => ({
+    ...binding,
+    key: new Uint8Array(binding.key),
+  });
+  return {
+    delete: vi.fn(async (sessionId: string) => bindings.delete(sessionId)),
+    list: vi.fn(async () =>
+      [...bindings].map(([sessionId, binding]) => ({ sessionId, ...copy(binding) })),
+    ),
+    getOrCreate: vi.fn(async (sessionId: string, relayTag: string) => {
+      let binding = bindings.get(sessionId);
+      if (!binding) {
+        binding = {
+          state: "pending",
+          relayTag,
+          key: new Uint8Array(32).fill(++generation),
+        };
+        bindings.set(sessionId, binding);
+      }
+      return copy(binding);
+    }),
+    markReady: vi.fn(async (sessionId: string, happySessionId: string) => {
+      const binding = bindings.get(sessionId);
+      if (!binding) throw new Error("missing binding");
+      if (binding.state === "retiring") throw new Error("binding is retiring");
+      if (binding.state === "ready" && binding.happySessionId !== happySessionId) {
+        throw new Error("relay row changed");
+      }
+      binding.state = "ready";
+      binding.happySessionId = happySessionId;
+      return copy(binding);
+    }),
+    markRetiring: vi.fn(
+      async (
+        sessionId: string,
+        happySessionId?: string,
+        providerRetired = false,
+        blockRevival = false,
+        conversationId?: string,
+        agentSessionId?: string,
+      ) => {
+      const binding = bindings.get(sessionId);
+      if (!binding) throw new Error("missing binding");
+      if (
+        binding.happySessionId &&
+        happySessionId &&
+        binding.happySessionId !== happySessionId
+      ) {
+        throw new Error("relay row changed");
+      }
+      binding.state = "retiring";
+      binding.providerRetired = binding.providerRetired === true || providerRetired;
+      binding.blockRevival = binding.blockRevival === true || blockRevival;
+      if (happySessionId) binding.happySessionId = happySessionId;
+      if (conversationId) binding.conversationId = conversationId;
+      if (agentSessionId) binding.agentSessionId = agentSessionId;
+      return copy(binding);
+      },
+    ),
+    replacePendingTag: vi.fn(async (sessionId: string, relayTag: string) => {
+      const binding = bindings.get(sessionId);
+      if (!binding || binding.state !== "pending") throw new Error("binding is not pending");
+      binding.relayTag = relayTag;
+      return copy(binding);
+    }),
+  };
+}
+
+function createLayerHarness({
+  initialSessions = [],
+  machineIdentity = {
+    token: "test",
+    machineId: "synthetic-machine",
+    encryption: { type: "legacy", secret: Buffer.alloc(32).toString("base64") },
+  },
+  sessionKeyStore = createMemorySessionKeyStore(),
+}: {
+  initialSessions?: Array<Record<string, unknown>>;
+  machineIdentity?: Record<string, unknown>;
+  sessionKeyStore?: ReturnType<typeof createMemorySessionKeyStore>;
+} = {}) {
   const client = createClient();
   let machineHandlers:
     | { spawnSession(options: Record<string, unknown>): Promise<Record<string, unknown>> }
@@ -56,13 +168,19 @@ function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<
     updateMachineMetadata: vi.fn(async () => {}),
   };
   const api = {
+    deactivateSession: vi.fn(async () => true),
     getOrCreateMachine: vi.fn(async () => ({ id: "relay-machine" })),
     getOrCreateSession: vi.fn(async ({ metadata }: { metadata: Record<string, unknown> }) => ({
       id: "relay-session",
       metadata,
     })),
     machineSyncClient: vi.fn(() => machineClient),
-    sessionSyncClient: vi.fn(() => client),
+    sessionSyncClient: vi.fn(
+      (_session: Record<string, unknown>, options?: { resumeFromSeq?: number }) => {
+        client.lastSeq = options?.resumeFromSeq ?? 0;
+        return client;
+      },
+    ),
   };
   happyLib.createApiClient.mockResolvedValue(api);
 
@@ -71,8 +189,9 @@ function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<
     advertise: vi.fn(async () => ({ agents: [] })),
     cancel: vi.fn(async () => {}),
     listSessions: vi.fn(async () => initialSessions),
-    spawn: vi.fn(async () => ({
-      sessionId: "spawned-session",
+    respondToPermission: vi.fn(async () => {}),
+    spawn: vi.fn(async (spec: Record<string, unknown>) => ({
+      sessionId: String(spec.localSessionId),
       agentType: "codex",
       cwd: SYNTHETIC_ROOT,
       status: "ready",
@@ -83,21 +202,29 @@ function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<
     }),
     terminate: vi.fn(async () => {}),
   };
+  const supervisorCall = vi.fn(async (method: string, params: Record<string, unknown>) => ({
+    conversationId:
+      method === "conversation_owner_lookup"
+        ? params.providerSessionId
+        : params.conversationId,
+  }));
+  const supervisorNotify = vi.fn();
+  let supervisorNotificationHandler:
+    | ((method: string, params: Record<string, unknown>) => void)
+    | undefined;
   const layer = createHappyLayer({
     config: {
-      machineIdentity: {
-        token: "test",
-        machineId: "synthetic-machine",
-        encryption: { type: "legacy", secret: Buffer.alloc(32).toString("base64") },
-      },
+      machineIdentity,
       machineName: "liveness-test",
       relayUrl: "https://relay.invalid",
     },
+    sessionKeyStore,
     source,
     supervisorChannel: {
-      call: vi.fn(async () => ({ conversationId: "synthetic-conversation" })),
-      notify: vi.fn(),
+      call: supervisorCall,
+      notify: supervisorNotify,
       onNotification(handler: (method: string, params: Record<string, unknown>) => void) {
+        supervisorNotificationHandler = handler;
         handler("roots_update", { roots: [SYNTHETIC_ROOT] });
         return () => {};
       },
@@ -117,6 +244,13 @@ function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<
       return machineHandlers.spawnSession(options);
     },
     source,
+    supervisorCall,
+    supervisorNotify,
+    notifySupervisor(method: string, params: Record<string, unknown>) {
+      if (!supervisorNotificationHandler) throw new Error("supervisor listener is not ready");
+      supervisorNotificationHandler(method, params);
+    },
+    sessionKeyStore,
   };
 }
 
@@ -169,17 +303,785 @@ describe("Happy session liveness", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
-    expect(harness.source.terminate).toHaveBeenCalledWith("local-session");
+    await vi.waitFor(() =>
+      expect(harness.source.terminate).toHaveBeenCalledWith("local-session"),
+    );
+    await vi.waitFor(() => expect(harness.client.sendSessionDeath).toHaveBeenCalledTimes(1));
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session");
 
-    let layerClosed = false;
-    const close = harness.layer.close().then(() => {
-      layerClosed = true;
-    });
-    await Promise.resolve();
-    expect(layerClosed).toBe(false);
     resolveClientClose?.();
-    await close;
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith("local-session"),
+    );
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: "local-session",
+      providerSessionId: "local-session",
+    });
+    expect(harness.supervisorCall.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.source.terminate.mock.invocationCallOrder[0],
+    );
+    harness.publish({
+      kind: "status",
+      sessionId: "local-session",
+      payload: { status: "ready" },
+    });
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
     expect(harness.client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("archives the owning conversation after provider-session promotion", async () => {
+    const summary = {
+      sessionId: "promoted-runtime-session",
+      agentSessionId: "native-provider-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic promoted session",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_owner_lookup") {
+        return { conversationId: "owning-conversation" };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+    harness.client.emit("archived");
+
+    await vi.waitFor(() =>
+      expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+        conversationId: "owning-conversation",
+        providerSessionId: summary.sessionId,
+      }),
+    );
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_owner_lookup", {
+      providerSessionId: summary.sessionId,
+      agentSessionId: summary.agentSessionId,
+    });
+    expect(harness.sessionKeyStore.markRetiring).toHaveBeenCalledWith(
+      summary.sessionId,
+      "relay-session",
+      false,
+      true,
+      "owning-conversation",
+      summary.agentSessionId,
+    );
+    expect(harness.sessionKeyStore.markRetiring.mock.invocationCallOrder[1]).toBeLessThan(
+      harness.supervisorCall.mock.invocationCallOrder.find(
+        (_, index) =>
+          harness.supervisorCall.mock.calls[index]?.[0] === "conversation_archive",
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId),
+    );
+    await harness.layer.close();
+  });
+
+  it("retires an unowned predictive standby through an exact provider fence", async () => {
+    const summary = {
+      sessionId: "unowned-standby",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic standby",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_owner_lookup") return {};
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+    harness.client.emit("archived");
+
+    await vi.waitFor(() =>
+      expect(harness.supervisorCall).toHaveBeenCalledWith(
+        "provider_session_archive",
+        { providerSessionId: summary.sessionId },
+      ),
+    );
+    expect(harness.supervisorCall).not.toHaveBeenCalledWith(
+      "conversation_archive",
+      expect.anything(),
+    );
+    await vi.waitFor(() =>
+      expect(harness.source.terminate).toHaveBeenCalledWith(summary.sessionId),
+    );
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session");
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId),
+    );
+    await harness.layer.close();
+  });
+
+  it("durably retires the exact provider session fenced by desktop", async () => {
+    const summary = {
+      sessionId: "00000000-0000-4000-8000-000000000321",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic sibling session",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    await harness.layer.start();
+
+    harness.notifySupervisor("provider_session_retire", {
+      providerSessionId: summary.sessionId,
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.markRetiring).toHaveBeenCalledWith(
+        summary.sessionId,
+        "relay-session",
+        false,
+        true,
+        undefined,
+        undefined,
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(harness.source.terminate).toHaveBeenCalledWith(summary.sessionId),
+    );
+    expect(
+      harness.sessionKeyStore.markRetiring.mock.invocationCallOrder[0],
+    ).toBeLessThan(harness.source.terminate.mock.invocationCallOrder[0]);
+    expect(harness.supervisorCall).not.toHaveBeenCalledWith(
+      "conversation_archive",
+      expect.anything(),
+    );
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(
+        summary.sessionId,
+      ),
+    );
+    await harness.layer.close();
+  });
+
+  it("uses a native agent id observed after the relay entry was created", async () => {
+    const summary = {
+      sessionId: "late-native-id-runtime",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic late native id session",
+      status: "initializing",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_owner_lookup") {
+        return { conversationId: "late-native-id-owner" };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready", agentSessionId: "native-id-after-start" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.client.sendSessionProtocolMessage).toHaveBeenCalled(),
+    );
+    harness.client.emit("archived");
+
+    await vi.waitFor(() =>
+      expect(harness.supervisorCall).toHaveBeenCalledWith(
+        "conversation_owner_lookup",
+        {
+          providerSessionId: summary.sessionId,
+          agentSessionId: "native-id-after-start",
+        },
+      ),
+    );
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: "late-native-id-owner",
+      providerSessionId: summary.sessionId,
+    });
+    await harness.layer.close();
+  });
+
+  it("retries a promoted archive after a crash before owner resolution", async () => {
+    const summary = {
+      sessionId: "promoted-crash-runtime",
+      agentSessionId: "native-crash-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic promoted crash session",
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const interrupted = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    interrupted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_owner_lookup") {
+        throw new Error("synthetic interrupted lookup");
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await interrupted.layer.start();
+    interrupted.client.emit("archived");
+    await vi.waitFor(() =>
+      expect(sessionKeyStore.markRetiring).toHaveBeenCalledWith(
+        summary.sessionId,
+        "relay-session",
+        false,
+        true,
+        undefined,
+        summary.agentSessionId,
+      ),
+    );
+    expect(await sessionKeyStore.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: summary.sessionId,
+          state: "retiring",
+          blockRevival: true,
+          agentSessionId: summary.agentSessionId,
+        }),
+      ]),
+    );
+    expect(interrupted.api.deactivateSession).not.toHaveBeenCalled();
+    await interrupted.layer.close();
+
+    sessionKeyStore.delete.mockClear();
+    const restarted = createLayerHarness({
+      initialSessions: [],
+      sessionKeyStore,
+    });
+    restarted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_owner_lookup") {
+        expect(params).toEqual({
+          providerSessionId: summary.sessionId,
+          agentSessionId: summary.agentSessionId,
+        });
+        return { conversationId: "promoted-owning-conversation" };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await restarted.layer.start();
+    expect(restarted.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: "promoted-owning-conversation",
+      providerSessionId: summary.sessionId,
+    });
+    expect(restarted.api.deactivateSession).toHaveBeenCalledWith("relay-session");
+    expect(restarted.source.terminate).not.toHaveBeenCalled();
+    expect(sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId);
+    await restarted.layer.close();
+  });
+
+  it("reuses one persisted data-key row across a graceful bridge restart", async () => {
+    vi.useFakeTimers();
+    const order: string[] = [];
+    const summary = {
+      sessionId: "local-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const first = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    first.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "stable-relay-session",
+      metadata,
+      seq: 0,
+    }));
+
+    await first.layer.start();
+    const firstOptions = first.api.getOrCreateSession.mock.calls[0]?.[0];
+    expect(firstOptions.tag).toBe("seren-local-session");
+    expect(firstOptions.encryptionKey).toBeInstanceOf(Uint8Array);
+    expect(sessionKeyStore.markReady).toHaveBeenCalledWith(
+      "local-session",
+      "stable-relay-session",
+    );
+    await first.layer.close();
+    expect(sessionKeyStore.delete).not.toHaveBeenCalled();
+
+    const restarted = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    restarted.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "stable-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    restarted.client.sendSessionDeath.mockImplementation(() => order.push("death"));
+    restarted.api.deactivateSession.mockImplementation(async () => {
+      order.push("deactivate");
+      return true;
+    });
+    restarted.client.close.mockImplementation(async () => {
+      order.push("close");
+    });
+
+    await restarted.layer.start();
+    const restartedOptions = restarted.api.getOrCreateSession.mock.calls[0]?.[0];
+    expect(restartedOptions.tag).toBe(firstOptions.tag);
+    expect(Buffer.from(restartedOptions.encryptionKey)).toEqual(
+      Buffer.from(firstOptions.encryptionKey),
+    );
+    expect(restarted.client.lastSeq).toBe(0);
+    expect(restarted.client.suppressNextArchiveSignal).not.toHaveBeenCalled();
+    expect(restarted.client.updateMetadata).not.toHaveBeenCalled();
+
+    await restarted.layer.close();
+    expect(order).toEqual(["death", "deactivate", "close"]);
+    const pulsesAtClose = restarted.client.keepAlive.mock.calls.length;
+    vi.advanceTimersByTime(4_000);
+    expect(restarted.client.keepAlive).toHaveBeenCalledTimes(pulsesAtClose);
+  });
+
+  it("retires archived metadata before constructing a client on restart", async () => {
+    const summary = {
+      sessionId: "archived-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic archived session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "archived-relay-session",
+      metadata: { ...metadata, lifecycleState: "archiveRequested" },
+      seq: 0,
+    }));
+
+    await harness.layer.start();
+
+    expect(harness.source.terminate).toHaveBeenCalledWith("archived-session");
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("archived-relay-session");
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: "archived-session",
+      providerSessionId: "archived-session",
+    });
+    expect(sessionKeyStore.delete).toHaveBeenCalledWith("archived-session");
+    await harness.layer.close();
+  });
+
+  it("retires a pre-stable Happy spawn row before creating its one-time replacement", async () => {
+    const summary = {
+      sessionId: "00000000-0000-4000-8000-000000000123",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic migrated session",
+      status: "ready",
+    };
+    const order: string[] = [];
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_happy_session_lookup") {
+        order.push("lookup");
+        return { happySessionId: "pre-stable-relay-row" };
+      }
+      return { conversationId: params.conversationId };
+    });
+    harness.api.deactivateSession.mockImplementation(async (happySessionId) => {
+      order.push(`deactivate:${happySessionId}`);
+      return true;
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => {
+      order.push("create-replacement");
+      return { id: "replacement-relay-row", metadata, seq: 0 };
+    });
+
+    await harness.layer.start();
+
+    expect(order.slice(0, 3)).toEqual([
+      "lookup",
+      "deactivate:pre-stable-relay-row",
+      "create-replacement",
+    ]);
+    expect(harness.sessionKeyStore.markReady).toHaveBeenCalledWith(
+      summary.sessionId,
+      "replacement-relay-row",
+    );
+    await harness.layer.close();
+  });
+
+  it("allows a naturally terminated provider to recover with the same desktop id", async () => {
+    const summary = {
+      sessionId: "recovering-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic recovering session",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    await harness.layer.start();
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "terminated" },
+    });
+    await vi.waitFor(() => expect(harness.sessionKeyStore.delete).toHaveBeenCalled());
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() => expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(2));
+
+    await harness.layer.close();
+  });
+
+  it("retries a durable retirement before creating any client or heartbeat", async () => {
+    const order: string[] = [];
+    const summary = {
+      sessionId: "terminal-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic terminal session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const first = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    first.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "terminal-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    first.api.deactivateSession.mockImplementation(async () => {
+      order.push("deactivate-failed");
+      return false;
+    });
+
+    await first.layer.start();
+    first.publish({
+      kind: "status",
+      sessionId: "terminal-session",
+      payload: { status: "terminated" },
+    });
+    await vi.waitFor(() => expect(order).toContain("deactivate-failed"));
+    expect(sessionKeyStore.markRetiring.mock.invocationCallOrder[0]).toBeLessThan(
+      first.api.deactivateSession.mock.invocationCallOrder[0],
+    );
+    expect(sessionKeyStore.delete).not.toHaveBeenCalled();
+    await first.layer.close();
+
+    const restarted = createLayerHarness({
+      initialSessions: [],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    restarted.api.deactivateSession.mockResolvedValue(true);
+    await restarted.layer.start();
+
+    expect(restarted.api.deactivateSession).toHaveBeenCalledWith("terminal-relay-session");
+    expect(sessionKeyStore.delete).toHaveBeenCalledWith("terminal-session");
+    expect(restarted.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(restarted.client.keepAlive).not.toHaveBeenCalled();
+    await restarted.layer.close();
+  });
+
+  it("consults the SQLite archive fence before reviving a persisted binding", async () => {
+    const summary = {
+      sessionId: "00000000-0000-4000-8000-000000000654",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic fenced restart",
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const first = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    await first.layer.start();
+    await first.layer.close();
+
+    sessionKeyStore.markRetiring.mockClear();
+    sessionKeyStore.delete.mockClear();
+    const restarted = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    restarted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "provider_session_archive_lookup") {
+        return { archived: params.providerSessionId === summary.sessionId };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await restarted.layer.start();
+
+    expect(restarted.supervisorCall).toHaveBeenCalledWith(
+      "provider_session_archive_lookup",
+      { providerSessionId: summary.sessionId },
+    );
+    expect(sessionKeyStore.markRetiring).toHaveBeenCalledWith(
+      summary.sessionId,
+      "relay-session",
+      false,
+      true,
+      undefined,
+      undefined,
+    );
+    expect(restarted.source.terminate).toHaveBeenCalledWith(summary.sessionId);
+    expect(restarted.api.sessionSyncClient).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId),
+    );
+    await restarted.layer.close();
+  });
+
+  it("keeps a ready binding through an empty cold-start list and resumes on the first event", async () => {
+    const summary = {
+      sessionId: "restored-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic restored session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const seeded = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    seeded.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "restored-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    await seeded.layer.start();
+    const originalOptions = seeded.api.getOrCreateSession.mock.calls[0]?.[0];
+    await seeded.layer.close();
+    sessionKeyStore.delete.mockClear();
+
+    const restarted = createLayerHarness({
+      initialSessions: [],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    restarted.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "restored-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    await restarted.layer.start();
+    expect(restarted.api.getOrCreateSession).not.toHaveBeenCalled();
+    expect(restarted.api.deactivateSession).not.toHaveBeenCalled();
+    expect(sessionKeyStore.delete).not.toHaveBeenCalled();
+
+    restarted.source.listSessions.mockResolvedValue([summary]);
+    restarted.publish({
+      kind: "status",
+      sessionId: "restored-session",
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() => expect(restarted.api.sessionSyncClient).toHaveBeenCalledTimes(1));
+    const resumedOptions = restarted.api.getOrCreateSession.mock.calls[0]?.[0];
+    expect(resumedOptions.tag).toBe(originalOptions.tag);
+    expect(Buffer.from(resumedOptions.encryptionKey)).toEqual(
+      Buffer.from(originalOptions.encryptionKey),
+    );
+    await restarted.layer.close();
+  });
+
+  it("terminates a late-restored retiring provider even after its root leaves scope", async () => {
+    const summary = {
+      sessionId: "late-retiring-session",
+      agentType: "codex",
+      cwd: `${SYNTHETIC_ROOT}-outside-advertised-roots`,
+      title: "Synthetic late retiring session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(summary.sessionId, `seren-${summary.sessionId}`);
+    await sessionKeyStore.markReady(summary.sessionId, "late-retiring-relay");
+    await sessionKeyStore.markRetiring(
+      summary.sessionId,
+      "late-retiring-relay",
+      false,
+      true,
+    );
+    sessionKeyStore.delete.mockClear();
+    const harness = createLayerHarness({
+      initialSessions: [],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    harness.api.deactivateSession.mockResolvedValue(true);
+
+    await harness.layer.start();
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("late-retiring-relay");
+    expect(sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId);
+    expect(harness.source.terminate).not.toHaveBeenCalled();
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: summary.sessionId,
+      providerSessionId: summary.sessionId,
+    });
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+
+    harness.source.listSessions.mockResolvedValue([summary]);
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() => expect(harness.source.terminate).toHaveBeenCalledWith(summary.sessionId));
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    expect(harness.api.getOrCreateSession).not.toHaveBeenCalled();
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
+  it("acknowledges identity reset only after every stored relay row is inactive", async () => {
+    const summary = {
+      sessionId: "reset-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic reset session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "reset-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    await harness.layer.start();
+
+    harness.notifySupervisor("identity_reset", { requestId: "synthetic-reset-request" });
+    await vi.waitFor(() =>
+      expect(harness.supervisorNotify).toHaveBeenCalledWith("identity_reset_result", {
+        requestId: "synthetic-reset-request",
+        success: true,
+      }),
+    );
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("reset-relay-session");
+    // Rust deletes the credential and encrypted store transactionally only
+    // after this acknowledgement; the bridge must not delete it early.
+    expect(sessionKeyStore.delete).not.toHaveBeenCalled();
+    // Once HTTP deactivation is confirmed, reset acknowledgement must not be
+    // held behind an SDK socket/outbox close. Rust stops the child next.
+    expect(harness.client.sendSessionDeath).not.toHaveBeenCalled();
+    expect(harness.client.close).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
+  it("rejects identity reset and retains bindings when relay retirement fails", async () => {
+    const summary = {
+      sessionId: "failed-reset-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic failed reset session",
+      status: "ready",
+    };
+    const machineIdentity = {
+      token: "test",
+      machineId: "synthetic-machine",
+      encryption: {
+        type: "dataKey",
+        publicKey: Buffer.alloc(32, 3).toString("base64"),
+        machineKey: Buffer.alloc(32, 7).toString("base64"),
+      },
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      machineIdentity,
+      sessionKeyStore,
+    });
+    harness.api.deactivateSession.mockResolvedValue(false);
+    await harness.layer.start();
+
+    harness.notifySupervisor("identity_reset", { requestId: "failed-reset-request" });
+    await vi.waitFor(() =>
+      expect(harness.supervisorNotify).toHaveBeenCalledWith("identity_reset_result", {
+        requestId: "failed-reset-request",
+        success: false,
+      }),
+    );
+    expect(sessionKeyStore.delete).not.toHaveBeenCalled();
+    await harness.layer.close();
   });
 
   it("does not start a pulse when a relay lookup finishes after shutdown", async () => {
@@ -217,16 +1119,172 @@ describe("Happy session liveness", () => {
     });
     await lookupStarted;
 
-    await harness.layer.close();
+    let closeSettled = false;
+    const close = harness.layer.close().then(() => {
+      closeSettled = true;
+    });
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(closeSettled).toBe(false);
     resolveSession?.({});
-    await Promise.resolve();
-    await Promise.resolve();
+    await close;
 
     expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
     expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("late-relay-session");
   });
 
-  it("terminates a provider whose spawn resolves after layer shutdown", async () => {
+  it("waits for terminal retirement that removed its session before shutdown", async () => {
+    const summary = {
+      sessionId: "terminal-during-close",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic terminal close race",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    await harness.layer.start();
+
+    let resolveClientClose: (() => void) | undefined;
+    harness.client.close.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClientClose = resolve;
+        }),
+    );
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "terminated" },
+    });
+    await vi.waitFor(() => expect(harness.client.close).toHaveBeenCalledTimes(1));
+
+    let closeSettled = false;
+    const close = harness.layer.close().then(() => {
+      closeSettled = true;
+    });
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(closeSettled).toBe(false);
+    resolveClientClose?.();
+    await close;
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId);
+  });
+
+  it("does not commit an entry when a terminal event overtakes relay creation", async () => {
+    const summary = {
+      sessionId: "terminal-create-race",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic terminal creation race",
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({ sessionKeyStore });
+    await harness.layer.start();
+    harness.source.listSessions.mockResolvedValue([summary]);
+
+    let resolveRelayLookup: (() => void) | undefined;
+    const relayLookupStarted = new Promise<void>((resolveStarted) => {
+      harness.api.getOrCreateSession.mockImplementation(
+        ({ metadata }: { metadata: Record<string, unknown> }) => {
+          resolveStarted();
+          return new Promise((resolve) => {
+            resolveRelayLookup = () =>
+              resolve({ id: "terminal-create-race-relay", metadata, seq: 0 });
+          });
+        },
+      );
+    });
+    const readBindings = sessionKeyStore.list.getMockImplementation();
+    if (!readBindings) throw new Error("memory session store list implementation missing");
+    let releaseTerminalBindingRead: (() => void) | undefined;
+    let bindingReadCount = 0;
+    const terminalBindingReadStarted = new Promise<void>((resolveStarted) => {
+      sessionKeyStore.list.mockImplementation(async () => {
+        bindingReadCount += 1;
+        if (bindingReadCount === 2) {
+          resolveStarted();
+          await new Promise<void>((resolve) => {
+            releaseTerminalBindingRead = resolve;
+          });
+        }
+        return readBindings();
+      });
+    });
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await relayLookupStarted;
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "terminated" },
+    });
+    await terminalBindingReadStarted;
+    resolveRelayLookup?.();
+
+    await vi.waitFor(() =>
+      expect(harness.api.deactivateSession).toHaveBeenCalledWith(
+        "terminal-create-race-relay",
+      ),
+    );
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    releaseTerminalBindingRead?.();
+    await vi.waitFor(() =>
+      expect(sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId),
+    );
+    await harness.layer.close();
+  });
+
+  it("does not commit an entry whose root leaves scope during relay creation", async () => {
+    const summary = {
+      sessionId: "roots-create-race",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic roots creation race",
+      status: "ready",
+    };
+    const harness = createLayerHarness();
+    await harness.layer.start();
+    harness.source.listSessions.mockResolvedValue([summary]);
+
+    let resolveRelayLookup: (() => void) | undefined;
+    const relayLookupStarted = new Promise<void>((resolveStarted) => {
+      harness.api.getOrCreateSession.mockImplementation(
+        ({ metadata }: { metadata: Record<string, unknown> }) => {
+          resolveStarted();
+          return new Promise((resolve) => {
+            resolveRelayLookup = () =>
+              resolve({ id: "roots-create-race-relay", metadata, seq: 0 });
+          });
+        },
+      );
+    });
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await relayLookupStarted;
+    harness.notifySupervisor("roots_update", { roots: [] });
+    resolveRelayLookup?.();
+
+    await vi.waitFor(() =>
+      expect(harness.api.deactivateSession).toHaveBeenCalledWith(
+        "roots-create-race-relay",
+      ),
+    );
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    expect(harness.sessionKeyStore.delete).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
+  it("waits for and unwinds a provider spawn that resolves during shutdown", async () => {
     vi.useFakeTimers();
     const harness = createLayerHarness();
     await harness.layer.start();
@@ -243,7 +1301,12 @@ describe("Happy session liveness", () => {
     });
     const result = harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" });
     await spawnStarted;
-    await harness.layer.close();
+    let closeSettled = false;
+    const close = harness.layer.close().then(() => {
+      closeSettled = true;
+    });
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(closeSettled).toBe(false);
 
     resolveSpawn?.({
       sessionId: "late-provider-session",
@@ -251,11 +1314,234 @@ describe("Happy session liveness", () => {
       cwd: SYNTHETIC_ROOT,
       status: "ready",
     });
+    await close;
     await expect(result).resolves.toEqual({
       type: "error",
       errorMessage: "Happy session closed during provider spawn",
     });
     expect(harness.source.terminate).toHaveBeenCalledWith("late-provider-session");
+    expect(harness.source.terminate).toHaveBeenCalledTimes(1);
     expect(harness.client.close).toHaveBeenCalledTimes(1);
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("retires a persisted relay binding when remote entry construction fails", async () => {
+    const harness = createLayerHarness();
+    harness.api.sessionSyncClient.mockImplementation(() => {
+      throw new Error("synthetic client construction failure");
+    });
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" })).resolves.toEqual({
+      type: "error",
+      errorMessage: "synthetic client construction failure",
+    });
+
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session");
+    expect(harness.source.spawn).not.toHaveBeenCalled();
+    expect(await harness.sessionKeyStore.list()).toEqual([]);
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
+  });
+
+  it("clears pending permission state when entry registration fails before retry", async () => {
+    const summary = {
+      sessionId: "entry-registration-retry",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic entry registration retry",
+      status: "ready",
+      pendingPermissions: [
+        {
+          requestId: "stale-request",
+          options: [{ optionId: "allow_once", kind: "allow_once" }],
+        },
+      ],
+    };
+    const harness = createLayerHarness();
+    await harness.layer.start();
+    harness.source.listSessions.mockResolvedValue([summary]);
+    harness.client.sendSessionEvent.mockImplementationOnce(() => {
+      throw new Error("synthetic registration failure");
+    });
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session"),
+    );
+
+    const refreshTrigger = {
+      sessionId: "out-of-scope-refresh-trigger",
+      agentType: "codex",
+      cwd: `${SYNTHETIC_ROOT}-outside-advertised-roots`,
+      title: "Synthetic refresh trigger",
+      status: "ready",
+    };
+    harness.source.listSessions.mockResolvedValue([
+      { ...summary, pendingPermissions: [] },
+      refreshTrigger,
+    ]);
+    harness.publish({
+      kind: "status",
+      sessionId: refreshTrigger.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.source.listSessions).toHaveBeenCalledTimes(3),
+    );
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(2),
+    );
+
+    await expect(
+      harness.client.invokeRpc("permission", {
+        requestId: "stale-request",
+        optionId: "allow_once",
+      }),
+    ).resolves.toEqual({ ok: false });
+    expect(harness.source.respondToPermission).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
+  it("serializes entry retry behind failed registration cleanup", async () => {
+    const summary = {
+      sessionId: "serialized-registration-retry",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic serialized retry",
+      status: "ready",
+    };
+    const harness = createLayerHarness();
+    await harness.layer.start();
+    harness.source.listSessions.mockResolvedValue([summary]);
+    harness.client.sendSessionEvent.mockImplementationOnce(() => {
+      throw new Error("synthetic registration failure");
+    });
+    let resolveCleanup: (() => void) | undefined;
+    harness.client.close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() => expect(harness.client.close).toHaveBeenCalledTimes(1));
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    for (let index = 0; index < 6; index += 1) await Promise.resolve();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+
+    resolveCleanup?.();
+    await vi.waitFor(() =>
+      expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session"),
+    );
+    for (let index = 0; index < 6; index += 1) await Promise.resolve();
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(2),
+    );
+    await harness.layer.close();
+  });
+
+  it("uses one stable id for a remotely spawned relay row, conversation, and provider", async () => {
+    const harness = createLayerHarness();
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" })).resolves.toEqual({
+      type: "success",
+      sessionId: "relay-session",
+    });
+
+    const relayTag = harness.api.getOrCreateSession.mock.calls[0]?.[0]?.tag;
+    const conversationId = harness.supervisorCall.mock.calls.find(
+      ([method]) => method === "conversation_create",
+    )?.[1]?.conversationId;
+    const providerId = harness.source.spawn.mock.calls[0]?.[0]?.localSessionId;
+    expect(typeof conversationId).toBe("string");
+    expect(relayTag).toBe(`seren-${String(conversationId)}`);
+    expect(providerId).toBe(conversationId);
+
+    await harness.layer.close();
+  });
+
+  it("retries cleanup of a provider returned under an unexpected id", async () => {
+    const harness = createLayerHarness();
+    harness.source.spawn.mockResolvedValue({
+      sessionId: "unexpected-provider-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    });
+    harness.source.terminate
+      .mockRejectedValueOnce(new Error("synthetic terminate interruption"))
+      .mockResolvedValueOnce(undefined);
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" })).resolves.toEqual({
+      type: "error",
+      errorMessage: "provider did not preserve the preallocated session id",
+    });
+
+    expect(harness.source.terminate).toHaveBeenCalledTimes(2);
+    expect(harness.source.terminate).toHaveBeenNthCalledWith(
+      1,
+      "unexpected-provider-session",
+    );
+    expect(harness.source.terminate).toHaveBeenNthCalledWith(
+      2,
+      "unexpected-provider-session",
+    );
+    expect(await harness.sessionKeyStore.list()).toEqual([]);
+    await harness.layer.close();
+  });
+
+  it("rolls back the preallocated conversation when remote provider spawn fails", async () => {
+    const harness = createLayerHarness();
+    harness.source.spawn.mockRejectedValue(
+      Object.assign(new Error("synthetic spawn failure"), {
+        providerRequestRejected: true,
+      }),
+    );
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" })).resolves.toEqual({
+      type: "error",
+      errorMessage: "synthetic spawn failure",
+    });
+
+    const createCall = harness.supervisorCall.mock.calls.find(
+      ([method]) => method === "conversation_create",
+    );
+    const deleteCall = harness.supervisorCall.mock.calls.find(
+      ([method]) => method === "conversation_delete",
+    );
+    expect(deleteCall?.[1]?.conversationId).toBe(createCall?.[1]?.conversationId);
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session");
+    expect(harness.source.terminate).not.toHaveBeenCalled();
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(
+      createCall?.[1]?.conversationId,
+    );
+    await harness.layer.close();
   });
 });

--- a/tests/unit/happy-session-recovery.test.ts
+++ b/tests/unit/happy-session-recovery.test.ts
@@ -1,21 +1,44 @@
-// ABOUTME: Guards Happy bridge recovery when a stable relay tag returns metadata
-// ABOUTME: that the restarted data-key client can no longer decrypt.
+// ABOUTME: Guards stable Happy session keys and one-time recovery from pre-fix
+// ABOUTME: relay rows whose process-local data key is no longer available.
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error — the bridge layer is plain ESM without declarations.
 import { getOrCreateUsableHappySession } from "../../bin/happy-bridge/happy-layer.mjs";
 
 describe("Happy relay session recovery", () => {
-  it("replaces an existing session whose metadata is unreadable", async () => {
+  it("keeps provider RPC available until Happy lifecycle cleanup finishes", () => {
+    const source = readFileSync(resolve("bin/happy-bridge.mjs"), "utf8");
+    const shutdownStart = source.indexOf("async function shutdown(");
+    const shutdownBody = source.slice(shutdownStart, shutdownStart + 1600);
+    const happyClose = shutdownBody.indexOf("happyLayer?.close()");
+    const providerClose = shutdownBody.indexOf("client?.close()");
+
+    expect(happyClose).toBeGreaterThan(0);
+    expect(providerClose).toBeGreaterThan(happyClose);
+    expect(shutdownBody).toContain("await Promise.allSettled([happyLayer?.close()])");
+    expect(shutdownBody).toContain("await Promise.allSettled([client?.close()])");
+    expect(shutdownBody).toContain("CLOSE_TIMEOUT_MS");
+  });
+
+  it("persists recovery state before replacing an unreadable legacy row", async () => {
     const metadata = { path: "/advertised/project" };
     const calls: Array<Record<string, unknown>> = [];
+    const order: string[] = [];
     const logs: string[] = [];
     const replacement = { id: "replacement", metadata };
+    const encryptionKey = new Uint8Array(32).fill(9);
     const api = {
       getOrCreateSession: async (input: Record<string, unknown>) => {
         calls.push(input);
+        order.push(`get:${String(input.tag)}`);
         return calls.length === 1 ? { id: "stale", metadata: null } : replacement;
+      },
+      deactivateSession: async (id: string) => {
+        order.push(`deactivate:${id}`);
+        return true;
       },
     };
 
@@ -25,20 +48,37 @@ describe("Happy relay session recovery", () => {
         tag: "seren-local-session",
         metadata,
         state: { controlledByUser: true },
+        encryptionKey,
+        allowLegacyReplacement: true,
         debugLog: (message: string) => logs.push(message),
-        replacementTag: () => "seren-recovery-test",
+        replacementTag: "seren-v2-machine-local-session",
+        persistReplacementTag: async (tag: string) => {
+          order.push(`persist-tag:${tag}`);
+        },
+        persistReady: async (sessionId: string) => {
+          order.push(`persist-ready:${sessionId}`);
+        },
       }),
     ).resolves.toBe(replacement);
     expect(calls.map((call) => call.tag)).toEqual([
       "seren-local-session",
-      "seren-recovery-test",
+      "seren-v2-machine-local-session",
     ]);
-    expect(logs).toEqual(["replacing Happy session with unreadable metadata"]);
+    expect(calls.every((call) => call.encryptionKey === encryptionKey)).toBe(true);
+    expect(order).toEqual([
+      "get:seren-local-session",
+      "deactivate:stale",
+      "persist-tag:seren-v2-machine-local-session",
+      "get:seren-v2-machine-local-session",
+      "persist-ready:replacement",
+    ]);
+    expect(logs).toEqual(["retiring Happy session with unreadable metadata"]);
   });
 
-  it("fails closed when the replacement session is also unreadable", async () => {
+  it("fails closed instead of exposing a replacement beside an unretired row", async () => {
     const api = {
       getOrCreateSession: async () => ({ id: "stale", metadata: null }),
+      deactivateSession: async () => false,
     };
 
     await expect(
@@ -47,8 +87,38 @@ describe("Happy relay session recovery", () => {
         tag: "seren-local-session",
         metadata: { path: "/advertised/project" },
         state: { controlledByUser: true },
-        replacementTag: () => "seren-recovery-test",
+        encryptionKey: new Uint8Array(32),
+        allowLegacyReplacement: true,
+        replacementTag: "seren-v2-machine-local-session",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("fails closed when a ready binding resolves to another relay row", async () => {
+    let persisted = false;
+    let deactivatedSessionId: string | null = null;
+    const api = {
+      getOrCreateSession: async () => ({ id: "unexpected-row", metadata: { path: "/safe" } }),
+      deactivateSession: async (sessionId: string) => {
+        deactivatedSessionId = sessionId;
+        return true;
+      },
+    };
+
+    await expect(
+      getOrCreateUsableHappySession({
+        api,
+        tag: "stored-recovery-tag",
+        metadata: { path: "/advertised/project" },
+        state: { controlledByUser: true },
+        encryptionKey: new Uint8Array(32),
+        expectedSessionId: "expected-row",
+        persistReady: async () => {
+          persisted = true;
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(persisted).toBe(false);
+    expect(deactivatedSessionId).toBe("unexpected-row");
   });
 });

--- a/tests/unit/per-session-force-kill.test.ts
+++ b/tests/unit/per-session-force-kill.test.ts
@@ -34,6 +34,22 @@ describe("#2313 — runtime spawn response carries the agent child PID", () => {
     // Sanity: the claude spawn return (not just a comment) carries it.
     expect(claudeRuntimeSource).toContain("pid: session.process?.pid ?? null");
   });
+
+  it("provider reattachment snapshots preserve the child PID", () => {
+    for (const file of [
+      "bin/browser-local/claude-runtime.mjs",
+      "bin/browser-local/providers.mjs",
+      "bin/browser-local/acp-runtime.mjs",
+    ]) {
+      const src = readFileSync(resolve(file), "utf-8");
+      const listStart = src.indexOf("async function listSessions()");
+      const listBody = src.slice(listStart, listStart + 900);
+      expect(listStart, `${file} must expose listSessions`).toBeGreaterThan(0);
+      expect(listBody, `${file} must preserve pid during reattachment`).toContain(
+        "pid: session.process?.pid ?? null",
+      );
+    }
+  });
 });
 
 describe("#2313 — forceKillSession service is native-guarded and invokes the command", () => {

--- a/tests/unit/predictive-compact-failure-drain.test.ts
+++ b/tests/unit/predictive-compact-failure-drain.test.ts
@@ -11,7 +11,7 @@ const agentStoreSource = readFileSync(
 );
 
 describe("#1769 — kickPredictiveCompact drains pendingPrompts on abort", () => {
-  it("non-success and catch branches both call drainAfterPredictiveAbort", () => {
+  it("non-success and catch both request an owner-guarded abort drain", () => {
     // Without this, the #1749 race-guard queue (pendingPrompts populated when
     // the user submits while a standby is being warmed) is stranded forever
     // when the standby's seed prompt fails — e.g. the Gateway 504 in the
@@ -31,24 +31,30 @@ describe("#1769 — kickPredictiveCompact drains pendingPrompts on abort", () =>
     );
     const kickBody = agentStoreSource.slice(fnStart, drainHelperStart);
 
-    const drainCalls = kickBody.match(
-      /this\.drainAfterPredictiveAbort\(sessionId\)/g,
-    );
+    const abortRequests = kickBody.match(/shouldDrainAfterAbort = true/g);
     expect(
-      drainCalls,
-      "kickPredictiveCompact must call drainAfterPredictiveAbort in both abort branches",
+      abortRequests,
+      "both abort branches must request the centralized drain",
     ).toHaveLength(2);
+    expect(
+      kickBody.match(/this\.drainAfterPredictiveAbort\(sessionId\)/g),
+      "the finally block must contain one generation-guarded drain",
+    ).toHaveLength(1);
 
-    // Each drain call must run AFTER the predictiveCompactInFlight flag is
-    // cleared on the same branch. Otherwise the drained sendPrompt re-enters
-    // and trips the #1749 enqueue guard, restranding the prompt.
+    // The centralized drain must run only after the current lease releases and
+    // the predictiveCompactInFlight flag clears. Otherwise a stale archived
+    // generation can drain or unlock a newer run on the same session id.
+    const leaseRelease = kickBody.indexOf(
+      "predictiveCompactMutex.release(predictiveCompactLease)",
+    );
     const nonSuccessFlagClear = kickBody.indexOf(
       'setState("sessions", sessionId, "predictiveCompactInFlight", false)',
     );
     const firstDrain = kickBody.indexOf(
       "this.drainAfterPredictiveAbort(sessionId)",
     );
-    expect(nonSuccessFlagClear).toBeGreaterThan(0);
+    expect(leaseRelease).toBeGreaterThan(0);
+    expect(nonSuccessFlagClear).toBeGreaterThan(leaseRelease);
     expect(firstDrain).toBeGreaterThan(nonSuccessFlagClear);
   });
 


### PR DESCRIPTION
Fixes #3212

## Summary

- persist each Happy session's stable encryption material and resume cursors in an encrypted, crash-safe local store
- reattach live provider sessions to their existing relay rows across Happy bridge restarts instead of creating orphan rows
- serialize bridge lifecycle transitions and fence remotely archived relay rows from being re-advertised
- retire duplicate/stale provider siblings with bounded graceful shutdown plus PID-guarded fallback
- harden predictive-compaction leases so stale asynchronous work cannot unlock a newer generation
- add focused regression coverage for session reuse, replay/cursor safety, archive fencing, provider retirement, and the affected lease races

## Validation

- `pnpm test`: 2,616 passed, 15 skipped
- `cargo test --lib --manifest-path src-tauri/Cargo.toml`: 978 passed, 2 ignored
- `pnpm check`: passed (existing warnings only)
- `pnpm build`: passed
- `pnpm build:provider-runtime`: passed; all embedded runtime sources byte-match
- `pnpm test:runtime-smoke`: passed against the real local provider runtime
- Node syntax checks and `git diff --check`: passed
- two independent code reviews found no blocker within #3212's bridge-restart scope
- real macOS Tauri + hosted Happy walkthrough, without mocks:
  - Happy-created session responded exactly once
  - bridge off/on kept one relay row online
  - pre-restart history was not duplicated
  - a post-restart synthetic prompt reached the same provider and responded exactly once
  - a remote archive stayed out of the active Happy view

The walkthrough also isolated two distinct P1 lifecycle defects outside this ticket's bridge-restart scope: full app relaunch does not restore the provider (#3221), and remote archive does not terminate/archive the local provider (#3213). Both have dedicated audited issues and are being fixed sequentially.

## Network path

The product path continues to use Happy directly:

- `POST /v1/machines`
- `POST /v1/sessions`
- Socket.IO `/v1/updates`
- `GET/POST /v3/sessions/{id}/messages`
- `POST /v1/sessions/{id}/archive`

The new lifecycle steps are local Tauri, supervisor-channel, SQLite, and provider-runtime IPC calls; they add no outbound API path. The live Seren publisher list was queried client-side and contains no Happy publisher.

## Evidence handling

The public issue, commits, and PR contain no user screenshots, local filesystem paths, account identifiers, pairing payloads, tokens, or raw logs. Functional validation used synthetic prompts only.