### PR TITLE
fix(sandbox): valid restricted-token parameters and non-vacuous Windows canaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,9 @@ jobs:
         run: pnpm tauri build --config src-tauri/tauri.ci.json
       - name: Run Windows sandbox canaries
         if: matrix.os == 'windows-latest'
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test sandbox_windows
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --lib restricted_token_creation_succeeds
+          cargo test --manifest-path src-tauri/Cargo.toml --test sandbox_windows
       - name: Build (macOS)
         if: matrix.os == 'macos-latest'
         run: pnpm tauri build --config src-tauri/tauri.ci.json

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -127,6 +127,7 @@ windows = { version = "0.62", features = [
     "Win32_System_Console",
     "Win32_System_JobObjects",
     "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -168,11 +168,12 @@ mod platform {
         let job = create_job()?;
         let (application_name, mut command_line) = command_line(command, args);
         let application_wide = wide(&application_name);
-        let current_directory_value = policy
+        let current_directory_path = policy
             .workspace_roots
             .first()
-            .map(|path| path.to_string_lossy().into_owned())
-            .unwrap_or_else(|| ".".to_string());
+            .map(|path| child_current_directory(path))
+            .unwrap_or_else(|| PathBuf::from("."));
+        let current_directory_value = current_directory_path.to_string_lossy().into_owned();
         let current_directory = wide(&current_directory_value);
         let mut startup = startup_info();
         let inherit_handles = configure_stdio(&mut startup);
@@ -252,10 +253,11 @@ mod platform {
             Ok(policy) => policy,
             Err(error) => exit_with(BAD_POLICY_EXIT, error),
         };
-        if let Some(workspace_root) = policy.workspace_roots.first()
-            && let Err(error) = std::env::set_current_dir(workspace_root)
-        {
-            exit_with(ENFORCEMENT_FAILURE_EXIT, error);
+        if let Some(workspace_root) = policy.workspace_roots.first() {
+            let current_directory = child_current_directory(workspace_root);
+            if let Err(error) = std::env::set_current_dir(&current_directory) {
+                exit_with(ENFORCEMENT_FAILURE_EXIT, error);
+            }
         }
 
         match apply_and_spawn_contained(&policy, &rest[3], &rest[4..]) {
@@ -284,6 +286,23 @@ mod platform {
             ));
         }
         Ok(())
+    }
+
+    fn child_current_directory(path: &Path) -> PathBuf {
+        let raw = path.to_string_lossy();
+        // std::fs::canonicalize produces extended-length paths on Windows.
+        // CreateProcess accepts them, but cmd.exe rejects `\\?\C:\...` as its
+        // current directory and defaults away from the workspace. Keep the
+        // canonical path for policy/ACL enforcement and convert only the child
+        // process's working-directory spelling. #3219.
+        let compatible = if let Some(unc) = raw.strip_prefix("\\\\?\\UNC\\") {
+            format!("\\\\{unc}")
+        } else if let Some(local) = raw.strip_prefix("\\\\?\\") {
+            local.to_owned()
+        } else {
+            raw.into_owned()
+        };
+        PathBuf::from(compatible)
     }
 
     fn capability_sid(policy: &SandboxPolicy) -> Result<OwnedSid, SandboxError> {

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -354,6 +354,10 @@ mod platform {
                 Attributes: 0,
             },
         ];
+        // This is the exact valid combination used by the pinned Codex
+        // backend. CreateRestrictedToken accepts the three flags together;
+        // the failure fixed by #3219 was the invalid app-package-style
+        // restricting SID, not this flag set.
         let flags = DISABLE_MAX_PRIVILEGE | LUA_TOKEN | WRITE_RESTRICTED;
         let mut restricted_token = HANDLE::default();
         unsafe {
@@ -417,6 +421,24 @@ mod platform {
         enable_change_notify_privilege(restricted_token.get())?;
 
         Ok(restricted_token)
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn restricted_token_creation_succeeds() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let policy = SandboxPolicy::new(
+            SandboxMode::WorkspaceWrite,
+            vec![workspace.path().to_path_buf()],
+            Vec::new(),
+            true,
+        )
+        .expect("test workspace policy is valid");
+        let capability = capability_sid(&policy).expect("capability SID is valid");
+        let token = create_restricted_token(capability.as_psid())
+            .expect("CreateRestrictedToken accepts the restricting SID set");
+
+        assert!(!token.get().is_invalid(), "restricted token is valid");
     }
 
     fn world_sid() -> Result<SidBytes, SandboxError> {

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -23,7 +23,7 @@ mod platform {
         ACL, AdjustTokenPrivileges, AllocateAndInitializeSid, CopySid, CreateRestrictedToken,
         CreateWellKnownSid, DACL_SECURITY_INFORMATION, DISABLE_MAX_PRIVILEGE, FreeSid,
         GetLengthSid, GetTokenInformation, LUA_TOKEN, LUID_AND_ATTRIBUTES, LookupPrivilegeValueW,
-        PSECURITY_DESCRIPTOR, PSID, SE_PRIVILEGE_ENABLED, SECURITY_APP_PACKAGE_AUTHORITY,
+        PSECURITY_DESCRIPTOR, PSID, SE_PRIVILEGE_ENABLED, SECURITY_NT_AUTHORITY,
         SID_AND_ATTRIBUTES, SUB_CONTAINERS_AND_OBJECTS_INHERIT, SetTokenInformation,
         TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_SESSIONID,
         TOKEN_ASSIGN_PRIMARY, TOKEN_DEFAULT_DACL, TOKEN_DUPLICATE, TOKEN_GROUPS, TOKEN_PRIVILEGES,
@@ -298,10 +298,14 @@ mod platform {
 
         let mut sid = PSID::default();
         unsafe {
+            // Use a synthetic NT-authority SID (S-1-5-21-...) as the restricting
+            // capability, matching the pinned Codex restricted-token backend.
+            // App-package capability SIDs (S-1-15-3-...) are rejected by
+            // CreateRestrictedToken with WRITE_RESTRICTED on windows-latest. #3219.
             AllocateAndInitializeSid(
-                &SECURITY_APP_PACKAGE_AUTHORITY,
+                &SECURITY_NT_AUTHORITY,
                 5,
-                3,
+                21,
                 hashes[0],
                 hashes[1],
                 hashes[2],

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -5,7 +5,7 @@
 mod platform {
     use std::ffi::c_void;
     use std::iter::once;
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
     use std::path::{Path, PathBuf};
     use std::process;
     use std::slice;
@@ -41,6 +41,7 @@ mod platform {
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
         SetInformationJobObject,
     };
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
     use windows::Win32::System::Threading::{
         CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessAsUserW, GetCurrentProcess,
         GetExitCodeProcess, INFINITE, OpenProcessToken, PROCESS_CREATION_FLAGS,
@@ -166,7 +167,7 @@ mod platform {
 
         let token = create_restricted_token(capability.as_psid())?;
         let job = create_job()?;
-        let (application_name, mut command_line) = command_line(command, args);
+        let (application_name, mut command_line) = command_line(command, args)?;
         let application_wide = wide(&application_name);
         let current_directory_path = policy
             .workspace_roots
@@ -763,7 +764,7 @@ mod platform {
         }
     }
 
-    fn command_line(command: &str, args: &[String]) -> (String, Vec<u16>) {
+    fn command_line(command: &str, args: &[String]) -> Result<(String, Vec<u16>), SandboxError> {
         let direct = once(command.to_string())
             .chain(args.iter().cloned())
             .map(|argument| quote_windows_arg(&argument))
@@ -772,12 +773,41 @@ mod platform {
         if command.to_ascii_lowercase().ends_with(".cmd")
             || command.to_ascii_lowercase().ends_with(".bat")
         {
-            let shell = std::env::var("ComSpec")
-                .unwrap_or_else(|_| "C:\\Windows\\System32\\cmd.exe".to_string());
-            let command_line = format!("/d /s /c {}", quote_windows_arg(&direct));
-            return (shell, wide(&command_line));
+            let shell = system_command_shell()?;
+            // cmd.exe does not use CommandLineToArgvW for its /C command text.
+            // Include argv[0], then give /S /C exactly one raw outer quote pair
+            // so inner quotes around batch paths and arguments survive. #3219.
+            let command_line = format!(
+                "{} /d /v:off /s /c \"{}\"",
+                quote_windows_arg(&shell),
+                direct
+            );
+            return Ok((shell, wide(&command_line)));
         }
-        (command.to_string(), wide(&direct))
+        Ok((command.to_string(), wide(&direct)))
+    }
+
+    fn system_command_shell() -> Result<String, SandboxError> {
+        // Resolve the OS-owned command interpreter without trusting ComSpec or
+        // the workspace/PATH, either of which could redirect a bounded launch.
+        let mut buffer = vec![0u16; 32_768];
+        let length = unsafe { GetSystemDirectoryW(Some(&mut buffer)) } as usize;
+        if length == 0 {
+            return Err(SandboxError::Windows(format!(
+                "GetSystemDirectoryW failed: {:?}",
+                unsafe { GetLastError() }
+            )));
+        }
+        if length >= buffer.len() {
+            return Err(SandboxError::Windows(
+                "GetSystemDirectoryW returned an oversized path".to_string(),
+            ));
+        }
+        let directory = std::ffi::OsString::from_wide(&buffer[..length]);
+        Ok(PathBuf::from(directory)
+            .join("cmd.exe")
+            .to_string_lossy()
+            .into_owned())
     }
 
     fn quote_windows_arg(argument: &str) -> String {

--- a/src-tauri/tests/sandbox_landlock.rs
+++ b/src-tauri/tests/sandbox_landlock.rs
@@ -11,6 +11,9 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use seren_desktop_lib::sandbox::{SandboxMode, SandboxPolicy};
 use tempfile::TempDir;
 
+const CANARY_DENIED_EXIT: i32 = 23;
+const CANARY_UNEXPECTED_ACCESS_EXIT: i32 = 41;
+
 fn policy_payload(policy: &SandboxPolicy) -> String {
     STANDARD.encode(serde_json::to_vec(policy).expect("policy serializes"))
 }
@@ -32,6 +35,36 @@ fn run_command(policy: &SandboxPolicy, cwd: &Path, command: &str, args: &[&str])
 fn workspace_policy(mode: SandboxMode, workspace: &TempDir) -> SandboxPolicy {
     SandboxPolicy::new(mode, vec![workspace.path().to_path_buf()], Vec::new(), true)
         .expect("test workspace policy is valid")
+}
+
+fn assert_launcher_ran(output: &Output) {
+    let status = output.status.code();
+    // A launcher fault is not a Landlock denial. Individual canaries must
+    // prove their own command ran and observed the expected restriction. #3219.
+    assert_ne!(status, Some(64), "launcher rejected arguments: {output:?}");
+    assert_ne!(status, Some(65), "launcher rejected policy: {output:?}");
+    assert_ne!(
+        status,
+        Some(69),
+        "launcher failed before the canary ran: {output:?}"
+    );
+}
+
+fn assert_contained_denial(output: &Output, denied_marker: &str) {
+    assert_launcher_ran(output);
+    assert_eq!(
+        output.status.code(),
+        Some(CANARY_DENIED_EXIT),
+        "canary did not report its contained denial: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(denied_marker),
+        "canary denial marker missing: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -65,10 +98,16 @@ fn sandbox_outside_write_canary_is_denied() {
         &policy,
         workspace.path(),
         "/bin/sh",
-        &["-c", &format!("touch '{}'", outside_file.display())],
+        &[
+            "-c",
+            &format!(
+                "printf 'SEREN_CANARY_OUTSIDE_WRITE_STARTED\\n'; if touch '{}'; then printf 'SEREN_CANARY_UNEXPECTED_WRITE\\n'; exit {CANARY_UNEXPECTED_ACCESS_EXIT}; else printf 'SEREN_CANARY_OUTSIDE_WRITE_DENIED\\n'; exit {CANARY_DENIED_EXIT}; fi",
+                outside_file.display()
+            ),
+        ],
     );
 
-    assert!(!output.status.success());
+    assert_contained_denial(&output, "SEREN_CANARY_OUTSIDE_WRITE_DENIED");
     assert!(!outside_file.exists());
 }
 
@@ -95,19 +134,26 @@ fn sandbox_deny_read_canary_is_denied() {
         &[
             "-c",
             &format!(
-                "cat '{}' && ! cat '{}'",
+                "cat '{}'; if cat '{}'; then printf 'SEREN_CANARY_UNEXPECTED_READ\\n'; exit {CANARY_UNEXPECTED_ACCESS_EXIT}; else printf 'SEREN_CANARY_DENY_READ_DENIED\\n'; fi",
                 readable_file.display(),
                 denied_file.display()
             ),
         ],
     );
 
+    assert_launcher_ran(&output);
     assert!(
         output.status.success(),
         "read canary failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "readable");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("readable"));
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("SEREN_CANARY_DENY_READ_DENIED"),
+        "deny-read canary did not reach its own denial marker: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -123,11 +169,21 @@ fn sandbox_grandchild_write_cannot_escape() {
         "/bin/sh",
         &[
             "-c",
-            &format!("/bin/sh -c \"touch '{}'\"", outside_file.display()),
+            &format!(
+                "/bin/sh -c \"printf 'SEREN_CANARY_GRANDCHILD_STARTED\\n'; touch '{}'\"; if [ -e '{}' ]; then printf 'SEREN_CANARY_UNEXPECTED_WRITE\\n'; exit {CANARY_UNEXPECTED_ACCESS_EXIT}; else printf 'SEREN_CANARY_GRANDCHILD_WRITE_DENIED\\n'; exit {CANARY_DENIED_EXIT}; fi",
+                outside_file.display(),
+                outside_file.display()
+            ),
         ],
     );
 
-    assert!(!output.status.success());
+    assert_contained_denial(&output, "SEREN_CANARY_GRANDCHILD_WRITE_DENIED");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("SEREN_CANARY_GRANDCHILD_STARTED"),
+        "grandchild canary never started: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(!outside_file.exists());
 }
 
@@ -148,19 +204,29 @@ fn sandbox_network_disabled_denies_tcp_or_fails_closed() {
         &policy,
         workspace.path(),
         "/bin/bash",
-        &["-c", &format!("exec 3<>/dev/tcp/127.0.0.1/{port}")],
+        &[
+            "-c",
+            &format!(
+                "if exec 3<>/dev/tcp/127.0.0.1/{port}; then printf 'SEREN_CANARY_UNEXPECTED_CONNECT\\n'; exit {CANARY_UNEXPECTED_ACCESS_EXIT}; else printf 'SEREN_CANARY_NETWORK_DENIED\\n'; exit {CANARY_DENIED_EXIT}; fi"
+            ),
+        ],
     );
 
-    if output.status.code() != Some(69) {
+    let status = output.status.code();
+    assert_ne!(status, Some(64), "launcher rejected arguments: {output:?}");
+    assert_ne!(status, Some(65), "launcher rejected policy: {output:?}");
+    if status == Some(69) {
+        // Older kernels may lack Landlock's TCP ABI. This remains an allowed,
+        // explicit fail-closed result only when the backend identifies that
+        // capability gap, not a generic launcher fault.
         assert!(
-            !output.status.success()
-                && (String::from_utf8_lossy(&output.stderr).contains("Permission denied")
-                    || String::from_utf8_lossy(&output.stderr).contains("Operation not permitted")
-                    || String::from_utf8_lossy(&output.stderr).contains("Network is unreachable")),
-            "network canary did not show a denied connect: status={:?} stderr={}",
-            output.status,
+            String::from_utf8_lossy(&output.stderr).contains("Landlock")
+                && String::from_utf8_lossy(&output.stderr).contains("TCP"),
+            "network launcher exit 69 was not the documented TCP-ABI fail-closed path: stderr={}",
             String::from_utf8_lossy(&output.stderr)
         );
+    } else {
+        assert_contained_denial(&output, "SEREN_CANARY_NETWORK_DENIED");
     }
 }
 
@@ -174,10 +240,15 @@ fn sandbox_read_only_denies_workspace_write() {
         &policy,
         workspace.path(),
         "/bin/sh",
-        &["-c", "touch read-only-escape"],
+        &[
+            "-c",
+            &format!(
+                "if touch read-only-escape; then printf 'SEREN_CANARY_UNEXPECTED_WRITE\\n'; exit {CANARY_UNEXPECTED_ACCESS_EXIT}; else printf 'SEREN_CANARY_READ_ONLY_WRITE_DENIED\\n'; exit {CANARY_DENIED_EXIT}; fi"
+            ),
+        ],
     );
 
-    assert!(!output.status.success());
+    assert_contained_denial(&output, "SEREN_CANARY_READ_ONLY_WRITE_DENIED");
     assert!(!inside_file.exists());
 }
 

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -1,228 +1,275 @@
 #![cfg(target_os = "windows")]
 
-// Real Windows restricted-token and Job Object canaries. These run on the
+// Real Windows restricted-token launcher canaries. These run on the
 // windows-latest matrix runner; no policy or process behavior is mocked.
 
 use std::env;
-use std::path::Path;
-use std::process::{Command, Output};
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command, Output};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use seren_desktop_lib::sandbox::{SandboxMode, SandboxPolicy};
 use tempfile::TempDir;
 
 const CANARY_DENIED_EXIT: i32 = 23;
-const CANARY_UNEXPECTED_WRITE_EXIT: i32 = 41;
+const CANARY_PROBE_FAILURE_EXIT: i32 = 42;
+const CANARY_TARGET_ENV: &str = "SEREN_WINDOWS_SANDBOX_CANARY_TARGET";
+const CANARY_GRANDCHILD_ENV: &str = "SEREN_WINDOWS_SANDBOX_CANARY_GRANDCHILD";
+const CANARY_WRITE_MARKER: &str = "SEREN_CANARY_WRITE_SUCCEEDED";
+const CANARY_DENIED_MARKER: &str = "SEREN_CANARY_WRITE_ACCESS_DENIED";
+const CANARY_GRANDCHILD_DENIED_MARKER: &str = "SEREN_CANARY_GRANDCHILD_ACCESS_DENIED";
 
 fn policy_payload(policy: &SandboxPolicy) -> String {
     STANDARD.encode(serde_json::to_vec(policy).expect("policy serializes"))
 }
 
-fn command_shell() -> String {
-    env::var("ComSpec").unwrap_or_else(|_| "C:\\Windows\\System32\\cmd.exe".to_string())
-}
-
-fn run_command(policy: &SandboxPolicy, cwd: &Path, command: &str, args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_Seren"))
-        .args([
-            "__seren-sandbox-run",
-            &policy_payload(policy),
-            "--",
-            command,
-        ])
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .expect("sandbox launcher starts")
-}
-
-fn workspace_policy(mode: SandboxMode, workspace: &TempDir) -> SandboxPolicy {
-    SandboxPolicy::new(mode, vec![workspace.path().to_path_buf()], Vec::new(), true)
+fn workspace_policy(mode: SandboxMode, workspace: &Path) -> SandboxPolicy {
+    SandboxPolicy::new(mode, vec![workspace.to_path_buf()], Vec::new(), true)
         .expect("test workspace policy is valid")
 }
 
-fn redirect(path: &Path) -> String {
-    format!("\"{}\"", cmd_compatible_path(path))
+fn workspace_fixture() -> (TempDir, PathBuf) {
+    let root = tempfile::tempdir().expect("sandbox fixture tempdir");
+    let workspace = root.path().join("workspace with spaces");
+    fs::create_dir(&workspace).expect("sandbox fixture workspace exists");
+    (root, workspace)
 }
 
-fn cmd_compatible_path(path: &Path) -> String {
-    let raw = path.to_string_lossy();
-    // tempfile paths can carry Windows' extended-length prefix. cmd.exe does
-    // not accept that spelling in redirections, even though the sandbox policy
-    // intentionally retains the canonical form for enforcement.
-    if let Some(unc) = raw.strip_prefix("\\\\?\\UNC\\") {
-        format!("\\\\{unc}")
-    } else if let Some(local) = raw.strip_prefix("\\\\?\\") {
-        local.to_owned()
+fn prove_target_is_writable(target: &Path) {
+    fs::write(target, b"preflight").expect("canary target is writable before sandboxing");
+    fs::remove_file(target).expect("canary preflight target is removed");
+}
+
+fn sandbox_launcher_command(policy: &SandboxPolicy, cwd: &Path, program: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_Seren"));
+    command
+        .arg("__seren-sandbox-run")
+        .arg(policy_payload(policy))
+        .arg("--")
+        .arg(program)
+        .current_dir(cwd);
+    command
+}
+
+fn run_native_write_probe(
+    policy: &SandboxPolicy,
+    cwd: &Path,
+    target: &Path,
+    spawn_grandchild: bool,
+) -> Output {
+    let source_executable = env::current_exe().expect("integration test executable is available");
+    let probe_executable = cwd.join("seren-sandbox-native-probe.exe");
+    fs::copy(source_executable, &probe_executable)
+        .expect("native probe is copied into the sandbox workspace");
+    let mut command = sandbox_launcher_command(policy, cwd, &probe_executable);
+    command
+        .args([
+            "--ignored",
+            "--exact",
+            "sandbox_windows_native_write_probe",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(CANARY_TARGET_ENV, target);
+    if spawn_grandchild {
+        command.env(CANARY_GRANDCHILD_ENV, "1");
     } else {
-        raw.into_owned()
+        command.env_remove(CANARY_GRANDCHILD_ENV);
     }
+    command.output().expect("sandbox launcher starts")
 }
 
-fn denied_write_script(path: &Path, started_marker: &str, denied_marker: &str) -> String {
-    let target = redirect(path);
-    format!(
-        "echo {started_marker} & echo denied>{target} & if exist {target} (echo SEREN_CANARY_UNEXPECTED_WRITE & exit /b {CANARY_UNEXPECTED_WRITE_EXIT}) else (echo {denied_marker} & exit /b {CANARY_DENIED_EXIT})"
-    )
-}
-
-fn assert_contained_denial(output: &Output, denied_marker: &str) {
-    let status = output.status.code();
-    // A launcher parse, policy, or enforcement failure must never satisfy a
-    // denial canary. The child command itself returns CANARY_DENIED_EXIT only
-    // after it observes that its write did not land. #3219.
-    assert_ne!(status, Some(64), "launcher rejected arguments: {output:?}");
-    assert_ne!(status, Some(65), "launcher rejected policy: {output:?}");
-    assert_ne!(
-        status,
-        Some(69),
-        "launcher failed before the canary ran: {output:?}"
-    );
+fn assert_access_denied(output: &Output, marker: &str) {
     assert_eq!(
-        status,
+        output.status.code(),
         Some(CANARY_DENIED_EXIT),
-        "canary did not report its contained denial: stdout={} stderr={}",
+        "native canary did not report Win32 access denied: status={:?} stdout={} stderr={}",
+        output.status,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains(denied_marker),
-        "canary denial marker missing: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout).contains(marker),
+        "native access-denied marker missing: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn exit_probe(code: i32, marker: &str) -> ! {
+    println!("{marker}");
+    let _ = std::io::stdout().flush();
+    process::exit(code);
+}
+
+fn fail_probe(error: &std::io::Error) -> ! {
+    eprintln!(
+        "SEREN_CANARY_UNEXPECTED_IO_ERROR kind={:?} os_code={:?}",
+        error.kind(),
+        error.raw_os_error()
+    );
+    let _ = std::io::stderr().flush();
+    process::exit(CANARY_PROBE_FAILURE_EXIT);
+}
+
+#[test]
+#[ignore = "child-only native write probe invoked through the sandbox launcher"]
+fn sandbox_windows_native_write_probe() {
+    let Some(target) = env::var_os(CANARY_TARGET_ENV) else {
+        eprintln!("SEREN_CANARY_TARGET_MISSING");
+        process::exit(CANARY_PROBE_FAILURE_EXIT);
+    };
+
+    if env::var_os(CANARY_GRANDCHILD_ENV).is_some() {
+        let probe_executable = env::current_exe().expect("probe executable is available");
+        let output = Command::new(probe_executable)
+            .args([
+                "--ignored",
+                "--exact",
+                "sandbox_windows_native_write_probe",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env_remove(CANARY_GRANDCHILD_ENV)
+            .output()
+            .expect("grandchild native probe starts");
+        if output.status.code() == Some(CANARY_DENIED_EXIT)
+            && String::from_utf8_lossy(&output.stdout).contains(CANARY_DENIED_MARKER)
+        {
+            exit_probe(CANARY_DENIED_EXIT, CANARY_GRANDCHILD_DENIED_MARKER);
+        }
+        eprintln!(
+            "SEREN_CANARY_GRANDCHILD_UNEXPECTED_RESULT status={:?}",
+            output.status
+        );
+        process::exit(CANARY_PROBE_FAILURE_EXIT);
+    }
+
+    let target = PathBuf::from(target);
+    let mut file = match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&target)
+    {
+        Ok(file) => file,
+        Err(error) if error.raw_os_error() == Some(5) => {
+            exit_probe(CANARY_DENIED_EXIT, CANARY_DENIED_MARKER);
+        }
+        Err(error) => fail_probe(&error),
+    };
+    if let Err(error) = file.write_all(b"allowed") {
+        if error.raw_os_error() == Some(5) {
+            exit_probe(CANARY_DENIED_EXIT, CANARY_DENIED_MARKER);
+        }
+        fail_probe(&error);
+    }
+    println!("{CANARY_WRITE_MARKER}");
 }
 
 #[test]
 fn sandbox_windows_workspace_write_canary_succeeds() {
-    let workspace = tempfile::tempdir().expect("workspace tempdir");
-    let inside = workspace.path().join("inside.txt");
+    let (_root, workspace) = workspace_fixture();
+    let inside = workspace.join("inside.txt");
+    prove_target_is_writable(&inside);
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
-    let shell = command_shell();
 
-    let output = run_command(
-        &policy,
-        workspace.path(),
-        &shell,
-        &["/d", "/c", &format!("echo allowed>{}", redirect(&inside))],
-    );
+    // A relative target exercises the child-current-directory conversion.
+    let output = run_native_write_probe(&policy, &workspace, Path::new("inside.txt"), false);
 
     assert!(
         output.status.success(),
-        "workspace write failed: status={:?} stderr={}",
+        "workspace write failed: status={:?} stdout={} stderr={}",
         output.status,
+        String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(inside.is_file());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(CANARY_WRITE_MARKER),
+        "workspace-write marker missing"
+    );
+    assert_eq!(
+        fs::read(&inside).expect("workspace canary file exists"),
+        b"allowed"
+    );
 }
 
 #[test]
 fn sandbox_windows_outside_write_canary_is_denied() {
-    let workspace = tempfile::tempdir().expect("workspace tempdir");
-    let outside = tempfile::tempdir().expect("outside tempdir");
-    let outside_file = outside.path().join("outside.txt");
+    let (root, workspace) = workspace_fixture();
+    let outside = root.path().join("outside.txt");
+    prove_target_is_writable(&outside);
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
-    let shell = command_shell();
-    let started_marker = "SEREN_CANARY_OUTSIDE_WRITE_STARTED";
-    let denied_marker = "SEREN_CANARY_OUTSIDE_WRITE_DENIED";
 
-    let output = run_command(
-        &policy,
-        workspace.path(),
-        &shell,
-        &[
-            "/d",
-            "/c",
-            &denied_write_script(&outside_file, started_marker, denied_marker),
-        ],
-    );
+    let output = run_native_write_probe(&policy, &workspace, &outside, false);
 
-    assert_contained_denial(&output, denied_marker);
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains(started_marker),
-        "outside-write canary never started: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !outside_file.exists(),
-        "outside write unexpectedly succeeded: status={:?} stdout={} stderr={}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    assert_access_denied(&output, CANARY_DENIED_MARKER);
+    assert!(!outside.exists(), "outside write unexpectedly succeeded");
 }
 
 #[test]
 fn sandbox_windows_read_only_denies_workspace_write() {
-    let workspace = tempfile::tempdir().expect("workspace tempdir");
-    let inside = workspace.path().join("read-only.txt");
+    let (_root, workspace) = workspace_fixture();
+    let inside = workspace.join("read-only.txt");
+    prove_target_is_writable(&inside);
     let policy = workspace_policy(SandboxMode::ReadOnly, &workspace);
-    let shell = command_shell();
-    let started_marker = "SEREN_CANARY_READ_ONLY_WRITE_STARTED";
-    let denied_marker = "SEREN_CANARY_READ_ONLY_WRITE_DENIED";
 
-    let output = run_command(
-        &policy,
-        workspace.path(),
-        &shell,
-        &[
-            "/d",
-            "/c",
-            &denied_write_script(&inside, started_marker, denied_marker),
-        ],
-    );
+    // A relative target proves the workspace is reachable but not writable.
+    let output = run_native_write_probe(&policy, &workspace, Path::new("read-only.txt"), false);
 
-    assert_contained_denial(&output, denied_marker);
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains(started_marker),
-        "read-only canary never started: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    assert_access_denied(&output, CANARY_DENIED_MARKER);
     assert!(
         !inside.exists(),
-        "read-only workspace write unexpectedly succeeded: status={:?} stdout={} stderr={}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        "read-only workspace write unexpectedly succeeded"
     );
 }
 
 #[test]
-fn sandbox_windows_grandchild_cannot_escape_job() {
-    let workspace = tempfile::tempdir().expect("workspace tempdir");
-    let outside = tempfile::tempdir().expect("outside tempdir");
-    let outside_file = outside.path().join("grandchild.txt");
+fn sandbox_windows_grandchild_inherits_restricted_token() {
+    let (root, workspace) = workspace_fixture();
+    let outside = root.path().join("grandchild.txt");
+    prove_target_is_writable(&outside);
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
-    let shell = command_shell();
-    let started_marker = "SEREN_CANARY_GRANDCHILD_STARTED";
-    let denied_marker = "SEREN_CANARY_GRANDCHILD_WRITE_DENIED";
-    // Run a marker from a real child cmd.exe before the write-attempt child.
-    // The parent then emits the denial marker only after observing no escape.
-    let grandchild_script = format!(
-        "{shell} /d /c echo {started_marker} & {shell} /d /c echo denied>{outside}",
-        outside = redirect(&outside_file)
-    );
-    let script = format!(
-        "{grandchild_script} & if exist {outside} (echo SEREN_CANARY_UNEXPECTED_WRITE & exit /b {CANARY_UNEXPECTED_WRITE_EXIT}) else (echo {denied_marker} & exit /b {CANARY_DENIED_EXIT})",
-        outside = redirect(&outside_file)
-    );
 
-    let output = run_command(&policy, workspace.path(), &shell, &["/d", "/c", &script]);
+    let output = run_native_write_probe(&policy, &workspace, &outside, true);
 
-    assert_contained_denial(&output, denied_marker);
+    assert_access_denied(&output, CANARY_GRANDCHILD_DENIED_MARKER);
+    assert!(!outside.exists(), "grandchild write unexpectedly succeeded");
+}
+
+#[test]
+fn sandbox_windows_batch_wrapper_preserves_quoted_paths_and_arguments() {
+    let (_root, workspace) = workspace_fixture();
+    let script_directory = workspace.join("batch scripts");
+    fs::create_dir(&script_directory).expect("batch-script directory exists");
+    let script = script_directory.join("write result.cmd");
+    let result_file = workspace.join("batch result.txt");
+    fs::write(
+        &script,
+        b"@echo off\r\nif not \"%~1\"==\"argument with spaces\" exit /b 43\r\n>\"%~2\" echo batch-ok\r\nexit /b 0\r\n",
+    )
+    .expect("batch canary is written");
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+
+    let output = sandbox_launcher_command(&policy, &workspace, &script)
+        .arg("argument with spaces")
+        .arg(&result_file)
+        .output()
+        .expect("sandbox batch launcher starts");
+
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains(started_marker),
-        "grandchild canary never started: stdout={} stderr={}",
+        output.status.success(),
+        "batch wrapper failed: status={:?} stdout={} stderr={}",
+        output.status,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        !outside_file.exists(),
-        "grandchild write unexpectedly succeeded: status={:?} stderr={}",
-        output.status,
-        String::from_utf8_lossy(&output.stderr)
+    assert_eq!(
+        fs::read_to_string(&result_file)
+            .expect("batch result exists")
+            .trim(),
+        "batch-ok"
     );
 }
 

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -42,7 +42,21 @@ fn workspace_policy(mode: SandboxMode, workspace: &TempDir) -> SandboxPolicy {
 }
 
 fn redirect(path: &Path) -> String {
-    format!("\"{}\"", path.display())
+    format!("\"{}\"", cmd_compatible_path(path))
+}
+
+fn cmd_compatible_path(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    // tempfile paths can carry Windows' extended-length prefix. cmd.exe does
+    // not accept that spelling in redirections, even though the sandbox policy
+    // intentionally retains the canonical form for enforcement.
+    if let Some(unc) = raw.strip_prefix("\\\\?\\UNC\\") {
+        format!("\\\\{unc}")
+    } else if let Some(local) = raw.strip_prefix("\\\\?\\") {
+        local.to_owned()
+    } else {
+        raw.into_owned()
+    }
 }
 
 fn denied_write_script(path: &Path, started_marker: &str, denied_marker: &str) -> String {

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -11,6 +11,9 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use seren_desktop_lib::sandbox::{SandboxMode, SandboxPolicy};
 use tempfile::TempDir;
 
+const CANARY_DENIED_EXIT: i32 = 23;
+const CANARY_UNEXPECTED_WRITE_EXIT: i32 = 41;
+
 fn policy_payload(policy: &SandboxPolicy) -> String {
     STANDARD.encode(serde_json::to_vec(policy).expect("policy serializes"))
 }
@@ -40,6 +43,40 @@ fn workspace_policy(mode: SandboxMode, workspace: &TempDir) -> SandboxPolicy {
 
 fn redirect(path: &Path) -> String {
     format!("\"{}\"", path.display())
+}
+
+fn denied_write_script(path: &Path, started_marker: &str, denied_marker: &str) -> String {
+    let target = redirect(path);
+    format!(
+        "echo {started_marker} & echo denied>{target} & if exist {target} (echo SEREN_CANARY_UNEXPECTED_WRITE & exit /b {CANARY_UNEXPECTED_WRITE_EXIT}) else (echo {denied_marker} & exit /b {CANARY_DENIED_EXIT})"
+    )
+}
+
+fn assert_contained_denial(output: &Output, denied_marker: &str) {
+    let status = output.status.code();
+    // A launcher parse, policy, or enforcement failure must never satisfy a
+    // denial canary. The child command itself returns CANARY_DENIED_EXIT only
+    // after it observes that its write did not land. #3219.
+    assert_ne!(status, Some(64), "launcher rejected arguments: {output:?}");
+    assert_ne!(status, Some(65), "launcher rejected policy: {output:?}");
+    assert_ne!(
+        status,
+        Some(69),
+        "launcher failed before the canary ran: {output:?}"
+    );
+    assert_eq!(
+        status,
+        Some(CANARY_DENIED_EXIT),
+        "canary did not report its contained denial: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(denied_marker),
+        "canary denial marker missing: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -72,6 +109,8 @@ fn sandbox_windows_outside_write_canary_is_denied() {
     let outside_file = outside.path().join("outside.txt");
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
     let shell = command_shell();
+    let started_marker = "SEREN_CANARY_OUTSIDE_WRITE_STARTED";
+    let denied_marker = "SEREN_CANARY_OUTSIDE_WRITE_DENIED";
 
     let output = run_command(
         &policy,
@@ -80,10 +119,17 @@ fn sandbox_windows_outside_write_canary_is_denied() {
         &[
             "/d",
             "/c",
-            &format!("echo denied>{}", redirect(&outside_file)),
+            &denied_write_script(&outside_file, started_marker, denied_marker),
         ],
     );
 
+    assert_contained_denial(&output, denied_marker);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(started_marker),
+        "outside-write canary never started: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(
         !outside_file.exists(),
         "outside write unexpectedly succeeded: status={:?} stdout={} stderr={}",
@@ -99,14 +145,27 @@ fn sandbox_windows_read_only_denies_workspace_write() {
     let inside = workspace.path().join("read-only.txt");
     let policy = workspace_policy(SandboxMode::ReadOnly, &workspace);
     let shell = command_shell();
+    let started_marker = "SEREN_CANARY_READ_ONLY_WRITE_STARTED";
+    let denied_marker = "SEREN_CANARY_READ_ONLY_WRITE_DENIED";
 
     let output = run_command(
         &policy,
         workspace.path(),
         &shell,
-        &["/d", "/c", &format!("echo denied>{}", redirect(&inside))],
+        &[
+            "/d",
+            "/c",
+            &denied_write_script(&inside, started_marker, denied_marker),
+        ],
     );
 
+    assert_contained_denial(&output, denied_marker);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(started_marker),
+        "read-only canary never started: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(
         !inside.exists(),
         "read-only workspace write unexpectedly succeeded: status={:?} stdout={} stderr={}",
@@ -123,15 +182,28 @@ fn sandbox_windows_grandchild_cannot_escape_job() {
     let outside_file = outside.path().join("grandchild.txt");
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
     let shell = command_shell();
-    let grandchild_script = format!("{} /d /c echo denied>{}", shell, redirect(&outside_file));
-
-    let output = run_command(
-        &policy,
-        workspace.path(),
-        &shell,
-        &["/d", "/c", &grandchild_script],
+    let started_marker = "SEREN_CANARY_GRANDCHILD_STARTED";
+    let denied_marker = "SEREN_CANARY_GRANDCHILD_WRITE_DENIED";
+    // Run a marker from a real child cmd.exe before the write-attempt child.
+    // The parent then emits the denial marker only after observing no escape.
+    let grandchild_script = format!(
+        "{shell} /d /c echo {started_marker} & {shell} /d /c echo denied>{outside}",
+        outside = redirect(&outside_file)
+    );
+    let script = format!(
+        "{grandchild_script} & if exist {outside} (echo SEREN_CANARY_UNEXPECTED_WRITE & exit /b {CANARY_UNEXPECTED_WRITE_EXIT}) else (echo {denied_marker} & exit /b {CANARY_DENIED_EXIT})",
+        outside = redirect(&outside_file)
     );
 
+    let output = run_command(&policy, workspace.path(), &shell, &["/d", "/c", &script]);
+
+    assert_contained_denial(&output, denied_marker);
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(started_marker),
+        "grandchild canary never started: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(
         !outside_file.exists(),
         "grandchild write unexpectedly succeeded: status={:?} stderr={}",


### PR DESCRIPTION
## Evidence

Windows non-full-access launches failed closed in `CreateRestrictedToken`, and the original denial tests could pass without starting a valid write attempt. A first correction fixed token construction but exposed two further live Windows failures:

1. canonical `\\?\C:\...` paths were passed verbatim as the child cwd, which `cmd.exe` treated as UNC; and
2. the shell-based redirection canaries used malformed nested quoting, so a syntax failure could masquerade as containment.

The same command-line defect affected bounded Claude launches when the installed CLI resolves to an npm `.cmd` wrapper.

## Corrected mechanism

- Uses a synthetic NT-authority restricting SID, matching the pinned Codex Windows sandbox implementation.
- Keeps canonical extended paths for policy and ACL enforcement, while converting only the spawned child's cwd to a Win32-compatible spelling.
- Resolves the OS-owned command interpreter with `GetSystemDirectoryW`; it does not trust `ComSpec`, `PATH`, or the workspace.
- Constructs batch launches as an explicit cmd argv0 followed by `/d /v:off /s /c` and one raw outer quote pair, preserving quoted batch paths and arguments.

## Non-vacuous Windows coverage

The Windows job now runs real restricted-token processes; no policy or filesystem behavior is mocked.

- A direct token probe proves `CreateRestrictedToken` succeeds.
- A native self-executing write probe is copied into the workspace and launched through the production Seren sandbox launcher.
- Every denial target is first written and removed outside the sandbox to prove that the path is valid and normally writable.
- Denial passes only for Win32 `ERROR_ACCESS_DENIED` (5), with a distinct exit and marker. Syntax, path, launcher, and other I/O failures cannot satisfy it.
- Workspace-write, outside-write, read-only, and restricted-token grandchild behavior are covered.
- A real batch file with spaces in its workspace, script path, output path, and argument protects the npm-Claude wrapper path.

## Dependency feature acknowledgment

This enables `Win32_System_SystemInformation` on the existing `windows = 0.62` dependency so the launcher can resolve the trusted system `cmd.exe`. It adds no new crate, version, or lockfile entry.

## Validation

- `rustfmt` on both touched Rust files
- `git diff --check`
- locked Cargo metadata
- host integration-test compilation
- authoritative Windows build and live canaries required before merge

Networked path: none. This change affects only local process construction, restricted-token ACL enforcement, and local filesystem canaries; no publisher or API slug, method, or path is added or modified.

Fixes #3219