### PR TITLE
fix(happy): keep mobile sessions active across desktop restarts

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -104,7 +104,13 @@ function createAcpSessionRecord({
 // JSON-RPC framing (newline-delimited JSON over stdio)
 // ============================================================================
 
-function sendRequest(session, method, params, timeoutMs = 30_000) {
+function sendRequest(
+  session,
+  method,
+  params,
+  timeoutMs = 30_000,
+  { onWritten } = {},
+) {
   const id = session.nextRequestId;
   session.nextRequestId += 1;
 
@@ -128,7 +134,31 @@ function sendRequest(session, method, params, timeoutMs = 30_000) {
       reject: rejectPromise,
     });
 
-    session.process.stdin.write(`${JSON.stringify(payload)}\n`);
+    const rejectWrite = (error) => {
+      session.pendingRequests.delete(String(id));
+      clearTimeout(timeout);
+      rejectPromise(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    };
+    try {
+      session.process.stdin.write(
+        `${JSON.stringify(payload)}\n`,
+        (error) => {
+          if (error) {
+            rejectWrite(error);
+            return;
+          }
+          try {
+            onWritten?.();
+          } catch (callbackError) {
+            rejectWrite(callbackError);
+          }
+        },
+      );
+    } catch (error) {
+      rejectWrite(error);
+    }
   });
 }
 
@@ -465,6 +495,20 @@ function buildSessionStatus(session, status = session.status) {
   };
 }
 
+async function applyAcpPermissionMode(session, mode, emit, request = sendRequest) {
+  await request(
+    session,
+    "session/set_mode",
+    { sessionId: session.agentSessionId, modeId: mode },
+    5_000,
+  );
+  session.currentModeId = mode;
+  emit("provider://session-status", {
+    ...buildSessionStatus(session),
+    readinessUnchanged: true,
+  });
+}
+
 function attachProcessListeners(emit, sessions, session) {
   const logPrefix =
     session.logPrefix ?? providerLogPrefix(session.agentType);
@@ -552,6 +596,7 @@ export function createAcpRuntime({
     const {
       cwd,
       localSessionId,
+      requireExactResume,
       apiKey,
       mcpServers,
       approvalPolicy,
@@ -560,6 +605,12 @@ export function createAcpRuntime({
       timeoutSecs,
       initialModelId,
     } = params;
+
+    if (requireExactResume === true) {
+      throw new Error(
+        `${adapter.agentName} does not support exact ACP session resume.`,
+      );
+    }
 
     const sessionId = localSessionId ?? randomUUID();
     const resolvedMode = adapter.resolveInitialMode({
@@ -715,7 +766,7 @@ export function createAcpRuntime({
     }
   }
 
-  async function sendPrompt({ sessionId, prompt, context }) {
+  async function sendPrompt({ sessionId, prompt, context, onAccepted }) {
     const session = sessions.get(sessionId);
     if (!session) {
       throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
@@ -771,6 +822,7 @@ export function createAcpRuntime({
         },
         // Coding-agent turns can run for minutes on large tasks.
         10 * 60_000,
+        { onWritten: onAccepted },
       );
 
       const stopReason = response?.stopReason ?? "completed";
@@ -786,10 +838,17 @@ export function createAcpRuntime({
       await pendingPrompt;
     } catch (error) {
       session.status = "ready";
+      const promptWasActive = session.currentPrompt !== null;
       rejectCurrentPrompt(
         session,
         error instanceof Error ? error : new Error(String(error)),
       );
+      if (promptWasActive && sessions.get(sessionId) === session) {
+        emit("provider://error", {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       emit("provider://session-status", buildSessionStatus(session, "ready"));
       throw error;
     }
@@ -880,17 +939,10 @@ export function createAcpRuntime({
       throw new Error(`Unknown ${adapter.agentName} mode: ${mode}`);
     }
 
-    session.currentModeId = mode;
-    // ACP `session/set_mode` lets the agent know about the change too.
-    sendRequest(
-      session,
-      "session/set_mode",
-      { sessionId: session.agentSessionId, modeId: mode },
-      5_000,
-    ).catch(() => {
-      // Best-effort — older ACP agents may not support set_mode yet.
-    });
-    emit("provider://session-status", buildSessionStatus(session));
+    // A restored Happy session must not advertise a saved restrictive mode
+    // until the ACP agent has acknowledged it. Treat unsupported/rejected mode
+    // changes as failures so the restore owner can retire the permissive child.
+    await applyAcpPermissionMode(session, mode, emit);
   }
 
   async function setOAuthRouting({ sessionId, routing }) {
@@ -987,3 +1039,8 @@ export function createAcpRuntime({
     setModel,
   };
 }
+
+export {
+  applyAcpPermissionMode as _applyAcpPermissionMode,
+  sendRequest as _sendAcpRequest,
+};

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1010,7 +1010,15 @@ function stringifyToolResultContent(content) {
   return undefined;
 }
 
-function emitToolCall(emit, session, toolName, input, toolUseId, status = "in_progress") {
+function emitToolCall(
+  emit,
+  session,
+  toolName,
+  input,
+  toolUseId,
+  status = "in_progress",
+  replay = false,
+) {
   if (typeof toolUseId === "string" && toolUseId.length > 0) {
     session.toolInputs.set(toolUseId, input ?? {});
   }
@@ -1022,16 +1030,25 @@ function emitToolCall(emit, session, toolName, input, toolUseId, status = "in_pr
     kind: toolKindForName(toolName),
     status,
     parameters: input,
+    ...(replay ? { replay: true } : {}),
   });
 }
 
-function emitToolResult(emit, session, toolUseId, content, isError = false) {
+function emitToolResult(
+  emit,
+  session,
+  toolUseId,
+  content,
+  isError = false,
+  replay = false,
+) {
   emit("provider://tool-result", {
     sessionId: session.id,
     toolCallId: toolUseId,
     status: isError ? "failed" : "completed",
     result: isError ? undefined : stringifyToolResultContent(content),
     error: isError ? stringifyToolResultContent(content) ?? "Tool failed." : undefined,
+    ...(replay ? { replay: true } : {}),
   });
 }
 
@@ -1065,6 +1082,25 @@ function rejectPendingControlRequests(session, error) {
 
 function writeMessage(session, payload) {
   session.process.stdin.write(`${JSON.stringify(payload)}\n`);
+}
+
+function writeMessageAccepted(session, payload) {
+  return new Promise((resolve, reject) => {
+    try {
+      session.process.stdin.write(
+        `${JSON.stringify(payload)}\n`,
+        (error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        },
+      );
+    } catch (error) {
+      reject(error);
+    }
+  });
 }
 
 function sendControlRequest(session, request, timeoutMs = 30_000) {
@@ -1757,6 +1793,7 @@ function replayClaudeHistoryEntry(emit, session, entry) {
           block.input ?? {},
           block.id,
           "completed",
+          true,
         );
         break;
 
@@ -1770,6 +1807,7 @@ function replayClaudeHistoryEntry(emit, session, entry) {
           block.tool_use_id,
           block.content ?? null,
           block.is_error === true,
+          true,
         );
         break;
 
@@ -2640,6 +2678,8 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       cwd,
       localSessionId,
       resumeAgentSessionId,
+      requireExactResume,
+      suppressHistoryReplay,
       apiKey,
       mcpServers,
       approvalPolicy,
@@ -2651,6 +2691,12 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       reasoningEffort,
       initialModelId,
     } = params;
+
+    if (requireExactResume === true && !resumeAgentSessionId) {
+      throw new Error(
+        "Claude exact resume requires a native agent session ID.",
+      );
+    }
 
     const sessionId = localSessionId ?? randomUUID();
 
@@ -2951,32 +2997,51 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // bookkeeping rides the same drain. Kick replay off in the
       // background and defer the "ready" emit until it drains so the
       // frontend's readyPromise still gates sendPrompt. #1889
-      const replayPromise = resumeAgentSessionId
-        ? replayClaudeHistoryBestEffort(
-            emit,
-            session,
-            cwd,
-            resumeAgentSessionId,
-          ).catch((err) => {
+      if (resumeAgentSessionId && suppressHistoryReplay !== true) {
+        replayClaudeHistoryBestEffort(
+          emit,
+          session,
+          cwd,
+          resumeAgentSessionId,
+        )
+          .catch((err) => {
             console.warn(
               `${claudeLogPrefix} history replay failed:`,
               err?.message ?? err,
             );
           })
-        : Promise.resolve();
+          .then(() => {
+            // The session may have been terminated mid-replay (user closed
+            // the thread). Only flip status + emit if our record is still
+            // the active one for this sessionId.
+            if (sessions.get(sessionId) === session) {
+              session.status = "ready";
+              emit(
+                "provider://session-status",
+                buildSessionStatus(session, "ready"),
+              );
+            }
+          });
+      } else {
+        // Fresh sessions and Happy's exact restore suppress replay entirely.
+        // Return a truthful ready snapshot so startup never depends on this
+        // notification surviving the provider client's bounded pre-subscribe
+        // event buffer.
+        session.status = "ready";
+        emit(
+          "provider://session-status",
+          buildSessionStatus(session, "ready"),
+        );
+      }
 
-      replayPromise.then(() => {
-        // The session may have been terminated mid-replay (user closed
-        // the thread). Only flip status + emit if our record is still
-        // the active one for this sessionId.
-        if (sessions.get(sessionId) === session) {
-          session.status = "ready";
-          emit(
-            "provider://session-status",
-            buildSessionStatus(session, "ready"),
-          );
-        }
-      });
+      if (
+        requireExactResume === true &&
+        session.agentSessionId !== resumeAgentSessionId
+      ) {
+        throw new Error(
+          "Claude resumed a different native session than the one requested.",
+        );
+      }
 
       return {
         id: session.id,
@@ -3005,7 +3070,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     }
   }
 
-  async function sendPrompt({ sessionId, prompt, context }) {
+  async function sendPrompt({ sessionId, prompt, context, onAccepted }) {
     const session = sessions.get(sessionId);
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
@@ -3030,17 +3095,39 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         reject: rejectPromise,
       };
     });
+    pendingPrompt.catch(() => {});
 
-    writeMessage(session, {
-      type: "user",
-      message: {
-        role: "user",
-        content: combinedPrompt,
-      },
-      session_id: session.agentSessionId,
-    });
+    try {
+      await writeMessageAccepted(session, {
+        type: "user",
+        message: {
+          role: "user",
+          content: combinedPrompt,
+        },
+        session_id: session.agentSessionId,
+      });
+      onAccepted?.();
+    } catch (error) {
+      const promptWasActive = session.currentPrompt !== null;
+      rejectCurrentPrompt(
+        session,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      if (promptWasActive && sessions.get(sessionId) === session) {
+        session.status = "ready";
+        emit("provider://error", {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        emit(
+          "provider://session-status",
+          buildSessionStatus(session, "ready"),
+        );
+      }
+      throw error;
+    }
 
-    return pendingPrompt;
+    await pendingPrompt;
   }
 
   async function cancelPrompt({ sessionId }) {
@@ -3183,7 +3270,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     );
 
     session.currentModeId = mode;
-    emit("provider://session-status", buildSessionStatus(session));
+    emit("provider://session-status", {
+      ...buildSessionStatus(session),
+      readinessUnchanged: true,
+    });
   }
 
   async function setOAuthRouting({ sessionId, routing }) {
@@ -3438,6 +3528,8 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
 // 1M-tier semantics and picker ordering can be exercised without spinning
 // up a full session.
 export {
+  writeMessageAccepted as _writeClaudeMessageAccepted,
+  replayClaudeHistoryEntry as _replayClaudeHistoryEntry,
   inferClaudeContextWindow as _inferClaudeContextWindow,
   augmentWithLegacyOpus as _augmentWithLegacyOpus,
   ensurePreferredModelRecord as _ensurePreferredModelRecord,

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -121,6 +121,7 @@ export function createUnavailableRuntime(label, reason) {
     listSessions: async () => [],
     spawnSession: unavailable,
     sendPrompt: unavailable,
+    submitPrompt: unavailable,
     cancelPrompt: unavailable,
     terminateSession: unavailable,
     setPermissionMode: unavailable,
@@ -136,6 +137,155 @@ export function createUnavailableRuntime(label, reason) {
     testConnection: unavailable,
     startServer: unavailable,
     stopServer: unavailable,
+  };
+}
+
+function optionalNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function spawnIdentity(params) {
+  return {
+    agentType: optionalNonEmptyString(params?.agentType),
+    cwd: optionalNonEmptyString(params?.cwd),
+    resumeAgentSessionId: optionalNonEmptyString(
+      params?.resumeAgentSessionId,
+    ),
+  };
+}
+
+function assertCompatibleSpawn(
+  identity,
+  candidate,
+  { allowMissingCandidateNative = false } = {},
+) {
+  if (
+    identity.agentType !== optionalNonEmptyString(candidate?.agentType) ||
+    identity.cwd !== optionalNonEmptyString(candidate?.cwd)
+  ) {
+    throw new Error(
+      "A provider session with this local session ID already exists with a different agent or working directory.",
+    );
+  }
+
+  const candidateAgentSessionId = optionalNonEmptyString(
+    candidate?.agentSessionId ?? candidate?.resumeAgentSessionId,
+  );
+  if (
+    identity.resumeAgentSessionId &&
+    (!allowMissingCandidateNative || candidateAgentSessionId) &&
+    identity.resumeAgentSessionId !== candidateAgentSessionId
+  ) {
+    throw new Error(
+      "A provider session with this local session ID already exists with a different native session ID.",
+    );
+  }
+}
+
+/**
+ * Claim a local session ID before any asynchronous lookup or process spawn.
+ * This keeps simultaneous Happy restore paths from creating two provider
+ * children for the same durable binding.
+ */
+export function createSynchronousSpawnCoordinator({
+  spawn,
+  listSessions,
+  emit,
+}) {
+  const inFlight = new Map();
+
+  const reemitReady = (session) => {
+    if (session?.status !== "ready") return;
+    emit("provider://session-status", {
+      sessionId: session.id,
+      status: "ready",
+      agentSessionId: session.agentSessionId,
+    });
+  };
+
+  return function coordinateSpawn(params = {}) {
+    const localSessionId = optionalNonEmptyString(params.localSessionId);
+    if (!localSessionId) {
+      return spawn(params).then((session) => ({
+        ...session,
+        reused: false,
+        owned: true,
+      }));
+    }
+
+    const identity = spawnIdentity(params);
+    const active = inFlight.get(localSessionId);
+    if (active) {
+      try {
+        assertCompatibleSpawn(identity, active.identity, {
+          allowMissingCandidateNative: true,
+        });
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      return active.promise.then((session) => {
+        // The winning caller may have had a weaker restore contract (for
+        // example, desktop replay versus Happy replay suppression). Validate
+        // the resolved process against this joiner's own native-ID
+        // postcondition before returning it.
+        assertCompatibleSpawn(identity, session);
+        reemitReady(session);
+        return {
+          ...session,
+          reused: true,
+          owned: false,
+        };
+      });
+    }
+
+    let resolveFlight;
+    let rejectFlight;
+    const flightPromise = new Promise((resolve, reject) => {
+      resolveFlight = resolve;
+      rejectFlight = reject;
+    });
+    const flight = { identity, promise: flightPromise };
+    // This write intentionally happens before listSessions() or spawn() can
+    // yield. Every later caller sees and joins this exact flight.
+    inFlight.set(localSessionId, flight);
+
+    void (async () => {
+      const listed = await listSessions();
+      const existing = listed.find(
+        (session) => session?.id === localSessionId,
+      );
+      if (existing) {
+        assertCompatibleSpawn(identity, existing);
+        if (existing.status !== "ready") {
+          throw new Error(
+            "A provider session with this local session ID exists but is not ready for reuse.",
+          );
+        }
+        reemitReady(existing);
+        return {
+          ...existing,
+          reused: true,
+          owned: false,
+        };
+      }
+
+      const session = await spawn(params);
+      return {
+        ...session,
+        reused: false,
+        owned: true,
+      };
+    })().then(resolveFlight, rejectFlight);
+
+    const clearFlight = () => {
+      if (inFlight.get(localSessionId) === flight) {
+        inFlight.delete(localSessionId);
+      }
+    };
+    // Handle both outcomes explicitly so cleanup cannot create an orphaned
+    // rejected promise.
+    void flightPromise.then(clearFlight, clearFlight);
+    return flightPromise;
   };
 }
 
@@ -882,8 +1032,8 @@ function replayToolLikeItem(emit, session, item) {
     return;
   }
 
-  emitToolCall(emit, session, item, item?.status ?? "completed");
-  emitToolResult(emit, session, item);
+  emitToolCall(emit, session, item, item?.status ?? "completed", true);
+  emitToolResult(emit, session, item, true);
 }
 
 function replayThreadItems(emit, session, thread) {
@@ -926,7 +1076,13 @@ function isToolLikeItem(item) {
   );
 }
 
-function emitToolCall(emit, session, item, statusOverride) {
+function emitToolCall(
+  emit,
+  session,
+  item,
+  statusOverride,
+  replay = false,
+) {
   const type = String(item?.type ?? "").toLowerCase();
   if (!isToolLikeItem(item)) {
     return;
@@ -952,10 +1108,11 @@ function emitToolCall(emit, session, item, statusOverride) {
     kind: item.type ?? "tool",
     status: statusOverride ?? item.status ?? "in_progress",
     parameters: item,
+    ...(replay ? { replay: true } : {}),
   });
 }
 
-function emitToolResult(emit, session, item) {
+function emitToolResult(emit, session, item, replay = false) {
   if (!isToolLikeItem(item)) {
     return;
   }
@@ -986,6 +1143,7 @@ function emitToolResult(emit, session, item) {
       (item.exitCode && item.exitCode !== 0
         ? `Command exited with code ${item.exitCode}`
         : undefined),
+    ...(replay ? { replay: true } : {}),
   });
 
   session.toolOutputs.delete(toolCallId);
@@ -1090,6 +1248,13 @@ function isRecoverableResumeError(message) {
     lower.includes("does not exist") ||
     lower.includes("no rollout") ||
     lower.includes("timed out")
+  );
+}
+
+export function shouldFallbackCodexResume(error, requireExactResume = false) {
+  return (
+    requireExactResume !== true &&
+    isRecoverableResumeError(error instanceof Error ? error.message : error)
   );
 }
 
@@ -1461,7 +1626,11 @@ function attachProcessListeners(
   });
 }
 
-export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-runtime" }) {
+export function createProviderHandlers({
+  emit: rawEmit,
+  runtimeMode = "provider-runtime",
+  spawnCodex = spawnCodexProcess,
+}) {
   const sessions = new Map();
   const permissionResolutions = createResolutionTracker();
   const diffProposalResolutions = createResolutionTracker();
@@ -1529,7 +1698,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
   );
 
   async function withTemporaryCodexSession(cwd, callback) {
-    const processHandle = spawnCodexProcess(cwd);
+    const processHandle = spawnCodex(cwd);
     const session = createCodexSessionRecord({
       sessionId: randomUUID(),
       cwd,
@@ -1564,12 +1733,14 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     }
   }
 
-  async function spawnSession(params) {
+  async function spawnOwnedSession(params) {
     const {
       agentType,
       cwd,
       localSessionId,
       resumeAgentSessionId,
+      requireExactResume,
+      suppressHistoryReplay,
       apiKey,
       mcpServers,
       approvalPolicy,
@@ -1604,6 +1775,11 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     if (agentType !== "codex") {
       throw new Error(`Unsupported browser-local agent type: ${agentType}`);
     }
+    if (requireExactResume === true && !resumeAgentSessionId) {
+      throw new Error(
+        "Codex exact resume requires a native agent session ID.",
+      );
+    }
 
     const sessionId = localSessionId ?? randomUUID();
     const resolvedMode = modeFromApprovalPolicy(approvalPolicy);
@@ -1612,7 +1788,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     let processHandle;
     try {
       if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
-      processHandle = spawnCodexProcess(cwd, {
+      processHandle = spawnCodex(cwd, {
         apiKey,
         mcpServers,
         serenMcpGatewayUrl: serenMcpProxy?.url,
@@ -1713,7 +1889,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           );
           resumedExistingThread = true;
         } catch (error) {
-          if (!isRecoverableResumeError(error instanceof Error ? error.message : error)) {
+          if (!shouldFallbackCodexResume(error, requireExactResume)) {
             throw error;
           }
           threadResult = await sendRequest(
@@ -1736,6 +1912,14 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         threadResult?.thread?.id ??
         threadResult?.threadId ??
         session.agentSessionId;
+      if (
+        requireExactResume === true &&
+        session.agentSessionId !== resumeAgentSessionId
+      ) {
+        throw new Error(
+          "Codex resumed a different native session than the one requested.",
+        );
+      }
       session.codexVersion = threadResult?.thread?.cliVersion ?? session.codexVersion;
       const requestedModelId =
         getSelectedModelRecord(session)?.modelId ??
@@ -1768,7 +1952,11 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       session.serviceTier =
         session.serviceTier ?? normalizeServiceTier(threadResult?.serviceTier);
 
-      if (resumedExistingThread && session.agentSessionId) {
+      if (
+        resumedExistingThread &&
+        session.agentSessionId &&
+        suppressHistoryReplay !== true
+      ) {
         let replayThread = threadResult?.thread;
         if (!Array.isArray(replayThread?.turns)) {
           const threadRead = await sendRequest(
@@ -1819,7 +2007,19 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     }
   }
 
-  async function sendPrompt({ sessionId, prompt, context, origin = "desktop" }) {
+  const spawnSession = createSynchronousSpawnCoordinator({
+    spawn: spawnOwnedSession,
+    listSessions,
+    emit,
+  });
+
+  async function sendPrompt({
+    sessionId,
+    prompt,
+    context,
+    origin = "desktop",
+    onAccepted,
+  }) {
     const source = normalizeOrigin(origin);
     const session = sessions.get(sessionId);
     if (!session) {
@@ -1829,7 +2029,13 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           text: prompt,
           origin: source,
         });
-        return pairedRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+        return pairedRuntime.sendPrompt({
+          sessionId,
+          prompt,
+          context,
+          origin: source,
+          onAccepted,
+        });
       }
       if (geminiRuntime.hasSession(sessionId)) {
         emit("provider://user-message", {
@@ -1837,7 +2043,13 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           text: prompt,
           origin: source,
         });
-        return geminiRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+        return geminiRuntime.sendPrompt({
+          sessionId,
+          prompt,
+          context,
+          origin: source,
+          onAccepted,
+        });
       }
       if (grokRuntime.hasSession(sessionId)) {
         emit("provider://user-message", {
@@ -1845,7 +2057,13 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           text: prompt,
           origin: source,
         });
-        return grokRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+        return grokRuntime.sendPrompt({
+          sessionId,
+          prompt,
+          context,
+          origin: source,
+          onAccepted,
+        });
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
         emit("provider://user-message", {
@@ -1853,14 +2071,26 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           text: prompt,
           origin: source,
         });
-        return lmStudioRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+        return lmStudioRuntime.sendPrompt({
+          sessionId,
+          prompt,
+          context,
+          origin: source,
+          onAccepted,
+        });
       }
       emit("provider://user-message", {
         sessionId,
         text: prompt,
         origin: source,
       });
-      return claudeRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+      return claudeRuntime.sendPrompt({
+        sessionId,
+        prompt,
+        context,
+        origin: source,
+        onAccepted,
+      });
     }
     if (session.currentPrompt) {
       throw new Error("Another prompt is already active for this session.");
@@ -1885,6 +2115,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         reject: rejectPromise,
       };
     });
+    // turn/start can fail before the success path reaches `await
+    // pendingPrompt`. Mark the internal turn promise handled immediately; the
+    // RPC-facing error still propagates through sendPrompt's catch below.
+    pendingPrompt.catch(() => {});
 
     try {
       const response = await sendRequest(
@@ -1898,16 +2132,63 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       if (typeof turnId === "string") {
         session.activeTurnId = turnId;
       }
+      onAccepted?.();
 
       await pendingPrompt;
     } catch (error) {
-      session.status = "ready";
+      const promptWasActive = session.currentPrompt !== null;
       rejectCurrentPrompt(
         session,
         error instanceof Error ? error : new Error(String(error)),
       );
+      if (promptWasActive && sessions.get(sessionId) === session) {
+        session.status = "ready";
+        emit("provider://error", {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        emit(
+          "provider://session-status",
+          buildSessionStatus(session, "ready"),
+        );
+      }
       throw error;
     }
+  }
+
+  function submitPrompt(params) {
+    if (
+      pairedRuntime.hasSession(params?.sessionId) ||
+      lmStudioRuntime.hasSession(params?.sessionId)
+    ) {
+      return Promise.reject(
+        new Error(
+          "This provider does not expose an explicit prompt acceptance boundary.",
+        ),
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      let accepted = false;
+      const promptPromise = sendPrompt({
+        ...params,
+        onAccepted() {
+          if (accepted) return;
+          accepted = true;
+          resolve({
+            accepted: true,
+            sessionId: params?.sessionId,
+          });
+        },
+      });
+
+      // The submit RPC ends at acceptance, but the turn keeps running. Always
+      // observe its eventual failure so it cannot become an unhandled
+      // rejection; provider runtimes emit their own late error/status events.
+      void promptPromise.catch((error) => {
+        if (!accepted) reject(error);
+      });
+    });
   }
 
   async function cancelPrompt({ sessionId }) {
@@ -2042,7 +2323,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     }
 
     session.currentModeId = mode === "ask" ? "ask" : "auto";
-    emit("provider://session-status", buildSessionStatus(session));
+    emit("provider://session-status", {
+      ...buildSessionStatus(session),
+      readinessUnchanged: true,
+    });
   }
 
   async function setOAuthRouting({ sessionId, routing }) {
@@ -2457,6 +2741,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
   return {
     spawnSession,
     sendPrompt,
+    submitPrompt,
     cancelPrompt,
     terminateSession,
     listSessions,
@@ -2487,6 +2772,7 @@ export {
   buildCodexThreadStartParams as _buildCodexThreadStartParams,
   buildCodexTurnStartParams as _buildCodexTurnStartParams,
   buildSessionStatus as _buildCodexSessionStatus,
+  replayThreadItems as _replayCodexThreadItems,
   codexServiceTierFromFastModeValue as _codexServiceTierFromFastModeValue,
   codexApprovalPolicy as _codexApprovalPolicy,
   modeFromApprovalPolicy as _modeFromApprovalPolicy,

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -25,6 +25,8 @@ const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const SESSION_KEEP_ALIVE_MS = 2000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
+const HAPPY_CONTEXT_RESET_NOTICE =
+  "Provider context reset: the original native session was unavailable, so Seren started a new provider context for this existing Happy thread.";
 const BUSY_SESSION_STATUSES = new Set(["prompting", "busy", "running"]);
 const DENY_OPTION_IDS = new Set([
   "deny",
@@ -230,6 +232,8 @@ const HAPPY_AGENT_TYPES = new Map([
   ["grok", "grok"],
   ["codex", "codex"],
 ]);
+const RESTORABLE_HAPPY_AGENT_TYPES = new Set(HAPPY_AGENT_TYPES.values());
+const EXACT_RESUME_HAPPY_AGENT_TYPES = new Set(["claude-code", "codex"]);
 
 function happyAgentType(agent) {
   if (agent === undefined || agent === null) return "claude-code";
@@ -399,50 +403,95 @@ export function createDeferredPromptQueue({
   const queues = new Map();
   const busySessions = new Set();
   const drainingSessions = new Set();
+  const readyDuringSubmission = new Set();
+  const cancelledSessions = new Set();
+  const failedSessions = new Set();
+  const drainOperations = new Set();
   let closed = false;
 
   async function drain(sessionId) {
-    if (closed || busySessions.has(sessionId) || drainingSessions.has(sessionId)) {
+    if (
+      closed ||
+      failedSessions.has(sessionId) ||
+      busySessions.has(sessionId) ||
+      drainingSessions.has(sessionId)
+    ) {
       return;
     }
     const queue = queues.get(sessionId);
     if (!queue?.length) return;
 
     drainingSessions.add(sessionId);
+    busySessions.add(sessionId);
     try {
-      while (!closed && queue.length > 0 && !busySessions.has(sessionId)) {
-        const item = queue[0];
-        try {
-          await send(sessionId, item.value);
-          queue.shift();
-          item.resolve(true);
-        } catch (error) {
-          if (shouldRetry(error)) {
-            busySessions.add(sessionId);
-            onError(error, { deferred: true, sessionId });
-            break;
+      // Submit exactly one head item. Acceptance only means the provider owns
+      // this prompt; the next relay record must wait for an explicit ready,
+      // error, or turn-complete event from that provider.
+      const item = queue[0];
+      try {
+        const outcome = await send(sessionId, item.value);
+        if (queue[0] === item) queue.shift();
+        item.resolve(!cancelledSessions.has(sessionId));
+        // Provider events and RPC responses use independent frames. Preserve an
+        // authoritative completion that overtakes the acceptance response;
+        // configuration-only status events are filtered by publishEvent.
+        const providerBecameReady = readyDuringSubmission.delete(sessionId);
+        if (outcome?.terminalDiscard === true || providerBecameReady) {
+          busySessions.delete(sessionId);
+        }
+      } catch (error) {
+        if (shouldRetry(error)) {
+          onError(error, { deferred: true, sessionId });
+          if (readyDuringSubmission.delete(sessionId)) {
+            busySessions.delete(sessionId);
           }
-          queue.shift();
-          item.resolve(false);
+        } else {
+          if (queue[0] === item) queue.shift();
+          item.reject(error);
+          failedSessions.add(sessionId);
           onError(error, { deferred: false, sessionId });
         }
       }
     } finally {
       drainingSessions.delete(sessionId);
-      if (queue.length === 0) queues.delete(sessionId);
+      if (queue.length === 0 || cancelledSessions.has(sessionId)) {
+        queues.delete(sessionId);
+        if (cancelledSessions.delete(sessionId)) failedSessions.delete(sessionId);
+      } else if (!closed && !busySessions.has(sessionId)) {
+        void startDrain(sessionId);
+      }
     }
+  }
+
+  function startDrain(sessionId) {
+    const operation = drain(sessionId);
+    drainOperations.add(operation);
+    void operation.then(
+      () => drainOperations.delete(operation),
+      () => drainOperations.delete(operation),
+    );
+    return operation;
   }
 
   function clear(sessionId) {
     const queue = queues.get(sessionId) ?? [];
-    queues.delete(sessionId);
     busySessions.delete(sessionId);
+    readyDuringSubmission.delete(sessionId);
+    if (drainingSessions.has(sessionId)) {
+      cancelledSessions.add(sessionId);
+      for (const item of queue.splice(1)) item.resolve(false);
+      return;
+    }
+    queues.delete(sessionId);
+    cancelledSessions.delete(sessionId);
+    failedSessions.delete(sessionId);
     for (const item of queue.splice(0)) item.resolve(false);
   }
 
   return {
     enqueue(sessionId, value) {
       if (closed) return Promise.resolve(false);
+      if (failedSessions.has(sessionId)) return Promise.resolve(false);
       const queue = queues.get(sessionId) ?? [];
       // A paired peer must not be able to grow memory without bound while a
       // long local turn is active. Preserve the oldest accepted prompts.
@@ -454,23 +503,35 @@ export function createDeferredPromptQueue({
         return Promise.resolve(false);
       }
       queues.set(sessionId, queue);
-      const result = new Promise((resolve) => queue.push({ value, resolve }));
-      void drain(sessionId);
+      const result = new Promise((resolve, reject) =>
+        queue.push({ value, resolve, reject }),
+      );
+      void startDrain(sessionId);
       return result;
     },
     setBusy(sessionId, busy) {
       if (busy) {
         busySessions.add(sessionId);
+        readyDuringSubmission.delete(sessionId);
+        return;
+      }
+      if (failedSessions.has(sessionId)) return;
+      if (drainingSessions.has(sessionId)) {
+        readyDuringSubmission.add(sessionId);
         return;
       }
       busySessions.delete(sessionId);
-      void drain(sessionId);
+      void startDrain(sessionId);
     },
     clear,
-    close() {
+    async close() {
       closed = true;
+      await Promise.allSettled([...drainOperations]);
       for (const sessionId of Array.from(queues.keys())) clear(sessionId);
       busySessions.clear();
+      readyDuringSubmission.clear();
+      cancelledSessions.clear();
+      failedSessions.clear();
     },
   };
 }
@@ -617,6 +678,8 @@ export function createHappyLayer({
   const spawnOperations = new Set();
   const layerOperations = new Set();
   const remotelyArchivedSessions = new Set();
+  const ownershipPendingSessions = new Set();
+  const ownershipPendingProviderStatuses = new Map();
   const terminatedSessions = createTerminatedSessionTracker();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
@@ -624,6 +687,8 @@ export function createHappyLayer({
   const assistantMessageCoalescer = createAssistantMessageCoalescer();
 
   const sessionSummaries = new Map();
+  const sessionSummaryRevisions = new Map();
+  let sessionSummaryRevision = 0;
   let summariesRefreshPromise = null;
 
   function debug(message) {
@@ -739,10 +804,11 @@ export function createHappyLayer({
     blockRevival = false,
     desktopAlreadyFenced = false,
     agentSessionId,
+    conversationId: knownConversationId,
   }) {
     let retiringBinding = binding;
     const shouldArchiveConversation = blockRevival || binding?.blockRevival === true;
-    let conversationId = binding?.conversationId;
+    let conversationId = knownConversationId ?? binding?.conversationId;
     let archiveProviderOnly = false;
     const ownerAgentSessionId =
       agentSessionId ?? entry?.summary?.agentSessionId ?? binding?.agentSessionId;
@@ -930,10 +996,406 @@ export function createHappyLayer({
           blockRevival: desktopAlreadyFenced,
           desktopAlreadyFenced,
         });
-        if (retired) terminatedSessions.mark(binding.sessionId);
+        if (!retired) {
+          throw new Error("Persisted Happy session retirement did not complete");
+        }
+        terminatedSessions.mark(binding.sessionId);
       });
-    await Promise.allSettled(retirements);
+    await Promise.all(retirements);
     return blocked;
+  }
+
+  async function migrateLegacyHappyProviderBindings(blockedSessionIds) {
+    if (!sessionKeyStore || !api || !identity) return;
+    const response = await supervisorChannel.call("conversation_restore_candidates", {});
+    if (!Array.isArray(response?.candidates)) {
+      throw new Error("Happy conversation migration returned an invalid candidate list");
+    }
+    const bindingsBySessionId = new Map(
+      (await persistedSessionBindings()).map((binding) => [binding.sessionId, binding]),
+    );
+    const machineId = identity.machineId ?? "seren-desktop";
+
+    for (const candidate of response.candidates) {
+      const sessionId = candidate?.conversationId;
+      const legacyHappySessionId = candidate?.happySessionId;
+      if (
+        typeof sessionId !== "string" ||
+        !UUID_PATTERN.test(sessionId) ||
+        typeof legacyHappySessionId !== "string" ||
+        legacyHappySessionId.length === 0 ||
+        blockedSessionIds.has(sessionId)
+      ) {
+        continue;
+      }
+      if (
+        typeof candidate.agentType !== "string" ||
+        !RESTORABLE_HAPPY_AGENT_TYPES.has(candidate.agentType) ||
+        typeof candidate.cwd !== "string"
+      ) {
+        throw new Error("Happy conversation migration candidate was invalid");
+      }
+      const root = validateSpawnRoot(candidate.cwd, advertisedRoots);
+      if (!root.ok || root.root !== candidate.cwd) {
+        throw new Error("Happy conversation migration root was no longer authorized");
+      }
+
+      let binding = bindingsBySessionId.get(sessionId) ?? null;
+      if (
+        binding?.state === "ready" &&
+        binding.happySessionId === legacyHappySessionId
+      ) {
+        // Rows created before the lifecycle fence existed can already have a
+        // valid encrypted binding. Acknowledge that exact pair in SQLite
+        // before provider notifications are subscribed so a later natural
+        // termination (which deletes the key binding) cannot be mistaken for
+        // another v3.72 migration candidate and resurrected.
+        await supervisorChannel.call("conversation_migrate_happy_session", {
+          conversationId: sessionId,
+          expectedHappySessionId: legacyHappySessionId,
+          replacementHappySessionId: legacyHappySessionId,
+        });
+        if (binding.legacyRelayRetired === true) {
+          binding = await sessionKeyStore.clearLegacyRelayRetired(sessionId);
+          bindingsBySessionId.set(sessionId, binding);
+        }
+        continue;
+      }
+      if (!binding) {
+        binding = await sessionKeyStore.getOrCreate(
+          sessionId,
+          `seren-migrated-${randomUUID()}`,
+        );
+        bindingsBySessionId.set(sessionId, binding);
+      }
+      if (binding.state === "retiring") continue;
+
+      if (
+        binding.state === "ready" &&
+        binding.happySessionId !== legacyHappySessionId &&
+        binding.legacyRelayRetired !== true
+      ) {
+        const retired = await api.deactivateSession(legacyHappySessionId);
+        if (!retired) {
+          throw new Error("Legacy Happy relay row could not be retired");
+        }
+        binding = await sessionKeyStore.markLegacyRelayRetired(sessionId);
+        bindingsBySessionId.set(sessionId, binding);
+      }
+
+      if (binding.state === "pending") {
+        if (binding.legacyRelayRetired !== true) {
+          const retired = await api.deactivateSession(legacyHappySessionId);
+          if (!retired) {
+            throw new Error("Legacy Happy relay row could not be retired");
+          }
+          binding = await sessionKeyStore.markLegacyRelayRetired(sessionId);
+          bindingsBySessionId.set(sessionId, binding);
+        }
+        if (binding.relayTag === `seren-${sessionId}`) {
+          binding = await sessionKeyStore.replacePendingTag(
+            sessionId,
+            `seren-migrated-${randomUUID()}`,
+          );
+          bindingsBySessionId.set(sessionId, binding);
+        }
+        const metadata = sessionMetadata(
+          config,
+          {
+            sessionId,
+            agentType: candidate.agentType,
+            cwd: root.root,
+            title: candidate.title,
+            status: "initializing",
+          },
+          machineId,
+        );
+        const replacement = await getOrCreateUsableHappySession({
+          api,
+          tag: binding.relayTag,
+          metadata,
+          state: { controlledByUser: true },
+          encryptionKey: binding.key,
+          persistReady: async (happySessionId) => {
+            binding = await sessionKeyStore.markReady(sessionId, happySessionId);
+            bindingsBySessionId.set(sessionId, binding);
+          },
+        });
+        if (!isUsableHappySession(replacement)) {
+          throw new Error("Replacement Happy relay row could not be created");
+        }
+      }
+
+      if (
+        binding?.state !== "ready" ||
+        typeof binding.happySessionId !== "string" ||
+        binding.happySessionId === legacyHappySessionId ||
+        binding.legacyRelayRetired !== true
+      ) {
+        throw new Error("Happy relay migration binding was inconsistent");
+      }
+      const migrated = await supervisorChannel.call(
+        "conversation_migrate_happy_session",
+        {
+          conversationId: sessionId,
+          expectedHappySessionId: legacyHappySessionId,
+          replacementHappySessionId: binding.happySessionId,
+        },
+      );
+      if (migrated?.migrated !== true) {
+        throw new Error("Happy relay migration was not committed");
+      }
+      binding = await sessionKeyStore.clearLegacyRelayRetired(sessionId);
+      bindingsBySessionId.set(sessionId, binding);
+    }
+  }
+
+  async function discardUnclaimedSessionEntry(sessionId) {
+    const creation = sessionCreationPromises.get(sessionId);
+    if (creation) await creation.catch(() => null);
+    const entry = sessions.get(sessionId);
+    if (!entry) return;
+    sessions.delete(sessionId);
+    liveSessions.delete(sessionId);
+    promptQueue.clear(sessionId);
+    turnCorrelator.clear(sessionId);
+    assistantMessageCoalescer.clear(sessionId);
+    delete pendingRequests[sessionId];
+    sessionCreationPromises.delete(sessionId);
+    entry.liveness.stop();
+    await entry.client.close().catch(() =>
+      debug("failed to close relay client for a rejected ownership claim"),
+    );
+  }
+
+  async function unwindStartupProviders(sessionIds) {
+    const ids = [...new Set(sessionIds)];
+    for (const sessionId of ids) {
+      // Provider termination emits its terminal status before the RPC returns.
+      // Reinstall the ownership fence first so that cleanup cannot retire the
+      // durable relay binding that a future bridge restart must reuse.
+      ownershipPendingSessions.add(sessionId);
+      promptQueue.setBusy(sessionId, true);
+    }
+    await Promise.allSettled(ids.map((sessionId) => discardUnclaimedSessionEntry(sessionId)));
+    await Promise.allSettled(ids.map((sessionId) => source.terminate(sessionId)));
+    for (const sessionId of ids) {
+      ownershipPendingProviderStatuses.delete(sessionId);
+      promptQueue.clear(sessionId);
+    }
+  }
+
+  async function restorePersistedProviderSessions(listed, blockedSessionIds) {
+    const listedIds = new Set(listed.map((summary) => summary.sessionId));
+    const bindings = await persistedSessionBindings();
+    const restored = [];
+    const spawnedByThisStartup = [];
+    const unclaimedSpawnedSessions = new Set();
+    const pendingStartupClaims = new Set();
+
+    try {
+      for (const binding of bindings) {
+        if (
+          binding.state !== "ready" ||
+          listedIds.has(binding.sessionId) ||
+          blockedSessionIds.has(binding.sessionId)
+        ) {
+          continue;
+        }
+
+        const lookup = await supervisorChannel.call("conversation_lookup", {
+          providerSessionId: binding.sessionId,
+          happySessionId: binding.happySessionId,
+        });
+        const happyOrigin = lookup?.happyOrigin === true;
+        const shouldRetire = happyOrigin && lookup?.retire === true;
+        if (shouldRetire) {
+          const retired = await retirePersistedSession({
+            sessionId: binding.sessionId,
+            binding,
+            providerAlreadyRetired: true,
+            blockRevival: lookup?.archived === true,
+            desktopAlreadyFenced: lookup?.archived === true,
+          });
+          if (!retired) {
+            throw new Error("Invalid Happy provider binding could not be retired");
+          }
+          blockedSessionIds.add(binding.sessionId);
+          continue;
+        }
+        // A ready binding can also belong to a desktop-originated session whose
+        // provider will be restored by the frontend. Never infer Happy
+        // ownership from the local/provider id alone.
+        if (!happyOrigin || lookup?.restorable !== true) continue;
+
+        if (
+          lookup.conversationId !== binding.sessionId ||
+          typeof lookup.agentType !== "string" ||
+          typeof lookup.cwd !== "string"
+        ) {
+          throw new Error("Happy conversation lookup returned an invalid restore descriptor");
+        }
+        if (!RESTORABLE_HAPPY_AGENT_TYPES.has(lookup.agentType)) {
+          const retired = await retirePersistedSession({
+            sessionId: binding.sessionId,
+            binding,
+            providerAlreadyRetired: true,
+          });
+          if (!retired) {
+            throw new Error("Unsupported Happy provider binding could not be retired");
+          }
+          blockedSessionIds.add(binding.sessionId);
+          continue;
+        }
+        const root = validateSpawnRoot(lookup.cwd, advertisedRoots);
+        if (!root.ok || root.root !== lookup.cwd) {
+          const retired = await retirePersistedSession({
+            sessionId: binding.sessionId,
+            binding,
+            providerAlreadyRetired: true,
+          });
+          if (!retired) {
+            throw new Error("Out-of-scope Happy provider binding could not be retired");
+          }
+          blockedSessionIds.add(binding.sessionId);
+          continue;
+        }
+        const hasStoredNativeSession =
+          typeof lookup.agentSessionId === "string" && lookup.agentSessionId.length > 0;
+        const canResumeExactNativeSession =
+          hasStoredNativeSession && EXACT_RESUME_HAPPY_AGENT_TYPES.has(lookup.agentType);
+        const spawnSpec = {
+          agentType: lookup.agentType,
+          cwd: root.root,
+          localSessionId: binding.sessionId,
+          ...(canResumeExactNativeSession
+            ? {
+                resumeAgentSessionId: lookup.agentSessionId,
+                requireExactResume: true,
+                suppressHistoryReplay: true,
+              }
+            : {
+                freshContextReset: true,
+                suppressHistoryReplay: true,
+              }),
+          ...(typeof lookup.agentModelId === "string" && lookup.agentModelId.length > 0
+            ? { initialModelId: lookup.agentModelId }
+            : {}),
+          ...(typeof lookup.agentPermissionMode === "string" &&
+          lookup.agentPermissionMode.length > 0
+            ? { permissionMode: lookup.agentPermissionMode }
+            : {}),
+          approvalPolicy: defaultApprovalPolicy(lookup.agentType),
+        };
+        ownershipPendingSessions.add(binding.sessionId);
+        pendingStartupClaims.add(binding.sessionId);
+        promptQueue.setBusy(binding.sessionId, true);
+        const spawned = await source.spawn(spawnSpec);
+        if (typeof spawned?.sessionId === "string" && spawned.sessionId.length > 0) {
+          // Spawning can reconfigure a same-ID process even when another caller
+          // owns it. Until the atomic claim succeeds, every touched process must
+          // be retired on failure so a stale permissive mode cannot survive.
+          unclaimedSpawnedSessions.add(spawned.sessionId);
+        }
+        const owned = spawned?.owned === true;
+        if (owned) spawnedByThisStartup.push(spawned.sessionId);
+        if (
+          spawned?.sessionId !== binding.sessionId ||
+          spawned?.agentType !== lookup.agentType ||
+          spawned?.cwd !== root.root ||
+          typeof spawned?.agentSessionId !== "string" ||
+          spawned.agentSessionId.length === 0
+        ) {
+          throw new Error("Happy provider restore did not preserve its exact identity");
+        }
+
+        const claim = await supervisorChannel.call("conversation_claim", {
+          conversationId: binding.sessionId,
+          providerSessionId: binding.sessionId,
+          happySessionId: binding.happySessionId,
+          cwd: root.root,
+          expectedAgentType: lookup.agentType,
+          expectedAgentSessionId: hasStoredNativeSession ? lookup.agentSessionId : null,
+          expectedAgentPermissionMode:
+            typeof lookup.agentPermissionMode === "string" ? lookup.agentPermissionMode : null,
+          agentSessionId: spawned.agentSessionId,
+        });
+        if (claim?.archived === true) {
+          // Archive wins over either caller's process ownership. A reused
+          // exact provider is still the process backing this archived row.
+          await source.terminate(binding.sessionId);
+          unclaimedSpawnedSessions.delete(binding.sessionId);
+          if (owned) {
+            spawnedByThisStartup.splice(
+              spawnedByThisStartup.lastIndexOf(binding.sessionId),
+              1,
+            );
+          }
+          const retired = await retirePersistedSession({
+            sessionId: binding.sessionId,
+            binding: {
+              ...binding,
+              conversationId: binding.sessionId,
+              agentSessionId: spawned.agentSessionId,
+            },
+            providerAlreadyRetired: true,
+            blockRevival: true,
+            desktopAlreadyFenced: true,
+          });
+          if (!retired) throw new Error("Archived Happy provider binding could not be retired");
+          pendingStartupClaims.delete(binding.sessionId);
+          ownershipPendingSessions.delete(binding.sessionId);
+          ownershipPendingProviderStatuses.delete(binding.sessionId);
+          promptQueue.clear(binding.sessionId);
+          blockedSessionIds.add(binding.sessionId);
+          continue;
+        }
+        if (claim?.archived !== false) {
+          throw new Error("Happy conversation ownership claim returned an invalid result");
+        }
+        unclaimedSpawnedSessions.delete(binding.sessionId);
+
+        const observedStatus = ownershipPendingProviderStatuses.get(binding.sessionId);
+        pendingStartupClaims.delete(binding.sessionId);
+        ownershipPendingSessions.delete(binding.sessionId);
+        ownershipPendingProviderStatuses.delete(binding.sessionId);
+
+        const summary = {
+          ...spawned,
+          ...(typeof observedStatus === "string" ? { status: observedStatus } : {}),
+          title: typeof lookup.title === "string" ? lookup.title : spawned.title,
+          freshContextReset: !canResumeExactNativeSession,
+        };
+        promptQueue.setBusy(
+          binding.sessionId,
+          BUSY_SESSION_STATUSES.has(summary.status) || summary.status === "initializing",
+        );
+        sessionSummaries.set(summary.sessionId, summary);
+        listedIds.add(summary.sessionId);
+        restored.push(summary);
+      }
+      return { summaries: restored, ownedSessionIds: spawnedByThisStartup };
+    } catch (error) {
+      const sessionsToTerminate = new Set([
+        ...spawnedByThisStartup,
+        ...unclaimedSpawnedSessions,
+      ]);
+      await unwindStartupProviders(sessionsToTerminate);
+      const abandonedPendingClaims = [...pendingStartupClaims].filter(
+        (sessionId) => !sessionsToTerminate.has(sessionId),
+      );
+      await Promise.allSettled(
+        abandonedPendingClaims.map((sessionId) => discardUnclaimedSessionEntry(sessionId)),
+      );
+      for (const sessionId of pendingStartupClaims) {
+        ownershipPendingProviderStatuses.delete(sessionId);
+        promptQueue.clear(sessionId);
+        if (!sessionsToTerminate.has(sessionId)) {
+          ownershipPendingSessions.delete(sessionId);
+        }
+      }
+      throw error;
+    }
   }
 
   function trackSessionDisposal(disposal) {
@@ -978,14 +1440,33 @@ export function createHappyLayer({
   async function refreshSessionSummaries() {
     if (summariesRefreshPromise) return summariesRefreshPromise;
     summariesRefreshPromise = (async () => {
+      const refreshRevision = sessionSummaryRevision;
       const listed = await source.listSessions();
+      const previous = new Map(sessionSummaries);
       sessionSummaries.clear();
       for (const summary of listed) {
-        sessionSummaries.set(summary.sessionId, summary);
+        const latest =
+          (sessionSummaryRevisions.get(summary.sessionId) ?? 0) > refreshRevision
+            ? { ...summary, ...previous.get(summary.sessionId) }
+            : summary;
+        sessionSummaries.set(summary.sessionId, latest);
         const entry = sessions.get(summary.sessionId);
-        if (entry) entry.summary = summary;
+        if (entry) entry.summary = latest;
       }
-      return listed;
+      // A provider event can introduce a session while the list RPC is in
+      // flight. Retain that newer event-backed summary even if the older list
+      // snapshot did not contain it.
+      for (const [sessionId, summary] of previous) {
+        if (
+          !sessionSummaries.has(sessionId) &&
+          (sessionSummaryRevisions.get(sessionId) ?? 0) > refreshRevision
+        ) {
+          sessionSummaries.set(sessionId, summary);
+        }
+      }
+      return listed.map(
+        (summary) => sessionSummaries.get(summary.sessionId) ?? summary,
+      );
     })();
     try {
       return await summariesRefreshPromise;
@@ -1054,6 +1535,14 @@ export function createHappyLayer({
 
   function registerInbound(entry) {
     const { client } = entry;
+    client.on("inboundProcessingError", () => {
+      entry.liveness.stop();
+      supervisorChannel.notify("status_report", {
+        state: "error",
+        detail: "relay input processing failed",
+      });
+      debug("Happy relay input processing stopped after a durable processing failure");
+    });
     client.on("archived", () => {
       const sessionId = entry.sessionId;
       if (sessions.get(sessionId) !== entry) return;
@@ -1080,8 +1569,17 @@ export function createHappyLayer({
       })();
       trackSessionDisposal(disposal);
     });
-    client.onUserMessage((message) => {
-      void promptQueue.enqueue(entry.sessionId, { entry, message });
+    client.onUserMessage(async (message) => {
+      const processed = await promptQueue.enqueue(entry.sessionId, { entry, message });
+      if (!processed) {
+        throw new Error("Happy user message was not accepted before session teardown");
+      }
+    });
+    client.onFileEvent(async () => {
+      // Provider runtimes do not accept binary/file attachments yet. Treat the
+      // record as a terminal discard so its exact relay sequence can advance
+      // without retrying it forever after every bridge restart.
+      debug("discarded unsupported Happy file attachment");
     });
     // Decryption failure yields null params rather than throwing, and these two
     // handlers ignore their argument, so without this guard a relay could cancel
@@ -1115,19 +1613,19 @@ export function createHappyLayer({
   async function handleUserMessage(entry, message) {
     if (message?.role !== "user" || message?.content?.type !== "text") {
       debug("dropped invalid Happy user message");
-      return;
+      return { accepted: false, terminalDiscard: true };
     }
     if (typeof message.content.text !== "string" || message.content.text.length === 0) {
       debug("dropped empty Happy user message");
-      return;
+      return { accepted: false, terminalDiscard: true };
     }
     const mode = message.meta?.permissionMode;
     if (message.meta && mode !== undefined && !isSupportedPermissionMode(mode)) {
       debug("dropped invalid Happy permission mode");
-      return;
+      return { accepted: false, terminalDiscard: true };
     }
     if (typeof mode === "string") await source.setPermissionMode(entry.sessionId, mode);
-    await source.sendPrompt(entry.sessionId, message.content.text);
+    return source.sendPrompt(entry.sessionId, message.content.text);
   }
 
   async function handlePermissionResponse(entry, response) {
@@ -1180,7 +1678,7 @@ export function createHappyLayer({
     const machineId = identity.machineId ?? "seren-desktop";
     const metadata = sessionMetadata(config, summary, machineId);
     const legacyTag = `seren-${sessionId}`;
-    const binding = sessionKeyStore
+    let binding = sessionKeyStore
       ? await sessionKeyStore.getOrCreate(sessionId, legacyTag)
       : null;
     if (binding?.state === "retiring") {
@@ -1206,15 +1704,23 @@ export function createHappyLayer({
         conversationId: sessionId,
       });
       const previousHappySessionId = recorded?.happySessionId;
-      if (
-        typeof previousHappySessionId === "string" &&
-        previousHappySessionId.length > 0 &&
-        !(await sessionApi.deactivateSession(previousHappySessionId))
-      ) {
-        throw new Error("Previous Happy relay row could not be retired");
+      if (typeof previousHappySessionId === "string" && previousHappySessionId.length > 0) {
+        if (!(await sessionApi.deactivateSession(previousHappySessionId))) {
+          throw new Error("Previous Happy relay row could not be retired");
+        }
+        // The archive endpoint retires the row, not its unique tag. Reusing
+        // that tag with a newly generated data key returns the old ciphertext
+        // and fails during decrypt, so persist the replacement tag before its
+        // POST and make a crash retry use the same safe row.
+        binding = await sessionKeyStore.replacePendingTag(
+          sessionId,
+          `seren-migrated-${randomUUID()}`,
+        );
       }
     }
     const resumedBinding = binding?.state === "ready";
+    const firstLegacyBinding =
+      binding?.state === "pending" && binding.relayTag === legacyTag;
     const session = await getOrCreateUsableHappySession({
       api: sessionApi,
       tag: binding?.relayTag ?? legacyTag,
@@ -1294,19 +1800,50 @@ export function createHappyLayer({
       return null;
     }
 
+    // Provider status can advance while relay/key-store HTTP calls above are
+    // pending. Install the entry from the latest authoritative summary so an
+    // early completion cannot be overwritten by the stale list snapshot.
+    summary = sessionSummaries.get(sessionId) ?? summary;
+
     let client;
-    const resumeFromSeq =
-      resumedBinding || session.seq > 0
-        ? typeof session.seq === "number"
-          ? session.seq
-          : 0
-        : 0;
+    const relaySnapshotSeq = Number.isSafeInteger(session.seq) && session.seq >= 0
+      ? session.seq
+      : 0;
+    let resumeFromSeq = 0;
     try {
-      // The SDK applies this cursor before opening its socket, so the initial
-      // fetch and a concurrent N+1 socket update cannot replay older prompts.
-      client = sessionApi.sessionSyncClient(session, { resumeFromSeq });
+      if (resumedBinding) {
+        if (Number.isSafeInteger(binding.processedThroughSeq)) {
+          if (binding.processedThroughSeq > relaySnapshotSeq) {
+            throw new Error("Persisted Happy processed sequence exceeds the relay snapshot");
+          }
+          resumeFromSeq = binding.processedThroughSeq;
+        } else {
+          // One-time migration for bindings written before durable inbound
+          // cursors existed. The old bridge already observed this snapshot and
+          // cannot prove which records were acted on, so seed at its high-water
+          // mark rather than replaying an arbitrary historical prompt.
+          await sessionKeyStore.markProcessedThroughSeq(sessionId, relaySnapshotSeq);
+          resumeFromSeq = relaySnapshotSeq;
+        }
+      } else if (firstLegacyBinding) {
+        // v3.72 had no durable binding/cursor. The POST snapshot is the exact
+        // high-water mark before this socket starts: seeding it prevents old
+        // inbound prompts from replaying, while records arriving after the
+        // response receive a larger sequence and are still delivered.
+        await sessionKeyStore.markProcessedThroughSeq(sessionId, relaySnapshotSeq);
+        resumeFromSeq = relaySnapshotSeq;
+      }
+      client = sessionApi.sessionSyncClient(session, {
+        resumeFromSeq,
+        onMessageProcessed: async (seq) => {
+          const persisted = await sessionKeyStore.markProcessedThroughSeq(sessionId, seq);
+          if (persisted.processedThroughSeq !== seq) {
+            throw new Error("Happy processed sequence did not advance exactly");
+          }
+        },
+      });
     } catch (error) {
-      await sessionApi.deactivateSession(session.id);
+      if (!resumedBinding) await sessionApi.deactivateSession(session.id);
       throw error;
     }
     // Do not rewrite lifecycle metadata when resuming. A mobile archive can
@@ -1321,13 +1858,24 @@ export function createHappyLayer({
         summary,
         session,
         client,
+        suppressProviderHistoryReplay: resumedBinding,
         liveness: createSessionLiveness(client, thinking),
       };
       sessions.set(sessionId, entry);
       liveSessions.add(sessionId);
-      promptQueue.setBusy(sessionId, thinking);
+      promptQueue.setBusy(
+        sessionId,
+        thinking || summary?.status === "initializing" || ownershipPendingSessions.has(sessionId),
+      );
       rememberPendingPermissions(sessionId, summary?.pendingPermissions);
       registerInbound(entry);
+      // ApiSessionClient connects inside its constructor. Its durable latch
+      // closes the constructor-to-listener window without changing the SDK's
+      // EventEmitter behavior for other consumers.
+      if (client.hasArchiveSignal?.()) {
+        client.emit("archived");
+      }
+      if (sessions.get(sessionId) !== entry) return null;
       client.sendSessionEvent({ type: "switch", mode: "remote" });
       return entry;
     } catch (error) {
@@ -1373,6 +1921,27 @@ export function createHappyLayer({
   }
 
   async function publishEvent(event) {
+    const providerStatus = event.kind === "status" ? event.payload?.status : null;
+    const readinessUnchanged = event.payload?.readinessUnchanged === true;
+    const providerThinking =
+      !readinessUnchanged && BUSY_SESSION_STATUSES.has(providerStatus);
+    const providerReady =
+      !readinessUnchanged &&
+      (event.kind === "turn-complete" ||
+        event.kind === "error" ||
+        ["ready", "idle", "completed"].includes(providerStatus));
+    if (ownershipPendingSessions.has(event.sessionId)) {
+      if (providerThinking) {
+        ownershipPendingProviderStatuses.set(event.sessionId, providerStatus);
+      } else if (providerReady) {
+        ownershipPendingProviderStatuses.set(event.sessionId, "ready");
+      }
+      // The provider is not authorized to own this desktop/relay identity
+      // until its atomic claim succeeds. Keep all output and entry creation
+      // behind that fence; the latest readiness is replayed from the spawn
+      // snapshot after ownership is established.
+      return;
+    }
     // An entry only exists if it passed the scope check when it was created, so
     // a tracked session stays tracked; an unknown one is gated here, before any
     // bookkeeping, so out-of-scope sessions accumulate no state either.
@@ -1399,16 +1968,32 @@ export function createHappyLayer({
       }
       return;
     }
+    const trackedBeforeReplay = sessions.get(event.sessionId);
+    if (
+      trackedBeforeReplay?.suppressProviderHistoryReplay === true &&
+      (event.payload?.replay === true || event.payload?.historyReplay === true)
+    ) {
+      return;
+    }
     let summary =
       (await sessionSummary(event.sessionId)) ?? sessions.get(event.sessionId)?.summary ?? null;
     const observedAgentSessionId = event.payload?.agentSessionId;
-    if (
-      summary &&
-      typeof observedAgentSessionId === "string" &&
-      observedAgentSessionId.length > 0
-    ) {
-      summary = { ...summary, agentSessionId: observedAgentSessionId };
+    if (summary) {
+      const observedStatus = providerThinking
+        ? providerStatus
+        : providerReady
+          ? providerStatus ?? "ready"
+          : null;
+      summary = {
+        ...summary,
+        ...(observedStatus ? { status: observedStatus } : {}),
+        ...(typeof observedAgentSessionId === "string" && observedAgentSessionId.length > 0
+          ? { agentSessionId: observedAgentSessionId }
+          : {}),
+      };
       sessionSummaries.set(event.sessionId, summary);
+      sessionSummaryRevision += 1;
+      sessionSummaryRevisions.set(event.sessionId, sessionSummaryRevision);
       const trackedEntry = sessions.get(event.sessionId);
       if (trackedEntry) trackedEntry.summary = summary;
     }
@@ -1443,15 +2028,9 @@ export function createHappyLayer({
       debug("dropped event for session outside advertised roots");
       return;
     }
-    const providerStatus = event.kind === "status" ? event.payload?.status : null;
-    const providerThinking = BUSY_SESSION_STATUSES.has(providerStatus);
-    const providerReady =
-      event.kind === "turn-complete" ||
-      event.kind === "error" ||
-      ["ready", "idle", "completed"].includes(providerStatus);
     if (providerThinking) {
       promptQueue.setBusy(event.sessionId, true);
-    } else if (providerReady) {
+    } else if (providerReady && !ownershipPendingSessions.has(event.sessionId)) {
       promptQueue.setBusy(event.sessionId, false);
     }
     if (terminal) {
@@ -1466,6 +2045,12 @@ export function createHappyLayer({
     rememberPermission(event);
     const entry = await findOrCreateSession(event.sessionId, summary);
     if (!entry) return;
+    if (
+      entry.suppressProviderHistoryReplay === true &&
+      (event.payload?.replay === true || event.payload?.historyReplay === true)
+    ) {
+      return;
+    }
     if (providerThinking) {
       entry.liveness.setThinking(true);
     } else if (providerReady) {
@@ -1533,6 +2118,10 @@ export function createHappyLayer({
     let providerConfirmedAbsent = false;
     let pendingProviderRetired = false;
     let unexpectedProviderSessionId = null;
+    let claimAttempted = false;
+    let archiveWon = false;
+    let pendingDisposed = false;
+    ownershipPendingSessions.add(pendingSessionId);
     try {
       // Entry creation itself persists the key/tag and can create the relay
       // row. Keep it inside the unwind scope so a client-construction failure
@@ -1568,10 +2157,10 @@ export function createHappyLayer({
           localSessionId: conversation.conversationId,
           approvalPolicy: defaultApprovalPolicy(agentType),
         });
-      } catch (error) {
-        providerConfirmedAbsent = error?.providerRequestRejected === true;
-        throw error;
-      }
+        } catch (error) {
+          providerConfirmedAbsent = error?.providerRequestRejected === true;
+          throw error;
+        }
       if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
       if (closing || identityResetting || sessions.get(pendingSessionId) !== pending) {
         try {
@@ -1597,23 +2186,70 @@ export function createHappyLayer({
         }
         throw new Error("provider did not preserve the preallocated session id");
       }
-      pending.summary = spawned;
+      claimAttempted = true;
+      const claim = await supervisorChannel.call("conversation_claim", {
+        conversationId: pendingSessionId,
+        providerSessionId: pendingSessionId,
+        happySessionId: pending.happySessionId,
+        cwd: validation.root,
+        expectedAgentType: agentType,
+        expectedAgentSessionId: null,
+        expectedAgentPermissionMode: null,
+        agentSessionId:
+          typeof spawned.agentSessionId === "string" && spawned.agentSessionId.length > 0
+            ? spawned.agentSessionId
+            : null,
+      });
+      if (claim?.archived === true) {
+        archiveWon = true;
+        // The frontend can win the same-ID spawn flight, returning owned:false.
+        // The archived claim still fences this exact provider process.
+        await source.terminate(pendingSessionId);
+        pendingProviderRetired = true;
+        await discardPendingSpawn(pendingSessionId, pending, {
+          providerAlreadyRetired: true,
+          blockRevival: true,
+          desktopAlreadyFenced: true,
+          conversationId: pendingSessionId,
+          agentSessionId: spawned.agentSessionId,
+        });
+        pendingDisposed = true;
+        throw new Error("Happy conversation was archived during provider spawn");
+      }
+      if (claim?.archived !== false) {
+        throw new Error("Happy conversation ownership claim returned an invalid result");
+      }
+      const observedStatus = ownershipPendingProviderStatuses.get(pendingSessionId);
+      const claimedSummary =
+        typeof observedStatus === "string" ? { ...spawned, status: observedStatus } : spawned;
+      pending.summary = claimedSummary;
       liveSessions.add(pendingSessionId);
       // Seed the cache so the first streamed event resolves this session's
       // provider without re-listing.
-      sessionSummaries.set(pendingSessionId, spawned);
+      sessionSummaries.set(pendingSessionId, claimedSummary);
+      ownershipPendingSessions.delete(pendingSessionId);
+      ownershipPendingProviderStatuses.delete(pendingSessionId);
+      promptQueue.setBusy(
+        pendingSessionId,
+        BUSY_SESSION_STATUSES.has(claimedSummary.status) ||
+          claimedSummary.status === "initializing",
+      );
       return { type: "success", sessionId: pending.happySessionId };
     } catch (error) {
+      ownershipPendingSessions.delete(pendingSessionId);
+      ownershipPendingProviderStatuses.delete(pendingSessionId);
       if (unexpectedProviderSessionId) {
         await source
           .terminate(unexpectedProviderSessionId)
           .catch(() => debug("failed to retry mismatched provider termination"));
       }
-      await discardPendingSpawn(pendingSessionId, pending, {
-        providerNeverStarted: !providerSpawnAttempted || providerConfirmedAbsent,
-        providerAlreadyRetired: pendingProviderRetired,
-      });
-      if (conversationCreated) {
+      if (!pendingDisposed) {
+        await discardPendingSpawn(pendingSessionId, pending, {
+          providerNeverStarted: !providerSpawnAttempted || providerConfirmedAbsent,
+          providerAlreadyRetired: pendingProviderRetired,
+        });
+      }
+      if (conversationCreated && !claimAttempted && !archiveWon) {
         await supervisorChannel
           .call("conversation_delete", { conversationId: pendingSessionId })
           .catch(() => debug("failed to roll back abandoned Happy conversation"));
@@ -1772,7 +2408,14 @@ export function createHappyLayer({
   async function discardPendingSpawn(
     pendingSessionId,
     pending,
-    { providerNeverStarted = false, providerAlreadyRetired = false } = {},
+    {
+      providerNeverStarted = false,
+      providerAlreadyRetired = false,
+      blockRevival = false,
+      desktopAlreadyFenced = false,
+      conversationId,
+      agentSessionId,
+    } = {},
   ) {
     if (pending && sessions.get(pendingSessionId) === pending) {
       sessions.delete(pendingSessionId);
@@ -1782,6 +2425,7 @@ export function createHappyLayer({
       delete pendingRequests[pendingSessionId];
       sessionCreationPromises.delete(pendingSessionId);
     }
+    promptQueue.clear(pendingSessionId);
     const binding = pending ? null : await persistedSessionBinding(pendingSessionId);
     if (!pending && !binding) return;
     const providerIsRetired = providerNeverStarted || providerAlreadyRetired;
@@ -1790,6 +2434,10 @@ export function createHappyLayer({
       ...(pending ? { entry: pending } : { binding }),
       terminateProvider: !providerIsRetired,
       providerAlreadyRetired: providerIsRetired,
+      blockRevival,
+      desktopAlreadyFenced,
+      conversationId,
+      agentSessionId,
     });
   }
 
@@ -1916,14 +2564,16 @@ export function createHappyLayer({
 
   async function finishRegistration() {
     return startupStatusGate.complete(async () => {
+      // The provider client buffers per-session notifications until subscribe.
+      // Complete the one-time pre-key-store relay migration and every atomic
+      // restore claim first: flushing a queued status any earlier could create
+      // an inbound relay handler for a provider that does not own the desktop
+      // conversation yet.
       await updateCapabilities();
       const listed = await refreshSessionSummaries();
       const blockedSessionIds = await reconcilePersistedSessions(listed);
-      for (const summary of listed) {
-        if (blockedSessionIds.has(summary.sessionId)) continue;
-        if (!isSessionInScope(summary)) continue;
-        await createSessionEntry(summary.sessionId, summary);
-      }
+      await migrateLegacyHappyProviderBindings(blockedSessionIds);
+      const restored = await restorePersistedProviderSessions(listed, blockedSessionIds);
       sourceSubscription?.();
       sourceSubscription = source.subscribe((event) => {
         void trackLayerOperation(
@@ -1931,6 +2581,30 @@ export function createHappyLayer({
           "failed to publish Happy session event",
         );
       });
+      try {
+        for (const summary of [...listed, ...restored.summaries]) {
+          if (blockedSessionIds.has(summary.sessionId)) continue;
+          if (!isSessionInScope(summary)) continue;
+          const entry = await findOrCreateSession(
+            summary.sessionId,
+            sessionSummaries.get(summary.sessionId) ?? summary,
+          );
+          if (entry && summary.freshContextReset === true) {
+            for (const message of translateNeutralEvent({
+              kind: "service-message",
+              sessionId: summary.sessionId,
+              payload: { text: HAPPY_CONTEXT_RESET_NOTICE },
+            })) {
+              if (message.transport === "session") {
+                entry.client.sendSessionProtocolMessage(message.envelope);
+              }
+            }
+          }
+        }
+      } catch (error) {
+        await unwindStartupProviders(restored.ownedSessionIds);
+        throw error;
+      }
     });
   }
 
@@ -1948,7 +2622,7 @@ export function createHappyLayer({
       closing = true;
       sourceSubscription?.();
       supervisorSubscription?.();
-      promptQueue.close();
+      await promptQueue.close();
       turnCorrelator.close();
       assistantMessageCoalescer.close();
       cancelPairing();
@@ -1959,20 +2633,23 @@ export function createHappyLayer({
       await drainOperations(spawnOperations);
       await drainOperations(layerOperations);
       await Promise.allSettled([...sessionCreationPromises.values()]);
-      // Awaited rather than fire-and-forget: the caller exits the process once
-      // this resolves, and tearing the event loop down while these closes are
-      // still in flight aborts the process on Windows.
+      // Shutdown is a passive detach. Provider crashes, updater restarts, app
+      // restarts, and the Off -> On pause must preserve the active relay row.
+      // Await each SDK close so accepted inbound work reaches its durable cursor.
       await Promise.allSettled(
-        [...sessions.values()].map((entry) =>
-          disposeHappySessionEntry({ api, entry, debugLog: debug }).catch(() =>
-            debug("failed to close Happy session"),
-          ),
-        ),
+        [...sessions.values()].map(async (entry) => {
+          entry.liveness.stop();
+          await entry.client.close().catch(() =>
+            debug("failed to detach Happy session client"),
+          );
+        }),
       );
       sessions.clear();
       await drainOperations(sessionDisposals);
       sessionDisposals.clear();
       remotelyArchivedSessions.clear();
+      ownershipPendingSessions.clear();
+      ownershipPendingProviderStatuses.clear();
       terminatedSessions.clear();
       machineClient?.shutdown();
       machineClient = null;

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -4,7 +4,7 @@
 import WebSocket from "ws";
 
 const RPC_TIMEOUT_MS = 30_000;
-const MAX_QUEUED_NOTIFICATIONS = 32;
+const MAX_QUEUED_NOTIFICATIONS_PER_SESSION = 32;
 
 const PROVIDER_EVENT_KINDS = new Map([
   ["provider://message-chunk", "assistant-delta"],
@@ -75,7 +75,8 @@ class ProviderRuntimeClient {
     this.nextId = 0;
     this.pending = new Map();
     this.notificationListeners = new Set();
-    this.notificationQueue = [];
+    this.notificationQueues = new Map();
+    this.notificationSequence = 0;
     this.onUnexpectedDisconnect = onUnexpectedDisconnect;
     this.intentionalClose = false;
     this.disconnectReported = false;
@@ -137,10 +138,15 @@ class ProviderRuntimeClient {
   // already running, leaving the queue for that session marked busy forever.
   dispatchNotification(method, params) {
     if (this.notificationListeners.size === 0) {
-      if (this.notificationQueue.length === MAX_QUEUED_NOTIFICATIONS) {
-        this.notificationQueue.shift();
+      const queueKey =
+        typeof params?.sessionId === "string" ? params.sessionId : "__provider_runtime__";
+      let queue = this.notificationQueues.get(queueKey);
+      if (!queue) {
+        queue = [];
+        this.notificationQueues.set(queueKey, queue);
       }
-      this.notificationQueue.push({ method, params });
+      if (queue.length === MAX_QUEUED_NOTIFICATIONS_PER_SESSION) queue.shift();
+      queue.push({ method, params, sequence: ++this.notificationSequence });
       return;
     }
     for (const listener of this.notificationListeners) listener(method, params);
@@ -148,8 +154,11 @@ class ProviderRuntimeClient {
 
   subscribeNotifications(listener) {
     this.notificationListeners.add(listener);
-    while (this.notificationQueue.length > 0) {
-      const notification = this.notificationQueue.shift();
+    const queued = [...this.notificationQueues.values()]
+      .flat()
+      .sort((left, right) => left.sequence - right.sequence);
+    this.notificationQueues.clear();
+    for (const notification of queued) {
       listener(notification.method, notification.params);
     }
     return () => this.notificationListeners.delete(listener);
@@ -179,7 +188,7 @@ class ProviderRuntimeClient {
     }
     this.pending.clear();
     this.notificationListeners.clear();
-    this.notificationQueue.length = 0;
+    this.notificationQueues.clear();
     const socket = this.socket;
     this.socket = null;
     if (!socket || socket.readyState !== WebSocket.OPEN) return Promise.resolve();
@@ -207,6 +216,11 @@ function normalizeSession(session) {
     ...(session.agentSessionId ? { agentSessionId: session.agentSessionId } : {}),
     ...(Array.isArray(session.pendingPermissions)
       ? { pendingPermissions: session.pendingPermissions }
+      : {}),
+    ...(typeof session.reused === "boolean" ? { reused: session.reused } : {}),
+    ...(typeof session.owned === "boolean" ? { owned: session.owned } : {}),
+    ...(session.freshContextReset === true
+      ? { freshContextReset: true }
       : {}),
   };
 }
@@ -274,11 +288,18 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
     },
 
     async sendPrompt(sessionId, text) {
-      await client.call("provider_prompt", {
+      const result = await client.call("provider_submit_prompt", {
         sessionId,
         prompt: text,
         origin: "remote",
       });
+      if (result?.accepted !== true) {
+        throw new Error("Provider did not acknowledge prompt acceptance.");
+      }
+      return {
+        accepted: true,
+        sessionId,
+      };
     },
 
     async cancel(sessionId) {
@@ -318,11 +339,30 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
     },
 
     async spawn(spec) {
+      const resumeAgentSessionId =
+        typeof spec.resumeAgentSessionId === "string" &&
+        spec.resumeAgentSessionId.length > 0
+          ? spec.resumeAgentSessionId
+          : null;
+      const requireExactResume =
+        spec.requireExactResume ?? (resumeAgentSessionId !== null);
+      const suppressHistoryReplay =
+        spec.suppressHistoryReplay ?? (resumeAgentSessionId !== null);
+      const freshContextReset = spec.freshContextReset === true;
+      if (freshContextReset && resumeAgentSessionId) {
+        throw new Error(
+          "A fresh context reset cannot also request an exact native resume.",
+        );
+      }
+
       const result = await client.call("provider_spawn", {
         agentType: spec.agentType,
         cwd: spec.cwd,
         localSessionId: spec.localSessionId ?? null,
-        resumeAgentSessionId: spec.resumeAgentSessionId ?? null,
+        resumeAgentSessionId,
+        requireExactResume,
+        suppressHistoryReplay,
+        freshContextReset,
         sandboxMode: spec.sandboxMode ?? null,
         approvalPolicy: spec.approvalPolicy ?? null,
         networkEnabled: spec.networkEnabled ?? null,
@@ -330,7 +370,49 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
         initialModelId: spec.initialModelId ?? null,
         reasoningEffort: spec.reasoningEffort ?? null,
       });
-      const session = normalizeSession(result);
+      const session = normalizeSession({
+        ...result,
+        ...(freshContextReset ? { freshContextReset: true } : {}),
+      });
+      const rejectSpawn = async (error) => {
+        if (typeof session.sessionId === "string" && session.sessionId.length > 0) {
+          try {
+            await client.call("provider_terminate", {
+              sessionId: session.sessionId,
+            });
+          } catch {
+            // Preserve the contract failure that made the session unusable.
+          }
+        }
+        throw error;
+      };
+      if (
+        freshContextReset &&
+        (typeof session.agentSessionId !== "string" ||
+          session.agentSessionId.length === 0)
+      ) {
+        return rejectSpawn(
+          new Error(
+            "Fresh context reset did not produce a native agent session ID.",
+          ),
+        );
+      }
+      if (
+        typeof spec.permissionMode === "string" &&
+        spec.permissionMode.length > 0
+      ) {
+        try {
+          await client.call("provider_set_permission_mode", {
+            sessionId: session.sessionId,
+            mode: providerPermissionMode(
+              spec.permissionMode,
+              session.agentType,
+            ),
+          });
+        } catch (error) {
+          return rejectSpawn(error);
+        }
+      }
       agentTypes.set(session.sessionId, session.agentType);
       return session;
     },

--- a/bin/happy-bridge/session-key-store.mjs
+++ b/bin/happy-bridge/session-key-store.mjs
@@ -101,6 +101,15 @@ function validateAgentSessionId(sessionId) {
   return sessionId;
 }
 
+function validateProcessedThroughSeq(processedThroughSeq) {
+  if (!Number.isSafeInteger(processedThroughSeq) || processedThroughSeq < 0) {
+    throw new TypeError(
+      "Happy processed sequence must be a non-negative safe integer",
+    );
+  }
+  return processedThroughSeq;
+}
+
 function copyBinding(binding) {
   return {
     state: binding.state,
@@ -121,6 +130,10 @@ function copyBinding(binding) {
     ...(typeof binding.happySessionId === "string"
       ? { happySessionId: binding.happySessionId }
       : {}),
+    ...(Number.isSafeInteger(binding.processedThroughSeq)
+      ? { processedThroughSeq: binding.processedThroughSeq }
+      : {}),
+    ...(binding.legacyRelayRetired === true ? { legacyRelayRetired: true } : {}),
   };
 }
 
@@ -179,22 +192,37 @@ function parsePayload(plaintext) {
       const hasHappySessionId = Object.hasOwn(entry, "happySessionId");
       const hasConversationId = Object.hasOwn(entry, "conversationId");
       const hasAgentSessionId = Object.hasOwn(entry, "agentSessionId");
+      const hasProcessedThroughSeq = Object.hasOwn(entry, "processedThroughSeq");
+      const hasLegacyRelayRetired = Object.hasOwn(entry, "legacyRelayRetired");
+      const legacyRetirementKey = hasLegacyRelayRetired
+        ? ["legacyRelayRetired"]
+        : [];
       const expectedKeys =
         entry.state === "retiring"
           ? [
               ...(hasAgentSessionId ? ["agentSessionId"] : []),
               "blockRevival",
               "key",
+              ...legacyRetirementKey,
               "providerRetired",
               "relayTag",
+              ...(hasProcessedThroughSeq ? ["processedThroughSeq"] : []),
               "sessionId",
               "state",
               ...(hasConversationId ? ["conversationId"] : []),
               ...(hasHappySessionId ? ["happySessionId"] : []),
             ].sort()
           : hasHappySessionId
-            ? ["happySessionId", "key", "relayTag", "sessionId", "state"]
-            : ["key", "relayTag", "sessionId", "state"];
+            ? [
+                "happySessionId",
+                "key",
+                ...legacyRetirementKey,
+                ...(hasProcessedThroughSeq ? ["processedThroughSeq"] : []),
+                "relayTag",
+                "sessionId",
+                "state",
+              ]
+            : ["key", ...legacyRetirementKey, "relayTag", "sessionId", "state"];
       if (Object.keys(entry).sort().join("\0") !== expectedKeys.join("\0")) {
         throw invalidStore();
       }
@@ -211,7 +239,8 @@ function parsePayload(plaintext) {
       if (
         (state === "ready" && !hasHappySessionId) ||
         (state === "pending" && hasHappySessionId) ||
-        (state !== "retiring" && (hasConversationId || hasAgentSessionId))
+        (state !== "retiring" && (hasConversationId || hasAgentSessionId)) ||
+        (state === "pending" && hasProcessedThroughSeq)
       ) {
         throw invalidStore();
       }
@@ -219,6 +248,9 @@ function parsePayload(plaintext) {
         state === "retiring" &&
         (typeof entry.providerRetired !== "boolean" || typeof entry.blockRevival !== "boolean")
       ) {
+        throw invalidStore();
+      }
+      if (hasLegacyRelayRetired && entry.legacyRelayRetired !== true) {
         throw invalidStore();
       }
       const binding = {
@@ -241,6 +273,12 @@ function parsePayload(plaintext) {
       if (hasHappySessionId) {
         binding.happySessionId = validateRelaySessionId(entry.happySessionId);
       }
+      if (hasProcessedThroughSeq) {
+        binding.processedThroughSeq = validateProcessedThroughSeq(
+          entry.processedThroughSeq,
+        );
+      }
+      if (hasLegacyRelayRetired) binding.legacyRelayRetired = true;
       entries.set(sessionId, binding);
     }
   } catch (error) {
@@ -316,6 +354,10 @@ function encryptEntries(entries, machineKey) {
         ...(typeof binding.happySessionId === "string"
           ? { happySessionId: binding.happySessionId }
           : {}),
+        ...(Number.isSafeInteger(binding.processedThroughSeq)
+          ? { processedThroughSeq: binding.processedThroughSeq }
+          : {}),
+        ...(binding.legacyRelayRetired === true ? { legacyRelayRetired: true } : {}),
       })),
     }),
     "utf8",
@@ -538,6 +580,59 @@ export function createHappySessionKeyStore({ directory, machineKey }) {
         }
         binding.state = "ready";
         binding.happySessionId = happySessionId;
+        binding.processedThroughSeq = 0;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async markProcessedThroughSeq(sessionId, processedThroughSeq) {
+      validateSessionId(sessionId);
+      validateProcessedThroughSeq(processedThroughSeq);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (binding.state !== "ready") {
+          throw new Error(
+            "Only a ready Happy session binding can advance its processed sequence",
+          );
+        }
+        const previous = binding.processedThroughSeq;
+        if (Number.isSafeInteger(previous) && previous >= processedThroughSeq) {
+          return copyBinding(binding);
+        }
+        binding.processedThroughSeq = processedThroughSeq;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async markLegacyRelayRetired(sessionId) {
+      validateSessionId(sessionId);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (binding.state !== "pending" && binding.state !== "ready") {
+          throw new Error(
+            "Only an active Happy session binding can retire its legacy relay row",
+          );
+        }
+        binding.legacyRelayRetired = true;
+        await writeEntries(filePath, entries, pairingMachineKey);
+        return copyBinding(binding);
+      });
+    },
+
+    async clearLegacyRelayRetired(sessionId) {
+      validateSessionId(sessionId);
+      return serializeForPath(filePath, async () => {
+        const entries = await loadEntries(filePath, pairingMachineKey);
+        const binding = entries?.get(sessionId);
+        if (!binding) throw new Error("Happy session binding does not exist");
+        if (binding.legacyRelayRetired !== true) return copyBinding(binding);
+        delete binding.legacyRelayRetired;
         await writeEntries(filePath, entries, pairingMachineKey);
         return copyBinding(binding);
       });
@@ -587,6 +682,7 @@ export function createHappySessionKeyStore({ directory, machineKey }) {
           throw new Error("Happy session binding resolved to a different agent session");
         }
         binding.state = "retiring";
+        delete binding.legacyRelayRetired;
         binding.providerRetired = binding.providerRetired === true || providerRetired;
         binding.blockRevival = binding.blockRevival === true || blockRevival;
         if (happySessionId !== undefined) binding.happySessionId = happySessionId;

--- a/bin/happy-bridge/session-source.mjs
+++ b/bin/happy-bridge/session-source.mjs
@@ -2,14 +2,15 @@
 // ABOUTME: It contains contracts only so protocol code cannot leak into providers.
 
 /**
- * @typedef {{sessionId: string, agentType: string, cwd: string, status?: string, title?: string, createdAt?: string, agentSessionId?: string, pendingPermissions?: unknown[]}} SessionSummary
+ * @typedef {{sessionId: string, agentType: string, cwd: string, status?: string, title?: string, createdAt?: string, agentSessionId?: string, pendingPermissions?: unknown[], reused?: boolean, owned?: boolean, freshContextReset?: boolean}} SessionSummary
  * @typedef {{kind: string, sessionId: string, payload: Record<string, unknown>}} SessionEvent
- * @typedef {{agentType: string, cwd: string, title?: string, localSessionId?: string, resumeAgentSessionId?: string, sandboxMode?: string, approvalPolicy?: string, networkEnabled?: boolean, timeoutSecs?: number, initialModelId?: string, reasoningEffort?: string, permissionMode?: string}} SpawnSpec
+ * @typedef {{agentType: string, cwd: string, title?: string, localSessionId?: string, resumeAgentSessionId?: string, requireExactResume?: boolean, suppressHistoryReplay?: boolean, freshContextReset?: boolean, sandboxMode?: string, approvalPolicy?: string, networkEnabled?: boolean, timeoutSecs?: number, initialModelId?: string, reasoningEffort?: string, permissionMode?: string}} SpawnSpec
+ * @typedef {{accepted: true, sessionId: string}} PromptAcceptance
  * @typedef {{machineName: string, agents: unknown[], roots: string[]}} Advertisement
  * @typedef {Object} SessionSource
  * @property {() => Promise<SessionSummary[]>} listSessions
  * @property {(listener: (event: SessionEvent) => void) => (() => void)} subscribe
- * @property {(sessionId: string, text: string) => Promise<void>} sendPrompt
+ * @property {(sessionId: string, text: string) => Promise<PromptAcceptance>} sendPrompt
  * @property {(sessionId: string) => Promise<void>} cancel
  * @property {(sessionId: string, requestId: string, optionId: string) => Promise<{ok: boolean}>} respondToPermission
  * @property {(sessionId: string, proposalId: string, accepted: boolean) => Promise<{ok: boolean}>} respondToDiffProposal

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -241,6 +241,8 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
   const text = stringValue(payload.text);
 
   switch (event.kind) {
+    case "service-message":
+      return text ? [service(payload, text)] : [];
     case "assistant-delta":
       if (!text) return [];
       return [eventEnvelope("agent", {

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -80,6 +80,7 @@ function registerProviderHandlers() {
 
   registerHandler("provider_spawn", providerHandlers.spawnSession);
   registerHandler("provider_prompt", providerHandlers.sendPrompt);
+  registerHandler("provider_submit_prompt", providerHandlers.submitPrompt);
   registerHandler("provider_cancel", providerHandlers.cancelPrompt);
   registerHandler("provider_terminate", providerHandlers.terminateSession);
   registerHandler("provider_list_sessions", providerHandlers.listSessions);

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -240,6 +240,7 @@ function registerBrowserLocalHandlers() {
 
   registerHandler("provider_spawn", providerHandlers.spawnSession);
   registerHandler("provider_prompt", providerHandlers.sendPrompt);
+  registerHandler("provider_submit_prompt", providerHandlers.submitPrompt);
   registerHandler("provider_cancel", providerHandlers.cancelPrompt);
   registerHandler("provider_terminate", providerHandlers.terminateSession);
   registerHandler("provider_list_sessions", providerHandlers.listSessions);

--- a/patches/happy@1.2.0.patch
+++ b/patches/happy@1.2.0.patch
@@ -1,8 +1,26 @@
 diff --git a/dist/lib.d.cts b/dist/lib.d.cts
-index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed55f6cd1a4 100644
+index 53beeafa77133ba937b0159185d32458a84ad6d1..fd7687a1edc7c18e366f905010ded86da53ee554 100644
 --- a/dist/lib.d.cts
 +++ b/dist/lib.d.cts
-@@ -772,6 +772,7 @@ declare class ApiClient {
+@@ -512,9 +512,14 @@ declare class ApiSessionClient extends EventEmitter {
+     private pendingOutbox;
+     private readonly sendSync;
+     private readonly receiveSync;
+-    constructor(token: string, session: Session);
+-    onUserMessage(callback: (data: UserMessage) => void): void;
+-    onFileEvent(callback: (data: FileEventMessage) => void): void;
++    constructor(token: string, session: Session, options?: {
++        resumeFromSeq?: number;
++        onMessageProcessed?: (seq: number) => void | Promise<void>;
++        inboundCloseTimeoutMs?: number;
++    });
++    hasArchiveSignal(): boolean;
++    onUserMessage(callback: (data: UserMessage) => void | Promise<void>): void;
++    onFileEvent(callback: (data: FileEventMessage) => void | Promise<void>): void;
+     /**
+      * Derive (and cache) the blob decryption key for this session.
+      * Legacy sessions use deriveKey(masterSecret, 'Happy Blobs', ['master']).
+@@ -772,6 +777,7 @@ declare class ApiClient {
          tag: string;
          metadata: Metadata;
          state: AgentState | null;
@@ -10,22 +28,42 @@ index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed5
      }): Promise<Session | null>;
      /**
       * Register or update machine with the server
-@@ -782,7 +783,9 @@ declare class ApiClient {
+@@ -782,7 +788,11 @@ declare class ApiClient {
          metadata: MachineMetadata;
          daemonState?: DaemonState;
      }): Promise<Machine>;
 -    sessionSyncClient(session: Session): ApiSessionClient;
 +    sessionSyncClient(session: Session, options?: {
 +        resumeFromSeq?: number;
++        onMessageProcessed?: (seq: number) => void | Promise<void>;
++        inboundCloseTimeoutMs?: number;
 +    }): ApiSessionClient;
      machineSyncClient(machine: Machine): ApiMachineClient;
      push(): PushNotificationClient;
      /**
 diff --git a/dist/lib.d.mts b/dist/lib.d.mts
-index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed55f6cd1a4 100644
+index 53beeafa77133ba937b0159185d32458a84ad6d1..fd7687a1edc7c18e366f905010ded86da53ee554 100644
 --- a/dist/lib.d.mts
 +++ b/dist/lib.d.mts
-@@ -772,6 +772,7 @@ declare class ApiClient {
+@@ -512,9 +512,14 @@ declare class ApiSessionClient extends EventEmitter {
+     private pendingOutbox;
+     private readonly sendSync;
+     private readonly receiveSync;
+-    constructor(token: string, session: Session);
+-    onUserMessage(callback: (data: UserMessage) => void): void;
+-    onFileEvent(callback: (data: FileEventMessage) => void): void;
++    constructor(token: string, session: Session, options?: {
++        resumeFromSeq?: number;
++        onMessageProcessed?: (seq: number) => void | Promise<void>;
++        inboundCloseTimeoutMs?: number;
++    });
++    hasArchiveSignal(): boolean;
++    onUserMessage(callback: (data: UserMessage) => void | Promise<void>): void;
++    onFileEvent(callback: (data: FileEventMessage) => void | Promise<void>): void;
+     /**
+      * Derive (and cache) the blob decryption key for this session.
+      * Legacy sessions use deriveKey(masterSecret, 'Happy Blobs', ['master']).
+@@ -772,6 +777,7 @@ declare class ApiClient {
          tag: string;
          metadata: Metadata;
          state: AgentState | null;
@@ -33,40 +71,110 @@ index 53beeafa77133ba937b0159185d32458a84ad6d1..06adc11d7bd9dc85887b25139eaefed5
      }): Promise<Session | null>;
      /**
       * Register or update machine with the server
-@@ -782,7 +783,9 @@ declare class ApiClient {
+@@ -782,7 +788,11 @@ declare class ApiClient {
          metadata: MachineMetadata;
          daemonState?: DaemonState;
      }): Promise<Machine>;
 -    sessionSyncClient(session: Session): ApiSessionClient;
 +    sessionSyncClient(session: Session, options?: {
 +        resumeFromSeq?: number;
++        onMessageProcessed?: (seq: number) => void | Promise<void>;
++        inboundCloseTimeoutMs?: number;
 +    }): ApiSessionClient;
      machineSyncClient(machine: Machine): ApiMachineClient;
      push(): PushNotificationClient;
      /**
 diff --git a/dist/types-CV0guBiJ.mjs b/dist/types-CV0guBiJ.mjs
-index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5a76443b7 100644
+index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..073aed7103490a1c46e6b68f9f6fc1207b53c3e3 100644
 --- a/dist/types-CV0guBiJ.mjs
 +++ b/dist/types-CV0guBiJ.mjs
-@@ -2142,10 +2142,16 @@ class ApiSessionClient extends EventEmitter {
+@@ -2128,6 +2128,7 @@ class ApiSessionClient extends EventEmitter {
+   encryptionVariant;
+   reconnectInterval = null;
+   ignoreArchiveSignal = false;
++  archiveSignaled = false;
+   skipInitialMessages = false;
+   claudeSessionProtocolState = {
+     currentTurnId: null,
+@@ -2141,11 +2142,41 @@ class ApiSessionClient extends EventEmitter {
+     activeSubagents: /* @__PURE__ */ new Set()
    };
    lastSeq = 0;
++  lastProcessedSeq = 0;
++  messageProcessedCallback = null;
++  orderedInbound = false;
++  inboundRecords = [];
++  inboundDraining = false;
++  inboundDrainPromise = null;
++  inboundFailed = false;
++  inboundFailurePending = null;
++  inboundActiveRecord = null;
++  inboundClosing = false;
++  inboundClosed = false;
++  inboundClosePromise = null;
++  inboundCloseTimeoutMs = 3e3;
    pendingOutbox = [];
 +  outboundMessageLocalIds = /* @__PURE__ */ new Set();
    sendSync;
    receiveSync;
 -  constructor(token, session) {
++  static MAX_PENDING_INBOUND_RECORDS = 256;
 +  constructor(token, session, options = {}) {
      super();
 +    const resumeFromSeq = options.resumeFromSeq ?? 0;
 +    if (!Number.isSafeInteger(resumeFromSeq) || resumeFromSeq < 0) {
 +      throw new Error("Session resume sequence must be a non-negative safe integer");
 +    }
++    if (options.onMessageProcessed !== void 0 && typeof options.onMessageProcessed !== "function") {
++      throw new Error("Session message processed callback must be a function");
++    }
++    if (options.inboundCloseTimeoutMs !== void 0 && (!Number.isSafeInteger(options.inboundCloseTimeoutMs) || options.inboundCloseTimeoutMs <= 0)) {
++      throw new Error("Session inbound close timeout must be a positive safe integer");
++    }
 +    this.lastSeq = resumeFromSeq;
++    this.lastProcessedSeq = resumeFromSeq;
++    this.messageProcessedCallback = options.onMessageProcessed ?? null;
++    this.orderedInbound = this.messageProcessedCallback !== null;
++    this.inboundCloseTimeoutMs = options.inboundCloseTimeoutMs ?? 3e3;
      this.token = token;
      this.sessionId = session.id;
      this.metadata = session.metadata;
-@@ -2206,18 +2212,22 @@ class ApiSessionClient extends EventEmitter {
+@@ -2177,6 +2208,10 @@ class ApiSessionClient extends EventEmitter {
+       autoConnect: false
+     });
+     this.socket.on("connect", () => {
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        this.socket.close();
++        return;
++      }
+       logger.debug("Socket connected successfully");
+       if (this.reconnectInterval) {
+         clearInterval(this.reconnectInterval);
+@@ -2191,33 +2226,59 @@ class ApiSessionClient extends EventEmitter {
+     this.socket.on("disconnect", (reason) => {
+       logger.debug(`[API] Socket disconnected: ${reason}`);
+       this.rpcHandlerManager.onSocketDisconnect();
+-      this.startSmartReconnect();
++      if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending) {
++        this.startSmartReconnect();
++      }
+     });
+     this.socket.on("connect_error", (error) => {
+       logger.debug("[API] Socket connection error:", error);
+       this.rpcHandlerManager.onSocketDisconnect();
+-      this.startSmartReconnect();
++      if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending) {
++        this.startSmartReconnect();
++      }
+     });
+     this.socket.on("update", (data) => {
+       try {
++        if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++          return;
++        }
+         logger.debugLargeJson("[SOCKET] [UPDATE] Received update:", data);
+         if (!data.body) {
+           logger.debug("[SOCKET] [UPDATE] [ERROR] No body in update!");
            return;
          }
          if (data.body.t === "new-message") {
@@ -74,6 +182,21 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
 -          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || data.body.message.content.t !== "encrypted") {
 +          const message = data.body.message;
 +          const messageSeq = message?.seq;
++          if (this.orderedInbound) {
++            if (!Number.isSafeInteger(messageSeq) || messageSeq < 0) {
++              this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++              return;
++            }
++            if (messageSeq <= this.lastSeq) {
++              return;
++            }
++            if (messageSeq !== this.lastSeq + 1) {
++              this.receiveSync.invalidate();
++              return;
++            }
++            this.acceptInboundRecord(message);
++            return;
++          }
 +          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || message?.content?.t !== "encrypted") {
              this.receiveSync.invalidate();
              return;
@@ -93,11 +216,353 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
          } else if (data.body.t === "update-session") {
            if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
              this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
-@@ -2454,7 +2464,17 @@ class ApiSessionClient extends EventEmitter {
+@@ -2229,6 +2290,7 @@ class ApiSessionClient extends EventEmitter {
+                 this.ignoreArchiveSignal = false;
+               } else {
+                 logger.debug(`[SOCKET] Session archived (${meta.lifecycleState}), exiting...`);
++                this.archiveSignaled = true;
+                 this.emit("archived");
+               }
+             }
+@@ -2251,14 +2313,43 @@ class ApiSessionClient extends EventEmitter {
+     });
+     this.socket.connect();
+   }
++  hasArchiveSignal() {
++    return this.archiveSignaled;
++  }
+   onUserMessage(callback) {
+     this.pendingMessageCallback = callback;
++    if (this.orderedInbound) {
++      for (const pending of this.pendingMessages.splice(0)) {
++        void Promise.resolve().then(() => {
++          if (this.inboundClosed || this.inboundFailed) {
++            const error = new Error("Session inbound processing stopped");
++            error.name = "AbortError";
++            throw error;
++          }
++          return callback(pending.data);
++        }).then(pending.resolve, pending.reject);
++      }
++      return;
++    }
+     while (this.pendingMessages.length > 0) {
+       callback(this.pendingMessages.shift());
+     }
+   }
+   onFileEvent(callback) {
+     this.pendingFileEventCallback = callback;
++    if (this.orderedInbound) {
++      for (const pending of this.pendingFileEvents.splice(0)) {
++        void Promise.resolve().then(() => {
++          if (this.inboundClosed || this.inboundFailed) {
++            const error = new Error("Session inbound processing stopped");
++            error.name = "AbortError";
++            throw error;
++          }
++          return callback(pending.data);
++        }).then(pending.resolve, pending.reject);
++      }
++      return;
++    }
+     while (this.pendingFileEvents.length > 0) {
+       callback(this.pendingFileEvents.shift());
+     }
+@@ -2403,6 +2494,257 @@ class ApiSessionClient extends EventEmitter {
+       "X-Happy-Client": `cli-coding-session/${configuration.currentCliVersion}`
+     };
+   }
++  acceptInboundRecord(message, skipRouting = false) {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++      return false;
++    }
++    const seq = message?.seq;
++    if (!Number.isSafeInteger(seq) || seq < 0) {
++      this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++      return false;
++    }
++    if (seq <= this.lastSeq) {
++      return true;
++    }
++    if (seq !== this.lastSeq + 1) {
++      this.requestInboundProcessingFailure(new Error(`Relay message sequence gap: expected ${this.lastSeq + 1}, received ${seq}`));
++      return false;
++    }
++    if (this.inboundRecords.length >= ApiSessionClient.MAX_PENDING_INBOUND_RECORDS) {
++      this.requestInboundProcessingFailure(new Error("Relay inbound processing queue is full"));
++      return false;
++    }
++    const isOutboundEcho = this.outboundMessageLocalIds.delete(message.localId);
++    this.lastSeq = seq;
++    this.inboundRecords.push({
++      seq,
++      message,
++      skipRouting,
++      isOutboundEcho
++    });
++    void this.drainInboundRecords();
++    return true;
++  }
++  drainInboundRecords() {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed) {
++      return Promise.resolve();
++    }
++    if (this.inboundDrainPromise) {
++      return this.inboundDrainPromise;
++    }
++    const operation = this.runInboundDrain();
++    this.inboundDrainPromise = operation;
++    void operation.then(
++      () => {
++        if (this.inboundDrainPromise === operation) this.inboundDrainPromise = null;
++      },
++      () => {
++        if (this.inboundDrainPromise === operation) this.inboundDrainPromise = null;
++      }
++    );
++    return operation;
++  }
++  async runInboundDrain() {
++    this.inboundDraining = true;
++    try {
++      while (this.inboundRecords.length > 0 && !this.inboundFailed && !this.inboundClosed) {
++        const record = this.inboundRecords[0];
++        this.inboundActiveRecord = record;
++        if (record.seq !== this.lastProcessedSeq + 1) {
++          throw new Error(`Relay processed sequence gap: expected ${this.lastProcessedSeq + 1}, received ${record.seq}`);
++        }
++        if (!record.skipRouting && !record.isOutboundEcho && record.message?.content?.t === "encrypted") {
++          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(record.message.content.c));
++          logger.debug("[API] Processing ordered relay message", {
++            seq: record.seq,
++            role: typeof body?.role === "string" ? body.role : "unknown",
++            contentType: typeof body?.content?.type === "string" ? body.content.type : "unknown"
++          });
++          await this.routeIncomingMessageOrdered(body, record.seq);
++        }
++        if (this.inboundClosed || this.inboundFailed) {
++          return;
++        }
++        await this.messageProcessedCallback(record.seq);
++        if (this.inboundClosed || this.inboundFailed) {
++          return;
++        }
++        this.lastProcessedSeq = record.seq;
++        this.inboundRecords.shift();
++        this.inboundActiveRecord = null;
++        if (this.inboundFailurePending) {
++          const failure = this.inboundFailurePending;
++          this.inboundFailurePending = null;
++          this.failInboundProcessing(failure);
++          return;
++        }
++      }
++    } catch (error) {
++      this.inboundActiveRecord = null;
++      if (!this.inboundClosed) {
++        this.failInboundProcessing(error);
++      }
++    } finally {
++      this.inboundActiveRecord = null;
++      this.inboundDraining = false;
++    }
++  }
++  async routeIncomingMessageOrdered(message, seq) {
++    const userResult = UserMessageSchema.safeParse(message);
++    if (userResult.success) {
++      if (this.pendingMessageCallback) {
++        await this.pendingMessageCallback(userResult.data);
++      } else {
++        await new Promise((resolve, reject) => {
++          this.pendingMessages.push({
++            data: userResult.data,
++            seq,
++            resolve,
++            reject
++          });
++        });
++      }
++      return;
++    }
++    const fileResult = FileEventMessageSchema.safeParse(message);
++    if (fileResult.success) {
++      const ev = fileResult.data.content.data.ev;
++      logger.debug("[API] Received ordered file event", {
++        seq,
++        size: ev.size,
++        hasMimeType: Boolean(ev.mimeType)
++      });
++      if (this.pendingFileEventCallback) {
++        await this.pendingFileEventCallback(fileResult.data);
++      } else {
++        await new Promise((resolve, reject) => {
++          this.pendingFileEvents.push({
++            data: fileResult.data,
++            seq,
++            resolve,
++            reject
++          });
++        });
++      }
++      return;
++    }
++    for (const listener of this.rawListeners("message")) {
++      await listener.call(this, message);
++    }
++  }
++  rejectPendingInbound(error) {
++    for (const pending of this.pendingMessages.splice(0)) {
++      pending.reject(error);
++    }
++    for (const pending of this.pendingFileEvents.splice(0)) {
++      pending.reject(error);
++    }
++  }
++  requestInboundProcessingFailure(error) {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed || this.inboundFailurePending) {
++      return;
++    }
++    const failure = error instanceof Error ? error : new Error("Relay inbound processing failed");
++    if (!this.inboundActiveRecord) {
++      this.failInboundProcessing(failure);
++      return;
++    }
++    this.inboundFailurePending = failure;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.socket.close();
++    this.rejectPendingInbound(failure);
++    if (this.inboundRecords[0] === this.inboundActiveRecord) {
++      this.inboundRecords.splice(1);
++    }
++    logger.debug("[API] Relay inbound processing will stop after its accepted record is checkpointed", { error: failure });
++  }
++  failInboundProcessing(error) {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed) {
++      return;
++    }
++    const failure = error instanceof Error ? error : new Error("Relay inbound processing failed");
++    this.inboundFailurePending = null;
++    this.inboundFailed = true;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.rejectPendingInbound(failure);
++    this.inboundRecords.length = 0;
++    this.socket.close();
++    logger.debug("[API] Relay inbound processing stopped", { error: failure });
++    try {
++      this.emit("inboundProcessingError", failure);
++    } catch (listenerError) {
++      logger.debug("[API] Relay inbound processing error listener failed", { error: listenerError });
++    }
++  }
++  closeInboundProcessing() {
++    if (this.inboundClosed) {
++      return;
++    }
++    this.inboundClosed = true;
++    if (!this.orderedInbound) {
++      return;
++    }
++    const error = new Error("Session client closed");
++    error.name = "AbortError";
++    this.receiveSync.stop();
++    this.rejectPendingInbound(error);
++    this.inboundRecords.length = 0;
++  }
++  drainInboundProcessingForClose() {
++    if (!this.orderedInbound) {
++      this.closeInboundProcessing();
++      return Promise.resolve();
++    }
++    if (this.inboundClosePromise) {
++      return this.inboundClosePromise;
++    }
++    const operation = this.runInboundClose();
++    this.inboundClosePromise = operation;
++    return operation;
++  }
++  async runInboundClose() {
++    if (this.inboundClosed) {
++      return;
++    }
++    this.inboundClosing = true;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.socket.close();
++    let timeout;
++    const timedOut = await Promise.race([
++      this.drainInboundRecords().then(() => false),
++      new Promise((resolve) => {
++        timeout = setTimeout(() => resolve(true), this.inboundCloseTimeoutMs);
++      })
++    ]);
++    if (timeout) clearTimeout(timeout);
++    if (timedOut) {
++      const failure = new Error(`Timed out draining relay input after ${this.inboundCloseTimeoutMs}ms`);
++      this.failInboundProcessing(failure);
++      this.inboundClosed = true;
++      throw failure;
++    }
++    if (this.inboundFailed) {
++      this.inboundClosed = true;
++      return;
++    }
++    this.inboundClosed = true;
++    const error = new Error("Session client closed");
++    error.name = "AbortError";
++    this.rejectPendingInbound(error);
++    this.inboundRecords.length = 0;
++  }
+   routeIncomingMessage(message) {
+     const userResult = UserMessageSchema.safeParse(message);
+     if (userResult.success) {
+@@ -2430,6 +2772,9 @@ class ApiSessionClient extends EventEmitter {
+     this.emit("message", message);
+   }
+   async fetchMessages() {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++      return;
++    }
+     const skipRouting = this.skipInitialMessages;
+     if (skipRouting) {
+       this.skipInitialMessages = false;
+@@ -2448,13 +2793,39 @@ class ApiSessionClient extends EventEmitter {
+           timeout: 6e4
+         }
+       );
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        return;
++      }
+       const messages = Array.isArray(response.data.messages) ? response.data.messages : [];
+       let maxSeq = afterSeq;
+       for (const message of messages) {
          if (message.seq > maxSeq) {
            maxSeq = message.seq;
          }
 -        if (skipRouting) continue;
++        if (this.orderedInbound) {
++          if (!Number.isSafeInteger(message?.seq) || message.seq < 0) {
++            this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++            return;
++          }
++          if (message.seq <= this.lastSeq) {
++            continue;
++          }
++          if (!this.acceptInboundRecord(message, skipRouting)) {
++            return;
++          }
++          continue;
++        }
 +        // The socket handler routes live messages and advances lastSeq while
 +        // this fetch is parked on its await. Without this guard the page that
 +        // comes back re-routes anything the socket already delivered, and a
@@ -112,7 +577,30 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
          if (message.content?.t !== "encrypted") {
            continue;
          }
-@@ -2487,10 +2507,13 @@ class ApiSessionClient extends EventEmitter {
+@@ -2469,16 +2840,19 @@ class ApiSessionClient extends EventEmitter {
+           });
+         }
+       }
+-      this.lastSeq = Math.max(this.lastSeq, maxSeq);
++      if (!this.orderedInbound) {
++        this.lastSeq = Math.max(this.lastSeq, maxSeq);
++      }
+       const hasMore = !!response.data.hasMore;
+-      if (hasMore && maxSeq === afterSeq) {
++      const nextAfterSeq = this.orderedInbound ? this.lastSeq : maxSeq;
++      if (hasMore && nextAfterSeq === afterSeq) {
+         logger.debug("[API] fetchMessages pagination stalled, stopping to avoid infinite loop", {
+           sessionId: this.sessionId,
+           afterSeq
+         });
+         break;
+       }
+-      afterSeq = maxSeq;
++      afterSeq = nextAfterSeq;
+       if (!hasMore) {
+         break;
+       }
+@@ -2487,10 +2861,13 @@ class ApiSessionClient extends EventEmitter {
    static MAX_OUTBOX_BATCH_SIZE = 50;
    async flushOutbox() {
      while (this.pendingOutbox.length > 0) {
@@ -129,7 +617,7 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
          `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
          {
            messages: batch
-@@ -2500,17 +2523,16 @@ class ApiSessionClient extends EventEmitter {
+@@ -2500,17 +2877,16 @@ class ApiSessionClient extends EventEmitter {
            timeout: 6e4
          }
        );
@@ -150,10 +638,17 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
      });
      if (invalidate) {
        this.sendSync.invalidate();
-@@ -2777,6 +2799,14 @@ class ApiSessionClient extends EventEmitter {
+@@ -2777,6 +3153,21 @@ class ApiSessionClient extends EventEmitter {
    }
    async close() {
      logger.debug("[API] socket.close() called");
++    let inboundCloseError = null;
++    try {
++      await this.drainInboundProcessingForClose();
++    } catch (error) {
++      inboundCloseError = error;
++      logger.debug("[API] Failed to drain relay input during close", { error });
++    }
 +    // Join the existing single-flight sender before stopping it. Calling
 +    // flushOutbox() directly here can overlap an in-flight drain, causing both
 +    // callers to POST and splice the same batch while the relay is delayed.
@@ -165,7 +660,36 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
      this.sendSync.stop();
      this.receiveSync.stop();
      if (this.reconnectInterval) {
-@@ -5229,7 +5259,10 @@ class ApiClient {
+@@ -2784,10 +3175,17 @@ class ApiSessionClient extends EventEmitter {
+       this.reconnectInterval = null;
+     }
+     this.socket.close();
++    if (inboundCloseError) throw inboundCloseError;
+   }
+   startSmartReconnect() {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) return;
+     if (this.reconnectInterval) return;
+     this.reconnectInterval = setInterval(() => {
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        clearInterval(this.reconnectInterval);
++        this.reconnectInterval = null;
++        return;
++      }
+       if (this.socket.connected) {
+         clearInterval(this.reconnectInterval);
+         this.reconnectInterval = null;
+@@ -2803,7 +3201,9 @@ class ApiSessionClient extends EventEmitter {
+     if (shouldReconnect()) {
+       logger.debug("[API] Network up + lid open \u2014 reconnecting in 1s");
+       setTimeout(() => {
+-        if (!this.socket.connected) this.socket.connect();
++        if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending && !this.socket.connected) {
++          this.socket.connect();
++        }
+       }, 1e3);
+     }
+   }
+@@ -5229,7 +5629,10 @@ class ApiClient {
      let encryptionKey;
      let encryptionVariant;
      if (this.credential.encryption.type === "dataKey") {
@@ -177,7 +701,7 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
        encryptionVariant = "dataKey";
        let encryptedDataKey = libsodiumEncryptForPublicKey(encryptionKey, this.credential.encryption.publicKey);
        dataEncryptionKey = new Uint8Array(encryptedDataKey.length + 1);
-@@ -5419,8 +5452,8 @@ class ApiClient {
+@@ -5419,8 +5822,8 @@ class ApiClient {
        throw error;
      }
    }
@@ -189,28 +713,96 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..c6fc8bed186aa1f3d76973f14d4752d5
    machineSyncClient(machine) {
      return new ApiMachineClient(this.credential.token, machine);
 diff --git a/dist/types-D0KwHfY9.cjs b/dist/types-D0KwHfY9.cjs
-index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac111682af27 100644
+index 4aebb1233520dbe47c2069294ff3664300e99177..eb34477c01d4a5a050f7a9401966e7e5d35e0a3f 100644
 --- a/dist/types-D0KwHfY9.cjs
 +++ b/dist/types-D0KwHfY9.cjs
-@@ -2145,10 +2145,16 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2131,6 +2131,7 @@ class ApiSessionClient extends node_events.EventEmitter {
+   encryptionVariant;
+   reconnectInterval = null;
+   ignoreArchiveSignal = false;
++  archiveSignaled = false;
+   skipInitialMessages = false;
+   claudeSessionProtocolState = {
+     currentTurnId: null,
+@@ -2144,11 +2145,41 @@ class ApiSessionClient extends node_events.EventEmitter {
+     activeSubagents: /* @__PURE__ */ new Set()
    };
    lastSeq = 0;
++  lastProcessedSeq = 0;
++  messageProcessedCallback = null;
++  orderedInbound = false;
++  inboundRecords = [];
++  inboundDraining = false;
++  inboundDrainPromise = null;
++  inboundFailed = false;
++  inboundFailurePending = null;
++  inboundActiveRecord = null;
++  inboundClosing = false;
++  inboundClosed = false;
++  inboundClosePromise = null;
++  inboundCloseTimeoutMs = 3e3;
    pendingOutbox = [];
 +  outboundMessageLocalIds = /* @__PURE__ */ new Set();
    sendSync;
    receiveSync;
 -  constructor(token, session) {
++  static MAX_PENDING_INBOUND_RECORDS = 256;
 +  constructor(token, session, options = {}) {
      super();
 +    const resumeFromSeq = options.resumeFromSeq ?? 0;
 +    if (!Number.isSafeInteger(resumeFromSeq) || resumeFromSeq < 0) {
 +      throw new Error("Session resume sequence must be a non-negative safe integer");
 +    }
++    if (options.onMessageProcessed !== void 0 && typeof options.onMessageProcessed !== "function") {
++      throw new Error("Session message processed callback must be a function");
++    }
++    if (options.inboundCloseTimeoutMs !== void 0 && (!Number.isSafeInteger(options.inboundCloseTimeoutMs) || options.inboundCloseTimeoutMs <= 0)) {
++      throw new Error("Session inbound close timeout must be a positive safe integer");
++    }
 +    this.lastSeq = resumeFromSeq;
++    this.lastProcessedSeq = resumeFromSeq;
++    this.messageProcessedCallback = options.onMessageProcessed ?? null;
++    this.orderedInbound = this.messageProcessedCallback !== null;
++    this.inboundCloseTimeoutMs = options.inboundCloseTimeoutMs ?? 3e3;
      this.token = token;
      this.sessionId = session.id;
      this.metadata = session.metadata;
-@@ -2209,18 +2215,22 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2180,6 +2211,10 @@ class ApiSessionClient extends node_events.EventEmitter {
+       autoConnect: false
+     });
+     this.socket.on("connect", () => {
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        this.socket.close();
++        return;
++      }
+       logger.debug("Socket connected successfully");
+       if (this.reconnectInterval) {
+         clearInterval(this.reconnectInterval);
+@@ -2194,33 +2229,59 @@ class ApiSessionClient extends node_events.EventEmitter {
+     this.socket.on("disconnect", (reason) => {
+       logger.debug(`[API] Socket disconnected: ${reason}`);
+       this.rpcHandlerManager.onSocketDisconnect();
+-      this.startSmartReconnect();
++      if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending) {
++        this.startSmartReconnect();
++      }
+     });
+     this.socket.on("connect_error", (error) => {
+       logger.debug("[API] Socket connection error:", error);
+       this.rpcHandlerManager.onSocketDisconnect();
+-      this.startSmartReconnect();
++      if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending) {
++        this.startSmartReconnect();
++      }
+     });
+     this.socket.on("update", (data) => {
+       try {
++        if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++          return;
++        }
+         logger.debugLargeJson("[SOCKET] [UPDATE] Received update:", data);
+         if (!data.body) {
+           logger.debug("[SOCKET] [UPDATE] [ERROR] No body in update!");
            return;
          }
          if (data.body.t === "new-message") {
@@ -218,6 +810,21 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
 -          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || data.body.message.content.t !== "encrypted") {
 +          const message = data.body.message;
 +          const messageSeq = message?.seq;
++          if (this.orderedInbound) {
++            if (!Number.isSafeInteger(messageSeq) || messageSeq < 0) {
++              this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++              return;
++            }
++            if (messageSeq <= this.lastSeq) {
++              return;
++            }
++            if (messageSeq !== this.lastSeq + 1) {
++              this.receiveSync.invalidate();
++              return;
++            }
++            this.acceptInboundRecord(message);
++            return;
++          }
 +          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || message?.content?.t !== "encrypted") {
              this.receiveSync.invalidate();
              return;
@@ -237,11 +844,353 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
          } else if (data.body.t === "update-session") {
            if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
              this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
-@@ -2457,7 +2467,17 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2232,6 +2293,7 @@ class ApiSessionClient extends node_events.EventEmitter {
+                 this.ignoreArchiveSignal = false;
+               } else {
+                 logger.debug(`[SOCKET] Session archived (${meta.lifecycleState}), exiting...`);
++                this.archiveSignaled = true;
+                 this.emit("archived");
+               }
+             }
+@@ -2254,14 +2316,43 @@ class ApiSessionClient extends node_events.EventEmitter {
+     });
+     this.socket.connect();
+   }
++  hasArchiveSignal() {
++    return this.archiveSignaled;
++  }
+   onUserMessage(callback) {
+     this.pendingMessageCallback = callback;
++    if (this.orderedInbound) {
++      for (const pending of this.pendingMessages.splice(0)) {
++        void Promise.resolve().then(() => {
++          if (this.inboundClosed || this.inboundFailed) {
++            const error = new Error("Session inbound processing stopped");
++            error.name = "AbortError";
++            throw error;
++          }
++          return callback(pending.data);
++        }).then(pending.resolve, pending.reject);
++      }
++      return;
++    }
+     while (this.pendingMessages.length > 0) {
+       callback(this.pendingMessages.shift());
+     }
+   }
+   onFileEvent(callback) {
+     this.pendingFileEventCallback = callback;
++    if (this.orderedInbound) {
++      for (const pending of this.pendingFileEvents.splice(0)) {
++        void Promise.resolve().then(() => {
++          if (this.inboundClosed || this.inboundFailed) {
++            const error = new Error("Session inbound processing stopped");
++            error.name = "AbortError";
++            throw error;
++          }
++          return callback(pending.data);
++        }).then(pending.resolve, pending.reject);
++      }
++      return;
++    }
+     while (this.pendingFileEvents.length > 0) {
+       callback(this.pendingFileEvents.shift());
+     }
+@@ -2406,6 +2497,257 @@ class ApiSessionClient extends node_events.EventEmitter {
+       "X-Happy-Client": `cli-coding-session/${configuration.currentCliVersion}`
+     };
+   }
++  acceptInboundRecord(message, skipRouting = false) {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++      return false;
++    }
++    const seq = message?.seq;
++    if (!Number.isSafeInteger(seq) || seq < 0) {
++      this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++      return false;
++    }
++    if (seq <= this.lastSeq) {
++      return true;
++    }
++    if (seq !== this.lastSeq + 1) {
++      this.requestInboundProcessingFailure(new Error(`Relay message sequence gap: expected ${this.lastSeq + 1}, received ${seq}`));
++      return false;
++    }
++    if (this.inboundRecords.length >= ApiSessionClient.MAX_PENDING_INBOUND_RECORDS) {
++      this.requestInboundProcessingFailure(new Error("Relay inbound processing queue is full"));
++      return false;
++    }
++    const isOutboundEcho = this.outboundMessageLocalIds.delete(message.localId);
++    this.lastSeq = seq;
++    this.inboundRecords.push({
++      seq,
++      message,
++      skipRouting,
++      isOutboundEcho
++    });
++    void this.drainInboundRecords();
++    return true;
++  }
++  drainInboundRecords() {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed) {
++      return Promise.resolve();
++    }
++    if (this.inboundDrainPromise) {
++      return this.inboundDrainPromise;
++    }
++    const operation = this.runInboundDrain();
++    this.inboundDrainPromise = operation;
++    void operation.then(
++      () => {
++        if (this.inboundDrainPromise === operation) this.inboundDrainPromise = null;
++      },
++      () => {
++        if (this.inboundDrainPromise === operation) this.inboundDrainPromise = null;
++      }
++    );
++    return operation;
++  }
++  async runInboundDrain() {
++    this.inboundDraining = true;
++    try {
++      while (this.inboundRecords.length > 0 && !this.inboundFailed && !this.inboundClosed) {
++        const record = this.inboundRecords[0];
++        this.inboundActiveRecord = record;
++        if (record.seq !== this.lastProcessedSeq + 1) {
++          throw new Error(`Relay processed sequence gap: expected ${this.lastProcessedSeq + 1}, received ${record.seq}`);
++        }
++        if (!record.skipRouting && !record.isOutboundEcho && record.message?.content?.t === "encrypted") {
++          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(record.message.content.c));
++          logger.debug("[API] Processing ordered relay message", {
++            seq: record.seq,
++            role: typeof body?.role === "string" ? body.role : "unknown",
++            contentType: typeof body?.content?.type === "string" ? body.content.type : "unknown"
++          });
++          await this.routeIncomingMessageOrdered(body, record.seq);
++        }
++        if (this.inboundClosed || this.inboundFailed) {
++          return;
++        }
++        await this.messageProcessedCallback(record.seq);
++        if (this.inboundClosed || this.inboundFailed) {
++          return;
++        }
++        this.lastProcessedSeq = record.seq;
++        this.inboundRecords.shift();
++        this.inboundActiveRecord = null;
++        if (this.inboundFailurePending) {
++          const failure = this.inboundFailurePending;
++          this.inboundFailurePending = null;
++          this.failInboundProcessing(failure);
++          return;
++        }
++      }
++    } catch (error) {
++      this.inboundActiveRecord = null;
++      if (!this.inboundClosed) {
++        this.failInboundProcessing(error);
++      }
++    } finally {
++      this.inboundActiveRecord = null;
++      this.inboundDraining = false;
++    }
++  }
++  async routeIncomingMessageOrdered(message, seq) {
++    const userResult = UserMessageSchema.safeParse(message);
++    if (userResult.success) {
++      if (this.pendingMessageCallback) {
++        await this.pendingMessageCallback(userResult.data);
++      } else {
++        await new Promise((resolve, reject) => {
++          this.pendingMessages.push({
++            data: userResult.data,
++            seq,
++            resolve,
++            reject
++          });
++        });
++      }
++      return;
++    }
++    const fileResult = FileEventMessageSchema.safeParse(message);
++    if (fileResult.success) {
++      const ev = fileResult.data.content.data.ev;
++      logger.debug("[API] Received ordered file event", {
++        seq,
++        size: ev.size,
++        hasMimeType: Boolean(ev.mimeType)
++      });
++      if (this.pendingFileEventCallback) {
++        await this.pendingFileEventCallback(fileResult.data);
++      } else {
++        await new Promise((resolve, reject) => {
++          this.pendingFileEvents.push({
++            data: fileResult.data,
++            seq,
++            resolve,
++            reject
++          });
++        });
++      }
++      return;
++    }
++    for (const listener of this.rawListeners("message")) {
++      await listener.call(this, message);
++    }
++  }
++  rejectPendingInbound(error) {
++    for (const pending of this.pendingMessages.splice(0)) {
++      pending.reject(error);
++    }
++    for (const pending of this.pendingFileEvents.splice(0)) {
++      pending.reject(error);
++    }
++  }
++  requestInboundProcessingFailure(error) {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed || this.inboundFailurePending) {
++      return;
++    }
++    const failure = error instanceof Error ? error : new Error("Relay inbound processing failed");
++    if (!this.inboundActiveRecord) {
++      this.failInboundProcessing(failure);
++      return;
++    }
++    this.inboundFailurePending = failure;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.socket.close();
++    this.rejectPendingInbound(failure);
++    if (this.inboundRecords[0] === this.inboundActiveRecord) {
++      this.inboundRecords.splice(1);
++    }
++    logger.debug("[API] Relay inbound processing will stop after its accepted record is checkpointed", { error: failure });
++  }
++  failInboundProcessing(error) {
++    if (!this.orderedInbound || this.inboundFailed || this.inboundClosed) {
++      return;
++    }
++    const failure = error instanceof Error ? error : new Error("Relay inbound processing failed");
++    this.inboundFailurePending = null;
++    this.inboundFailed = true;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.rejectPendingInbound(failure);
++    this.inboundRecords.length = 0;
++    this.socket.close();
++    logger.debug("[API] Relay inbound processing stopped", { error: failure });
++    try {
++      this.emit("inboundProcessingError", failure);
++    } catch (listenerError) {
++      logger.debug("[API] Relay inbound processing error listener failed", { error: listenerError });
++    }
++  }
++  closeInboundProcessing() {
++    if (this.inboundClosed) {
++      return;
++    }
++    this.inboundClosed = true;
++    if (!this.orderedInbound) {
++      return;
++    }
++    const error = new Error("Session client closed");
++    error.name = "AbortError";
++    this.receiveSync.stop();
++    this.rejectPendingInbound(error);
++    this.inboundRecords.length = 0;
++  }
++  drainInboundProcessingForClose() {
++    if (!this.orderedInbound) {
++      this.closeInboundProcessing();
++      return Promise.resolve();
++    }
++    if (this.inboundClosePromise) {
++      return this.inboundClosePromise;
++    }
++    const operation = this.runInboundClose();
++    this.inboundClosePromise = operation;
++    return operation;
++  }
++  async runInboundClose() {
++    if (this.inboundClosed) {
++      return;
++    }
++    this.inboundClosing = true;
++    this.receiveSync.stop();
++    if (this.reconnectInterval) {
++      clearInterval(this.reconnectInterval);
++      this.reconnectInterval = null;
++    }
++    this.socket.close();
++    let timeout;
++    const timedOut = await Promise.race([
++      this.drainInboundRecords().then(() => false),
++      new Promise((resolve) => {
++        timeout = setTimeout(() => resolve(true), this.inboundCloseTimeoutMs);
++      })
++    ]);
++    if (timeout) clearTimeout(timeout);
++    if (timedOut) {
++      const failure = new Error(`Timed out draining relay input after ${this.inboundCloseTimeoutMs}ms`);
++      this.failInboundProcessing(failure);
++      this.inboundClosed = true;
++      throw failure;
++    }
++    if (this.inboundFailed) {
++      this.inboundClosed = true;
++      return;
++    }
++    this.inboundClosed = true;
++    const error = new Error("Session client closed");
++    error.name = "AbortError";
++    this.rejectPendingInbound(error);
++    this.inboundRecords.length = 0;
++  }
+   routeIncomingMessage(message) {
+     const userResult = UserMessageSchema.safeParse(message);
+     if (userResult.success) {
+@@ -2433,6 +2775,9 @@ class ApiSessionClient extends node_events.EventEmitter {
+     this.emit("message", message);
+   }
+   async fetchMessages() {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++      return;
++    }
+     const skipRouting = this.skipInitialMessages;
+     if (skipRouting) {
+       this.skipInitialMessages = false;
+@@ -2451,13 +2796,39 @@ class ApiSessionClient extends node_events.EventEmitter {
+           timeout: 6e4
+         }
+       );
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        return;
++      }
+       const messages = Array.isArray(response.data.messages) ? response.data.messages : [];
+       let maxSeq = afterSeq;
+       for (const message of messages) {
          if (message.seq > maxSeq) {
            maxSeq = message.seq;
          }
 -        if (skipRouting) continue;
++        if (this.orderedInbound) {
++          if (!Number.isSafeInteger(message?.seq) || message.seq < 0) {
++            this.requestInboundProcessingFailure(new Error("Relay message sequence must be a non-negative safe integer"));
++            return;
++          }
++          if (message.seq <= this.lastSeq) {
++            continue;
++          }
++          if (!this.acceptInboundRecord(message, skipRouting)) {
++            return;
++          }
++          continue;
++        }
 +        // The socket handler routes live messages and advances lastSeq while
 +        // this fetch is parked on its await. Without this guard the page that
 +        // comes back re-routes anything the socket already delivered, and a
@@ -256,7 +1205,30 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
          if (message.content?.t !== "encrypted") {
            continue;
          }
-@@ -2490,10 +2510,13 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2472,16 +2843,19 @@ class ApiSessionClient extends node_events.EventEmitter {
+           });
+         }
+       }
+-      this.lastSeq = Math.max(this.lastSeq, maxSeq);
++      if (!this.orderedInbound) {
++        this.lastSeq = Math.max(this.lastSeq, maxSeq);
++      }
+       const hasMore = !!response.data.hasMore;
+-      if (hasMore && maxSeq === afterSeq) {
++      const nextAfterSeq = this.orderedInbound ? this.lastSeq : maxSeq;
++      if (hasMore && nextAfterSeq === afterSeq) {
+         logger.debug("[API] fetchMessages pagination stalled, stopping to avoid infinite loop", {
+           sessionId: this.sessionId,
+           afterSeq
+         });
+         break;
+       }
+-      afterSeq = maxSeq;
++      afterSeq = nextAfterSeq;
+       if (!hasMore) {
+         break;
+       }
+@@ -2490,10 +2864,13 @@ class ApiSessionClient extends node_events.EventEmitter {
    static MAX_OUTBOX_BATCH_SIZE = 50;
    async flushOutbox() {
      while (this.pendingOutbox.length > 0) {
@@ -273,7 +1245,7 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
          `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
          {
            messages: batch
-@@ -2503,17 +2526,16 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2503,17 +2880,16 @@ class ApiSessionClient extends node_events.EventEmitter {
            timeout: 6e4
          }
        );
@@ -294,10 +1266,17 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
      });
      if (invalidate) {
        this.sendSync.invalidate();
-@@ -2780,6 +2802,14 @@ class ApiSessionClient extends node_events.EventEmitter {
+@@ -2780,6 +3156,21 @@ class ApiSessionClient extends node_events.EventEmitter {
    }
    async close() {
      logger.debug("[API] socket.close() called");
++    let inboundCloseError = null;
++    try {
++      await this.drainInboundProcessingForClose();
++    } catch (error) {
++      inboundCloseError = error;
++      logger.debug("[API] Failed to drain relay input during close", { error });
++    }
 +    // Join the existing single-flight sender before stopping it. Calling
 +    // flushOutbox() directly here can overlap an in-flight drain, causing both
 +    // callers to POST and splice the same batch while the relay is delayed.
@@ -309,7 +1288,36 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
      this.sendSync.stop();
      this.receiveSync.stop();
      if (this.reconnectInterval) {
-@@ -5232,7 +5262,10 @@ class ApiClient {
+@@ -2787,10 +3178,17 @@ class ApiSessionClient extends node_events.EventEmitter {
+       this.reconnectInterval = null;
+     }
+     this.socket.close();
++    if (inboundCloseError) throw inboundCloseError;
+   }
+   startSmartReconnect() {
++    if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) return;
+     if (this.reconnectInterval) return;
+     this.reconnectInterval = setInterval(() => {
++      if (this.inboundClosing || this.inboundClosed || this.inboundFailed || this.inboundFailurePending) {
++        clearInterval(this.reconnectInterval);
++        this.reconnectInterval = null;
++        return;
++      }
+       if (this.socket.connected) {
+         clearInterval(this.reconnectInterval);
+         this.reconnectInterval = null;
+@@ -2806,7 +3204,9 @@ class ApiSessionClient extends node_events.EventEmitter {
+     if (shouldReconnect()) {
+       logger.debug("[API] Network up + lid open \u2014 reconnecting in 1s");
+       setTimeout(() => {
+-        if (!this.socket.connected) this.socket.connect();
++        if (!this.inboundClosing && !this.inboundClosed && !this.inboundFailed && !this.inboundFailurePending && !this.socket.connected) {
++          this.socket.connect();
++        }
+       }, 1e3);
+     }
+   }
+@@ -5232,7 +5632,10 @@ class ApiClient {
      let encryptionKey;
      let encryptionVariant;
      if (this.credential.encryption.type === "dataKey") {
@@ -321,7 +1329,7 @@ index 4aebb1233520dbe47c2069294ff3664300e99177..c08a2a3c7a733a8c2947e7044f73ac11
        encryptionVariant = "dataKey";
        let encryptedDataKey = libsodiumEncryptForPublicKey(encryptionKey, this.credential.encryption.publicKey);
        dataEncryptionKey = new Uint8Array(encryptedDataKey.length + 1);
-@@ -5422,8 +5455,8 @@ class ApiClient {
+@@ -5422,8 +5825,8 @@ class ApiClient {
        throw error;
      }
    }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  happy@1.2.0: bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e
+  happy@1.2.0: 897952581507acec7ea0ca98126a5f5cb391105dc5d549b11d636996d7bc209f
 
 importers:
 
@@ -79,7 +79,7 @@ importers:
         version: 2.10.1
       happy:
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
+        version: 1.2.0(patch_hash=897952581507acec7ea0ca98126a5f5cb391105dc5d549b11d636996d7bc209f)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -10140,7 +10140,7 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  happy@1.2.0(patch_hash=bd216c354a952bf2d22c4074f066745b2dac221c16eef4461723af079663e45e)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
+  happy@1.2.0(patch_hash=897952581507acec7ea0ca98126a5f5cb391105dc5d549b11d636996d7bc209f)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk': 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7974,6 +7974,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "unicode-normalization",
  "unicode-width",
  "url",
  "urlencoding",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ async-trait = "0.1"
 uuid = { version = "1", features = ["v4", "v5"] }
 portable-pty = "0.9"
 termwiz = "0.23"
+unicode-normalization = "0.1"
 unicode-width = "0.2"
 jiff = { version = "0.2", features = ["serde"] }
 thiserror = "2"

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -225,6 +225,40 @@ pub struct AgentConversation {
     pub is_archived: bool,
 }
 
+/// Exact desktop record required to restore a provider process for a persisted
+/// Happy relay binding. This deliberately carries both stored root columns so
+/// the supervisor can canonicalize and compare them immediately before spawn
+/// and again before the atomic ownership claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HappyRestorationCandidate {
+    pub conversation_id: String,
+    pub title: String,
+    pub agent_type: String,
+    pub agent_session_id: Option<String>,
+    pub agent_cwd: String,
+    pub agent_model_id: Option<String>,
+    pub agent_permission_mode: Option<String>,
+    pub project_root: String,
+    pub is_archived: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HappyRestorationLookup {
+    NotHappyOrigin,
+    InvalidHappyOrigin { is_archived: bool },
+    Candidate(HappyRestorationCandidate),
+}
+
+/// Pre-key-store Happy conversation paired with the relay row recorded by the
+/// released desktop build. Startup uses this only to migrate rows that have no
+/// durable encrypted binding yet; exact lookup/claim still revalidates every
+/// field after the replacement relay row exists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LegacyHappyRestorationCandidate {
+    pub happy_session_id: String,
+    pub conversation: HappyRestorationCandidate,
+}
+
 /// Wire-format row for the unified `list_conversations` command. Carries
 /// every column either kind of thread needs so the chat and agent stores
 /// can both project from a single read, and exposes a `kind` field that
@@ -691,48 +725,329 @@ fn upsert_agent_conversation_in_db(
     )
 }
 
-pub(crate) async fn lookup_agent_conversation_by_happy_session(
+pub(crate) async fn lookup_happy_restoration_candidate(
     app: AppHandle,
+    provider_session_id: String,
     happy_session_id: String,
-) -> Result<Option<AgentConversation>, String> {
+) -> Result<HappyRestorationLookup, String> {
     run_db(app, move |conn| {
-        let sql = format!(
-            "SELECT c.id, c.title, c.created_at, c.agent_type, c.agent_session_id,
-                    c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
-                    c.agent_metadata, c.project_id, c.project_root, c.is_archived
-             FROM conversations c
-             LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
-             WHERE ({case}) = 'agent'
-               AND json_extract(c.agent_metadata, '$.happy_session_id') = ?1
-             LIMIT 1",
-            case = DERIVED_KIND_CASE_SQL,
-        );
-        let mut stmt = conn.prepare(&sql)?;
-
-        let conversation = stmt.query_row(params![happy_session_id], |row| {
-            Ok(AgentConversation {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                created_at: row.get(2)?,
-                agent_type: row.get(3)?,
-                agent_session_id: row.get(4)?,
-                agent_cwd: row.get(5)?,
-                agent_model_id: row.get(6)?,
-                agent_permission_mode: row.get(7)?,
-                agent_metadata: row.get(8)?,
-                project_id: row.get(9)?,
-                project_root: row.get(10)?,
-                is_archived: row.get::<_, i32>(11)? != 0,
-            })
-        });
-
-        match conversation {
-            Ok(conversation) => Ok(Some(conversation)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(error) => Err(error),
-        }
+        lookup_happy_restoration_candidate_in_db(conn, &provider_session_id, &happy_session_id)
     })
     .await
+}
+
+pub(crate) async fn list_legacy_happy_restoration_candidates(
+    app: AppHandle,
+) -> Result<Vec<LegacyHappyRestorationCandidate>, String> {
+    run_db(app, list_legacy_happy_restoration_candidates_in_db).await
+}
+
+fn list_legacy_happy_restoration_candidates_in_db(
+    conn: &Connection,
+) -> rusqlite::Result<Vec<LegacyHappyRestorationCandidate>> {
+    let sql = format!(
+        "SELECT c.id,
+                json_extract(c.agent_metadata, '$.happy_session_id')
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         LEFT JOIN happy_provider_session_lifecycle hpsl
+           ON hpsl.provider_session_id = c.id
+         WHERE c.is_archived = 0
+           AND hpsl.provider_session_id IS NULL
+           AND ({case}) = 'agent'
+           AND json_valid(c.agent_metadata)
+           AND json_type(c.agent_metadata, '$.happy_session_id') = 'text'
+         ORDER BY c.created_at ASC, c.id ASC",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let rows = conn
+        .prepare(&sql)?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut candidates = Vec::new();
+    for (conversation_id, happy_session_id) in rows {
+        if let HappyRestorationLookup::Candidate(conversation) =
+            lookup_happy_restoration_candidate_in_db(conn, &conversation_id, &happy_session_id)?
+            && !conversation.is_archived
+        {
+            candidates.push(LegacyHappyRestorationCandidate {
+                happy_session_id,
+                conversation,
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+pub(crate) async fn migrate_happy_restoration_relay(
+    app: AppHandle,
+    conversation_id: String,
+    expected_happy_session_id: String,
+    replacement_happy_session_id: String,
+) -> Result<bool, String> {
+    run_db(app, move |conn| {
+        migrate_happy_restoration_relay_in_db(
+            conn,
+            &conversation_id,
+            &expected_happy_session_id,
+            &replacement_happy_session_id,
+        )
+    })
+    .await
+}
+
+fn migrate_happy_restoration_relay_in_db(
+    conn: &Connection,
+    conversation_id: &str,
+    expected_happy_session_id: &str,
+    replacement_happy_session_id: &str,
+) -> rusqlite::Result<bool> {
+    if replacement_happy_session_id.trim().is_empty() {
+        return Ok(false);
+    }
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let lookup =
+        lookup_happy_restoration_candidate_in_db(&tx, conversation_id, expected_happy_session_id)?;
+    let HappyRestorationLookup::Candidate(candidate) = lookup else {
+        return Ok(false);
+    };
+    if candidate.is_archived || candidate.conversation_id != conversation_id {
+        return Ok(false);
+    }
+
+    // A successful current bridge claim leaves a durable lifecycle row. Its
+    // presence distinguishes a genuinely retired current session (whose
+    // encrypted key binding is intentionally deleted) from a pre-lifecycle
+    // v3.72 row that still needs one-time migration. A matching ready binding
+    // can acknowledge the old relay id without rotating it.
+    let recorded_lifecycle = tx
+        .query_row(
+            "SELECT conversation_id, is_archived
+             FROM happy_provider_session_lifecycle
+             WHERE provider_session_id = ?1",
+            params![conversation_id],
+            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, bool>(1)?)),
+        )
+        .optional()?;
+    if replacement_happy_session_id == expected_happy_session_id {
+        if matches!(
+            recorded_lifecycle.as_ref(),
+            Some((Some(owner), _)) if owner != conversation_id
+        ) || matches!(
+            recorded_lifecycle.as_ref(),
+            Some((_, archived)) if *archived
+        ) {
+            return Ok(false);
+        }
+        tx.execute(
+            "INSERT INTO happy_provider_session_lifecycle
+                (provider_session_id, conversation_id, is_archived, updated_at)
+             VALUES (?1, ?1, 0, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+             ON CONFLICT(provider_session_id) DO UPDATE SET
+                conversation_id = excluded.conversation_id,
+                updated_at = excluded.updated_at",
+            params![conversation_id],
+        )?;
+        tx.commit()?;
+        return Ok(true);
+    }
+    // A lifecycle row appearing after candidate discovery means another
+    // current bridge already claimed or retired this provider. Never rotate
+    // its relay identity using a stale legacy-migration response.
+    if recorded_lifecycle.is_some() {
+        return Ok(false);
+    }
+
+    let replacement_owner_sql = format!(
+        "SELECT c.id
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE ({case}) = 'agent'
+           AND json_valid(c.agent_metadata)
+           AND json_extract(c.agent_metadata, '$.happy_session_id') = ?1
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    if tx
+        .query_row(
+            &replacement_owner_sql,
+            params![replacement_happy_session_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .is_some()
+    {
+        return Ok(false);
+    }
+
+    let original_metadata = tx.query_row(
+        "SELECT agent_metadata FROM conversations WHERE id = ?1 AND is_archived = 0",
+        params![conversation_id],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut metadata = match serde_json::from_str::<serde_json::Value>(&original_metadata) {
+        Ok(serde_json::Value::Object(object)) => object,
+        _ => return Ok(false),
+    };
+    if metadata
+        .get("happy_session_id")
+        .and_then(serde_json::Value::as_str)
+        != Some(expected_happy_session_id)
+    {
+        return Ok(false);
+    }
+    metadata.insert(
+        "happy_session_id".to_string(),
+        serde_json::Value::String(replacement_happy_session_id.to_string()),
+    );
+    let replacement_metadata = serde_json::to_string(&metadata)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
+    let updated = tx.execute(
+        "UPDATE conversations
+         SET agent_metadata = ?1
+         WHERE id = ?2 AND is_archived = 0 AND agent_metadata = ?3",
+        params![replacement_metadata, conversation_id, original_metadata],
+    )?;
+    if updated != 1 {
+        return Ok(false);
+    }
+    tx.execute(
+        "INSERT INTO happy_provider_session_lifecycle
+            (provider_session_id, conversation_id, is_archived, updated_at)
+         VALUES (?1, ?1, 0, CAST(strftime('%s', 'now') AS INTEGER) * 1000)",
+        params![conversation_id],
+    )?;
+    mark_sync_upsert(&tx, "conversations", conversation_id)?;
+    tx.commit()?;
+    Ok(true)
+}
+
+fn lookup_happy_restoration_candidate_in_db(
+    conn: &Connection,
+    provider_session_id: &str,
+    happy_session_id: &str,
+) -> rusqlite::Result<HappyRestorationLookup> {
+    let sql = format!(
+        "SELECT c.id, c.title, c.agent_type, c.agent_session_id,
+                c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
+                c.agent_metadata, c.project_root, c.is_archived,
+                ({case}) AS derived_kind
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1
+         LIMIT 1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let row = conn
+        .query_row(&sql, params![provider_session_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, i32>(9)? != 0,
+                row.get::<_, String>(10)?,
+            ))
+        })
+        .optional()?;
+    let Some((
+        conversation_id,
+        title,
+        agent_type,
+        agent_session_id,
+        agent_cwd,
+        agent_model_id,
+        agent_permission_mode,
+        agent_metadata,
+        project_root,
+        is_archived,
+        derived_kind,
+    )) = row
+    else {
+        return Ok(HappyRestorationLookup::NotHappyOrigin);
+    };
+
+    // A local/provider id match is necessary but never sufficient. The
+    // Happy-origin marker written by `conversation_create` must parse and map
+    // to this exact relay row; otherwise a desktop-origin thread with the same
+    // UUID could be revived remotely.
+    let parsed_metadata = agent_metadata
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
+    let Some(happy_session_marker) = parsed_metadata
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|object| object.get("happy_session_id"))
+    else {
+        return Ok(HappyRestorationLookup::NotHappyOrigin);
+    };
+    let Some(recorded_happy_session_id) = happy_session_marker
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    };
+    if recorded_happy_session_id != happy_session_id || derived_kind != "agent" {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    }
+
+    // A relay id is a one-to-one provenance key. Duplicate metadata is
+    // ambiguous even when one duplicate happens to share the requested local
+    // id, so fail closed rather than selecting a row with LIMIT 1.
+    let unique_sql = format!(
+        "SELECT c.id
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE ({case}) = 'agent'
+           AND json_valid(c.agent_metadata)
+           AND json_extract(
+                CASE WHEN json_valid(c.agent_metadata)
+                     THEN c.agent_metadata
+                     ELSE NULL END,
+                '$.happy_session_id'
+           ) = ?1
+         LIMIT 2",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    let mapped_ids = conn
+        .prepare(&unique_sql)?
+        .query_map(params![happy_session_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if mapped_ids.len() != 1 || mapped_ids[0] != provider_session_id {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    }
+
+    let Some(agent_type) = agent_type.filter(|value| !value.trim().is_empty()) else {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    };
+    let Some(agent_cwd) = agent_cwd.filter(|value| !value.trim().is_empty()) else {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    };
+    let Some(project_root) = project_root.filter(|value| !value.trim().is_empty()) else {
+        return Ok(HappyRestorationLookup::InvalidHappyOrigin { is_archived });
+    };
+
+    Ok(HappyRestorationLookup::Candidate(
+        HappyRestorationCandidate {
+            conversation_id,
+            title,
+            agent_type,
+            agent_session_id,
+            agent_cwd,
+            agent_model_id,
+            agent_permission_mode,
+            project_root,
+            is_archived,
+        },
+    ))
 }
 
 pub(crate) async fn lookup_happy_session_id_by_conversation(
@@ -840,21 +1155,72 @@ fn claim_happy_provider_session_owner_in_db(
     provider_session_id: &str,
     agent_session_id: Option<&str>,
 ) -> rusqlite::Result<bool> {
+    claim_happy_provider_session_owner_with_provenance_in_db(
+        conn,
+        conversation_id,
+        provider_session_id,
+        agent_session_id,
+        None,
+    )?
+    .ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+/// Identity captured by the pre-spawn lookup and echoed by the bridge. Because
+/// this struct is itself optional, a `None` native session id is an exact
+/// expected-absence assertion rather than a wildcard.
+struct ExpectedHappyRestoration<'a> {
+    happy_session_id: &'a str,
+    agent_type: &'a str,
+    agent_session_id: Option<&'a str>,
+    agent_permission_mode: Option<&'a str>,
+    agent_cwd: &'a str,
+    project_root: &'a str,
+}
+
+fn claim_happy_provider_session_owner_with_provenance_in_db(
+    conn: &Connection,
+    conversation_id: &str,
+    provider_session_id: &str,
+    agent_session_id: Option<&str>,
+    expected: Option<ExpectedHappyRestoration<'_>>,
+) -> rusqlite::Result<Option<bool>> {
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    let sql = format!(
-        "SELECT 1
-         FROM conversations c
-         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
-         WHERE c.id = ?1 AND ({case}) = 'agent'
-         LIMIT 1",
-        case = DERIVED_KIND_CASE_SQL,
-    );
-    if tx
-        .query_row(&sql, params![conversation_id], |_| Ok(()))
-        .optional()?
-        .is_none()
-    {
-        return Err(rusqlite::Error::QueryReturnedNoRows);
+    if let Some(expected) = expected {
+        if conversation_id != provider_session_id {
+            return Ok(None);
+        }
+        let exact = lookup_happy_restoration_candidate_in_db(
+            &tx,
+            provider_session_id,
+            expected.happy_session_id,
+        )?;
+        let HappyRestorationLookup::Candidate(candidate) = exact else {
+            return Ok(None);
+        };
+        if candidate.agent_type != expected.agent_type
+            || candidate.agent_session_id.as_deref() != expected.agent_session_id
+            || candidate.agent_permission_mode.as_deref() != expected.agent_permission_mode
+            || candidate.agent_cwd != expected.agent_cwd
+            || candidate.project_root != expected.project_root
+        {
+            return Ok(None);
+        }
+    } else {
+        let sql = format!(
+            "SELECT 1
+             FROM conversations c
+             LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+             WHERE c.id = ?1 AND ({case}) = 'agent'
+             LIMIT 1",
+            case = DERIVED_KIND_CASE_SQL,
+        );
+        if tx
+            .query_row(&sql, params![conversation_id], |_| Ok(()))
+            .optional()?
+            .is_none()
+        {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
     }
 
     tx.execute(
@@ -888,7 +1254,7 @@ fn claim_happy_provider_session_owner_in_db(
         }
     }
     tx.commit()?;
-    Ok(archived)
+    Ok(Some(archived))
 }
 
 /// Persist an exact provider-session archive fence without emitting another
@@ -1114,7 +1480,7 @@ fn set_agent_conversation_session_id_in_db(
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HappyProviderSessionOwnerClaim {
-    archived: bool,
+    pub(crate) archived: bool,
 }
 
 #[tauri::command]
@@ -1139,6 +1505,61 @@ pub async fn claim_happy_provider_session_owner(
         )
     })
     .await?;
+    if archived {
+        refresh_conversation_index_meta_best_effort(
+            app.clone(),
+            index_id.clone(),
+            None,
+            Some(true),
+        )
+        .await;
+        emit_happy_provider_archive_event(&app, Some(&index_id), &target_provider_session_id);
+    }
+    Ok(HappyProviderSessionOwnerClaim { archived })
+}
+
+pub(crate) async fn claim_restored_happy_provider_session_owner(
+    app: AppHandle,
+    conversation_id: String,
+    provider_session_id: String,
+    happy_session_id: String,
+    agent_session_id: Option<String>,
+    expected_agent_type: String,
+    expected_agent_session_id: Option<String>,
+    expected_agent_permission_mode: Option<String>,
+    expected_agent_cwd: String,
+    expected_project_root: String,
+) -> Result<HappyProviderSessionOwnerClaim, String> {
+    uuid::Uuid::parse_str(&conversation_id)
+        .map_err(|_| "conversationId must be a UUID".to_string())?;
+    uuid::Uuid::parse_str(&provider_session_id)
+        .map_err(|_| "providerSessionId must be a UUID".to_string())?;
+    if conversation_id != provider_session_id || happy_session_id.trim().is_empty() {
+        return Err("Happy restoration claim was rejected".to_string());
+    }
+
+    let index_id = conversation_id.clone();
+    let target_provider_session_id = provider_session_id.clone();
+    let claimed = run_db(app.clone(), move |conn| {
+        claim_happy_provider_session_owner_with_provenance_in_db(
+            conn,
+            &conversation_id,
+            &provider_session_id,
+            agent_session_id.as_deref(),
+            Some(ExpectedHappyRestoration {
+                happy_session_id: &happy_session_id,
+                agent_type: &expected_agent_type,
+                agent_session_id: expected_agent_session_id.as_deref(),
+                agent_permission_mode: expected_agent_permission_mode.as_deref(),
+                agent_cwd: &expected_agent_cwd,
+                project_root: &expected_project_root,
+            }),
+        )
+    })
+    .await?;
+    let Some(archived) = claimed else {
+        return Err("Happy restoration claim was rejected".to_string());
+    };
     if archived {
         refresh_conversation_index_meta_best_effort(
             app.clone(),
@@ -1642,12 +2063,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentArchiveOrigin, AgentConversation, DERIVED_KIND_CASE_SQL,
-        archive_agent_conversation_in_db, archive_happy_provider_session_in_db,
-        claim_happy_provider_session_owner_in_db, emit_happy_archive_event,
+        AgentArchiveOrigin, AgentConversation, DERIVED_KIND_CASE_SQL, ExpectedHappyRestoration,
+        HappyRestorationCandidate, HappyRestorationLookup, archive_agent_conversation_in_db,
+        archive_happy_provider_session_in_db, claim_happy_provider_session_owner_in_db,
+        claim_happy_provider_session_owner_with_provenance_in_db, emit_happy_archive_event,
         emit_happy_provider_archive_event, is_happy_provider_session_archived_in_db,
-        lookup_agent_conversation_owner_in_db, lookup_happy_session_id_by_conversation_in_db,
-        set_agent_conversation_session_id_in_db, upsert_agent_conversation_in_db,
+        list_legacy_happy_restoration_candidates_in_db, lookup_agent_conversation_owner_in_db,
+        lookup_happy_restoration_candidate_in_db, lookup_happy_session_id_by_conversation_in_db,
+        migrate_happy_restoration_relay_in_db, set_agent_conversation_session_id_in_db,
+        upsert_agent_conversation_in_db,
     };
     use crate::services::database::setup_schema;
     use rusqlite::{Connection, params};
@@ -1659,6 +2083,450 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         setup_schema(&conn).unwrap();
         conn
+    }
+
+    fn insert_happy_restoration_candidate(conn: &Connection, id: &str, happy_session_id: &str) {
+        conn.execute(
+            "INSERT INTO conversations (
+                id, title, created_at, kind, agent_type, agent_session_id,
+                agent_cwd, agent_model_id, agent_permission_mode,
+                agent_metadata, project_root
+             ) VALUES (
+                ?1, 'Remote thread', 1000, 'agent', 'codex', 'native-before',
+                '/synthetic/consented', 'saved-model', 'saved-permission',
+                ?2, '/synthetic/consented'
+             )",
+            params![
+                id,
+                serde_json::json!({ "happy_session_id": happy_session_id }).to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn happy_restoration_lookup_returns_exact_saved_resume_fields() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "provider-local-id", "relay-id");
+
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(&conn, "provider-local-id", "relay-id",)
+                .unwrap(),
+            HappyRestorationLookup::Candidate(HappyRestorationCandidate {
+                conversation_id: "provider-local-id".to_string(),
+                title: "Remote thread".to_string(),
+                agent_type: "codex".to_string(),
+                agent_session_id: Some("native-before".to_string()),
+                agent_cwd: "/synthetic/consented".to_string(),
+                agent_model_id: Some("saved-model".to_string()),
+                agent_permission_mode: Some("saved-permission".to_string()),
+                project_root: "/synthetic/consented".to_string(),
+                is_archived: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn legacy_happy_candidates_are_exact_unarchived_rows_and_rebind_atomically() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "provider-local-id", "legacy-relay-id");
+
+        let candidates = list_legacy_happy_restoration_candidates_in_db(&conn).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].happy_session_id, "legacy-relay-id");
+        assert_eq!(
+            candidates[0].conversation.conversation_id,
+            "provider-local-id"
+        );
+
+        assert!(
+            migrate_happy_restoration_relay_in_db(
+                &conn,
+                "provider-local-id",
+                "legacy-relay-id",
+                "replacement-relay-id",
+            )
+            .unwrap()
+        );
+        assert!(matches!(
+            lookup_happy_restoration_candidate_in_db(
+                &conn,
+                "provider-local-id",
+                "replacement-relay-id",
+            )
+            .unwrap(),
+            HappyRestorationLookup::Candidate(_)
+        ));
+        assert!(
+            list_legacy_happy_restoration_candidates_in_db(&conn)
+                .unwrap()
+                .is_empty(),
+            "the committed migration lifecycle must exclude this current row",
+        );
+        assert!(
+            !migrate_happy_restoration_relay_in_db(
+                &conn,
+                "provider-local-id",
+                "legacy-relay-id",
+                "stale-replacement",
+            )
+            .unwrap(),
+            "a stale migration must not overwrite the committed relay marker",
+        );
+
+        conn.execute(
+            "UPDATE conversations SET is_archived = 1 WHERE id = 'provider-local-id'",
+            [],
+        )
+        .unwrap();
+        assert!(
+            list_legacy_happy_restoration_candidates_in_db(&conn)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn matching_ready_binding_marks_legacy_row_as_current_without_rotating_it() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "provider-local-id", "relay-id");
+
+        assert!(
+            migrate_happy_restoration_relay_in_db(
+                &conn,
+                "provider-local-id",
+                "relay-id",
+                "relay-id",
+            )
+            .unwrap()
+        );
+        assert!(
+            list_legacy_happy_restoration_candidates_in_db(&conn)
+                .unwrap()
+                .is_empty(),
+            "a current row must not become a migration candidate after its key is retired",
+        );
+        assert!(matches!(
+            lookup_happy_restoration_candidate_in_db(&conn, "provider-local-id", "relay-id",)
+                .unwrap(),
+            HappyRestorationLookup::Candidate(_)
+        ));
+        assert!(
+            !migrate_happy_restoration_relay_in_db(
+                &conn,
+                "provider-local-id",
+                "relay-id",
+                "stale-rotation",
+            )
+            .unwrap(),
+            "a lifecycle claim appearing after discovery must reject stale rotation",
+        );
+    }
+
+    #[test]
+    fn happy_restoration_lookup_never_falls_back_and_rejects_ambiguous_provenance() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "provider-local-id", "relay-id");
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, agent_type)
+             VALUES ('desktop-origin', 'Desktop thread', 1001, 'agent', 'codex')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversations (
+                id, title, created_at, kind, agent_type, agent_cwd,
+                agent_metadata, project_root
+             ) VALUES (
+                'invalid-marker', 'Invalid marker', 1002, 'agent', 'codex',
+                '/synthetic/consented', '{\"happy_session_id\":42}',
+                '/synthetic/consented'
+             )",
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(&conn, "missing-local-id", "relay-id")
+                .unwrap(),
+            HappyRestorationLookup::NotHappyOrigin,
+            "a matching relay id must never substitute for the exact local/provider id",
+        );
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(&conn, "desktop-origin", "relay-id").unwrap(),
+            HappyRestorationLookup::NotHappyOrigin,
+            "a desktop-origin row is not remotely restorable without the Happy marker",
+        );
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(&conn, "invalid-marker", "relay-id").unwrap(),
+            HappyRestorationLookup::InvalidHappyOrigin { is_archived: false },
+            "a present but invalid Happy marker is not a desktop-origin row",
+        );
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(
+                &conn,
+                "provider-local-id",
+                "different-relay-id",
+            )
+            .unwrap(),
+            HappyRestorationLookup::InvalidHappyOrigin { is_archived: false },
+        );
+
+        insert_happy_restoration_candidate(&conn, "duplicate-local-id", "relay-id");
+        assert_eq!(
+            lookup_happy_restoration_candidate_in_db(&conn, "provider-local-id", "relay-id",)
+                .unwrap(),
+            HappyRestorationLookup::InvalidHappyOrigin { is_archived: false },
+            "duplicate relay metadata is ambiguous and must fail closed",
+        );
+    }
+
+    #[test]
+    fn restored_happy_claim_revalidates_provenance_and_preserves_archive_wins() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "provider-local-id", "relay-id");
+
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "provider-local-id",
+                "provider-local-id",
+                Some("native-rejected"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "different-relay-id",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-before"),
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            None,
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM happy_provider_session_lifecycle",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0,
+            "a rejected restoration cannot claim lifecycle ownership",
+        );
+
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "provider-local-id",
+                "provider-local-id",
+                Some("native-restored"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "relay-id",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-before"),
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            Some(false),
+        );
+        assert_eq!(
+            archive_happy_provider_session_in_db(&conn, "provider-local-id").unwrap(),
+            Some("provider-local-id".to_string()),
+        );
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "provider-local-id",
+                "provider-local-id",
+                Some("native-too-late"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "relay-id",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-restored"),
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            Some(true),
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT is_archived, agent_session_id
+                 FROM conversations
+                 WHERE id = 'provider-local-id'",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .unwrap(),
+            (1, Some("native-restored".to_string())),
+            "the archive fence wins and a late claim cannot install its native session id",
+        );
+    }
+
+    #[test]
+    fn restored_happy_claim_rejects_concurrent_agent_identity_changes() {
+        let conn = open();
+        insert_happy_restoration_candidate(&conn, "type-changed", "type-relay");
+        conn.execute(
+            "UPDATE conversations SET agent_type = 'claude' WHERE id = 'type-changed'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "type-changed",
+                "type-changed",
+                Some("native-after-spawn"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "type-relay",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-before"),
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            None,
+            "a provider-kind mutation after lookup must reject the claim",
+        );
+
+        insert_happy_restoration_candidate(&conn, "native-changed", "native-relay");
+        conn.execute(
+            "UPDATE conversations
+             SET agent_session_id = 'native-concurrent'
+             WHERE id = 'native-changed'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "native-changed",
+                "native-changed",
+                Some("native-after-spawn"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "native-relay",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-before"),
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            None,
+            "a native resume-id mutation after lookup must reject the claim",
+        );
+
+        insert_happy_restoration_candidate(&conn, "permission-changed", "permission-relay");
+        conn.execute(
+            "UPDATE conversations
+             SET agent_permission_mode = 'ask'
+             WHERE id = 'permission-changed'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "permission-changed",
+                "permission-changed",
+                Some("native-after-spawn"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "permission-relay",
+                    agent_type: "codex",
+                    agent_session_id: Some("native-before"),
+                    agent_permission_mode: Some("bypassPermissions"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            None,
+            "a permission-mode mutation after lookup must reject the claim",
+        );
+
+        insert_happy_restoration_candidate(&conn, "absence-changed", "absence-relay");
+        conn.execute(
+            "UPDATE conversations
+             SET agent_session_id = 'native-concurrent'
+             WHERE id = 'absence-changed'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "absence-changed",
+                "absence-changed",
+                Some("native-after-spawn"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "absence-relay",
+                    agent_type: "codex",
+                    agent_session_id: None,
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            None,
+            "an expected-absent native id must not act as a wildcard",
+        );
+
+        insert_happy_restoration_candidate(&conn, "absence-stable", "stable-relay");
+        conn.execute(
+            "UPDATE conversations SET agent_session_id = NULL WHERE id = 'absence-stable'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            claim_happy_provider_session_owner_with_provenance_in_db(
+                &conn,
+                "absence-stable",
+                "absence-stable",
+                Some("native-after-spawn"),
+                Some(ExpectedHappyRestoration {
+                    happy_session_id: "stable-relay",
+                    agent_type: "codex",
+                    agent_session_id: None,
+                    agent_permission_mode: Some("saved-permission"),
+                    agent_cwd: "/synthetic/consented",
+                    project_root: "/synthetic/consented",
+                }),
+            )
+            .unwrap(),
+            Some(false),
+            "a stable expected absence may install the spawned native id",
+        );
+
+        assert_eq!(
+            conn.query_row(
+                "SELECT agent_session_id FROM conversations WHERE id = 'native-changed'",
+                [],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .unwrap(),
+            Some("native-concurrent".to_string()),
+            "a rejected claim must not overwrite the concurrent native id",
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT agent_session_id FROM conversations WHERE id = 'absence-stable'",
+                [],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .unwrap(),
+            Some("native-after-spawn".to_string()),
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -16,7 +16,7 @@ fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
     store.save().map_err(|err| err.to_string())
 }
 
-fn is_enabled(app: &AppHandle) -> bool {
+pub(crate) fn is_enabled(app: &AppHandle) -> bool {
     app.store(SETTINGS_STORE)
         .ok()
         .and_then(|store| store.get(ENABLED_KEY))

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::time::Instant;
 use tauri::{AppHandle, Manager, State};
 
-use crate::{mcp, provider_runtime, terminal};
+use crate::{happy_bridge, mcp, provider_runtime, terminal};
 
 /// Global flag set by `updater_pre_install` and cleared only by relaunch.
 /// While set, spawn-side commands must reject new child processes so the
@@ -191,6 +191,15 @@ pub async fn updater_pre_install(
         false
     };
 
+    // Stop the Happy bridge while the provider runtime is still reachable so
+    // its graceful, passive shutdown can drain accepted relay work. Operational
+    // shutdown preserves relay rows and bindings for the post-update restart.
+    if let Some(state) = app.try_state::<happy_bridge::HappyBridgeManager>()
+        && let Err(error) = state.stop(&app).await
+    {
+        log::warn!("[Updater] Happy bridge did not stop cleanly: {error}");
+    }
+
     // Drain the provider runtime supervisor. This is the largest holder of
     // the embedded `node.exe` handle.
     let provider_runtime_drained =
@@ -237,10 +246,20 @@ pub async fn updater_pre_install(
 /// (#2230 functional audit).
 #[tauri::command]
 pub async fn updater_pre_install_release(
+    app: AppHandle,
     guard: State<'_, Arc<ShutdownGuard>>,
+    happy_state: State<'_, happy_bridge::HappyBridgeManager>,
 ) -> Result<(), String> {
     guard.release();
     log::info!("[Updater] Pre-install shutdown released (install failed or cancelled)");
+
+    if crate::commands::happy_bridge::is_enabled(&app) {
+        happy_state
+            .start(&app)
+            .await
+            .map_err(|error| format!("Failed to restart Happy bridge: {error}"))?;
+    }
+
     Ok(())
 }
 
@@ -333,6 +352,50 @@ mod tests {
         // Re-engaging after release works (a second update attempt).
         guard.engage();
         assert!(guard.is_engaged());
+    }
+
+    #[test]
+    fn updater_happy_lifecycle_preserves_restart_order() {
+        // The Happy bridge must drain while its provider runtime is still
+        // reachable. If install is cancelled, the spawn guard must be released
+        // before an enabled bridge is restarted.
+        let source = include_str!("updater.rs");
+        let pre_install_start = source
+            .find("pub async fn updater_pre_install(")
+            .expect("updater_pre_install must exist");
+        let release_start = source
+            .find("pub async fn updater_pre_install_release(")
+            .expect("updater_pre_install_release must exist");
+        let pre_install = &source[pre_install_start..release_start];
+        let happy_stop = pre_install
+            .find("state.stop(&app).await")
+            .expect("pre-install must stop the Happy bridge");
+        let provider_kill = pre_install
+            .find("state.kill_sync()")
+            .expect("pre-install must kill the provider runtime");
+        assert!(
+            happy_stop < provider_kill,
+            "Happy must stop before the provider runtime"
+        );
+
+        let release_end = source[release_start..]
+            .find("async fn wait_for_node_handle_release")
+            .map(|offset| release_start + offset)
+            .expect("release command must precede the handle-release helper");
+        let release = &source[release_start..release_end];
+        let guard_release = release
+            .find("guard.release()")
+            .expect("release command must clear the shutdown guard");
+        let enabled_check = release
+            .find("is_enabled(&app)")
+            .expect("release command must re-check persisted Happy consent");
+        let happy_start = release
+            .find(".start(&app)")
+            .expect("release command must restart the Happy bridge");
+        assert!(
+            guard_release < enabled_check && enabled_check < happy_start,
+            "release must clear the guard, check consent, then restart Happy"
+        );
     }
 
     #[test]

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -3,7 +3,7 @@
 
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -12,6 +12,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
+use unicode_normalization::UnicodeNormalization;
 
 pub const HAPPY_RELAY_URL: &str = "https://api.cluster-fluster.com";
 const MAX_RESTART_ATTEMPTS: u32 = 3;
@@ -887,26 +888,33 @@ async fn monitor_process(
 }
 
 /// Asks the bridge to shut down over the supervisor channel, then falls back to
-/// signals. Windows has no SIGTERM, so before this the child was never told to
-/// exit: every stop burned the full grace period and was then hard-killed,
-/// skipping the relay disconnect so the machine was left to time out. The
-/// notification is sent on every platform, which also gives unix a clean
-/// shutdown ahead of SIGTERM rather than relying on the signal handler alone.
+/// signals only when that notification cannot be delivered. Windows has no
+/// SIGTERM, so before this the child was never told to exit: every stop burned
+/// the full grace period and was then hard-killed, skipping the relay disconnect
+/// so the machine was left to time out. On unix, immediately signaling after a
+/// successful notification is also unsafe: the signal handler could win the
+/// race and lose the explicit-disable retirement flag carried by the request.
 async fn terminate_child(
     child: &mut Child,
     stdin: Option<&Arc<Mutex<ChildStdin>>>,
 ) -> Result<(), String> {
-    if let Some(stdin) = stdin {
+    let shutdown_notified = if let Some(stdin) = stdin {
         // Bounded: a wedged bridge that is not draining stdin must not stall the
         // stop path, which is exactly the deadlock the grace period exists for.
         // The signal and kill fallbacks below cover a failed write.
-        let _ = notify_supervisor(stdin, json!({ "jsonrpc": "2.0", "method": "shutdown" })).await;
-    }
+        notify_supervisor(stdin, shutdown_notification())
+            .await
+            .is_ok()
+    } else {
+        false
+    };
 
     #[cfg(unix)]
-    if let Some(pid) = child.id() {
-        unsafe {
-            libc::kill(pid as i32, libc::SIGTERM);
+    if !shutdown_notified {
+        if let Some(pid) = child.id() {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
         }
     }
 
@@ -917,6 +925,13 @@ async fn terminate_child(
             .await
             .map_err(|err| format!("Failed to stop Happy bridge: {err}")),
     }
+}
+
+fn shutdown_notification() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "shutdown",
+    })
 }
 
 fn restart_delay(attempt: u32) -> Duration {
@@ -1126,6 +1141,47 @@ fn is_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -> bool 
         .any(|root| root == candidate)
 }
 
+/// Serialize an already-canonical path in the same form Node's `realpath`
+/// returns. Windows' Rust canonicalizer uses verbatim paths (`\\?\C:\...` or
+/// `\\?\UNC\...`), while Node returns ordinary DOS/UNC paths. This conversion
+/// also applies the NFC normalization used by `canonicalAbsolutePath` in
+/// `validate.mjs`. It is intentionally wire-only: authorization and symlink
+/// checks continue to compare canonical `PathBuf`s before reaching this
+/// function.
+fn canonical_path_for_wire(path: &Path) -> Option<String> {
+    let path = path.to_str()?;
+    let path = if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{unc}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(path).to_owned()
+    };
+    Some(path.nfc().collect())
+}
+
+/// Resolve the two root columns written for a Happy-originated conversation to
+/// one exact, currently authorized canonical directory. Requiring both columns
+/// prevents a partially overwritten desktop row from choosing whichever path
+/// happens to remain usable.
+fn canonical_happy_restoration_root<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    agent_cwd: &str,
+    project_root: &str,
+) -> Option<String> {
+    let agent_cwd = std::fs::canonicalize(agent_cwd).ok()?;
+    let project_root = std::fs::canonicalize(project_root).ok()?;
+    if agent_cwd != project_root {
+        return None;
+    }
+    let authorized = crate::commands::happy_bridge::saved_advertised_roots(app)
+        .iter()
+        .filter_map(|root| std::fs::canonicalize(root).ok())
+        .any(|root| root == agent_cwd);
+    if !authorized {
+        return None;
+    }
+    canonical_path_for_wire(&agent_cwd)
+}
+
 /// The distinct project folders behind the user's agent conversations, in the
 /// order they were seen. A failed lookup is reported rather than absorbed: an
 /// empty set is also what a user with no projects has, so absorbing it started a
@@ -1181,6 +1237,9 @@ fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
             | "conversation_delete"
             | "conversation_happy_session_lookup"
             | "conversation_lookup"
+            | "conversation_restore_candidates"
+            | "conversation_migrate_happy_session"
+            | "conversation_claim"
             | "conversation_owner_lookup"
             | "provider_session_archive"
             | "provider_session_archive_lookup"
@@ -1209,6 +1268,14 @@ fn required_uuid(params: &Value, key: &str) -> Result<String, String> {
     let value = required_string(params, key)?;
     uuid::Uuid::parse_str(&value).map_err(|_| format!("{key} must be a UUID"))?;
     Ok(value)
+}
+
+fn required_nullable_string(params: &Value, key: &str) -> Result<Option<String>, String> {
+    match params.get(key) {
+        Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(Some(value.clone())),
+        _ => Err(format!("{key} must be a non-empty string or null")),
+    }
 }
 
 async fn dispatch_supervisor_request(
@@ -1247,21 +1314,166 @@ async fn dispatch_supervisor_request(
             Ok(json!({ "conversationId": conversation.id }))
         }
         "conversation_lookup" => {
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
             let happy_session_id = required_string(&request.params, "happySessionId")?;
-            let conversation = crate::commands::chat::lookup_agent_conversation_by_happy_session(
+            let lookup = crate::commands::chat::lookup_happy_restoration_candidate(
                 app.clone(),
+                provider_session_id,
                 happy_session_id,
             )
             .await?;
-            Ok(match conversation {
-                Some(conversation) => json!({
-                    "conversationId": conversation.id,
-                    "agentSessionId": conversation.agent_session_id,
-                    "cwd": conversation.agent_cwd,
-                    "agentType": conversation.agent_type,
+            Ok(match lookup {
+                crate::commands::chat::HappyRestorationLookup::NotHappyOrigin => json!({
+                    "restorable": false,
+                    "happyOrigin": false,
+                    "retire": false,
                 }),
-                None => json!({}),
+                crate::commands::chat::HappyRestorationLookup::InvalidHappyOrigin {
+                    is_archived,
+                } => json!({
+                    "restorable": false,
+                    "happyOrigin": true,
+                    "retire": true,
+                    "archived": is_archived,
+                }),
+                crate::commands::chat::HappyRestorationLookup::Candidate(conversation)
+                    if conversation.is_archived =>
+                {
+                    json!({
+                        "restorable": false,
+                        "happyOrigin": true,
+                        "retire": true,
+                        "archived": true,
+                    })
+                }
+                crate::commands::chat::HappyRestorationLookup::Candidate(conversation) => {
+                    match canonical_happy_restoration_root(
+                        app,
+                        &conversation.agent_cwd,
+                        &conversation.project_root,
+                    ) {
+                        Some(cwd) => json!({
+                            "restorable": true,
+                            "happyOrigin": true,
+                            "retire": false,
+                            "conversationId": conversation.conversation_id,
+                            "agentSessionId": conversation.agent_session_id,
+                            "agentModelId": conversation.agent_model_id,
+                            "agentPermissionMode": conversation.agent_permission_mode,
+                            "cwd": cwd,
+                            "agentType": conversation.agent_type,
+                            "title": conversation.title,
+                            "archived": false,
+                        }),
+                        None => json!({
+                            "restorable": false,
+                            "happyOrigin": true,
+                            "retire": true,
+                            "archived": false,
+                        }),
+                    }
+                }
             })
+        }
+        "conversation_restore_candidates" => {
+            let candidates =
+                crate::commands::chat::list_legacy_happy_restoration_candidates(app.clone())
+                    .await?;
+            let candidates = candidates
+                .into_iter()
+                .filter_map(|candidate| {
+                    let conversation = candidate.conversation;
+                    let cwd = canonical_happy_restoration_root(
+                        app,
+                        &conversation.agent_cwd,
+                        &conversation.project_root,
+                    )?;
+                    Some(json!({
+                        "conversationId": conversation.conversation_id,
+                        "happySessionId": candidate.happy_session_id,
+                        "agentSessionId": conversation.agent_session_id,
+                        "agentModelId": conversation.agent_model_id,
+                        "agentPermissionMode": conversation.agent_permission_mode,
+                        "cwd": cwd,
+                        "agentType": conversation.agent_type,
+                        "title": conversation.title,
+                    }))
+                })
+                .collect::<Vec<_>>();
+            Ok(json!({ "candidates": candidates }))
+        }
+        "conversation_migrate_happy_session" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
+            let expected_happy_session_id =
+                required_string(&request.params, "expectedHappySessionId")?;
+            let replacement_happy_session_id =
+                required_string(&request.params, "replacementHappySessionId")?;
+            let migrated = crate::commands::chat::migrate_happy_restoration_relay(
+                app.clone(),
+                conversation_id,
+                expected_happy_session_id,
+                replacement_happy_session_id,
+            )
+            .await?;
+            if !migrated {
+                return Err("Happy relay migration was rejected".to_string());
+            }
+            Ok(json!({ "migrated": true }))
+        }
+        "conversation_claim" => {
+            let conversation_id = required_uuid(&request.params, "conversationId")?;
+            let provider_session_id = required_uuid(&request.params, "providerSessionId")?;
+            if conversation_id != provider_session_id {
+                return Err("Happy restoration claim was rejected".to_string());
+            }
+            let happy_session_id = required_string(&request.params, "happySessionId")?;
+            let cwd = required_string(&request.params, "cwd")?;
+            let expected_agent_type = required_string(&request.params, "expectedAgentType")?;
+            let expected_agent_session_id =
+                required_nullable_string(&request.params, "expectedAgentSessionId")?;
+            let expected_agent_permission_mode =
+                required_nullable_string(&request.params, "expectedAgentPermissionMode")?;
+            let agent_session_id = request
+                .params
+                .get("agentSessionId")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned);
+            let lookup = crate::commands::chat::lookup_happy_restoration_candidate(
+                app.clone(),
+                provider_session_id.clone(),
+                happy_session_id.clone(),
+            )
+            .await?;
+            let crate::commands::chat::HappyRestorationLookup::Candidate(conversation) = lookup
+            else {
+                return Err("Happy restoration claim was rejected".to_string());
+            };
+            if !conversation.is_archived {
+                let canonical_root = canonical_happy_restoration_root(
+                    app,
+                    &conversation.agent_cwd,
+                    &conversation.project_root,
+                )
+                .ok_or_else(|| "Happy restoration root is no longer authorized".to_string())?;
+                if cwd != canonical_root {
+                    return Err("Happy restoration root changed before claim".to_string());
+                }
+            }
+            let claim = crate::commands::chat::claim_restored_happy_provider_session_owner(
+                app.clone(),
+                conversation_id,
+                provider_session_id,
+                happy_session_id,
+                agent_session_id,
+                expected_agent_type,
+                expected_agent_session_id,
+                expected_agent_permission_mode,
+                conversation.agent_cwd,
+                conversation.project_root,
+            )
+            .await?;
+            Ok(json!({ "archived": claim.archived }))
         }
         "conversation_happy_session_lookup" => {
             let conversation_id = required_uuid(&request.params, "conversationId")?;
@@ -1617,10 +1829,11 @@ fn pipe_bridge_output(
 mod tests {
     use super::{
         BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES,
-        SESSION_KEY_STORE_FILENAME, SESSION_KEY_STORE_RESET_FILENAME, discovered_project_roots,
+        SESSION_KEY_STORE_FILENAME, SESSION_KEY_STORE_RESET_FILENAME,
+        canonical_happy_restoration_root, canonical_path_for_wire, discovered_project_roots,
         error_response, is_advertised_root, matching_identity_reset_result, next_restart_attempt,
         notify_supervisor, parse_supervisor_line, read_bounded_line,
-        reconcile_session_key_store_reset, report_state, required_uuid,
+        reconcile_session_key_store_reset, report_state, required_nullable_string, required_uuid,
         reset_session_key_store_transaction, restart_allowed, restart_delay, should_rearm,
         stage_session_key_store_reset,
     };
@@ -1905,6 +2118,83 @@ mod tests {
     }
 
     #[test]
+    fn happy_restoration_requires_matching_canonical_advertised_root_columns() {
+        let consented = tempfile::tempdir().expect("consented dir");
+        let other = tempfile::tempdir().expect("other dir");
+        let consented_path = consented.path().to_string_lossy().to_string();
+        let other_path = other.path().to_string_lossy().to_string();
+        let canonical =
+            canonical_path_for_wire(&std::fs::canonicalize(consented.path()).unwrap()).unwrap();
+        let app = mock_app_with_roots(Some(vec![consented_path.clone()]));
+
+        assert_eq!(
+            canonical_happy_restoration_root(app.handle(), &consented_path, &consented_path,),
+            Some(canonical),
+        );
+        assert_eq!(
+            canonical_happy_restoration_root(app.handle(), &consented_path, &other_path),
+            None,
+            "stored cwd and project root must resolve to the same exact consented directory",
+        );
+    }
+
+    #[test]
+    fn canonical_root_wire_format_matches_node_on_windows() {
+        assert_eq!(
+            canonical_path_for_wire(std::path::Path::new(r"\\?\C:\Users\Example\Project")),
+            Some(r"C:\Users\Example\Project".to_string()),
+        );
+        assert_eq!(
+            canonical_path_for_wire(std::path::Path::new(
+                r"\\?\UNC\server.example\share\Project",
+            )),
+            Some(r"\\server.example\share\Project".to_string()),
+        );
+        assert_eq!(
+            canonical_path_for_wire(std::path::Path::new(r"C:\Users\Example\Project")),
+            Some(r"C:\Users\Example\Project".to_string()),
+            "an ordinary Node-shaped path remains unchanged",
+        );
+    }
+
+    #[test]
+    fn canonical_root_wire_format_normalizes_decomposed_macos_paths() {
+        assert_eq!(
+            canonical_path_for_wire(std::path::Path::new("/tmp/Cafe\u{301}/A\u{30a}")),
+            Some("/tmp/Caf\u{e9}/\u{c5}".to_string()),
+            "decomposed filesystem paths must match JavaScript's NFC identity",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn happy_restoration_root_recheck_detects_symlink_retarget() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let first = directory.path().join("first");
+        let second = directory.path().join("second");
+        let alias = directory.path().join("consented-alias");
+        std::fs::create_dir(&first).unwrap();
+        std::fs::create_dir(&second).unwrap();
+        symlink(&first, &alias).unwrap();
+        let alias_path = alias.to_string_lossy().to_string();
+        let app = mock_app_with_roots(Some(vec![alias_path.clone()]));
+
+        let before =
+            canonical_happy_restoration_root(app.handle(), &alias_path, &alias_path).unwrap();
+        std::fs::remove_file(&alias).unwrap();
+        symlink(&second, &alias).unwrap();
+        let after =
+            canonical_happy_restoration_root(app.handle(), &alias_path, &alias_path).unwrap();
+
+        assert_ne!(
+            before, after,
+            "the post-spawn canonical comparison must reject a retargeted root alias",
+        );
+    }
+
+    #[test]
     fn effective_advertised_roots_keeps_only_discovered_projects() {
         let consented = tempfile::tempdir().expect("temp dir");
         let consented_path = consented.path().to_string_lossy().to_string();
@@ -2004,6 +2294,34 @@ mod tests {
         )
         .expect("lookup method is allowlisted");
         assert_eq!(request.method, "conversation_happy_session_lookup");
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_conversation_claim() {
+        let request = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":12,"method":"conversation_claim","params":{"conversationId":"00000000-0000-4000-8000-000000000123","providerSessionId":"00000000-0000-4000-8000-000000000123","happySessionId":"relay-id","cwd":"/synthetic/consented","expectedAgentType":"codex","expectedAgentSessionId":null,"expectedAgentPermissionMode":null}}"#,
+        )
+        .expect("restoration claim method is allowlisted");
+        assert_eq!(request.method, "conversation_claim");
+        assert_eq!(
+            required_nullable_string(&request.params, "expectedAgentSessionId").unwrap(),
+            None,
+            "JSON null is an explicit expected-absence assertion",
+        );
+        assert!(
+            required_nullable_string(&request.params, "missingExpectedAgentSessionId").is_err(),
+            "a missing expectation must not be treated as expected absence",
+        );
+        assert_eq!(
+            required_nullable_string(&request.params, "expectedAgentPermissionMode").unwrap(),
+            None,
+            "JSON null is an explicit expected permission-mode absence assertion",
+        );
+        assert!(
+            required_nullable_string(&request.params, "missingExpectedAgentPermissionMode")
+                .is_err(),
+            "a missing permission expectation must not be treated as expected absence",
+        );
     }
 
     #[test]

--- a/tests/unit/acp-permission-mode.test.ts
+++ b/tests/unit/acp-permission-mode.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Guards acknowledged ACP permission-mode changes used by Happy restoration.
+// ABOUTME: A rejected restrictive mode must not be reported or persisted as active.
+
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error — the browser-local runtime is plain ESM without declarations.
+import { _applyAcpPermissionMode } from "../../bin/browser-local/acp-runtime.mjs";
+
+describe("ACP permission mode acknowledgement", () => {
+  it("keeps the prior mode and emits nothing when session/set_mode rejects", async () => {
+    const session = {
+      id: "synthetic-session",
+      agentType: "gemini",
+      agentSessionId: "synthetic-native-session",
+      status: "ready",
+      currentModeId: "auto_edit",
+      currentModelId: "synthetic-model",
+      pendingPermissions: new Map(),
+      adapter: { buildModes: () => ({ availableModes: [] }) },
+    };
+    const emit = vi.fn();
+    const request = vi.fn(async () => {
+      throw new Error("synthetic set_mode rejection");
+    });
+
+    await expect(
+      _applyAcpPermissionMode(session, "plan", emit, request),
+    ).rejects.toThrow("synthetic set_mode rejection");
+
+    expect(request).toHaveBeenCalledWith(
+      session,
+      "session/set_mode",
+      { sessionId: "synthetic-native-session", modeId: "plan" },
+      5_000,
+    );
+    expect(session.currentModeId).toBe("auto_edit");
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/claude-spawn-replay-deferred.test.ts
+++ b/tests/unit/claude-spawn-replay-deferred.test.ts
@@ -80,20 +80,13 @@ describe("#1889 — Claude spawnSession defers history replay off the await path
     ).toMatch(/sessions\.get\(sessionId\)\s*===\s*session/);
   });
 
-  it("spawn return reports the pre-replay status (still 'initializing')", () => {
-    // After the fix, spawnSession returns BEFORE replay finishes. At return
-    // time the session is still in 'initializing' state — the deferred
-    // emit flips it to 'ready' later. The literal status value isn't what
-    // matters; what matters is that `session.status = "ready"` happens
-    // INSIDE the deferred .then, not before the return.
-    const readyAssignmentInThen =
-      /\.then\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?session\.status\s*=\s*"ready"[\s\S]*?\}\s*\)/.test(
-        body,
-      );
-    expect(
-      readyAssignmentInThen,
-      "session.status = 'ready' must happen inside the deferred .then(...), not synchronously before the spawn return.",
-    ).toBe(true);
+  it("returns ready synchronously only when no history replay is running", () => {
+    expect(body).toMatch(
+      /if\s*\(resumeAgentSessionId\s*&&\s*suppressHistoryReplay\s*!==\s*true\)/,
+    );
+    expect(body).toMatch(
+      /\.then\s*\([\s\S]*?session\.status\s*=\s*"ready"[\s\S]*?\}\s*else\s*\{[\s\S]*?session\.status\s*=\s*"ready"/,
+    );
   });
 });
 

--- a/tests/unit/happy-bridge-translate-provider.test.ts
+++ b/tests/unit/happy-bridge-translate-provider.test.ts
@@ -78,18 +78,26 @@ describe("provider-to-neutral session event translation", () => {
       client: {
         call: async (method: string, params: Record<string, unknown>) => {
           calls.push([method, params]);
-          return [];
+          return method === "provider_submit_prompt"
+            ? { accepted: true, sessionId: params.sessionId }
+            : [];
         },
         subscribeNotifications: () => () => {},
       },
     });
 
-    await source.sendPrompt("session-1", "hello");
+    await expect(source.sendPrompt("session-1", "hello")).resolves.toEqual({
+      accepted: true,
+      sessionId: "session-1",
+    });
     await source.terminate("session-1");
     await source.respondToPermission("session-1", "request-1", "allow_once");
 
     expect(calls).toEqual([
-      ["provider_prompt", { sessionId: "session-1", prompt: "hello", origin: "remote" }],
+      [
+        "provider_submit_prompt",
+        { sessionId: "session-1", prompt: "hello", origin: "remote" },
+      ],
       ["provider_terminate", { sessionId: "session-1" }],
       [
         "provider_respond_to_permission",
@@ -100,6 +108,154 @@ describe("provider-to-neutral session event translation", () => {
           origin: "remote",
         },
       ],
+    ]);
+  });
+
+  it("fails closed when the provider does not explicitly accept a prompt", async () => {
+    const source = createProviderSource({
+      config: { machineName: "test-machine" },
+      client: {
+        call: async () => ({ accepted: false }),
+        subscribeNotifications: () => () => {},
+      },
+    });
+
+    await expect(source.sendPrompt("session-1", "hello")).rejects.toThrow(
+      /did not acknowledge prompt acceptance/,
+    );
+  });
+
+  it("marks exact restores and applies persisted permission mode before returning", async () => {
+    const calls: Array<[string, Record<string, unknown>]> = [];
+    const source = createProviderSource({
+      config: { machineName: "test-machine" },
+      client: {
+        call: async (method: string, params: Record<string, unknown>) => {
+          calls.push([method, params]);
+          if (method === "provider_spawn") {
+            return {
+              id: "local-session",
+              agentType: "codex",
+              cwd: "/project",
+              status: "ready",
+              agentSessionId: "native-session",
+              reused: true,
+              owned: false,
+            };
+          }
+          return null;
+        },
+        subscribeNotifications: () => () => {},
+      },
+    });
+
+    await expect(
+      source.spawn({
+        agentType: "codex",
+        cwd: "/project",
+        localSessionId: "local-session",
+        resumeAgentSessionId: "native-session",
+        initialModelId: "model-1",
+        permissionMode: "bypassPermissions",
+      }),
+    ).resolves.toMatchObject({
+      sessionId: "local-session",
+      agentSessionId: "native-session",
+      reused: true,
+      owned: false,
+    });
+
+    expect(calls).toEqual([
+      [
+        "provider_spawn",
+        expect.objectContaining({
+          localSessionId: "local-session",
+          resumeAgentSessionId: "native-session",
+          requireExactResume: true,
+          suppressHistoryReplay: true,
+          freshContextReset: false,
+          initialModelId: "model-1",
+        }),
+      ],
+      [
+        "provider_set_permission_mode",
+        {
+          sessionId: "local-session",
+          mode: "auto",
+        },
+      ],
+    ]);
+  });
+
+  it("requires a native ID from a fresh context-reset spawn", async () => {
+    const source = createProviderSource({
+      config: { machineName: "test-machine" },
+      client: {
+        call: async () => ({
+          id: "local-session",
+          agentType: "claude-code",
+          cwd: "/project",
+          status: "ready",
+          owned: true,
+        }),
+        subscribeNotifications: () => () => {},
+      },
+    });
+
+    await expect(
+      source.spawn({
+        agentType: "claude-code",
+        cwd: "/project",
+        localSessionId: "local-session",
+        freshContextReset: true,
+      }),
+    ).rejects.toThrow(/did not produce a native agent session ID/);
+  });
+
+  it("retires a reused ACP provider when saved permission mode is rejected", async () => {
+    const calls: Array<[string, Record<string, unknown>]> = [];
+    const source = createProviderSource({
+      config: { machineName: "test-machine" },
+      client: {
+        call: async (method: string, params: Record<string, unknown>) => {
+          calls.push([method, params]);
+          if (method === "provider_spawn") {
+            return {
+              id: "local-acp-session",
+              agentType: "gemini",
+              cwd: "/project",
+              status: "ready",
+              agentSessionId: "fresh-acp-native",
+              reused: true,
+              owned: false,
+            };
+          }
+          if (method === "provider_set_permission_mode") {
+            throw new Error("synthetic ACP set_mode rejection");
+          }
+          return null;
+        },
+        subscribeNotifications: () => () => {},
+      },
+    });
+
+    await expect(
+      source.spawn({
+        agentType: "gemini",
+        cwd: "/project",
+        localSessionId: "local-acp-session",
+        freshContextReset: true,
+        permissionMode: "plan",
+      }),
+    ).rejects.toThrow("synthetic ACP set_mode rejection");
+
+    expect(calls).toEqual([
+      ["provider_spawn", expect.objectContaining({ freshContextReset: true })],
+      [
+        "provider_set_permission_mode",
+        { sessionId: "local-acp-session", mode: "plan" },
+      ],
+      ["provider_terminate", { sessionId: "local-acp-session" }],
     ]);
   });
 });

--- a/tests/unit/happy-prompt-queue.test.ts
+++ b/tests/unit/happy-prompt-queue.test.ts
@@ -30,6 +30,123 @@ describe("Happy deferred prompt queue", () => {
     expect(sent).toEqual(["phone prompt"]);
   });
 
+  it("submits only one accepted prompt until the provider reports ready again", async () => {
+    const sent: string[] = [];
+    const queue = createDeferredPromptQueue({
+      send: async (_sessionId: string, prompt: string) => {
+        sent.push(prompt);
+        return { accepted: true };
+      },
+    });
+
+    const first = queue.enqueue("session-1", "first");
+    const second = queue.enqueue("session-1", "second");
+    await expect(first).resolves.toBe(true);
+    expect(sent).toEqual(["first"]);
+
+    queue.setBusy("session-1", false);
+    await expect(second).resolves.toBe(true);
+    expect(sent).toEqual(["first", "second"]);
+    await queue.close();
+  });
+
+  it("preserves an authoritative ready event that overtakes prompt acceptance", async () => {
+    const sent: string[] = [];
+    let acceptFirst: (() => void) | undefined;
+    const queue = createDeferredPromptQueue({
+      send: async (_sessionId: string, prompt: string) => {
+        sent.push(prompt);
+        if (prompt === "first") {
+          await new Promise<void>((resolve) => {
+            acceptFirst = resolve;
+          });
+        }
+        return { accepted: true };
+      },
+    });
+
+    const first = queue.enqueue("session-1", "first");
+    const second = queue.enqueue("session-1", "second");
+    await Promise.resolve();
+    expect(sent).toEqual(["first"]);
+
+    // Provider completion and the submit RPC response use independent frames.
+    queue.setBusy("session-1", false);
+    acceptFirst?.();
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(sent).toEqual(["first", "second"]);
+    await queue.close();
+  });
+
+  it("retries when provider readiness overtakes a busy rejection", async () => {
+    const sent: string[] = [];
+    let rejectFirst: ((error: Error) => void) | undefined;
+    const queue = createDeferredPromptQueue({
+      send: (_sessionId: string, prompt: string) => {
+        sent.push(prompt);
+        if (sent.length > 1) return Promise.resolve({ accepted: true });
+        return new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        });
+      },
+      shouldRetry: isPromptBusyError,
+    });
+
+    const delivered = queue.enqueue("session-1", "first");
+    await Promise.resolve();
+    queue.setBusy("session-1", false);
+    rejectFirst?.(new Error("Another prompt is already active for this session."));
+
+    await expect(delivered).resolves.toBe(true);
+    expect(sent).toEqual(["first", "first"]);
+    await queue.close();
+  });
+
+  it("does not advance to a later prompt after a non-acceptance failure", async () => {
+    const sent: string[] = [];
+    const failure = new Error("provider rejected the prompt");
+    const queue = createDeferredPromptQueue({
+      send: async (_sessionId: string, prompt: string) => {
+        sent.push(prompt);
+        throw failure;
+      },
+    });
+
+    const first = queue.enqueue("session-1", "first");
+    const second = queue.enqueue("session-1", "second");
+    await expect(first).rejects.toBe(failure);
+    queue.setBusy("session-1", false);
+    await Promise.resolve();
+    expect(sent).toEqual(["first"]);
+
+    await queue.close();
+    await expect(second).resolves.toBe(false);
+  });
+
+  it("waits for an in-flight acceptance before clearing unsent prompts on close", async () => {
+    let accept: (() => void) | undefined;
+    const queue = createDeferredPromptQueue({
+      send: () => new Promise<void>((resolve) => {
+        accept = resolve;
+      }),
+    });
+    const first = queue.enqueue("session-1", "first");
+    const second = queue.enqueue("session-1", "second");
+    const closing = queue.close();
+    let closed = false;
+    void closing.then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    accept?.();
+    await closing;
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(false);
+  });
+
   it("defers on the busy error every runtime actually throws", () => {
     // Read the sentences out of the runtimes rather than restating them, so a
     // provider that words its message differently fails here instead of

--- a/tests/unit/happy-provider-notification-buffer.test.ts
+++ b/tests/unit/happy-provider-notification-buffer.test.ts
@@ -164,4 +164,42 @@ describe("Happy provider notification buffering (#3150)", () => {
     expect(received[0].payload.text).toBe("chunk-8");
     expect(received[31].payload.text).toBe("chunk-39");
   });
+
+  it("does not evict one session's completion behind restore chatter from other sessions", async () => {
+    const runtime = await startProviderRuntime();
+    const client = connectedClient(runtime.port);
+    await client.connect();
+    const socket = await runtime.socket;
+
+    socket.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "provider://prompt-complete",
+        params: { sessionId: "active-session", stopReason: "completed" },
+      }),
+    );
+    for (let index = 0; index < 40; index += 1) {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "provider://session-status",
+          params: { sessionId: `restored-session-${index}`, status: "ready" },
+        }),
+      );
+    }
+    await client.call("provider_ping");
+
+    const received: Array<{ kind: string; sessionId: string }> = [];
+    const source = createProviderSource({
+      client,
+      config: { machineName: "buffer-test" },
+    }) as { subscribe(onEvent: (event: unknown) => void): () => void };
+    source.subscribe((event) => received.push(event as { kind: string; sessionId: string }));
+
+    expect(received).toHaveLength(41);
+    expect(received[0]).toMatchObject({
+      kind: "turn-complete",
+      sessionId: "active-session",
+    });
+  });
 });

--- a/tests/unit/happy-relay-sync-patch.test.ts
+++ b/tests/unit/happy-relay-sync-patch.test.ts
@@ -139,7 +139,9 @@ describe("happy relay sync patch", () => {
     for (const { source } of sources) {
       const closeIndex = source.indexOf("[API] socket.close() called");
       expect(closeIndex).toBeGreaterThan(-1);
-      const closeBody = source.slice(closeIndex, closeIndex + 600);
+      const closeEnd = source.indexOf("startSmartReconnect()", closeIndex);
+      expect(closeEnd).toBeGreaterThan(closeIndex);
+      const closeBody = source.slice(closeIndex, closeEnd);
       const flushIndex = closeBody.indexOf("await this.sendSync.invalidateAndAwait()");
       const stopIndex = closeBody.indexOf("this.sendSync.stop()");
       expect(flushIndex).toBeGreaterThan(-1);

--- a/tests/unit/happy-sdk-ordered-processing.test.ts
+++ b/tests/unit/happy-sdk-ordered-processing.test.ts
@@ -1,0 +1,676 @@
+// ABOUTME: Exercises Happy's opt-in durable inbound sequencing through the real installed SDK.
+// ABOUTME: Uses a local relay only; socket/fetch ordering, callbacks, and checkpoints are not mocked.
+
+import { createCipheriv, randomBytes } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ApiSessionClient, configuration } from "happy/lib";
+
+// @ts-expect-error — the bridge key store is plain ESM without declarations.
+import { createHappySessionKeyStore } from "../../bin/happy-bridge/session-key-store.mjs";
+
+type RelayMessage = {
+  seq: number;
+  localId: string;
+  content: { t: string; c?: string };
+};
+
+type ClientInternals = {
+  fetchMessages(): Promise<void>;
+  lastSeq: number;
+  lastProcessedSeq: number;
+  inboundFailed: boolean;
+  pendingMessages: Array<{ seq?: number; data?: unknown } | unknown>;
+  pendingFileEvents: Array<{ seq?: number; data?: unknown } | unknown>;
+  outboundMessageLocalIds: Set<string>;
+  socket: {
+    listeners(event: string): Array<(data: unknown) => void>;
+  };
+};
+
+const originalServerUrl = configuration.serverUrl;
+const require = createRequire(import.meta.url);
+const commonJsHappy = require("happy/lib") as typeof import("happy/lib");
+const originalCommonJsServerUrl = commonJsHappy.configuration.serverUrl;
+const mutableConfiguration = configuration as unknown as { serverUrl: string };
+const mutableCommonJsConfiguration = commonJsHappy.configuration as unknown as {
+  serverUrl: string;
+};
+const servers = new Set<ReturnType<typeof createServer>>();
+const clients = new Set<ApiSessionClient>();
+const temporaryDirectories = new Set<string>();
+const dataKey = new Uint8Array(32).fill(0x29);
+
+afterEach(async () => {
+  await Promise.allSettled([...clients].map((client) => client.close()));
+  clients.clear();
+  mutableConfiguration.serverUrl = originalServerUrl;
+  mutableCommonJsConfiguration.serverUrl = originalCommonJsServerUrl;
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections();
+        }),
+    ),
+  );
+  servers.clear();
+  await Promise.all(
+    [...temporaryDirectories].map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+  temporaryDirectories.clear();
+});
+
+function defer() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean, detail: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${detail}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function encryptMessage(value: unknown): string {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", dataKey, nonce);
+  const encrypted = Buffer.concat([
+    cipher.update(Buffer.from(JSON.stringify(value), "utf8")),
+    cipher.final(),
+  ]);
+  return Buffer.concat([Buffer.from([0]), nonce, encrypted, cipher.getAuthTag()]).toString(
+    "base64",
+  );
+}
+
+function encryptedRecord(seq: number, value: unknown, localId = `remote-${seq}`): RelayMessage {
+  return {
+    seq,
+    localId,
+    content: { t: "encrypted", c: encryptMessage(value) },
+  };
+}
+
+function userRecord(seq: number, text: string): RelayMessage {
+  return encryptedRecord(seq, {
+    role: "user",
+    content: { type: "text", text },
+  });
+}
+
+function fileRecord(seq: number): RelayMessage {
+  return encryptedRecord(seq, {
+    role: "session",
+    content: {
+      type: "session",
+      data: {
+        id: `file-event-${seq}`,
+        time: seq,
+        role: "user",
+        ev: {
+          t: "file",
+          ref: `file-ref-${seq}`,
+          name: "asset.txt",
+          size: 12,
+          mimeType: "text/plain",
+        },
+      },
+    },
+  });
+}
+
+async function startRelay(messages: RelayMessage[]): Promise<string> {
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method !== "GET" || !url.pathname.endsWith("/messages")) {
+      response.writeHead(404).end();
+      return;
+    }
+    const afterSeq = Number(url.searchParams.get("after_seq") ?? 0);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        messages: messages.filter((message) => message.seq > afterSeq),
+        hasMore: false,
+      }),
+    );
+  });
+  servers.add(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function createClient(
+  resumeFromSeq: number,
+  onMessageProcessed?: (seq: number) => void | Promise<void>,
+  inboundCloseTimeoutMs?: number,
+): ApiSessionClient {
+  const client = new ApiSessionClient(
+    "synthetic-token",
+    {
+      id: "synthetic-ordered-session",
+      seq: resumeFromSeq,
+      metadata: { path: "/synthetic/project", host: "synthetic-host" },
+      metadataVersion: 1,
+      agentState: null,
+      agentStateVersion: 1,
+      encryptionKey: dataKey,
+      encryptionVariant: "dataKey",
+    } as never,
+    { resumeFromSeq, onMessageProcessed, inboundCloseTimeoutMs },
+  );
+  clients.add(client);
+  return client;
+}
+
+async function createReadyCursorStore(sessionId: string) {
+  const directory = await mkdtemp(path.join(tmpdir(), "seren-happy-close-drain-"));
+  temporaryDirectories.add(directory);
+  const machineKey = Buffer.alloc(32, 0x62);
+  const store = createHappySessionKeyStore({ directory, machineKey });
+  await store.getOrCreate(sessionId, `seren-${sessionId}`);
+  await store.markReady(sessionId, "synthetic-relay-row");
+  return { directory, machineKey, store };
+}
+
+async function closeClient(client: ApiSessionClient): Promise<void> {
+  clients.delete(client);
+  await client.close();
+}
+
+function internals(client: ApiSessionClient): ClientInternals {
+  return client as unknown as ClientInternals;
+}
+
+function processingFailure(client: ApiSessionClient): Promise<Error> {
+  return new Promise((resolve) => {
+    client.once("inboundProcessingError", resolve);
+  });
+}
+
+describe("installed Happy ordered inbound processing patch", () => {
+  it("durably latches an archive update received before a consumer registers its listener", async () => {
+    mutableConfiguration.serverUrl = await startRelay([]);
+    const client = createClient(0);
+    const state = internals(client);
+    const socketUpdate = state.socket.listeners("update")[0];
+    expect(socketUpdate).toBeTypeOf("function");
+
+    socketUpdate({
+      body: {
+        t: "update-session",
+        metadata: {
+          version: 2,
+          value: encryptMessage({
+            path: "/synthetic/project",
+            host: "synthetic-host",
+            lifecycleState: "archiveRequested",
+          }),
+        },
+      },
+    });
+
+    expect(client.hasArchiveSignal()).toBe(true);
+    let lateListenerCalls = 0;
+    client.on("archived", () => {
+      lateListenerCalls += 1;
+    });
+    expect(lateListenerCalls).toBe(0);
+    await closeClient(client);
+  });
+
+  it("serializes user, file, generic, no-op, and echo records before exact checkpoints", async () => {
+    const messages = [
+      userRecord(8, "first"),
+      fileRecord(9),
+      encryptedRecord(10, { role: "assistant", content: { type: "text", text: "generic" } }),
+      { seq: 11, localId: "plain-no-op", content: { t: "unsupported" } },
+      encryptedRecord(12, { role: "assistant", content: { type: "text", text: "echo" } }, "own-echo"),
+      userRecord(13, "second"),
+    ];
+    mutableConfiguration.serverUrl = await startRelay(messages);
+    const firstCallbackGate = defer();
+    const firstCheckpointGate = defer();
+    const genericHandlerGate = defer();
+    const events: string[] = [];
+    const client = createClient(7, async (seq) => {
+      if (seq === 8) {
+        events.push("checkpoint:8:start");
+        await firstCheckpointGate.promise;
+        events.push("checkpoint:8:end");
+        return;
+      }
+      events.push(`checkpoint:${seq}`);
+    });
+    const state = internals(client);
+    state.outboundMessageLocalIds.add("own-echo");
+    client.on("message", async () => {
+      events.push("generic:start");
+      await genericHandlerGate.promise;
+      events.push("generic:end");
+    });
+
+    await state.fetchMessages();
+
+    expect(state.lastSeq).toBe(13);
+    expect(state.lastProcessedSeq).toBe(7);
+    expect(state.pendingMessages).toHaveLength(1);
+    expect(state.pendingMessages[0]).toMatchObject({ seq: 8 });
+
+    client.onUserMessage(async (message) => {
+      events.push(`user:${message.content.text}:start`);
+      if (message.content.text === "first") await firstCallbackGate.promise;
+      events.push(`user:${message.content.text}:end`);
+    });
+    await waitFor(() => events.includes("user:first:start"), "first user callback");
+    expect(events).toEqual(["user:first:start"]);
+
+    firstCallbackGate.resolve();
+    await waitFor(() => events.includes("checkpoint:8:start"), "first checkpoint");
+    expect(state.pendingFileEvents).toHaveLength(0);
+
+    firstCheckpointGate.resolve();
+    await waitFor(() => state.pendingFileEvents.length === 1, "buffered file event");
+    expect(state.pendingFileEvents[0]).toMatchObject({ seq: 9 });
+
+    client.onFileEvent(async (message) => {
+      events.push(`file:${message.content.data.ev.name}`);
+    });
+    await waitFor(() => events.includes("generic:start"), "generic message handler");
+    expect(state.lastProcessedSeq).toBe(9);
+
+    genericHandlerGate.resolve();
+    await waitFor(() => state.lastProcessedSeq === 13, "all ordered checkpoints");
+
+    expect(events).toEqual([
+      "user:first:start",
+      "user:first:end",
+      "checkpoint:8:start",
+      "checkpoint:8:end",
+      "file:asset.txt",
+      "checkpoint:9",
+      "generic:start",
+      "generic:end",
+      "checkpoint:10",
+      "checkpoint:11",
+      "checkpoint:12",
+      "user:second:start",
+      "user:second:end",
+      "checkpoint:13",
+    ]);
+    await closeClient(client);
+  });
+
+  it("preserves the SDK's fire-and-forget buffering when the hook is omitted", async () => {
+    mutableConfiguration.serverUrl = await startRelay([
+      userRecord(1, "first"),
+      userRecord(2, "second"),
+    ]);
+    const client = createClient(0);
+    const state = internals(client);
+
+    await state.fetchMessages();
+
+    expect(state.lastSeq).toBe(2);
+    expect(state.pendingMessages).toHaveLength(2);
+    expect(state.pendingMessages[0]).toMatchObject({
+      content: { type: "text", text: "first" },
+    });
+    expect(state.pendingMessages[0]).not.toHaveProperty("seq");
+
+    const observed: string[] = [];
+    client.onUserMessage((message) => {
+      observed.push(message.content.text);
+    });
+    expect(observed).toEqual(["first", "second"]);
+    await closeClient(client);
+  });
+
+  it("deduplicates a socket record from fetch while preserving one ordered chain", async () => {
+    const first = userRecord(1, "socket");
+    const second = userRecord(2, "fetch");
+    mutableConfiguration.serverUrl = await startRelay([first, second]);
+    const callbackGate = defer();
+    const events: string[] = [];
+    const client = createClient(0, (seq) => {
+      events.push(`checkpoint:${seq}`);
+    });
+    const state = internals(client);
+    client.onUserMessage(async (message) => {
+      events.push(`user:${message.content.text}`);
+      if (message.content.text === "socket") await callbackGate.promise;
+    });
+    const socketUpdate = state.socket.listeners("update")[0];
+    expect(socketUpdate).toBeTypeOf("function");
+
+    socketUpdate({ body: { t: "new-message", message: first } });
+    await waitFor(() => events.includes("user:socket"), "socket callback");
+    await state.fetchMessages();
+
+    expect(state.lastSeq).toBe(2);
+    expect(events).toEqual(["user:socket"]);
+
+    callbackGate.resolve();
+    await waitFor(() => state.lastProcessedSeq === 2, "socket/fetch checkpoints");
+    expect(events).toEqual([
+      "user:socket",
+      "checkpoint:1",
+      "user:fetch",
+      "checkpoint:2",
+    ]);
+    await closeClient(client);
+  });
+
+  it("exposes the same ordered callback contract from the CommonJS bundle", async () => {
+    mutableCommonJsConfiguration.serverUrl = await startRelay([userRecord(1, "commonjs")]);
+    const checkpoints: number[] = [];
+    const handled: string[] = [];
+    const client = new commonJsHappy.ApiSessionClient(
+      "synthetic-token",
+      {
+        id: "synthetic-commonjs-session",
+        seq: 0,
+        metadata: { path: "/synthetic/project", host: "synthetic-host" },
+        metadataVersion: 1,
+        agentState: null,
+        agentStateVersion: 1,
+        encryptionKey: dataKey,
+        encryptionVariant: "dataKey",
+      } as never,
+      {
+        resumeFromSeq: 0,
+        onMessageProcessed: async (seq) => {
+          checkpoints.push(seq);
+        },
+      },
+    );
+    clients.add(client);
+    client.onUserMessage(async (message) => {
+      handled.push(message.content.text);
+    });
+
+    await internals(client).fetchMessages();
+    await waitFor(() => checkpoints.length === 1, "CommonJS checkpoint");
+
+    expect(handled).toEqual(["commonjs"]);
+    expect(checkpoints).toEqual([1]);
+    await closeClient(client);
+  });
+
+  it.each(["handler", "checkpoint"] as const)(
+    "poisons later records when the %s rejects",
+    async (failurePoint) => {
+      mutableConfiguration.serverUrl = await startRelay([
+        userRecord(1, "first"),
+        userRecord(2, "second"),
+      ]);
+      const checkpoints: number[] = [];
+      const client = createClient(0, async (seq) => {
+        if (failurePoint === "checkpoint" && seq === 1) throw new Error("checkpoint rejected");
+        checkpoints.push(seq);
+      });
+      const state = internals(client);
+      const failure = processingFailure(client);
+      const handled: string[] = [];
+      client.onUserMessage(async (message) => {
+        handled.push(message.content.text);
+        if (failurePoint === "handler") throw new Error("handler rejected");
+      });
+
+      await state.fetchMessages();
+      expect((await failure).message).toContain(`${failurePoint} rejected`);
+
+      expect(state.lastSeq).toBe(2);
+      expect(state.lastProcessedSeq).toBe(0);
+      expect(state.inboundFailed).toBe(true);
+      expect(handled).toEqual(["first"]);
+      expect(checkpoints).toEqual([]);
+      await closeClient(client);
+    },
+  );
+
+  it("poisons later records when an async generic message listener rejects", async () => {
+    mutableConfiguration.serverUrl = await startRelay([
+      encryptedRecord(1, {
+        role: "assistant",
+        content: { type: "text", text: "generic" },
+      }),
+      userRecord(2, "blocked"),
+    ]);
+    const checkpoints: number[] = [];
+    const client = createClient(0, (seq) => {
+      checkpoints.push(seq);
+    });
+    const state = internals(client);
+    const failure = processingFailure(client);
+    const handled: string[] = [];
+    client.on("message", async () => {
+      throw new Error("generic listener rejected");
+    });
+    client.onUserMessage(async (message) => {
+      handled.push(message.content.text);
+    });
+
+    await state.fetchMessages();
+    expect((await failure).message).toContain("generic listener rejected");
+
+    expect(state.lastSeq).toBe(2);
+    expect(state.lastProcessedSeq).toBe(0);
+    expect(state.inboundFailed).toBe(true);
+    expect(handled).toEqual([]);
+    expect(checkpoints).toEqual([]);
+    await closeClient(client);
+  });
+
+  it.each([
+    {
+      name: "gap",
+      messages: [userRecord(1, "blocked"), userRecord(3, "gap")],
+      expected: /sequence gap/,
+      observedSeq: 1,
+    },
+    {
+      name: "unsafe sequence",
+      messages: [
+        {
+          seq: Number.MAX_SAFE_INTEGER + 1,
+          localId: "unsafe",
+          content: { t: "unsupported" },
+        },
+      ],
+      expected: /non-negative safe integer/,
+      observedSeq: 0,
+    },
+  ])("fails closed on an exact-sequence $name", async ({ messages, expected, observedSeq }) => {
+    mutableConfiguration.serverUrl = await startRelay(messages);
+    const checkpoints: number[] = [];
+    const client = createClient(0, (seq) => {
+      checkpoints.push(seq);
+    });
+    const state = internals(client);
+    const failure = processingFailure(client);
+
+    await state.fetchMessages();
+    expect((await failure).message).toMatch(expected);
+
+    expect(state.lastSeq).toBe(observedSeq);
+    expect(state.lastProcessedSeq).toBe(0);
+    expect(checkpoints).toEqual([]);
+    await closeClient(client);
+  });
+
+  it("durably checkpoints an accepted blocked head before overflow poisons its queued tail", async () => {
+    const messages: RelayMessage[] = [userRecord(1, "blocked")];
+    for (let seq = 2; seq <= 257; seq += 1) {
+      messages.push({ seq, localId: `plain-${seq}`, content: { t: "unsupported" } });
+    }
+    mutableConfiguration.serverUrl = await startRelay(messages);
+    const providerSessionId = "synthetic-provider-overflow-head";
+    const { directory, machineKey, store } =
+      await createReadyCursorStore(providerSessionId);
+    const providerAcceptanceGate = defer();
+    const handlerStarted = defer();
+    const checkpoints: number[] = [];
+    const client = createClient(0, async (seq) => {
+      checkpoints.push(seq);
+      await store.markProcessedThroughSeq(providerSessionId, seq);
+    });
+    const state = internals(client);
+    let failureSettled = false;
+    const failure = processingFailure(client).then((error) => {
+      failureSettled = true;
+      return error;
+    });
+    const handled: string[] = [];
+    client.onUserMessage(async (message) => {
+      handled.push(message.content.text);
+      handlerStarted.resolve();
+      await providerAcceptanceGate.promise;
+    });
+
+    await state.fetchMessages();
+    await handlerStarted.promise;
+
+    expect(state.lastSeq).toBe(256);
+    expect(state.lastProcessedSeq).toBe(0);
+    expect(state.inboundFailed).toBe(false);
+    expect(state.pendingMessages).toHaveLength(0);
+    expect(checkpoints).toEqual([]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(failureSettled).toBe(false);
+
+    providerAcceptanceGate.resolve();
+    expect((await failure).message).toMatch(/queue is full/);
+
+    expect(state.lastProcessedSeq).toBe(1);
+    expect(state.inboundFailed).toBe(true);
+    expect(handled).toEqual(["blocked"]);
+    expect(checkpoints).toEqual([1]);
+    expect(
+      await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+        providerSessionId,
+        "ignored",
+      ),
+    ).toMatchObject({ processedThroughSeq: 1 });
+    await closeClient(client);
+  });
+
+  it("joins an accepted handler and its durable cursor write before close resolves", async () => {
+    mutableConfiguration.serverUrl = await startRelay([userRecord(1, "accepted")]);
+    const providerSessionId = "synthetic-provider-close-join";
+    const { directory, machineKey, store } =
+      await createReadyCursorStore(providerSessionId);
+    const handlerGate = defer();
+    const checkpointStarted = defer();
+    const checkpointGate = defer();
+    const client = createClient(0, async (seq) => {
+      checkpointStarted.resolve();
+      await checkpointGate.promise;
+      const persisted = await store.markProcessedThroughSeq(providerSessionId, seq);
+      expect(persisted.processedThroughSeq).toBe(seq);
+    });
+    const state = internals(client);
+    const handlerStarted = defer();
+    client.onUserMessage(async () => {
+      handlerStarted.resolve();
+      await handlerGate.promise;
+    });
+
+    await state.fetchMessages();
+    await handlerStarted.promise;
+
+    let closeSettled = false;
+    const closing = closeClient(client).then(() => {
+      closeSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(closeSettled).toBe(false);
+
+    handlerGate.resolve();
+    await checkpointStarted.promise;
+    expect(closeSettled).toBe(false);
+    expect(
+      await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+        providerSessionId,
+        "ignored",
+      ),
+    ).toMatchObject({ processedThroughSeq: 0 });
+
+    checkpointGate.resolve();
+    await closing;
+
+    expect(
+      await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+        providerSessionId,
+        "ignored",
+      ),
+    ).toMatchObject({ processedThroughSeq: 1 });
+    expect(state.lastProcessedSeq).toBe(1);
+  });
+
+  it("bounds close without checkpointing a prompt whose handler never accepted it", async () => {
+    mutableConfiguration.serverUrl = await startRelay([userRecord(1, "unaccepted")]);
+    const providerSessionId = "synthetic-provider-close-timeout";
+    const { directory, machineKey, store } =
+      await createReadyCursorStore(providerSessionId);
+    const handlerGate = defer();
+    const checkpoints: number[] = [];
+    const client = createClient(
+      0,
+      async (seq) => {
+        checkpoints.push(seq);
+        await store.markProcessedThroughSeq(providerSessionId, seq);
+      },
+      40,
+    );
+    const state = internals(client);
+    const handlerStarted = defer();
+    client.onUserMessage(async () => {
+      handlerStarted.resolve();
+      await handlerGate.promise;
+    });
+
+    await state.fetchMessages();
+    await handlerStarted.promise;
+
+    const startedAt = Date.now();
+    await expect(closeClient(client)).rejects.toThrow(
+      "Timed out draining relay input after 40ms",
+    );
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(state.lastProcessedSeq).toBe(0);
+    expect(checkpoints).toEqual([]);
+    expect(
+      await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+        providerSessionId,
+        "ignored",
+      ),
+    ).toMatchObject({ processedThroughSeq: 0 });
+
+    handlerGate.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(state.lastProcessedSeq).toBe(0);
+    expect(checkpoints).toEqual([]);
+    expect(
+      await createHappySessionKeyStore({ directory, machineKey }).getOrCreate(
+        providerSessionId,
+        "ignored",
+      ),
+    ).toMatchObject({ processedThroughSeq: 0 });
+  });
+});

--- a/tests/unit/happy-session-key-store.test.ts
+++ b/tests/unit/happy-session-key-store.test.ts
@@ -60,13 +60,27 @@ describe("Happy session key store", () => {
       expect((await stat(store.filePath)).mode & 0o777).toBe(0o600);
     }
 
+    expect(await store.markLegacyRelayRetired(sessionId)).toMatchObject({
+      state: "pending",
+      legacyRelayRetired: true,
+    });
     const reopened = createHappySessionKeyStore({ directory, machineKey });
+    expect(await reopened.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId, legacyRelayRetired: true }),
+      ]),
+    );
     const ready = await reopened.markReady(sessionId, "synthetic-relay-row");
     expect(ready).toMatchObject({
       state: "ready",
       relayTag: "seren-synthetic-session",
       happySessionId: "synthetic-relay-row",
+      processedThroughSeq: 0,
+      legacyRelayRetired: true,
     });
+    expect(await reopened.clearLegacyRelayRetired(sessionId)).not.toHaveProperty(
+      "legacyRelayRetired",
+    );
     expect(Buffer.from(ready.key)).toEqual(Buffer.from(first.key));
     await expect(reopened.replacePendingTag(sessionId, "replacement")).rejects.toThrow(
       /cannot change relay tags/,
@@ -79,8 +93,19 @@ describe("Happy session key store", () => {
       state: "ready",
       relayTag: "seren-synthetic-session",
       happySessionId: "synthetic-relay-row",
+      processedThroughSeq: 0,
     });
     expect(Buffer.from(reopenedReady.key)).toEqual(Buffer.from(first.key));
+    expect(await reopened.markProcessedThroughSeq(sessionId, 7)).toMatchObject({
+      state: "ready",
+      processedThroughSeq: 7,
+    });
+    expect(await reopened.markProcessedThroughSeq(sessionId, 3)).toMatchObject({
+      processedThroughSeq: 7,
+    });
+    await expect(reopened.markProcessedThroughSeq(sessionId, -1)).rejects.toThrow(
+      /non-negative safe integer/,
+    );
     await expect(reopened.markReady(sessionId, "different-relay-row")).rejects.toThrow(
       /different relay row/,
     );
@@ -90,6 +115,7 @@ describe("Happy session key store", () => {
       happySessionId: "synthetic-relay-row",
       providerRetired: false,
       blockRevival: false,
+      processedThroughSeq: 7,
     });
     const providerRetired = await reopened.markRetiring(
       sessionId,

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -24,7 +24,14 @@ afterEach(() => {
 });
 
 function createClient() {
-  const eventHandlers = new Map<string, () => void>();
+  const eventHandlers = new Map<string, (...args: unknown[]) => void>();
+  let archiveSignaled = false;
+  let userMessageHandler:
+    | ((message: Record<string, unknown>) => void | Promise<void>)
+    | undefined;
+  let fileEventHandler:
+    | ((message: Record<string, unknown>) => void | Promise<void>)
+    | undefined;
   const rpcHandlers = new Map<
     string,
     (payload: Record<string, unknown>) => unknown
@@ -32,7 +39,19 @@ function createClient() {
   return {
     close: vi.fn(async () => {}),
     emit(event: string) {
+      if (event === "archived") archiveSignaled = true;
       eventHandlers.get(event)?.();
+    },
+    hasArchiveSignal() {
+      return archiveSignaled;
+    },
+    async dispatchUserMessage(message: Record<string, unknown>) {
+      if (!userMessageHandler) throw new Error("Happy user-message handler is not registered");
+      await userMessageHandler(message);
+    },
+    async dispatchFileEvent(message: Record<string, unknown>) {
+      if (!fileEventHandler) throw new Error("Happy file-event handler is not registered");
+      await fileEventHandler(message);
     },
     keepAlive: vi.fn(),
     lastSeq: 0,
@@ -41,10 +60,19 @@ function createClient() {
       if (!handler) throw new Error(`Happy RPC handler ${name} is not registered`);
       return handler(payload);
     },
-    on: vi.fn((event: string, handler: () => void) => {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       eventHandlers.set(event, handler);
     }),
-    onUserMessage: vi.fn(),
+    onFileEvent: vi.fn(
+      (handler: (message: Record<string, unknown>) => void | Promise<void>) => {
+        fileEventHandler = handler;
+      },
+    ),
+    onUserMessage: vi.fn(
+      (handler: (message: Record<string, unknown>) => void | Promise<void>) => {
+        userMessageHandler = handler;
+      },
+    ),
     rpcHandlerManager: {
       registerHandler: vi.fn(
         (name: string, handler: (payload: Record<string, unknown>) => unknown) => {
@@ -71,6 +99,8 @@ function createMemorySessionKeyStore() {
     blockRevival?: boolean;
     conversationId?: string;
     agentSessionId?: string;
+    processedThroughSeq?: number;
+    legacyRelayRetired?: boolean;
   };
   const bindings = new Map<string, Binding>();
   let generation = 0;
@@ -102,9 +132,36 @@ function createMemorySessionKeyStore() {
       if (binding.state === "ready" && binding.happySessionId !== happySessionId) {
         throw new Error("relay row changed");
       }
+      if (binding.state === "ready") return copy(binding);
       binding.state = "ready";
       binding.happySessionId = happySessionId;
+      binding.processedThroughSeq = 0;
       return copy(binding);
+    }),
+    markProcessedThroughSeq: vi.fn(async (sessionId: string, seq: number) => {
+      const binding = bindings.get(sessionId);
+      if (!binding || binding.state !== "ready") throw new Error("binding is not ready");
+      binding.processedThroughSeq = Math.max(binding.processedThroughSeq ?? 0, seq);
+      return copy(binding);
+    }),
+    markLegacyRelayRetired: vi.fn(async (sessionId: string) => {
+      const binding = bindings.get(sessionId);
+      if (!binding || (binding.state !== "pending" && binding.state !== "ready")) {
+        throw new Error("binding is not active");
+      }
+      binding.legacyRelayRetired = true;
+      return copy(binding);
+    }),
+    clearLegacyRelayRetired: vi.fn(async (sessionId: string) => {
+      const binding = bindings.get(sessionId);
+      if (!binding) throw new Error("missing binding");
+      delete binding.legacyRelayRetired;
+      return copy(binding);
+    }),
+    clearProcessedThroughSeq: vi.fn(async (sessionId: string) => {
+      const binding = bindings.get(sessionId);
+      if (!binding || binding.state !== "ready") throw new Error("binding is not ready");
+      delete binding.processedThroughSeq;
     }),
     markRetiring: vi.fn(
       async (
@@ -125,6 +182,7 @@ function createMemorySessionKeyStore() {
         throw new Error("relay row changed");
       }
       binding.state = "retiring";
+      delete binding.legacyRelayRetired;
       binding.providerRetired = binding.providerRetired === true || providerRetired;
       binding.blockRevival = binding.blockRevival === true || blockRevival;
       if (happySessionId) binding.happySessionId = happySessionId;
@@ -143,6 +201,7 @@ function createMemorySessionKeyStore() {
 }
 
 function createLayerHarness({
+  archiveDuringClientConstruction = false,
   initialSessions = [],
   machineIdentity = {
     token: "test",
@@ -151,11 +210,13 @@ function createLayerHarness({
   },
   sessionKeyStore = createMemorySessionKeyStore(),
 }: {
+  archiveDuringClientConstruction?: boolean;
   initialSessions?: Array<Record<string, unknown>>;
   machineIdentity?: Record<string, unknown>;
   sessionKeyStore?: ReturnType<typeof createMemorySessionKeyStore>;
 } = {}) {
   const client = createClient();
+  let onMessageProcessed: ((seq: number) => void | Promise<void>) | undefined;
   let machineHandlers:
     | { spawnSession(options: Record<string, unknown>): Promise<Record<string, unknown>> }
     | undefined;
@@ -176,8 +237,16 @@ function createLayerHarness({
     })),
     machineSyncClient: vi.fn(() => machineClient),
     sessionSyncClient: vi.fn(
-      (_session: Record<string, unknown>, options?: { resumeFromSeq?: number }) => {
+      (
+        _session: Record<string, unknown>,
+        options?: {
+          resumeFromSeq?: number;
+          onMessageProcessed?: (seq: number) => void | Promise<void>;
+        },
+      ) => {
         client.lastSeq = options?.resumeFromSeq ?? 0;
+        onMessageProcessed = options?.onMessageProcessed;
+        if (archiveDuringClientConstruction) client.emit("archived");
         return client;
       },
     ),
@@ -190,11 +259,16 @@ function createLayerHarness({
     cancel: vi.fn(async () => {}),
     listSessions: vi.fn(async () => initialSessions),
     respondToPermission: vi.fn(async () => {}),
+    sendPrompt: vi.fn(async () => ({ accepted: true })),
+    setPermissionMode: vi.fn(async () => {}),
     spawn: vi.fn(async (spec: Record<string, unknown>) => ({
       sessionId: String(spec.localSessionId),
       agentType: "codex",
+      agentSessionId: "synthetic-native-session",
       cwd: SYNTHETIC_ROOT,
       status: "ready",
+      reused: false,
+      owned: true,
     })),
     subscribe: vi.fn((handler: (event: Record<string, unknown>) => void) => {
       publishProviderEvent = handler;
@@ -202,12 +276,20 @@ function createLayerHarness({
     }),
     terminate: vi.fn(async () => {}),
   };
-  const supervisorCall = vi.fn(async (method: string, params: Record<string, unknown>) => ({
-    conversationId:
-      method === "conversation_owner_lookup"
-        ? params.providerSessionId
-        : params.conversationId,
-  }));
+  const supervisorCall = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === "conversation_restore_candidates") return { candidates: [] };
+    if (method === "conversation_migrate_happy_session") return { migrated: true };
+    if (method === "conversation_lookup") {
+      return { restorable: false, happyOrigin: false, retire: false };
+    }
+    if (method === "conversation_claim") return { archived: false };
+    return {
+      conversationId:
+        method === "conversation_owner_lookup"
+          ? params.providerSessionId
+          : params.conversationId,
+    };
+  });
   const supervisorNotify = vi.fn();
   let supervisorNotificationHandler:
     | ((method: string, params: Record<string, unknown>) => void)
@@ -235,6 +317,14 @@ function createLayerHarness({
     api,
     client,
     layer,
+    async processUserMessage(message: Record<string, unknown>, seq: number) {
+      await client.dispatchUserMessage(message);
+      await onMessageProcessed?.(seq);
+    },
+    async processFileEvent(message: Record<string, unknown>, seq: number) {
+      await client.dispatchFileEvent(message);
+      await onMessageProcessed?.(seq);
+    },
     publish(event: Record<string, unknown>) {
       if (!publishProviderEvent) throw new Error("provider subscription is not ready");
       publishProviderEvent(event);
@@ -255,6 +345,39 @@ function createLayerHarness({
 }
 
 describe("Happy session liveness", () => {
+  it("retires an archive delivered while the session client is being constructed", async () => {
+    const summary = {
+      sessionId: "constructor-archive-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic constructor archive",
+      status: "ready",
+    };
+    const harness = createLayerHarness({
+      archiveDuringClientConstruction: true,
+      initialSessions: [summary],
+    });
+
+    await harness.layer.start();
+
+    await vi.waitFor(() =>
+      expect(harness.source.terminate).toHaveBeenCalledWith(summary.sessionId),
+    );
+    await vi.waitFor(() =>
+      expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session"),
+    );
+    expect(harness.client.sendSessionEvent).not.toHaveBeenCalled();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await Promise.resolve();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+  });
+
   it("wires provider status into pulses and stops an entry archived from mobile", async () => {
     vi.useFakeTimers();
     const summary = {
@@ -342,6 +465,7 @@ describe("Happy session liveness", () => {
     };
     const harness = createLayerHarness({ initialSessions: [summary] });
     harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_owner_lookup") {
         return { conversationId: "owning-conversation" };
       }
@@ -391,6 +515,7 @@ describe("Happy session liveness", () => {
     };
     const harness = createLayerHarness({ initialSessions: [summary] });
     harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_owner_lookup") return {};
       return { conversationId: params.conversationId };
     });
@@ -471,6 +596,7 @@ describe("Happy session liveness", () => {
     };
     const harness = createLayerHarness({ initialSessions: [summary] });
     harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_owner_lookup") {
         return { conversationId: "late-native-id-owner" };
       }
@@ -519,6 +645,7 @@ describe("Happy session liveness", () => {
       sessionKeyStore,
     });
     interrupted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_owner_lookup") {
         throw new Error("synthetic interrupted lookup");
       }
@@ -556,6 +683,7 @@ describe("Happy session liveness", () => {
       sessionKeyStore,
     });
     restarted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_owner_lookup") {
         expect(params).toEqual({
           providerSessionId: summary.sessionId,
@@ -617,6 +745,9 @@ describe("Happy session liveness", () => {
       "stable-relay-session",
     );
     await first.layer.close();
+    expect(first.client.sendSessionDeath).not.toHaveBeenCalled();
+    expect(first.api.deactivateSession).not.toHaveBeenCalled();
+    expect(first.client.close).toHaveBeenCalledTimes(1);
     expect(sessionKeyStore.delete).not.toHaveBeenCalled();
 
     const restarted = createLayerHarness({
@@ -649,10 +780,1170 @@ describe("Happy session liveness", () => {
     expect(restarted.client.updateMetadata).not.toHaveBeenCalled();
 
     await restarted.layer.close();
-    expect(order).toEqual(["death", "deactivate", "close"]);
+    expect(order).toEqual(["close"]);
+    expect(restarted.client.sendSessionDeath).not.toHaveBeenCalled();
+    expect(restarted.api.deactivateSession).not.toHaveBeenCalled();
     const pulsesAtClose = restarted.client.keepAlive.mock.calls.length;
     vi.advanceTimersByTime(4_000);
     expect(restarted.client.keepAlive).toHaveBeenCalledTimes(pulsesAtClose);
+  });
+
+  it("restores an exact Happy provider and checkpoints only its accepted relay sequence", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000321";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "persisted-relay-session");
+    await sessionKeyStore.markProcessedThroughSeq(providerSessionId, 4);
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "persisted-relay-session",
+      metadata,
+      seq: 9,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        expect(params).toEqual({
+          providerSessionId,
+          happySessionId: "persisted-relay-session",
+        });
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "native-session-to-resume",
+          agentModelId: "synthetic-model",
+          agentPermissionMode: "ask",
+          title: "Synthetic restored provider",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.source.spawn).toHaveBeenCalledWith({
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      localSessionId: providerSessionId,
+      resumeAgentSessionId: "native-session-to-resume",
+      requireExactResume: true,
+      suppressHistoryReplay: true,
+      initialModelId: "synthetic-model",
+      permissionMode: "ask",
+      approvalPolicy: "on-failure",
+    });
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_claim", {
+      conversationId: providerSessionId,
+      providerSessionId,
+      happySessionId: "persisted-relay-session",
+      cwd: SYNTHETIC_ROOT,
+      expectedAgentType: "codex",
+      expectedAgentSessionId: "native-session-to-resume",
+      expectedAgentPermissionMode: "ask",
+      agentSessionId: "synthetic-native-session",
+    });
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "persisted-relay-session" }),
+      expect.objectContaining({ resumeFromSeq: 4 }),
+    );
+
+    let acceptPrompt: (() => void) | undefined;
+    harness.source.sendPrompt.mockImplementationOnce(
+      () => new Promise<{ accepted: true }>((resolve) => {
+        acceptPrompt = () => resolve({ accepted: true });
+      }),
+    );
+    sessionKeyStore.markProcessedThroughSeq.mockClear();
+    harness.client.lastSeq = 99;
+    const processing = harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "continue" } },
+      5,
+    );
+    await vi.waitFor(() =>
+      expect(harness.source.sendPrompt).toHaveBeenCalledWith(providerSessionId, "continue"),
+    );
+    expect(sessionKeyStore.markProcessedThroughSeq).not.toHaveBeenCalled();
+
+    acceptPrompt?.();
+    await processing;
+    expect(sessionKeyStore.markProcessedThroughSeq).toHaveBeenCalledWith(
+      providerSessionId,
+      5,
+    );
+    expect(sessionKeyStore.markProcessedThroughSeq).not.toHaveBeenCalledWith(
+      providerSessionId,
+      99,
+    );
+    await harness.layer.close();
+  });
+
+  it("keeps buffered provider readiness inert until the restore claim succeeds", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000324";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "claim-gated-relay");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "claim-gated-relay",
+      metadata,
+      seq: 0,
+    }));
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "codex",
+      agentSessionId: "claim-gated-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "initializing",
+      reused: true,
+      owned: false,
+    }));
+    let releaseClaim: (() => void) | undefined;
+    let claimReturned = false;
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "claim-gated-native-session",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") {
+        await claimGate;
+        claimReturned = true;
+        return { archived: false };
+      }
+      return { conversationId: params.conversationId };
+    });
+    harness.source.subscribe.mockImplementation((handler) => {
+      expect(claimReturned).toBe(true);
+      handler({
+        kind: "status",
+        sessionId: providerSessionId,
+        payload: {
+          status: "ready",
+          agentSessionId: "claim-gated-native-session",
+        },
+      });
+      return () => {};
+    });
+
+    const starting = harness.layer.start();
+    await vi.waitFor(() =>
+      expect(harness.supervisorCall).toHaveBeenCalledWith(
+        "conversation_claim",
+        expect.anything(),
+      ),
+    );
+    expect(harness.source.subscribe).not.toHaveBeenCalled();
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.onUserMessage).not.toHaveBeenCalled();
+    expect(harness.source.sendPrompt).not.toHaveBeenCalled();
+
+    releaseClaim?.();
+    await starting;
+
+    expect(harness.source.subscribe).toHaveBeenCalledTimes(1);
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    expect(harness.client.onUserMessage).toHaveBeenCalledTimes(1);
+    expect(harness.source.sendPrompt).not.toHaveBeenCalled();
+
+    await harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "after claim" } },
+      1,
+    );
+    expect(harness.source.sendPrompt).toHaveBeenCalledWith(
+      providerSessionId,
+      "after claim",
+    );
+    await harness.layer.close();
+  });
+
+  it("retires a reused provider when archive wins the startup ownership claim", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000322";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "archived-restore-relay");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "archived-restore-relay",
+      metadata,
+      seq: 0,
+    }));
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "codex",
+      agentSessionId: "reused-restored-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+      reused: true,
+      owned: false,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "reused-restored-native-session",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") return { archived: true };
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.source.terminate).toHaveBeenCalledWith(providerSessionId);
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("archived-restore-relay");
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(providerSessionId);
+    await harness.layer.close();
+  });
+
+  it("retires a reconfigured reused provider when its atomic restore claim is rejected", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000323";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "rejected-restore-relay");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    let rejectClaim: (() => void) | undefined;
+    const claimGate = new Promise<never>((_resolve, reject) => {
+      rejectClaim = () => reject(new Error("Happy restoration claim was rejected"));
+    });
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "codex",
+      agentSessionId: "reused-rejected-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "initializing",
+      reused: true,
+      owned: false,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "reused-rejected-native-session",
+          agentPermissionMode: "bypassPermissions",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") {
+        return claimGate;
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    const starting = harness.layer.start();
+    await vi.waitFor(() =>
+      expect(harness.supervisorCall).toHaveBeenCalledWith(
+        "conversation_claim",
+        expect.anything(),
+      ),
+    );
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.onUserMessage).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+    expect(harness.source.sendPrompt).not.toHaveBeenCalled();
+    rejectClaim?.();
+    await expect(starting).rejects.toThrow(
+      "Happy restoration claim was rejected",
+    );
+
+    expect(harness.source.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ permissionMode: "bypassPermissions" }),
+    );
+    expect(harness.source.terminate).toHaveBeenCalledWith(providerSessionId);
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
+  it("does not treat a permission-only status as provider readiness", async () => {
+    const summary = {
+      sessionId: "permission-status-session",
+      agentType: "claude-code",
+      agentSessionId: "native-permission-status",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    let acceptFirst: (() => void) | undefined;
+    harness.source.sendPrompt.mockImplementation(async (_sessionId, text) => {
+      if (text === "first") {
+        await new Promise<void>((resolve) => {
+          acceptFirst = resolve;
+        });
+      }
+      return { accepted: true };
+    });
+    await harness.layer.start();
+
+    const first = harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "first" } },
+      1,
+    );
+    await vi.waitFor(() =>
+      expect(harness.source.sendPrompt).toHaveBeenCalledWith(summary.sessionId, "first"),
+    );
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready", readinessUnchanged: true },
+    });
+    acceptFirst?.();
+    await first;
+
+    const second = harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "second" } },
+      2,
+    );
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(harness.source.sendPrompt).toHaveBeenCalledTimes(1);
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
+      payload: { status: "ready" },
+    });
+    await second;
+    expect(harness.source.sendPrompt).toHaveBeenNthCalledWith(
+      2,
+      summary.sessionId,
+      "second",
+    );
+    await harness.layer.close();
+  });
+
+  it("captures completion before slow startup work despite restore chatter", async () => {
+    const active = {
+      sessionId: "active-startup-session",
+      agentType: "codex",
+      agentSessionId: "active-startup-native",
+      cwd: SYNTHETIC_ROOT,
+      status: "prompting",
+    };
+    const harness = createLayerHarness({ initialSessions: [active] });
+    let finishRelayLookup: (() => void) | undefined;
+    harness.api.getOrCreateSession.mockImplementation(
+      ({ metadata }: { metadata: Record<string, unknown> }) =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          finishRelayLookup ??= () =>
+            resolve({ id: "startup-race-relay", metadata });
+        }),
+    );
+
+    const starting = harness.layer.start();
+    await vi.waitFor(() => expect(harness.source.subscribe).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(harness.api.getOrCreateSession).toHaveBeenCalledTimes(1));
+    harness.publish({
+      kind: "turn-complete",
+      sessionId: active.sessionId,
+      payload: { stopReason: "completed" },
+    });
+    for (let index = 0; index < 40; index += 1) {
+      harness.publish({
+        kind: "status",
+        sessionId: `restore-chatter-${index}`,
+        payload: { status: "ready" },
+      });
+    }
+    finishRelayLookup?.();
+    await starting;
+
+    expect(harness.api.getOrCreateSession).toHaveBeenCalledTimes(1);
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    expect(harness.client.onUserMessage).toHaveBeenCalledTimes(1);
+    await harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "after restart" } },
+      1,
+    );
+    await vi.waitFor(() =>
+      expect(harness.source.sendPrompt).toHaveBeenCalledWith(
+        active.sessionId,
+        "after restart",
+      ),
+    );
+    await harness.layer.close();
+  });
+
+  it("seeds a legacy ready binding at the relay snapshot exactly once", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000984";
+    const summary = {
+      sessionId: providerSessionId,
+      agentType: "codex",
+      agentSessionId: "native-existing",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "legacy-cursor-relay");
+    await sessionKeyStore.clearProcessedThroughSeq(providerSessionId);
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "legacy-cursor-relay",
+      metadata,
+      seq: 9,
+    }));
+
+    await harness.layer.start();
+
+    expect(sessionKeyStore.markProcessedThroughSeq).toHaveBeenCalledTimes(1);
+    expect(sessionKeyStore.markProcessedThroughSeq).toHaveBeenCalledWith(
+      providerSessionId,
+      9,
+    );
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "legacy-cursor-relay" }),
+      expect.objectContaining({ resumeFromSeq: 9 }),
+    );
+    await harness.layer.close();
+  });
+
+  it("seeds an unbound v3.72 relay snapshot before accepting only newer input", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000988";
+    const summary = {
+      sessionId: providerSessionId,
+      agentType: "codex",
+      agentSessionId: "native-existing",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "v372-existing-relay",
+      metadata,
+      seq: 12,
+    }));
+
+    await harness.layer.start();
+
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "v372-existing-relay" }),
+      expect.objectContaining({ resumeFromSeq: 12 }),
+    );
+    expect(sessionKeyStore.markProcessedThroughSeq).toHaveBeenCalledWith(
+      providerSessionId,
+      12,
+    );
+    expect(harness.source.sendPrompt).not.toHaveBeenCalled();
+
+    await harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "new after upgrade" } },
+      13,
+    );
+    expect(harness.source.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(harness.source.sendPrompt).toHaveBeenCalledWith(
+      providerSessionId,
+      "new after upgrade",
+    );
+    await harness.layer.close();
+  });
+
+  it("does not resurrect a current session after successful terminal retirement", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000987";
+    const happySessionId = "current-terminal-relay";
+    const summary = {
+      sessionId: providerSessionId,
+      agentType: "codex",
+      agentSessionId: "current-terminal-native",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic current terminal thread",
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, happySessionId);
+    let lifecycleRecorded = false;
+    const restorationCandidates = () =>
+      lifecycleRecorded
+        ? []
+        : [
+            {
+              conversationId: providerSessionId,
+              happySessionId,
+              agentType: summary.agentType,
+              agentSessionId: summary.agentSessionId,
+              cwd: summary.cwd,
+              title: summary.title,
+            },
+          ];
+    const first = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    first.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: happySessionId,
+      metadata,
+      seq: 0,
+    }));
+    first.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") {
+        return { candidates: restorationCandidates() };
+      }
+      if (method === "conversation_migrate_happy_session") {
+        expect(params).toEqual({
+          conversationId: providerSessionId,
+          expectedHappySessionId: happySessionId,
+          replacementHappySessionId: happySessionId,
+        });
+        lifecycleRecorded = true;
+        return { migrated: true };
+      }
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+
+    await first.layer.start();
+    expect(lifecycleRecorded).toBe(true);
+    expect(
+      first.supervisorCall.mock.invocationCallOrder.find(
+        (_, index) =>
+          first.supervisorCall.mock.calls[index]?.[0] ===
+          "conversation_migrate_happy_session",
+      ),
+    ).toBeLessThan(first.source.subscribe.mock.invocationCallOrder[0]);
+
+    first.publish({
+      kind: "status",
+      sessionId: providerSessionId,
+      payload: { status: "terminated" },
+    });
+    await vi.waitFor(() =>
+      expect(sessionKeyStore.delete).toHaveBeenCalledWith(providerSessionId),
+    );
+    expect(await sessionKeyStore.list()).toEqual([]);
+    await first.layer.close();
+
+    const restarted = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    restarted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") {
+        return { candidates: restorationCandidates() };
+      }
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+
+    await restarted.layer.start();
+
+    expect(restarted.api.getOrCreateSession).not.toHaveBeenCalled();
+    expect(restarted.api.deactivateSession).not.toHaveBeenCalled();
+    expect(restarted.source.spawn).not.toHaveBeenCalled();
+    expect(restarted.api.sessionSyncClient).not.toHaveBeenCalled();
+    await restarted.layer.close();
+  });
+
+  it("migrates a v3.72 Happy conversation with no binding or provider before restoring it", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000989";
+    const legacyHappySessionId = "v372-lost-key-relay";
+    const replacementHappySessionId = "v372-replacement-relay";
+    let recordedHappySessionId = legacyHappySessionId;
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: replacementHappySessionId,
+      metadata,
+      seq: 0,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") {
+        return {
+          candidates: [
+            {
+              conversationId: providerSessionId,
+              happySessionId: recordedHappySessionId,
+              agentType: "codex",
+              agentSessionId: "v372-native-session",
+              cwd: SYNTHETIC_ROOT,
+              title: "Synthetic v3.72 thread",
+            },
+          ],
+        };
+      }
+      if (method === "conversation_migrate_happy_session") {
+        expect(params).toEqual({
+          conversationId: providerSessionId,
+          expectedHappySessionId: legacyHappySessionId,
+          replacementHappySessionId,
+        });
+        recordedHappySessionId = replacementHappySessionId;
+        return { migrated: true };
+      }
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        expect(params).toEqual({
+          providerSessionId,
+          happySessionId: replacementHappySessionId,
+        });
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "v372-native-session",
+          cwd: SYNTHETIC_ROOT,
+          title: "Synthetic v3.72 thread",
+        };
+      }
+      if (method === "conversation_claim") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith(
+      legacyHappySessionId,
+    );
+    expect(harness.supervisorCall.mock.invocationCallOrder.find((_, index) =>
+      harness.supervisorCall.mock.calls[index]?.[0] ===
+      "conversation_migrate_happy_session"
+    )).toBeLessThan(harness.source.subscribe.mock.invocationCallOrder[0]);
+    expect(harness.source.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localSessionId: providerSessionId,
+        resumeAgentSessionId: "v372-native-session",
+        requireExactResume: true,
+      }),
+    );
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledWith(
+      expect.objectContaining({ id: replacementHappySessionId }),
+      expect.anything(),
+    );
+    expect(await sessionKeyStore.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: providerSessionId,
+          state: "ready",
+          happySessionId: replacementHappySessionId,
+          processedThroughSeq: 0,
+        }),
+      ]),
+    );
+    await harness.layer.close();
+  });
+
+  it("rotates a pending legacy tag before a listed v3.72 provider and survives the next cold restart", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000990";
+    const legacyHappySessionId = "v372-pre-stable-relay";
+    const replacementHappySessionId = "v372-listed-replacement";
+    const summary = {
+      sessionId: providerSessionId,
+      agentType: "codex",
+      agentSessionId: "v372-listed-native",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    let recordedHappySessionId = legacyHappySessionId;
+    let migrationRecorded = false;
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+
+    const configureSupervisor = (harness: ReturnType<typeof createLayerHarness>) => {
+      harness.supervisorCall.mockImplementation(async (method, params) => {
+        if (method === "conversation_restore_candidates") {
+          return {
+            candidates: migrationRecorded
+              ? []
+              : [
+                  {
+                    conversationId: providerSessionId,
+                    happySessionId: recordedHappySessionId,
+                    agentType: "codex",
+                    agentSessionId: "v372-listed-native",
+                    cwd: SYNTHETIC_ROOT,
+                    title: "Synthetic listed v3.72 thread",
+                  },
+                ],
+          };
+        }
+        if (method === "conversation_migrate_happy_session") {
+          expect(params.expectedHappySessionId).toBe(legacyHappySessionId);
+          expect(params.replacementHappySessionId).toBe(replacementHappySessionId);
+          recordedHappySessionId = replacementHappySessionId;
+          migrationRecorded = true;
+          return { migrated: true };
+        }
+        if (method === "provider_session_archive_lookup") return { archived: false };
+        if (method === "conversation_lookup") {
+          return {
+            restorable: true,
+            happyOrigin: true,
+            retire: false,
+            archived: false,
+            conversationId: providerSessionId,
+            agentType: "codex",
+            agentSessionId: "v372-listed-native",
+            cwd: SYNTHETIC_ROOT,
+            title: "Synthetic listed v3.72 thread",
+          };
+        }
+        if (method === "conversation_claim") return { archived: false };
+        return { conversationId: params.conversationId };
+      });
+    };
+
+    const upgraded = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    configureSupervisor(upgraded);
+    upgraded.api.getOrCreateSession.mockImplementation(async ({ tag, metadata }) => {
+      expect(tag).toMatch(/^seren-migrated-/);
+      return { id: replacementHappySessionId, metadata, seq: 0 };
+    });
+
+    await upgraded.layer.start();
+
+    expect(sessionKeyStore.replacePendingTag).toHaveBeenCalledWith(
+      providerSessionId,
+      expect.stringMatching(/^seren-migrated-/),
+    );
+    expect(upgraded.source.spawn).not.toHaveBeenCalled();
+    expect(upgraded.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    expect(upgraded.api.sessionSyncClient).toHaveBeenCalledWith(
+      expect.objectContaining({ id: replacementHappySessionId }),
+      expect.anything(),
+    );
+    await upgraded.layer.close();
+
+    const restarted = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    configureSupervisor(restarted);
+    restarted.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: replacementHappySessionId,
+      metadata,
+      seq: 0,
+    }));
+    await restarted.layer.start();
+
+    expect(restarted.api.deactivateSession).not.toHaveBeenCalledWith(
+      legacyHappySessionId,
+    );
+    expect(restarted.source.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localSessionId: providerSessionId,
+        resumeAgentSessionId: "v372-listed-native",
+        requireExactResume: true,
+      }),
+    );
+    expect(restarted.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    await restarted.layer.close();
+  });
+
+  it("repairs a ready #3218 replacement whose SQLite marker was never migrated", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000991";
+    const legacyHappySessionId = "intermediate-legacy-relay";
+    const replacementHappySessionId = "intermediate-ready-relay";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, "seren-v2-intermediate");
+    await sessionKeyStore.markReady(providerSessionId, replacementHappySessionId);
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: replacementHappySessionId,
+      metadata,
+      seq: 0,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") {
+        return {
+          candidates: [
+            {
+              conversationId: providerSessionId,
+              happySessionId: legacyHappySessionId,
+              agentType: "codex",
+              agentSessionId: "intermediate-native",
+              cwd: SYNTHETIC_ROOT,
+              title: "Synthetic intermediate thread",
+            },
+          ],
+        };
+      }
+      if (method === "conversation_migrate_happy_session") {
+        expect(params).toMatchObject({
+          conversationId: providerSessionId,
+          expectedHappySessionId: legacyHappySessionId,
+          replacementHappySessionId,
+        });
+        return { migrated: true };
+      }
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: "intermediate-native",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith(
+      legacyHappySessionId,
+    );
+    expect(sessionKeyStore.markLegacyRelayRetired).toHaveBeenCalledWith(
+      providerSessionId,
+    );
+    expect(sessionKeyStore.clearLegacyRelayRetired).toHaveBeenCalledWith(
+      providerSessionId,
+    );
+    expect(harness.source.spawn).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
+  });
+
+  it("fails startup when a persisted cursor exceeds the relay snapshot", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000985";
+    const summary = {
+      sessionId: providerSessionId,
+      agentType: "codex",
+      agentSessionId: "native-existing",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "invalid-cursor-relay");
+    await sessionKeyStore.markProcessedThroughSeq(providerSessionId, 10);
+    const harness = createLayerHarness({
+      initialSessions: [summary],
+      sessionKeyStore,
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "invalid-cursor-relay",
+      metadata,
+      seq: 9,
+    }));
+
+    await expect(harness.layer.start()).rejects.toThrow(
+      "Persisted Happy processed sequence exceeds the relay snapshot",
+    );
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.supervisorNotify).toHaveBeenCalledWith("status_report", {
+      state: "error",
+      detail: "startup failed",
+    });
+    await harness.layer.close();
+  });
+
+  it.each([true, false])(
+    "unwinds an earlier restore on later startup failure (owned: %s)",
+    async (firstOwned) => {
+    const firstProviderSessionId = "00000000-0000-4000-8000-000000000986";
+    const failedProviderSessionId = "00000000-0000-4000-8000-000000000987";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(
+      firstProviderSessionId,
+      `seren-${firstProviderSessionId}`,
+    );
+    await sessionKeyStore.markReady(firstProviderSessionId, "first-restore-relay");
+    await sessionKeyStore.getOrCreate(
+      failedProviderSessionId,
+      `seren-${failedProviderSessionId}`,
+    );
+    await sessionKeyStore.markReady(failedProviderSessionId, "failed-restore-relay");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: params.providerSessionId,
+          agentType: "codex",
+          agentSessionId: `native-${params.providerSessionId}`,
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") return { archived: false };
+      return { conversationId: params.conversationId };
+    });
+    harness.source.spawn.mockImplementation(async (spec) => {
+      if (spec.localSessionId === failedProviderSessionId) {
+        throw new Error("synthetic exact-resume failure");
+      }
+      return {
+        sessionId: firstProviderSessionId,
+        agentType: "codex",
+        agentSessionId: `native-${firstProviderSessionId}`,
+        cwd: SYNTHETIC_ROOT,
+        status: "ready",
+        reused: !firstOwned,
+        owned: firstOwned,
+      };
+    });
+    harness.source.terminate.mockImplementation(async (sessionId) => {
+      if (firstOwned && sessionId === firstProviderSessionId) {
+        harness.publish({
+          kind: "status",
+          sessionId,
+          payload: { status: "terminated" },
+        });
+      }
+    });
+
+    await expect(harness.layer.start()).rejects.toThrow("synthetic exact-resume failure");
+    if (firstOwned) {
+      expect(harness.source.terminate).toHaveBeenCalledWith(firstProviderSessionId);
+    } else {
+      expect(harness.source.terminate).not.toHaveBeenCalledWith(firstProviderSessionId);
+    }
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.supervisorNotify).toHaveBeenCalledWith("status_report", {
+      state: "error",
+      detail: "startup failed",
+    });
+    expect(harness.supervisorNotify).not.toHaveBeenCalledWith(
+      "status_report",
+      expect.objectContaining({ state: "connected" }),
+    );
+    await harness.layer.close();
+    expect(harness.api.deactivateSession).not.toHaveBeenCalledWith(
+      "first-restore-relay",
+    );
+    expect(harness.sessionKeyStore.delete).not.toHaveBeenCalledWith(
+      firstProviderSessionId,
+    );
+    expect(await harness.sessionKeyStore.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: firstProviderSessionId,
+          state: "ready",
+          happySessionId: "first-restore-relay",
+        }),
+      ]),
+    );
+    },
+  );
+
+  it("claims a legacy fresh context before registering relay input and emits a reset notice", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000765";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "legacy-relay-session");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    const order: string[] = [];
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "legacy-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    harness.source.spawn.mockImplementation(async (spec) => {
+      order.push("spawn");
+      return {
+        sessionId: String(spec.localSessionId),
+        agentType: "codex",
+        agentSessionId: "fresh-native-session",
+        cwd: SYNTHETIC_ROOT,
+        status: "ready",
+        freshContextReset: true,
+        reused: false,
+        owned: true,
+      };
+    });
+    harness.api.sessionSyncClient.mockImplementation((session, options) => {
+      order.push("register-relay-input");
+      harness.client.lastSeq = options?.resumeFromSeq ?? 0;
+      return harness.client;
+    });
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "codex",
+          agentSessionId: null,
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") {
+        order.push("claim");
+        expect(params.expectedAgentType).toBe("codex");
+        expect(params.expectedAgentSessionId).toBeNull();
+        expect(params.expectedAgentPermissionMode).toBeNull();
+        expect(params.agentSessionId).toBe("fresh-native-session");
+        return { archived: false };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.source.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localSessionId: providerSessionId,
+        freshContextReset: true,
+        suppressHistoryReplay: true,
+      }),
+    );
+    expect(order).toEqual(["spawn", "claim", "register-relay-input"]);
+    expect(harness.client.sendSessionProtocolMessage).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
+  });
+
+  it("starts a fresh ACP context when the saved native session cannot resume exactly", async () => {
+    const providerSessionId = "00000000-0000-4000-8000-000000000766";
+    const sessionKeyStore = createMemorySessionKeyStore();
+    await sessionKeyStore.getOrCreate(providerSessionId, `seren-${providerSessionId}`);
+    await sessionKeyStore.markReady(providerSessionId, "legacy-acp-relay-session");
+    const harness = createLayerHarness({ initialSessions: [], sessionKeyStore });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "legacy-acp-relay-session",
+      metadata,
+      seq: 0,
+    }));
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "gemini",
+      agentSessionId: "fresh-acp-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+      freshContextReset: true,
+      reused: false,
+      owned: true,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "provider_session_archive_lookup") return { archived: false };
+      if (method === "conversation_lookup") {
+        return {
+          restorable: true,
+          happyOrigin: true,
+          retire: false,
+          archived: false,
+          conversationId: providerSessionId,
+          agentType: "gemini",
+          agentSessionId: "saved-acp-native-session",
+          cwd: SYNTHETIC_ROOT,
+        };
+      }
+      if (method === "conversation_claim") {
+        expect(params).toMatchObject({
+          expectedAgentType: "gemini",
+          expectedAgentSessionId: "saved-acp-native-session",
+          expectedAgentPermissionMode: null,
+          agentSessionId: "fresh-acp-native-session",
+        });
+        return { archived: false };
+      }
+      return { conversationId: params.conversationId };
+    });
+
+    await harness.layer.start();
+
+    expect(harness.source.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentType: "gemini",
+        localSessionId: providerSessionId,
+        freshContextReset: true,
+        suppressHistoryReplay: true,
+      }),
+    );
+    expect(harness.source.spawn).not.toHaveBeenCalledWith(
+      expect.objectContaining({ requireExactResume: true }),
+    );
+    expect(harness.client.sendSessionProtocolMessage).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
+  });
+
+  it("suppresses provider history replay when reopening an existing relay row", async () => {
+    const summary = {
+      sessionId: "replay-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const sessionKeyStore = createMemorySessionKeyStore();
+    const first = createLayerHarness({ initialSessions: [summary], sessionKeyStore });
+    await first.layer.start();
+    await first.layer.close();
+
+    const restarted = createLayerHarness({ initialSessions: [summary], sessionKeyStore });
+    await restarted.layer.start();
+    restarted.client.sendSessionProtocolMessage.mockClear();
+    restarted.client.sendAgentMessage.mockClear();
+
+    restarted.publish({
+      kind: "assistant-delta",
+      sessionId: summary.sessionId,
+      payload: { text: "historical", replay: true },
+    });
+    restarted.publish({
+      kind: "turn-complete",
+      sessionId: summary.sessionId,
+      payload: { stopReason: "HistoryReplay", historyReplay: true },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(restarted.client.sendSessionProtocolMessage).not.toHaveBeenCalled();
+    expect(restarted.client.sendAgentMessage).not.toHaveBeenCalled();
+
+    restarted.publish({
+      kind: "assistant-delta",
+      sessionId: summary.sessionId,
+      payload: { text: "live" },
+    });
+    restarted.publish({
+      kind: "turn-complete",
+      sessionId: summary.sessionId,
+      payload: { stopReason: "completed" },
+    });
+    await vi.waitFor(() =>
+      expect(restarted.client.sendSessionProtocolMessage).toHaveBeenCalled(),
+    );
+    await restarted.layer.close();
   });
 
   it("retires archived metadata before constructing a client on restart", async () => {
@@ -709,6 +2000,7 @@ describe("Happy session liveness", () => {
     const order: string[] = [];
     const harness = createLayerHarness({ initialSessions: [summary] });
     harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "conversation_happy_session_lookup") {
         order.push("lookup");
         return { happySessionId: "pre-stable-relay-row" };
@@ -719,7 +2011,8 @@ describe("Happy session liveness", () => {
       order.push(`deactivate:${happySessionId}`);
       return true;
     });
-    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => {
+    harness.api.getOrCreateSession.mockImplementation(async ({ tag, metadata }) => {
+      expect(tag).toMatch(/^seren-migrated-/);
       order.push("create-replacement");
       return { id: "replacement-relay-row", metadata, seq: 0 };
     });
@@ -735,19 +2028,44 @@ describe("Happy session liveness", () => {
       summary.sessionId,
       "replacement-relay-row",
     );
+    expect(harness.sessionKeyStore.replacePendingTag).toHaveBeenCalledWith(
+      summary.sessionId,
+      expect.stringMatching(/^seren-migrated-/),
+    );
     await harness.layer.close();
   });
 
   it("allows a naturally terminated provider to recover with the same desktop id", async () => {
     const summary = {
-      sessionId: "recovering-session",
+      sessionId: "00000000-0000-4000-8000-000000000992",
       agentType: "codex",
       cwd: SYNTHETIC_ROOT,
       title: "Synthetic recovering session",
       status: "ready",
     };
     const harness = createLayerHarness({ initialSessions: [summary] });
+    let priorRelayRecorded = false;
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "conversation_happy_session_lookup") {
+        return priorRelayRecorded
+          ? { happySessionId: "natural-recovery-old-relay" }
+          : {};
+      }
+      return { conversationId: params.conversationId };
+    });
+    harness.api.getOrCreateSession.mockImplementation(async ({ tag, metadata }) => {
+      if (!priorRelayRecorded) {
+        return { id: "natural-recovery-old-relay", metadata, seq: 0 };
+      }
+      if (tag === `seren-${summary.sessionId}`) {
+        throw new Error("synthetic lost-key decrypt collision");
+      }
+      expect(tag).toMatch(/^seren-migrated-/);
+      return { id: "natural-recovery-new-relay", metadata, seq: 0 };
+    });
     await harness.layer.start();
+    priorRelayRecorded = true;
 
     harness.publish({
       kind: "status",
@@ -761,6 +2079,10 @@ describe("Happy session liveness", () => {
       payload: { status: "ready" },
     });
     await vi.waitFor(() => expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(2));
+    expect(harness.sessionKeyStore.replacePendingTag).toHaveBeenCalledWith(
+      summary.sessionId,
+      expect.stringMatching(/^seren-migrated-/),
+    );
 
     await harness.layer.close();
   });
@@ -850,6 +2172,7 @@ describe("Happy session liveness", () => {
       sessionKeyStore,
     });
     restarted.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
       if (method === "provider_session_archive_lookup") {
         return { archived: params.providerSessionId === summary.sessionId };
       }
@@ -1481,7 +2804,110 @@ describe("Happy session liveness", () => {
     expect(typeof conversationId).toBe("string");
     expect(relayTag).toBe(`seren-${String(conversationId)}`);
     expect(providerId).toBe(conversationId);
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_claim", {
+      conversationId,
+      providerSessionId: conversationId,
+      happySessionId: "relay-session",
+      cwd: SYNTHETIC_ROOT,
+      expectedAgentType: "codex",
+      expectedAgentSessionId: null,
+      expectedAgentPermissionMode: null,
+      agentSessionId: "synthetic-native-session",
+    });
 
+    await harness.layer.close();
+  });
+
+  it("replays Claude readiness only after the remote spawn owns its conversation", async () => {
+    let finishClaim: (() => void) | undefined;
+    const claimGate = new Promise<void>((resolve) => {
+      finishClaim = resolve;
+    });
+    const harness = createLayerHarness();
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "claude-code",
+      agentSessionId: "synthetic-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "initializing",
+      reused: false,
+      owned: true,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "conversation_lookup") {
+        return { restorable: false, happyOrigin: false, retire: false };
+      }
+      if (method === "conversation_claim") {
+        await claimGate;
+        return { archived: false };
+      }
+      return { conversationId: params.conversationId };
+    });
+    await harness.layer.start();
+
+    const spawning = harness.spawn({ directory: SYNTHETIC_ROOT, agent: "claude" });
+    await vi.waitFor(() => expect(harness.source.spawn).toHaveBeenCalled());
+    const providerSessionId = String(
+      harness.source.spawn.mock.calls[0]?.[0]?.localSessionId,
+    );
+    const processing = harness.processUserMessage(
+      { role: "user", content: { type: "text", text: "after claim" } },
+      1,
+    );
+    harness.publish({
+      kind: "status",
+      sessionId: providerSessionId,
+      payload: { status: "ready", agentSessionId: "synthetic-native-session" },
+    });
+    await Promise.resolve();
+    expect(harness.source.sendPrompt).not.toHaveBeenCalled();
+
+    finishClaim?.();
+    await expect(spawning).resolves.toMatchObject({ type: "success" });
+    await processing;
+    expect(harness.source.sendPrompt).toHaveBeenCalledWith(
+      providerSessionId,
+      "after claim",
+    );
+    await harness.layer.close();
+  });
+
+  it("preserves an archive that wins the remote spawn ownership claim", async () => {
+    const harness = createLayerHarness();
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: "codex",
+      agentSessionId: "reused-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+      reused: true,
+      owned: false,
+    }));
+    harness.supervisorCall.mockImplementation(async (method, params) => {
+      if (method === "conversation_restore_candidates") return { candidates: [] };
+      if (method === "conversation_lookup") {
+        return { restorable: false, happyOrigin: false, retire: false };
+      }
+      if (method === "conversation_claim") return { archived: true };
+      return { conversationId: params.conversationId };
+    });
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" })).resolves.toEqual({
+      type: "error",
+      errorMessage: "Happy conversation was archived during provider spawn",
+    });
+
+    const conversationId = harness.supervisorCall.mock.calls.find(
+      ([method]) => method === "conversation_create",
+    )?.[1]?.conversationId;
+    expect(harness.source.terminate).toHaveBeenCalledWith(conversationId);
+    expect(harness.supervisorCall).not.toHaveBeenCalledWith(
+      "conversation_delete",
+      expect.anything(),
+    );
+    expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(conversationId);
     await harness.layer.close();
   });
 

--- a/tests/unit/provider-resume-and-acceptance-contract.test.ts
+++ b/tests/unit/provider-resume-and-acceptance-contract.test.ts
@@ -1,0 +1,499 @@
+// ABOUTME: Protects provider restore de-duplication, replay tagging, and prompt acceptance boundaries.
+// ABOUTME: Uses provider seams only; no agent process or network is required.
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+// @ts-expect-error — provider runtime files are plain ESM without generated declarations.
+import {
+  _sendAcpRequest,
+  createAcpRuntime,
+} from "../../bin/browser-local/acp-runtime.mjs";
+// @ts-expect-error — provider runtime files are plain ESM without generated declarations.
+import {
+  _replayClaudeHistoryEntry,
+  _writeClaudeMessageAccepted,
+  createClaudeRuntime,
+} from "../../bin/browser-local/claude-runtime.mjs";
+// @ts-expect-error — provider runtime files are plain ESM without generated declarations.
+import {
+  _replayCodexThreadItems,
+  createProviderHandlers,
+  createSynchronousSpawnCoordinator,
+  shouldFallbackCodexResume,
+} from "../../bin/browser-local/providers.mjs";
+
+function createCodexProcessHarness() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const processHandle = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    pid: 42,
+    kill: vi.fn(),
+    stdin: {
+      write: vi.fn((line: string) => {
+        const request = JSON.parse(line.trim());
+        if (request.id == null) return true;
+
+        let result: unknown = {};
+        if (request.method === "model/list") result = { data: [] };
+        if (request.method === "thread/start") {
+          result = { thread: { id: "native-codex" } };
+        }
+        if (request.method === "turn/start") {
+          result = { turn: { id: "turn-1" } };
+        }
+        queueMicrotask(() => {
+          stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result })}\n`);
+        });
+        return true;
+      }),
+    },
+  });
+
+  return {
+    processHandle,
+    notify(method: string, params: unknown) {
+      stdout.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+    },
+  };
+}
+
+describe("provider local-session spawn coordination", () => {
+  it("claims the local ID synchronously and joins one compatible spawn flight", async () => {
+    let releaseList: (sessions: unknown[]) => void = () => {};
+    const listSessions = vi.fn(
+      () =>
+        new Promise<unknown[]>((resolve) => {
+          releaseList = resolve;
+        }),
+    );
+    const spawn = vi.fn(async () => ({
+      id: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      status: "ready",
+      agentSessionId: "native-1",
+    }));
+    const emit = vi.fn();
+    const coordinate = createSynchronousSpawnCoordinator({
+      spawn,
+      listSessions,
+      emit,
+    });
+    const spec = {
+      localSessionId: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      resumeAgentSessionId: "native-1",
+      requireExactResume: true,
+    };
+
+    const owner = coordinate(spec);
+    const joiner = coordinate(spec);
+
+    expect(listSessions).toHaveBeenCalledTimes(1);
+    expect(spawn).not.toHaveBeenCalled();
+    releaseList([]);
+
+    await expect(owner).resolves.toMatchObject({
+      id: "local-1",
+      reused: false,
+      owned: true,
+    });
+    await expect(joiner).resolves.toMatchObject({
+      id: "local-1",
+      reused: true,
+      owned: false,
+    });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith("provider://session-status", {
+      sessionId: "local-1",
+      status: "ready",
+      agentSessionId: "native-1",
+    });
+  });
+
+  it("reuses only an exact ready agent/cwd/native binding", async () => {
+    const spawn = vi.fn();
+    const emit = vi.fn();
+    const existing = {
+      id: "local-1",
+      agentType: "claude-code",
+      cwd: "/project",
+      status: "ready",
+      agentSessionId: "native-1",
+    };
+    const coordinate = createSynchronousSpawnCoordinator({
+      spawn,
+      listSessions: async () => [existing],
+      emit,
+    });
+
+    await expect(
+      coordinate({
+        localSessionId: "local-1",
+        agentType: "claude-code",
+        cwd: "/project",
+        resumeAgentSessionId: "native-1",
+        requireExactResume: true,
+      }),
+    ).resolves.toMatchObject({
+      reused: true,
+      owned: false,
+    });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith("provider://session-status", {
+      sessionId: "local-1",
+      status: "ready",
+      agentSessionId: "native-1",
+    });
+  });
+
+  it("rejects an incompatible native ID instead of spawning a duplicate", async () => {
+    const spawn = vi.fn();
+    const coordinate = createSynchronousSpawnCoordinator({
+      spawn,
+      listSessions: async () => [
+        {
+          id: "local-1",
+          agentType: "codex",
+          cwd: "/project",
+          status: "ready",
+          agentSessionId: "other-native",
+        },
+      ],
+      emit: vi.fn(),
+    });
+
+    await expect(
+      coordinate({
+        localSessionId: "local-1",
+        agentType: "codex",
+        cwd: "/project",
+        resumeAgentSessionId: "native-1",
+        requireExactResume: true,
+      }),
+    ).rejects.toThrow(/different native session ID/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("joins compatible desktop and Happy flights despite different replay flags", async () => {
+    let releaseList: (sessions: unknown[]) => void = () => {};
+    const spawn = vi.fn(async () => ({
+      id: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      status: "ready",
+      agentSessionId: "native-1",
+    }));
+    const coordinate = createSynchronousSpawnCoordinator({
+      spawn,
+      listSessions: () =>
+        new Promise<unknown[]>((resolve) => {
+          releaseList = resolve;
+        }),
+      emit: vi.fn(),
+    });
+
+    const desktop = coordinate({
+      localSessionId: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      resumeAgentSessionId: "native-1",
+    });
+    const happy = coordinate({
+      localSessionId: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      resumeAgentSessionId: "native-1",
+      requireExactResume: true,
+      suppressHistoryReplay: true,
+    });
+    releaseList([]);
+
+    await expect(desktop).resolves.toMatchObject({ owned: true });
+    await expect(happy).resolves.toMatchObject({
+      reused: true,
+      owned: false,
+      agentSessionId: "native-1",
+    });
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces an exact joiner's native ID against the resolved winning flight", async () => {
+    let releaseList: (sessions: unknown[]) => void = () => {};
+    const coordinate = createSynchronousSpawnCoordinator({
+      spawn: async () => ({
+        id: "local-1",
+        agentType: "codex",
+        cwd: "/project",
+        status: "ready",
+        agentSessionId: "different-native",
+      }),
+      listSessions: () =>
+        new Promise<unknown[]>((resolve) => {
+          releaseList = resolve;
+        }),
+      emit: vi.fn(),
+    });
+
+    const desktop = coordinate({
+      localSessionId: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+    });
+    const happy = coordinate({
+      localSessionId: "local-1",
+      agentType: "codex",
+      cwd: "/project",
+      resumeAgentSessionId: "native-1",
+      requireExactResume: true,
+      suppressHistoryReplay: true,
+    });
+    releaseList([]);
+
+    await expect(desktop).resolves.toMatchObject({ owned: true });
+    await expect(happy).rejects.toThrow(/different native session ID/);
+  });
+});
+
+describe("provider exact-resume contract", () => {
+  it("never treats a recoverable Codex resume error as permission to start fresh", () => {
+    expect(shouldFallbackCodexResume(new Error("thread not found"), false)).toBe(
+      true,
+    );
+    expect(shouldFallbackCodexResume(new Error("thread not found"), true)).toBe(
+      false,
+    );
+  });
+
+  it("requires a native ID before exact Codex or Claude restore", async () => {
+    const codex = createProviderHandlers({ emit: vi.fn() });
+    await expect(
+      codex.spawnSession({
+        localSessionId: "local-codex",
+        agentType: "codex",
+        cwd: "/project",
+        requireExactResume: true,
+      }),
+    ).rejects.toThrow(/exact resume requires a native agent session ID/);
+
+    const claude = createClaudeRuntime({ emit: vi.fn() });
+    await expect(
+      claude.spawnSession({
+        localSessionId: "local-claude",
+        cwd: "/project",
+        requireExactResume: true,
+      }),
+    ).rejects.toThrow(/exact resume requires a native agent session ID/);
+  });
+
+  it("rejects unsupported ACP exact resume before spawning a child", async () => {
+    const spawnProcess = vi.fn();
+    const runtime = createAcpRuntime({
+      emit: vi.fn(),
+      adapter: {
+        agentType: "synthetic-acp",
+        agentName: "Synthetic ACP",
+        spawnProcess,
+      },
+    });
+
+    await expect(
+      runtime.spawnSession({
+        localSessionId: "local-acp",
+        cwd: "/project",
+        requireExactResume: true,
+        resumeAgentSessionId: "native-acp",
+      }),
+    ).rejects.toThrow(/does not support exact ACP session resume/);
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+});
+
+describe("provider replay tagging", () => {
+  it("marks replayed Codex tool start and end events", () => {
+    const emit = vi.fn();
+    _replayCodexThreadItems(
+      emit,
+      { id: "local-1", toolOutputs: new Map() },
+      {
+        turns: [
+          {
+            items: [
+              {
+                id: "tool-1",
+                type: "commandExecution",
+                command: "synthetic command",
+                status: "completed",
+                output: "synthetic output",
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(emit).toHaveBeenCalledWith(
+      "provider://tool-call",
+      expect.objectContaining({ toolCallId: "tool-1", replay: true }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      "provider://tool-result",
+      expect.objectContaining({ toolCallId: "tool-1", replay: true }),
+    );
+  });
+
+  it("marks replayed Claude tool start and end events", () => {
+    const emit = vi.fn();
+    const session = { id: "local-1", toolInputs: new Map() };
+    _replayClaudeHistoryEntry(emit, session, {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Read",
+            input: { path: "synthetic.txt" },
+          },
+        ],
+      },
+    });
+    _replayClaudeHistoryEntry(emit, session, {
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-1",
+            content: "synthetic result",
+          },
+        ],
+      },
+    });
+
+    expect(emit).toHaveBeenCalledWith(
+      "provider://tool-call",
+      expect.objectContaining({ toolCallId: "tool-1", replay: true }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      "provider://tool-result",
+      expect.objectContaining({ toolCallId: "tool-1", replay: true }),
+    );
+  });
+});
+
+describe("provider prompt acceptance writes", () => {
+  it("ends the Codex submit RPC at turn acceptance and events a late failure", async () => {
+    const emit = vi.fn();
+    const processHarness = createCodexProcessHarness();
+    const handlers = createProviderHandlers({
+      emit,
+      spawnCodex: vi.fn(() => processHarness.processHandle),
+    });
+    await handlers.spawnSession({
+      localSessionId: "local-codex",
+      agentType: "codex",
+      cwd: "/project",
+    });
+
+    await expect(
+      handlers.submitPrompt({
+        sessionId: "local-codex",
+        prompt: "synthetic prompt",
+        source: "remote",
+      }),
+    ).resolves.toEqual({ accepted: true, sessionId: "local-codex" });
+
+    vi.useFakeTimers();
+    try {
+      await vi.advanceTimersByTimeAsync(31_000);
+      await expect(handlers.listSessions()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "local-codex", status: "prompting" }),
+        ]),
+      );
+
+      processHarness.notify("turn/completed", {
+        turn: {
+          id: "turn-1",
+          status: "failed",
+          error: { message: "synthetic late failure" },
+        },
+      });
+      await Promise.resolve();
+      expect(emit).toHaveBeenCalledWith("provider://error", {
+        sessionId: "local-codex",
+        error: "synthetic late failure",
+      });
+    } finally {
+      vi.useRealTimers();
+      await handlers.terminateSession({ sessionId: "local-codex" });
+    }
+  });
+
+  it("acknowledges ACP only from the stdin write callback", async () => {
+    let writeCallback: ((error?: Error | null) => void) | undefined;
+    const onWritten = vi.fn();
+    const session = {
+      nextRequestId: 1,
+      pendingRequests: new Map(),
+      process: {
+        stdin: {
+          write: vi.fn((_line: string, callback: (error?: Error | null) => void) => {
+            writeCallback = callback;
+            return true;
+          }),
+        },
+      },
+    };
+
+    const request = _sendAcpRequest(
+      session,
+      "session/prompt",
+      { prompt: [] },
+      1_000,
+      { onWritten },
+    );
+    expect(onWritten).not.toHaveBeenCalled();
+    writeCallback?.();
+    expect(onWritten).toHaveBeenCalledTimes(1);
+
+    const pending = session.pendingRequests.get("1");
+    clearTimeout(pending.timeout);
+    session.pendingRequests.delete("1");
+    pending.resolve({ stopReason: "end_turn" });
+    await expect(request).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("acknowledges Claude only after its stdin write callback succeeds", async () => {
+    let writeCallback: ((error?: Error | null) => void) | undefined;
+    const session = {
+      process: {
+        stdin: {
+          write: vi.fn((_line: string, callback: (error?: Error | null) => void) => {
+            writeCallback = callback;
+            return true;
+          }),
+        },
+      },
+    };
+
+    const accepted = _writeClaudeMessageAccepted(session, {
+      type: "user",
+      message: { content: "synthetic prompt" },
+    });
+    let settled = false;
+    void accepted.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    writeCallback?.();
+    await expect(accepted).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #3221

## Summary

- preserve the same Happy relay row, encrypted session binding, and accepted-message cursor across ordinary bridge stops, full desktop restarts, Remote Access Off/On, and updater pre-install recovery
- restore Happy-origin providers by exact desktop/native identity behind an atomic ownership claim, with startup notification buffering and replay suppression
- migrate pre-lifecycle v3.72 rows to durable random relay bindings without resurrecting current sessions that ended normally
- checkpoint inbound relay messages only after the provider accepts them, including bounded ordered drain on shutdown
- retain saved provider/model/permission/root semantics across exact restore; fail closed when ACP cannot resume exactly

## Audit

Traced the macOS app-exit lifecycle, Remote Access toggle, updater pre-install/release path, Happy bridge supervisor RPCs, local provider JSON-RPC, SQLite conversation provenance, encrypted relay-key persistence, and Happy SDK inbound message processing. Reviewed the related fixes and discussion in #3208/#3210, #3212/#3218, and #3219/#3220 before implementation.

## Network paths

No new outbound API or publisher path is introduced. Existing Happy traffic remains:

- `POST /v1/machines`
- `POST /v1/sessions`
- Socket.IO `/v1/updates`
- `GET/POST /v3/sessions/{id}/messages`
- `POST /v1/sessions/{id}/archive`
- local provider JSON-RPC

These paths were traced from the UI/lifecycle action to the installed Happy 1.2.0 SDK contract. Fresh live Seren publisher discovery returned no Happy publisher, so there is no Seren publisher slug to change or invoke for this path.

## Validation

- `pnpm test` — 2,674 passed, 15 skipped
- `cargo test --locked --lib --manifest-path src-tauri/Cargo.toml` — 990 passed, 2 ignored
- `pnpm check` — pass (existing repository warnings only)
- `pnpm build` — pass
- `pnpm install --offline --frozen-lockfile` — pass
- `pnpm test:runtime-smoke` — pass
- macOS Happy bridge graceful-shutdown verifier — pass
- patched Happy ESM/CJS syntax and focused restart/migration suites — pass
- two independent adversarial reviews — pass
- real hosted-Happy validation walkthrough — pending before merge
