### PR TITLE
Fix Happy mobile unpair confirmation

### DIFF
--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -1,7 +1,6 @@
 // ABOUTME: Settings controls for the Happy remote access bridge.
 // ABOUTME: Keeps pairing, connection state, and advertised project roots local to Settings.
 
-import { confirm } from "@tauri-apps/plugin-dialog";
 import {
   type Component,
   createSignal,
@@ -114,6 +113,7 @@ export const HappyRemoteSettings: Component = () => {
   const [advertisedRoots, setAdvertisedRoots] = createSignal<string[]>([]);
   const [busy, setBusy] = createSignal(false);
   const [message, setMessage] = createSignal<string | null>(null);
+  const [confirmingReset, setConfirmingReset] = createSignal(false);
   const [pairingPayload, setPairingPayload] = createSignal<string | null>(null);
   const [pairingQr, setPairingQr] = createSignal<string | null>(null);
   const [pairingError, setPairingError] = createSignal(false);
@@ -246,11 +246,7 @@ export const HappyRemoteSettings: Component = () => {
   };
 
   const unpair = async () => {
-    const confirmed = await confirm(RESET_COPY, {
-      title: "Reset Happy remote access",
-      kind: "warning",
-    });
-    if (!confirmed) return;
+    setConfirmingReset(false);
     setBusy(true);
     setMessage(null);
     try {
@@ -258,7 +254,11 @@ export const HappyRemoteSettings: Component = () => {
       setStatus(await disableRemoteAccess());
       setPairingPayload(null);
       setPairingQr(null);
-    } catch {
+    } catch (error) {
+      console.error(
+        "[HappyRemoteSettings] Could not reset remote access:",
+        error,
+      );
       setMessage("Could not reset remote access.");
     } finally {
       setBusy(false);
@@ -446,23 +446,57 @@ export const HappyRemoteSettings: Component = () => {
         </div>
       </Show>
 
-      <div class="flex items-center justify-between gap-4 py-4 border-b border-border">
-        <span class="flex flex-col gap-0.5">
-          <span class="text-[0.95rem] font-medium text-foreground">
-            Unpair and reset
+      <div class="py-4 border-b border-border">
+        <div class="flex items-center justify-between gap-4">
+          <span class="flex flex-col gap-0.5">
+            <span class="text-[0.95rem] font-medium text-foreground">
+              Unpair and reset
+            </span>
+            <span class="text-[0.8rem] text-muted-foreground">
+              Remove this machine's remote identity and disable remote access
+            </span>
           </span>
-          <span class="text-[0.8rem] text-muted-foreground">
-            Remove this machine's remote identity and disable remote access
-          </span>
-        </span>
-        <button
-          type="button"
-          class="px-3 py-1.5 border border-destructive/60 bg-transparent rounded-md text-destructive text-[0.8rem] cursor-pointer hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={() => void unpair()}
-          disabled={busy()}
-        >
-          Unpair and reset
-        </button>
+          <Show when={!confirmingReset()}>
+            <button
+              type="button"
+              data-testid="happy-unpair-start"
+              class="px-3 py-1.5 border border-destructive/60 bg-transparent rounded-md text-destructive text-[0.8rem] cursor-pointer hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={() => setConfirmingReset(true)}
+              disabled={busy()}
+            >
+              Unpair and reset
+            </button>
+          </Show>
+        </div>
+
+        <Show when={confirmingReset()}>
+          <div
+            role="alert"
+            data-testid="happy-unpair-confirmation"
+            class="mt-3 rounded-lg border border-destructive/40 bg-destructive/5 p-3"
+          >
+            <p class="m-0 text-[0.8rem] leading-normal text-foreground">
+              {RESET_COPY}
+            </p>
+            <div class="mt-3 flex justify-end gap-2">
+              <button
+                type="button"
+                class="px-3 py-1.5 border border-border-strong bg-transparent rounded-md text-foreground text-[0.8rem] cursor-pointer hover:bg-surface-2"
+                onClick={() => setConfirmingReset(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="happy-unpair-confirm"
+                class="px-3 py-1.5 border border-destructive bg-destructive rounded-md text-white text-[0.8rem] cursor-pointer hover:opacity-90"
+                onClick={() => void unpair()}
+              >
+                Reset identity
+              </button>
+            </div>
+          </div>
+        </Show>
       </div>
 
       <Show when={message()}>

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Settings controls for the Happy remote access bridge.
 // ABOUTME: Keeps pairing, connection state, and advertised project roots local to Settings.
 
+import { confirm } from "@tauri-apps/plugin-dialog";
 import {
   type Component,
   createSignal,
@@ -245,7 +246,11 @@ export const HappyRemoteSettings: Component = () => {
   };
 
   const unpair = async () => {
-    if (!window.confirm(RESET_COPY)) return;
+    const confirmed = await confirm(RESET_COPY, {
+      title: "Reset Happy remote access",
+      kind: "warning",
+    });
+    if (!confirmed) return;
     setBusy(true);
     setMessage(null);
     try {

--- a/tests/unit/happy-remote-settings-ui.test.ts
+++ b/tests/unit/happy-remote-settings-ui.test.ts
@@ -76,21 +76,37 @@ describe("Happy advertised-root consent (#3144)", () => {
   });
 });
 
-describe("Happy identity reset confirmation (#3223)", () => {
-  it("awaits the supported Tauri dialog before invoking the reset", () => {
+describe("Happy identity reset confirmation (#3223, #3225)", () => {
+  it("requires a second explicit app-owned action before invoking the reset", () => {
     const unpair = remoteSettings.slice(
       remoteSettings.indexOf("const unpair = async () => {"),
       remoteSettings.indexOf("\n  return ("),
     );
+    const startButton = remoteSettings.slice(
+      remoteSettings.indexOf('data-testid="happy-unpair-start"'),
+      remoteSettings.indexOf(
+        "</button>",
+        remoteSettings.indexOf('data-testid="happy-unpair-start"'),
+      ),
+    );
 
+    expect(remoteSettings).not.toContain("window.confirm");
+    expect(remoteSettings).not.toContain("@tauri-apps/plugin-dialog");
     expect(remoteSettings).toContain(
-      'import { confirm } from "@tauri-apps/plugin-dialog";',
+      'data-testid="happy-unpair-confirmation"',
     );
-    expect(unpair).toContain("const confirmed = await confirm(RESET_COPY");
-    expect(unpair).toContain("if (!confirmed) return;");
-    expect(unpair).not.toContain("window.confirm");
-    expect(unpair.indexOf("await confirm")).toBeLessThan(
-      unpair.indexOf("resetRemoteIdentity()"),
+    expect(remoteSettings).toContain(
+      "onClick={() => setConfirmingReset(true)}",
     );
+    expect(remoteSettings).toContain(
+      "onClick={() => setConfirmingReset(false)}",
+    );
+    expect(startButton).toContain("onClick={() => setConfirmingReset(true)}");
+    expect(startButton).not.toContain("unpair()");
+    expect(remoteSettings).toMatch(
+      /data-testid="happy-unpair-confirm"[\s\S]*onClick=\{\(\) => void unpair\(\)\}/,
+    );
+    expect(unpair).toContain("setConfirmingReset(false);");
+    expect(unpair).toContain("await resetRemoteIdentity();");
   });
 });

--- a/tests/unit/happy-remote-settings-ui.test.ts
+++ b/tests/unit/happy-remote-settings-ui.test.ts
@@ -75,3 +75,22 @@ describe("Happy advertised-root consent (#3144)", () => {
     expect(call?.[1].trim()).toBe('Some("agent".to_string())');
   });
 });
+
+describe("Happy identity reset confirmation (#3223)", () => {
+  it("awaits the supported Tauri dialog before invoking the reset", () => {
+    const unpair = remoteSettings.slice(
+      remoteSettings.indexOf("const unpair = async () => {"),
+      remoteSettings.indexOf("\n  return ("),
+    );
+
+    expect(remoteSettings).toContain(
+      'import { confirm } from "@tauri-apps/plugin-dialog";',
+    );
+    expect(unpair).toContain("const confirmed = await confirm(RESET_COPY");
+    expect(unpair).toContain("if (!confirmed) return;");
+    expect(unpair).not.toContain("window.confirm");
+    expect(unpair.indexOf("await confirm")).toBeLessThan(
+      unpair.indexOf("resetRemoteIdentity()"),
+    );
+  });
+});


### PR DESCRIPTION
Closes #3223
Closes #3225

## Summary
- replace the broken global confirmation with an app-owned two-step reset confirmation
- keep the destructive Happy identity reset unreachable until the user clicks the second explicit action
- preserve Cancel as a no-op and log reset failures while retaining generic user-facing copy
- add focused regression coverage for the two-action gate and reset ordering

## Root cause
The release path called Tauri's injected `window.confirm` synchronously. That global returned a Promise and invoked the obsolete `plugin:dialog|confirm` command, which the current dialog ACL rejects.

The first replacement used the supported dialog plugin, but the required real macOS walkthrough found that its blocking parented message path returned the affirmative result without displaying a persistent prompt. That P1 safety finding is tracked in #3225 and is fixed here with deterministic app-owned state.

## Network path audit
The confirmation has no network path and uses no Seren publisher. After the second explicit action, the UI invokes local Tauri command `happy_bridge_reset_identity`, which reaches the Happy supervisor `identity_reset` RPC. With an active persisted binding, the supervisor can use Happy's direct `POST /v1/sessions` request to resolve a relay session and `POST /v1/sessions/{sessionId}/archive` to deactivate it. The archive method and path were verified against the current official `slopus/happy` client and server source.

## Validation
- `pnpm vitest run tests/unit/happy-remote-settings-ui.test.ts` (5 passed)
- `pnpm check` (passed; 48 pre-existing warnings and one schema-version info)
- `pnpm build` (passed)
- `pnpm test` (2,675 passed, 15 skipped)
- `pnpm prepare:mcp-servers`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` (passed)

### Post-PR real-app walkthrough
Run in the real macOS Tauri/WebKit app with a fresh validation-only bundle identity and the macOS Keychain available; no mocks.

1. Opened Settings → Remote access with status Off.
2. Clicked **Unpair and reset** once: the warning plus Cancel and Reset identity actions appeared; no reset/keyring call occurred.
3. Clicked **Cancel**: the warning closed, status remained Off, and no error appeared.
4. Reopened the warning and clicked **Reset identity**: the local reset completed, status remained Off, no error appeared, and no validation credential remained.
5. Confirmed the original `plugin:dialog|confirm` ACL rejection did not recur.

No P0/P1/P2 findings remain after the #3225 fix. The standard hermetic launcher has no default macOS Keychain under its scratch home; that production-unrelated limitation was classified non-blocking and bypassed with the fresh validation-only launch above. A physical-phone pairing was not created, so the direct Happy retirement endpoints were audited and covered by existing lifecycle tests rather than invoked during this walkthrough.