### PR TITLE
feat(privacy): erase remote conversation content and zero SQLite free pages on delete

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -5,8 +5,8 @@ use crate::commands::provider_runtime::DERIVED_KIND_CASE_SQL;
 use crate::happy_bridge::HappyBridgeManager;
 use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use crate::services::database::{
-    DbPool, PersistedMessage, enqueue_sync_tombstone, init_db, mark_sync_upsert,
-    save_message_record,
+    DbPool, PersistedMessage, WalCheckpointMode, checkpoint_wal, enqueue_sync_tombstone, init_db,
+    mark_sync_upsert, save_message_record,
 };
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,21 @@ fn delete_conversation_index_best_effort(app: &AppHandle, conversation_id: &str)
             conversation_id,
             err
         ),
+    }
+}
+
+fn vacuum_database(conn: &Connection) -> rusqlite::Result<()> {
+    // `delete_conversation_records` commits before its callers reach this helper;
+    // VACUUM is intentionally outside that delete transaction.
+    conn.execute_batch("VACUUM")?;
+    checkpoint_wal(conn, WalCheckpointMode::Truncate)?;
+    Ok(())
+}
+
+fn vacuum_conversation_index_best_effort(app: &AppHandle) {
+    match open_index_db(app).and_then(|conn| vacuum_database(&conn)) {
+        Ok(()) => {}
+        Err(err) => log::warn!("[ConversationIndex] Failed to vacuum index after deletion: {err}"),
     }
 }
 
@@ -552,10 +567,12 @@ pub async fn delete_conversation(app: AppHandle, id: String) -> Result<(), Strin
     let index_id = id.clone();
     run_db(app.clone(), move |conn| {
         delete_conversation_records(conn, &[id])?;
+        vacuum_database(conn)?;
         Ok(())
     })
     .await?;
     delete_conversation_index_best_effort(&app, &index_id);
+    vacuum_conversation_index_best_effort(&app);
     Ok(())
 }
 
@@ -571,12 +588,14 @@ pub async fn delete_conversations_by_employee(
             .collect::<rusqlite::Result<Vec<_>>>()?;
         drop(stmt);
         let deleted = delete_conversation_records(conn, &conversation_ids)?;
+        vacuum_database(conn)?;
         Ok((deleted as i64, conversation_ids))
     })
     .await?;
     for conversation_id in &conversation_ids {
         delete_conversation_index_best_effort(&app, conversation_id);
     }
+    vacuum_conversation_index_best_effort(&app);
     Ok(deleted)
 }
 
@@ -2066,14 +2085,14 @@ mod tests {
         AgentArchiveOrigin, AgentConversation, DERIVED_KIND_CASE_SQL, ExpectedHappyRestoration,
         HappyRestorationCandidate, HappyRestorationLookup, archive_agent_conversation_in_db,
         archive_happy_provider_session_in_db, claim_happy_provider_session_owner_in_db,
-        claim_happy_provider_session_owner_with_provenance_in_db, emit_happy_archive_event,
-        emit_happy_provider_archive_event, is_happy_provider_session_archived_in_db,
-        list_legacy_happy_restoration_candidates_in_db, lookup_agent_conversation_owner_in_db,
-        lookup_happy_restoration_candidate_in_db, lookup_happy_session_id_by_conversation_in_db,
-        migrate_happy_restoration_relay_in_db, set_agent_conversation_session_id_in_db,
-        upsert_agent_conversation_in_db,
+        claim_happy_provider_session_owner_with_provenance_in_db, delete_conversation_records,
+        emit_happy_archive_event, emit_happy_provider_archive_event,
+        is_happy_provider_session_archived_in_db, list_legacy_happy_restoration_candidates_in_db,
+        lookup_agent_conversation_owner_in_db, lookup_happy_restoration_candidate_in_db,
+        lookup_happy_session_id_by_conversation_in_db, migrate_happy_restoration_relay_in_db,
+        set_agent_conversation_session_id_in_db, upsert_agent_conversation_in_db, vacuum_database,
     };
-    use crate::services::database::setup_schema;
+    use crate::services::database::{configure_connection, setup_schema};
     use rusqlite::{Connection, params};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -2083,6 +2102,47 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         setup_schema(&conn).unwrap();
         conn
+    }
+
+    #[test]
+    fn true_deletion_delete_and_vacuum_erases_deleted_message_canary_from_chat_db() {
+        const CANARY: &str = "true-deletion-canary-1a6b4ec5-83d7-44e4-a044-81c1fe94b24d";
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("chat.db");
+        let wal_path = temp_dir.path().join("chat.db-wal");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            configure_connection(&conn).unwrap();
+            setup_schema(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO conversations (id, title, created_at) VALUES ('c1', 'Chat', 1)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, role, content, timestamp)
+                 VALUES ('m1', 'c1', 'user', ?1, 2)",
+                params![CANARY],
+            )
+            .unwrap();
+
+            delete_conversation_records(&conn, &["c1".to_string()]).unwrap();
+            vacuum_database(&conn).unwrap();
+        }
+
+        for path in [&db_path, &wal_path] {
+            if path.exists() {
+                let bytes = std::fs::read(path).unwrap();
+                assert!(
+                    !bytes
+                        .windows(CANARY.len())
+                        .any(|window| window == CANARY.as_bytes()),
+                    "deleted canary remained in {}",
+                    path.display()
+                );
+            }
+        }
     }
 
     fn insert_happy_restoration_candidate(conn: &Connection, id: &str, happy_session_id: &str) {

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -108,7 +108,8 @@ impl WalCheckpointTask {
 pub fn configure_connection(conn: &Connection) -> Result<()> {
     conn.busy_timeout(Duration::from_millis(5000))?;
     conn.execute_batch(&format!(
-        "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA wal_autocheckpoint={};",
+        "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA secure_delete=ON; \
+         PRAGMA wal_autocheckpoint={};",
         WAL_AUTOCHECKPOINT_PAGES
     ))?;
     Ok(())
@@ -1539,6 +1540,17 @@ mod tests {
             .query_row("PRAGMA wal_autocheckpoint", [], |row| row.get(0))
             .unwrap();
         assert_eq!(autocheckpoint_pages, WAL_AUTOCHECKPOINT_PAGES as i64);
+    }
+
+    #[test]
+    fn true_deletion_configure_connection_enables_secure_delete() {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+
+        let secure_delete: i64 = conn
+            .query_row("PRAGMA secure_delete", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(secure_delete, 1);
     }
 
     #[test]

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -2,15 +2,15 @@
 // ABOUTME: Keeps local SQLite as the fast path and mirrors durable text rows to Postgres.
 
 use postgres::{Client as PgClient, Row as PgRow};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashSet;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 
 use crate::auth;
-use crate::services::database::{now_ms, DbPool, HISTORY_SYNC_TABLES};
+use crate::services::database::{DbPool, HISTORY_SYNC_TABLES, now_ms};
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com/publishers/seren-db";
 const HISTORY_SYNC_STORE: &str = "history_sync.json";
@@ -775,31 +775,86 @@ fn mark_synced(app: &AppHandle, table_name: &str, row_id: &str) -> Result<(), St
     })
 }
 
+const TOMBSTONE_CONVERSATION_SQL: &str = "UPDATE seren_desktop.conversations
+    SET title = '', payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE id = $1";
+const TOMBSTONE_MESSAGE_SQL: &str = "UPDATE seren_desktop.messages
+    SET content = NULL, payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE id = $1";
+const TOMBSTONE_MESSAGE_EVENT_SQL: &str = "UPDATE seren_desktop.message_events
+    SET payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE id = $1";
+const TOMBSTONE_MEETING_SQL: &str = "UPDATE seren_desktop.meetings
+    SET title = '', notes_markdown = NULL, notes_struct_json = NULL, payload = '{}'::jsonb,
+        deleted_at = $2, row_version = row_version + 1
+    WHERE id = $1";
+const TOMBSTONE_TRANSCRIPT_SEGMENT_SQL: &str = "UPDATE seren_desktop.transcript_segments
+    SET text = '', payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE id = $1";
+const TOMBSTONE_MEETING_SPEAKER_ASSIGNMENT_SQL: &str =
+    "UPDATE seren_desktop.meeting_speaker_assignments
+     SET display_name = '', attendee_email = NULL, source_key = '', payload = '{}'::jsonb,
+         deleted_at = $2, row_version = row_version + 1
+     WHERE id = $1";
+const TOMBSTONE_MESSAGES_BY_CONVERSATION_SQL: &str = "UPDATE seren_desktop.messages
+    SET content = NULL, payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE conversation_id = $1";
+const TOMBSTONE_MESSAGE_EVENTS_BY_CONVERSATION_SQL: &str = "UPDATE seren_desktop.message_events
+    SET payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE conversation_id = $1";
+const TOMBSTONE_MESSAGE_EVENTS_BY_MESSAGE_SQL: &str = "UPDATE seren_desktop.message_events
+    SET payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+    WHERE message_id = $1";
+const TOMBSTONE_TRANSCRIPT_SEGMENTS_BY_MEETING_SQL: &str =
+    "UPDATE seren_desktop.transcript_segments
+     SET text = '', payload = '{}'::jsonb, deleted_at = $2, row_version = row_version + 1
+     WHERE meeting_id = $1";
+const TOMBSTONE_MEETING_SPEAKER_ASSIGNMENTS_BY_MEETING_SQL: &str =
+    "UPDATE seren_desktop.meeting_speaker_assignments
+     SET display_name = '', attendee_email = NULL, source_key = '', payload = '{}'::jsonb,
+         deleted_at = $2, row_version = row_version + 1
+     WHERE meeting_id = $1";
+
+fn tombstone_update_sql(table_name: &str) -> Option<&'static str> {
+    match table_name {
+        "conversations" => Some(TOMBSTONE_CONVERSATION_SQL),
+        "messages" => Some(TOMBSTONE_MESSAGE_SQL),
+        "message_events" => Some(TOMBSTONE_MESSAGE_EVENT_SQL),
+        "meetings" => Some(TOMBSTONE_MEETING_SQL),
+        "transcript_segments" => Some(TOMBSTONE_TRANSCRIPT_SEGMENT_SQL),
+        "meeting_speaker_assignments" => Some(TOMBSTONE_MEETING_SPEAKER_ASSIGNMENT_SQL),
+        _ => None,
+    }
+}
+
+fn update_tombstone_row(
+    client: &mut PgClient,
+    table_name: &str,
+    row_id: &str,
+    deleted_at: i64,
+) -> Result<(), String> {
+    let sql = tombstone_update_sql(table_name)
+        .ok_or_else(|| format!("unsupported history-sync tombstone table: {table_name}"))?;
+    client
+        .execute(sql, &[&row_id, &deleted_at])
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
 fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String> {
     let deleted_at = item.enqueued_at;
     match item.table_name.as_str() {
         "conversations" => {
+            update_tombstone_row(client, "conversations", &item.row_id, deleted_at)?;
             client
                 .execute(
-                    "UPDATE seren_desktop.conversations
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE id = $1",
+                    TOMBSTONE_MESSAGES_BY_CONVERSATION_SQL,
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
             client
                 .execute(
-                    "UPDATE seren_desktop.messages
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE conversation_id = $1",
-                    &[&item.row_id, &deleted_at],
-                )
-                .map_err(|err| err.to_string())?;
-            client
-                .execute(
-                    "UPDATE seren_desktop.message_events
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE conversation_id = $1",
+                    TOMBSTONE_MESSAGE_EVENTS_BY_CONVERSATION_SQL,
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
@@ -811,31 +866,25 @@ fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String
                 .map_err(|err| err.to_string())?;
         }
         "messages" => {
-            update_deleted_at(client, "messages", &item.row_id, deleted_at)?;
+            update_tombstone_row(client, "messages", &item.row_id, deleted_at)?;
             client
                 .execute(
-                    "UPDATE seren_desktop.message_events
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE message_id = $1",
+                    TOMBSTONE_MESSAGE_EVENTS_BY_MESSAGE_SQL,
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
         }
         "meetings" => {
-            update_deleted_at(client, "meetings", &item.row_id, deleted_at)?;
+            update_tombstone_row(client, "meetings", &item.row_id, deleted_at)?;
             client
                 .execute(
-                    "UPDATE seren_desktop.transcript_segments
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE meeting_id = $1",
+                    TOMBSTONE_TRANSCRIPT_SEGMENTS_BY_MEETING_SQL,
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
             client
                 .execute(
-                    "UPDATE seren_desktop.meeting_speaker_assignments
-                     SET deleted_at = $2, row_version = row_version + 1
-                     WHERE meeting_id = $1",
+                    TOMBSTONE_MEETING_SPEAKER_ASSIGNMENTS_BY_MEETING_SQL,
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
@@ -849,27 +898,10 @@ fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String
                 .map_err(|err| err.to_string())?;
         }
         "message_events" | "transcript_segments" | "meeting_speaker_assignments" => {
-            update_deleted_at(client, &item.table_name, &item.row_id, deleted_at)?;
+            update_tombstone_row(client, &item.table_name, &item.row_id, deleted_at)?;
         }
         _ => {}
     }
-    Ok(())
-}
-
-fn update_deleted_at(
-    client: &mut PgClient,
-    table_name: &str,
-    row_id: &str,
-    deleted_at: i64,
-) -> Result<(), String> {
-    let sql = format!(
-        "UPDATE seren_desktop.{table_name}
-         SET deleted_at = $2, row_version = row_version + 1
-         WHERE id = $1"
-    );
-    client
-        .execute(&sql, &[&row_id, &deleted_at])
-        .map_err(|err| err.to_string())?;
     Ok(())
 }
 
@@ -1971,7 +2003,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::database::{save_message_record, setup_schema, PersistedMessage};
+    use crate::services::database::{PersistedMessage, save_message_record, setup_schema};
     use std::cell::RefCell;
 
     const SCOPE_A: &str = "scope-a";
@@ -2004,6 +2036,63 @@ mod tests {
                 !ddl.contains(forbidden),
                 "history sync schema must not contain {forbidden}"
             );
+        }
+    }
+
+    #[test]
+    fn true_deletion_tombstone_sql_clears_remote_content_in_the_delete_update() {
+        let ddl = remote_schema_sql().join("\n").to_lowercase();
+        assert!(ddl.contains("title           text not null"));
+        assert!(ddl.contains("content         text"));
+        assert!(ddl.contains("payload         jsonb not null"));
+
+        for (table, expected_assignments) in [
+            (
+                "conversations",
+                &["title = ''", "payload = '{}'::jsonb"] as &[&str],
+            ),
+            ("messages", &["content = NULL", "payload = '{}'::jsonb"]),
+            ("message_events", &["payload = '{}'::jsonb"]),
+            (
+                "transcript_segments",
+                &["text = ''", "payload = '{}'::jsonb"],
+            ),
+        ] {
+            let sql = tombstone_update_sql(table).expect("known tombstone table");
+            assert!(
+                sql.contains("deleted_at = $2"),
+                "{table} must set deleted_at in its content-erasure update"
+            );
+            assert!(
+                sql.contains("row_version = row_version + 1"),
+                "{table} must advance row_version with the tombstone"
+            );
+            for assignment in expected_assignments {
+                assert!(
+                    sql.contains(assignment),
+                    "{table} tombstone must clear {assignment}"
+                );
+            }
+        }
+
+        for (sql, expected_assignments) in [
+            (
+                TOMBSTONE_MESSAGES_BY_CONVERSATION_SQL,
+                &["content = NULL", "payload = '{}'::jsonb"] as &[&str],
+            ),
+            (
+                TOMBSTONE_MESSAGE_EVENTS_BY_CONVERSATION_SQL,
+                &["payload = '{}'::jsonb"],
+            ),
+            (
+                TOMBSTONE_MESSAGE_EVENTS_BY_MESSAGE_SQL,
+                &["payload = '{}'::jsonb"],
+            ),
+        ] {
+            assert!(sql.contains("deleted_at = $2"));
+            for assignment in expected_assignments {
+                assert!(sql.contains(assignment));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Erase replicated conversation, message, and event content while retaining tombstones for history-sync convergence.
- Enable SQLite secure deletion and compact the chat database after conversation deletion; compact the conversation index on a best-effort basis.
- Add real SQLite canaries for the pragma and deleted-content byte scan, plus SQL-shape coverage for remote tombstones.

## Audit trace

- `src-tauri/src/services/history_sync.rs::push_tombstone`
- `src-tauri/src/services/database.rs::configure_connection`
- `src-tauri/src/commands/chat.rs::delete_conversation`
- `src-tauri/src/commands/chat.rs::delete_conversations_by_employee`

## Networked path

`push_tombstone` runs `UPDATE`/`DELETE` statements against the SerenDB `seren_desktop` Postgres schema through the existing history-sync `PgClient`; no publisher or API slug is added or modified.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml true_deletion -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml history_sync -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml delete_conversation -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm check`

## Residual scope

The next deletion stages cover retained cloud-memory cascade removal, `memory_cache.db` cleanup, local Claude/Codex transcript files, and a unified erase flow. Live SerenDB row inspection after deletion remains a signed-in end-to-end verification.

Refs #3197

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
