### PR TITLE
feat(privacy): make verbatim source retention opt-in and surface it

### DIFF
--- a/src/components/chat/DataDestinationsPanel.tsx
+++ b/src/components/chat/DataDestinationsPanel.tsx
@@ -4,7 +4,7 @@
 import type { Component } from "solid-js";
 import { createMemo, For, Show } from "solid-js";
 import { privacyStore } from "@/stores/privacy.store";
-import { settingsState } from "@/stores/settings.store";
+import { settingsState, settingsStore } from "@/stores/settings.store";
 import { threadStore } from "@/stores/thread.store";
 
 interface DataDestinationsPanelProps {
@@ -47,6 +47,25 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
       control: "Settings → Memory",
       enabled: () =>
         settingsState.app.memoryEnabled &&
+        !privacyStore.isMemoryExcluded(props.conversationId),
+    },
+    {
+      label: "Verbatim transcript archival",
+      detail: () => {
+        if (privacyStore.isMemoryExcluded(props.conversationId)) {
+          return "Excluded for this conversation";
+        }
+        if (!settingsState.app.memoryEnabled) {
+          return "Memory capture is disabled";
+        }
+        return settingsStore.get("sourceRetentionEnabled")
+          ? "Completed turns may be retained as verbatim sources by cloud memory"
+          : "Off by default; derived memories may still be created";
+      },
+      control: "Settings → Memory",
+      enabled: () =>
+        settingsState.app.memoryEnabled &&
+        settingsStore.get("sourceRetentionEnabled") &&
         !privacyStore.isMemoryExcluded(props.conversationId),
     },
     {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -2023,6 +2023,32 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               </label>
             </div>
 
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.sourceRetentionEnabled}
+                  onChange={(e) =>
+                    handleBooleanChange(
+                      "sourceRetentionEnabled",
+                      e.currentTarget.checked,
+                    )
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Verbatim Transcript Archival
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Store completed conversation text alongside derived cloud
+                    memories. This is off by default. Memory-excluded
+                    conversations never send transcript sources.
+                  </span>
+                </span>
+              </label>
+            </div>
+
             <h4 class="mt-6 mb-3 text-base font-semibold text-muted-foreground border-t border-border-medium pt-5">
               Claude Code Auto-Memory Interceptor
             </h4>

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -752,7 +752,9 @@ export async function processConversationTurn(
     conversationId: context?.conversationId,
     sessionId: context?.sessionId,
     projectContext: context?.projectContext,
-    retainSource: sourceExternalId !== undefined,
+    retainSource:
+      sourceExternalId !== undefined &&
+      settingsStore.get("sourceRetentionEnabled") === true,
     sourceExternalId,
     sourceRevision: context?.sourceRevision,
     sourceUri: context?.sourceUri,
@@ -778,7 +780,9 @@ export async function processAssistantResponseMemory(
     conversationId: context?.conversationId,
     sessionId: context?.sessionId,
     projectContext: context?.projectContext,
-    retainSource: sourceExternalId !== undefined,
+    retainSource:
+      sourceExternalId !== undefined &&
+      settingsStore.get("sourceRetentionEnabled") === true,
     sourceExternalId,
     sourceRevision: context?.sourceRevision,
     sourceUri: context?.sourceUri,

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -106,6 +106,12 @@ export interface Settings {
   // Memory settings
   memoryEnabled: boolean;
   /**
+   * Retain completed conversation text as a verbatim source in the cloud
+   * memory service. Derived memories are controlled independently by
+   * `memoryEnabled`; transcript retention is opt-in for privacy.
+   */
+  sourceRetentionEnabled: boolean;
+  /**
    * Intercept Claude Code auto-memory writes at
    * ~/.claude/projects/*\/memory/*.md, persist each file to SerenDB through
    * the auto-provisioned `claude-agent-prefs` project, and delete the
@@ -264,6 +270,7 @@ const DEFAULT_SETTINGS: Settings = {
   semanticIndexingEnabled: false,
   // Memory
   memoryEnabled: true,
+  sourceRetentionEnabled: false,
   // Claude Code auto-memory interceptor — on by default so every Seren
   // Desktop user gets secure SerenDB-backed preference storage out of the
   // box. The interceptor auto-provisions a "claude-agent-prefs" project +

--- a/tests/services/memory.test.ts
+++ b/tests/services/memory.test.ts
@@ -167,7 +167,7 @@ describe("memory service integration path", () => {
       sessionId: undefined,
       orgId: undefined,
       projectContext: undefined,
-      retainSource: true,
+      retainSource: false,
       sourceExternalId: "desktop:test:message-1",
       sourceRevision: "1",
       sourceUri: "seren://desktop/conversations/test/messages/message-1",

--- a/tests/unit/memory-source-retention.test.ts
+++ b/tests/unit/memory-source-retention.test.ts
@@ -1,0 +1,128 @@
+// ABOUTME: Verifies verbatim source retention is opt-in at the memory capture choke point.
+// ABOUTME: Keeps conversation-level memory exclusion ahead of all memory-service invokes.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  invokeMock,
+  authStoreMock,
+  projectStoreMock,
+  sourceRetentionState,
+  settingsGetMock,
+} = vi.hoisted(() => {
+  const sourceRetentionState = { enabled: false };
+  return {
+    invokeMock: vi.fn(),
+    authStoreMock: {
+      isAuthenticated: true,
+      user: { id: "user-1" },
+    },
+    projectStoreMock: {
+      activeProject: { id: "project-1" },
+    },
+    sourceRetentionState,
+    settingsGetMock: vi.fn((key: string): boolean | undefined => {
+      if (key === "memoryEnabled") return true;
+      if (key === "sourceRetentionEnabled") {
+        return sourceRetentionState.enabled;
+      }
+      return undefined;
+    }),
+  };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: authStoreMock,
+}));
+
+vi.mock("@/stores/project.store", () => ({
+  projectStore: projectStoreMock,
+}));
+
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: settingsGetMock,
+  },
+}));
+
+import { processAssistantResponseMemory } from "@/services/memory";
+import { privacyStore } from "@/stores/privacy.store";
+
+describe("verbatim source retention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeMock.mockResolvedValue({ extracted_count: 0 });
+    sourceRetentionState.enabled = false;
+    privacyStore.setConversationPrivacy("source-retention-off", {
+      excludeMemory: false,
+      excludeHistorySync: false,
+    });
+    privacyStore.setConversationPrivacy("source-retention-on", {
+      excludeMemory: false,
+      excludeHistorySync: false,
+    });
+    privacyStore.setConversationPrivacy("source-retention-excluded", {
+      excludeMemory: false,
+      excludeHistorySync: false,
+    });
+  });
+
+  it("sends retain_source false when verbatim source retention is off", async () => {
+    await processAssistantResponseMemory("Answer", {
+      conversationId: "source-retention-off",
+      userQuery: "Question",
+      sourceExternalId: "desktop:conversation:off",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "memory_process_conversation",
+      expect.objectContaining({
+        retainSource: false,
+        sourceExternalId: "desktop:conversation:off",
+      }),
+    );
+  });
+
+  it("sends retain_source true when verbatim source retention is enabled", async () => {
+    sourceRetentionState.enabled = true;
+
+    await processAssistantResponseMemory("Answer", {
+      conversationId: "source-retention-on",
+      userQuery: "Question",
+      sourceExternalId: "desktop:conversation:on",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "memory_process_conversation",
+      expect.objectContaining({
+        retainSource: true,
+        sourceExternalId: "desktop:conversation:on",
+      }),
+    );
+  });
+
+  it("does not invoke process_conversation for a memory-excluded conversation", async () => {
+    sourceRetentionState.enabled = true;
+    privacyStore.setConversationPrivacy("source-retention-excluded", {
+      excludeMemory: true,
+      excludeHistorySync: false,
+    });
+
+    await expect(
+      processAssistantResponseMemory("Answer", {
+        conversationId: "source-retention-excluded",
+        userQuery: "Question",
+        sourceExternalId: "desktop:conversation:excluded",
+      }),
+    ).resolves.toBeNull();
+
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "memory_process_conversation",
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Makes verbatim source retention for cloud-memory conversation capture opt-in and default-off. Derived-memory extraction remains controlled by the existing memory setting.

## Audit trace

- `src/services/memory.ts`: both `retainSource` capture sites now require a stable source ID and `sourceRetentionEnabled`.
- `b5119a1b` source identity flow: retained sources use `source_external_id` and `source_uri`.
- `src/components/settings/SettingsPanel.tsx` and `src/components/chat/DataDestinationsPanel.tsx`: user control plus live egress disclosure.
- serenorg/seren-desktop#3196's existing conversation-level memory-exclusion gate remains before any `process_conversation` invoke; this PR adds a regression test.

## Default decision

Defaulting verbatim transcript archival to off is privacy-forward: users still receive derived facts from memory when Memory Operations is enabled, but completed transcript text is not retained as a cloud-memory source unless they explicitly opt in. Existing persisted settings merge the new default safely.

## Networked path

`process_conversation` → `memory.serendb.com/mcp`; `retain_source` is now gated client-side. No publisher slug or outbound route is added.

## Cascade dependency

Live `seren-memory` tool enumeration and a read-only `list_memories` call confirm records expose `source_external_id` and `source_uri`, but list has no source-key filter and permanent deletion accepts only `memory_id`. The required source-keyed delete/list capability is tracked in serenorg/seren-memory#24. This PR intentionally does not fake a non-functional client-side cascade.

Refs serenorg/seren-desktop#3198

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com