### PR TITLE
fix(happy): terminate remotely archived sessions

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -1533,6 +1533,29 @@ export function createHappyLayer({
     }
   }
 
+  function retireTrackedSession(entry) {
+    const sessionId = entry.sessionId;
+    if (sessions.get(sessionId) !== entry) return;
+
+    sessions.delete(sessionId);
+    liveSessions.delete(sessionId);
+    promptQueue.clear(sessionId);
+    turnCorrelator.clear(sessionId);
+    assistantMessageCoalescer.clear(sessionId);
+    delete pendingRequests[sessionId];
+    sessionCreationPromises.delete(sessionId);
+    terminatedSessions.mark(sessionId);
+    remotelyArchivedSessions.add(sessionId);
+    entry.liveness.stop();
+    const disposal = retirePersistedSession({
+      sessionId,
+      entry,
+      terminateProvider: true,
+      blockRevival: true,
+    });
+    trackSessionDisposal(disposal);
+  }
+
   function registerInbound(entry) {
     const { client } = entry;
     client.on("inboundProcessingError", () => {
@@ -1543,32 +1566,7 @@ export function createHappyLayer({
       });
       debug("Happy relay input processing stopped after a durable processing failure");
     });
-    client.on("archived", () => {
-      const sessionId = entry.sessionId;
-      if (sessions.get(sessionId) !== entry) return;
-
-      // Happy's native runners treat a mobile archive as termination. Mirror
-      // that contract without letting the next pulse reactivate the relay row.
-      sessions.delete(sessionId);
-      liveSessions.delete(sessionId);
-      promptQueue.clear(sessionId);
-      turnCorrelator.clear(sessionId);
-      assistantMessageCoalescer.clear(sessionId);
-      delete pendingRequests[sessionId];
-      sessionCreationPromises.delete(sessionId);
-      terminatedSessions.mark(sessionId);
-      remotelyArchivedSessions.add(sessionId);
-      entry.liveness.stop();
-      const disposal = (async () => {
-        await retirePersistedSession({
-          sessionId,
-          entry,
-          terminateProvider: true,
-          blockRevival: true,
-        });
-      })();
-      trackSessionDisposal(disposal);
-    });
+    client.on("archived", () => retireTrackedSession(entry));
     client.onUserMessage(async (message) => {
       const processed = await promptQueue.enqueue(entry.sessionId, { entry, message });
       if (!processed) {
@@ -1600,6 +1598,20 @@ export function createHappyLayer({
     };
     client.rpcHandlerManager.registerHandler("abort", cancelSession("abort"));
     client.rpcHandlerManager.registerHandler("switch", cancelSession("switch"));
+    client.rpcHandlerManager.registerHandler("killSession", async (params) => {
+      if (params === null) {
+        debug("dropped unauthenticated Happy killSession request");
+        return {
+          success: false,
+          message: "Unauthenticated kill request",
+        };
+      }
+      retireTrackedSession(entry);
+      return {
+        success: true,
+        message: "Killing happy-cli process",
+      };
+    });
     client.rpcHandlerManager.registerHandler("permission", async (response) => {
       try {
         return await handlePermissionResponse(entry, response);

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -34,7 +34,7 @@ function createClient() {
     | undefined;
   const rpcHandlers = new Map<
     string,
-    (payload: Record<string, unknown>) => unknown
+    (payload: Record<string, unknown> | null) => unknown
   >();
   return {
     close: vi.fn(async () => {}),
@@ -55,7 +55,7 @@ function createClient() {
     },
     keepAlive: vi.fn(),
     lastSeq: 0,
-    invokeRpc(name: string, payload: Record<string, unknown>) {
+    invokeRpc(name: string, payload: Record<string, unknown> | null) {
       const handler = rpcHandlers.get(name);
       if (!handler) throw new Error(`Happy RPC handler ${name} is not registered`);
       return handler(payload);
@@ -75,7 +75,10 @@ function createClient() {
     ),
     rpcHandlerManager: {
       registerHandler: vi.fn(
-        (name: string, handler: (payload: Record<string, unknown>) => unknown) => {
+        (
+          name: string,
+          handler: (payload: Record<string, unknown> | null) => unknown,
+        ) => {
           rpcHandlers.set(name, handler);
         },
       ),
@@ -446,6 +449,68 @@ describe("Happy session liveness", () => {
     harness.publish({
       kind: "status",
       sessionId: "local-session",
+      payload: { status: "ready" },
+    });
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    await harness.layer.close();
+    expect(harness.client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("authenticates killSession and retires the tracked provider exactly once", async () => {
+    vi.useFakeTimers();
+    const summary = {
+      sessionId: "kill-session",
+      agentSessionId: "kill-native-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic kill session",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+
+    await harness.layer.start();
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(1);
+
+    await expect(harness.client.invokeRpc("killSession", null)).resolves.toEqual({
+      success: false,
+      message: "Unauthenticated kill request",
+    });
+    vi.advanceTimersByTime(2_000);
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(2);
+    expect(harness.source.terminate).not.toHaveBeenCalled();
+
+    await expect(harness.client.invokeRpc("killSession", {})).resolves.toEqual({
+      success: true,
+      message: "Killing happy-cli process",
+    });
+    const stoppedAt = harness.client.keepAlive.mock.calls.length;
+    vi.advanceTimersByTime(4_000);
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(stoppedAt);
+
+    await expect(harness.client.invokeRpc("killSession", {})).resolves.toEqual({
+      success: true,
+      message: "Killing happy-cli process",
+    });
+    await vi.waitFor(() =>
+      expect(harness.source.terminate).toHaveBeenCalledWith(summary.sessionId),
+    );
+    expect(harness.source.terminate).toHaveBeenCalledTimes(1);
+    expect(harness.supervisorCall).toHaveBeenCalledWith("conversation_archive", {
+      conversationId: summary.sessionId,
+      providerSessionId: summary.sessionId,
+    });
+    expect(harness.supervisorCall.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.source.terminate.mock.invocationCallOrder[0],
+    );
+    expect(harness.api.deactivateSession).toHaveBeenCalledWith("relay-session");
+    await vi.waitFor(() =>
+      expect(harness.sessionKeyStore.delete).toHaveBeenCalledWith(summary.sessionId),
+    );
+
+    harness.publish({
+      kind: "status",
+      sessionId: summary.sessionId,
       payload: { status: "ready" },
     });
     for (let index = 0; index < 4; index += 1) await Promise.resolve();


### PR DESCRIPTION
## Summary
- register Happy's encrypted `killSession` RPC and reuse the durable session-retirement path
- stop bridge liveness and fence the tracked session before acknowledging the mobile archive
- reject unauthenticated/decryption-failed kill payloads and keep repeated authenticated calls idempotent
- add one focused regression test for authentication, disposal order, exact-once provider termination, and no revival

Fixes #3213

## Audited network path
- Happy Archive action -> encrypted Socket.IO `rpc-call` on `/v1/updates`, method `{sessionId}:killSession`
- unchanged server fallback -> `POST /v1/sessions/{sessionId}/archive`
- local bridge teardown -> provider runtime JSON-RPC `provider_terminate`

The live Seren publisher catalog was checked in full. It contains no Happy/cluster-fluster publisher, so this feature has no Seren Gateway publisher path; it talks directly to Happy's hosted API. This PR adds no new outbound endpoint.

## Validation
- `pnpm vitest run tests/unit/happy-session-liveness.test.ts` (49 passed)
- `pnpm test` (2687 passed, 15 skipped)
- `pnpm check`
- `pnpm build`
- `pnpm build:provider-runtime`
- authoritative/generated Happy bridge bundle comparison
- `pnpm test:runtime-smoke`
- `pnpm prepare:mcp-servers && cargo test --locked --lib --manifest-path src-tauri/Cargo.toml` (997 passed, 2 ignored)

Live hosted-Happy/macOS walkthrough is intentionally pending until after PR creation, per the issue workflow. Only synthetic markers will be used; local paths, credentials, pairing payloads, and raw logs/screenshots will not be posted publicly.
