### PR TITLE
fix(happy): retry reset pairing polls

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -210,6 +210,10 @@ async function readAuthRequest(relayUrl, publicKey, signal) {
   return JSON.parse(response.body);
 }
 
+function isRetryableAuthPollError(error) {
+  return error && typeof error === "object" && error.code === "ECONNRESET";
+}
+
 function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
   return {
     host: config.machineName,
@@ -2496,7 +2500,16 @@ export function createHappyLayer({
         debug("pairing abandoned before authorization");
         return false;
       }
-      const result = await readAuthRequest(config.relayUrl, keyPair.publicKey, signal);
+      let result;
+      try {
+        result = await readAuthRequest(config.relayUrl, keyPair.publicKey, signal);
+      } catch (error) {
+        if (pairingCancelled || error?.name === "AbortError") throw error;
+        if (!isRetryableAuthPollError(error)) throw error;
+        debug("pairing authorization poll retrying after ECONNRESET");
+        await new Promise((resolve) => setTimeout(resolve, AUTH_POLL_MS));
+        continue;
+      }
       // Checked again after the round trip: an authorization that lands while
       // the user is dismissing the dialog must not be accepted.
       if (pairingCancelled) {

--- a/tests/unit/happy-pairing-shutdown.test.ts
+++ b/tests/unit/happy-pairing-shutdown.test.ts
@@ -22,6 +22,69 @@ afterEach(async () => {
 });
 
 describe("Happy pairing shutdown", () => {
+  it("retries a reset authorization poll with the same keypair", async () => {
+    const publicKeys: string[] = [];
+    let requestCount = 0;
+    let resolveRetryStarted: (() => void) | undefined;
+    const retryStarted = new Promise<void>((resolve) => {
+      resolveRetryStarted = resolve;
+    });
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        publicKeys.push(String(JSON.parse(body).publicKey));
+        requestCount += 1;
+        if (requestCount === 1) {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end("{}");
+          return;
+        }
+        if (requestCount === 2) {
+          request.socket.destroy();
+          return;
+        }
+        resolveRetryStarted?.();
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test server did not bind");
+    }
+
+    const layer = createHappyLayer({
+      config: {
+        machineIdentity: null,
+        machineName: "pairing-retry-test",
+        relayUrl: `http://127.0.0.1:${address.port}`,
+      },
+      source: {},
+      supervisorChannel: {
+        notify: () => {},
+        onNotification: () => () => {},
+      },
+    });
+
+    await layer.start();
+    try {
+      await Promise.race([
+        retryStarted,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("authorization poll was not retried")), 3_000),
+        ),
+      ]);
+      expect(requestCount).toBe(3);
+      expect(new Set(publicKeys)).toHaveLength(1);
+    } finally {
+      await layer.close();
+    }
+  });
+
   it("aborts the authorization request before close resolves", async () => {
     let requestCount = 0;
     let authorizationRequestClosed = false;


### PR DESCRIPTION
## Summary
- preserve the active Happy pairing keypair when an authorization poll receives `ECONNRESET`
- retry only that observed transient transport condition within the existing cancellation and five-minute timeout boundaries
- keep HTTP rejection, malformed response, abort, decryption, credential persistence, and machine registration failures terminal
- add one live-HTTP regression that resets a poll socket and proves the next poll reuses the same public key

Fixes #3231

## Audited network path
- QR creation and authorization polling -> `POST /v1/auth/request`
- official Happy server metadata returns `requested` or `authorized` from that route
- authorized identity -> local supervisor `identity_store`, then existing Happy machine registration

The live Seren publisher catalog was checked in full during the parent walkthrough. It contains no Happy/cluster-fluster publisher, so this path talks directly to Happy's hosted API. This PR adds no outbound endpoint or request field.

## Validation
- focused red/green live-HTTP regression (2 tests passed after fix)
- `pnpm test` (2688 passed, 15 skipped)
- `pnpm check` (passes; pre-existing warnings only)
- `pnpm build:provider-runtime`
- authoritative/generated Happy bridge bundle comparison
- `pnpm build`
- `pnpm test:runtime-smoke`
- `pnpm prepare:mcp-servers && cargo test --locked --lib --manifest-path src-tauri/Cargo.toml` (997 passed, 2 ignored)

## Evidence handling
Only the sanitized transport code is documented. No QR payload, credential, device/account identifier, filesystem path, raw log, or screenshot is included.
