### PR TITLE
feat(privacy): per-conversation Privileged Matter Mode

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -226,6 +226,7 @@ pub struct Conversation {
     pub project_root: Option<String>,
     pub is_archived: bool,
     pub employee_id: Option<String>,
+    #[serde(default)]
     pub privileged: bool,
     pub counsel_direction: Option<String>,
 }
@@ -244,6 +245,7 @@ pub struct AgentConversation {
     pub project_id: Option<String>,
     pub project_root: Option<String>,
     pub is_archived: bool,
+    #[serde(default)]
     pub privileged: bool,
     pub counsel_direction: Option<String>,
 }
@@ -306,6 +308,10 @@ pub struct UnifiedConversationRow {
     pub agent_permission_mode: Option<String>,
     pub agent_metadata: Option<String>,
     pub project_id: Option<String>,
+    // Older bridge/cache payloads predate Privileged Matter Mode. Treat an
+    // omitted value as non-privileged so rolling updates keep deserializing;
+    // the durable SQLite value is hydrated immediately after the read.
+    #[serde(default)]
     pub privileged: bool,
     pub counsel_direction: Option<String>,
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -6,7 +6,7 @@ use crate::happy_bridge::HappyBridgeManager;
 use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use crate::services::database::{
     DbPool, PersistedMessage, WalCheckpointMode, checkpoint_wal, enqueue_sync_tombstone, init_db,
-    mark_sync_upsert, save_message_record,
+    mark_sync_upsert, save_message_record, stamp_existing_privileged_messages,
 };
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,9 @@ use tauri::{AppHandle, Emitter, Manager};
 fn load_indexable_message_meta(
     conn: &Connection,
     conversation_id: &str,
-) -> rusqlite::Result<Option<(String, Option<String>, Option<String>, Option<String>, bool)>> {
+) -> rusqlite::Result<
+    Option<(String, Option<String>, Option<String>, Option<String>, bool, bool)>,
+> {
     let sql = format!(
         "SELECT {case} AS derived_kind,
                 c.title,
@@ -24,7 +26,8 @@ fn load_indexable_message_meta(
                      THEN COALESCE(c.agent_type, psr.provider)
                      ELSE c.agent_type END AS agent_type,
                 COALESCE(c.project_root, c.agent_cwd, c.project_id) AS project_root,
-                c.is_archived
+                c.is_archived,
+                c.privileged
          FROM conversations c
          LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
          WHERE c.id = ?1",
@@ -37,6 +40,7 @@ fn load_indexable_message_meta(
             row.get(2)?,
             row.get(3)?,
             row.get::<_, i32>(4)? != 0,
+            row.get::<_, i32>(5)? != 0,
         ))
     })
     .optional()
@@ -222,6 +226,8 @@ pub struct Conversation {
     pub project_root: Option<String>,
     pub is_archived: bool,
     pub employee_id: Option<String>,
+    pub privileged: bool,
+    pub counsel_direction: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -238,6 +244,8 @@ pub struct AgentConversation {
     pub project_id: Option<String>,
     pub project_root: Option<String>,
     pub is_archived: bool,
+    pub privileged: bool,
+    pub counsel_direction: Option<String>,
 }
 
 /// Exact desktop record required to restore a provider process for a persisted
@@ -298,6 +306,8 @@ pub struct UnifiedConversationRow {
     pub agent_permission_mode: Option<String>,
     pub agent_metadata: Option<String>,
     pub project_id: Option<String>,
+    pub privileged: bool,
+    pub counsel_direction: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -342,6 +352,8 @@ pub async fn create_conversation(
         project_root: normalized_project_root.clone(),
         is_archived: false,
         employee_id: employee_id.clone(),
+        privileged: false,
+        counsel_direction: None,
     };
 
     run_db(app, move |conn| {
@@ -409,7 +421,8 @@ pub async fn list_conversations(
                        c.project_root, c.selected_provider, c.selected_model,
                        c.employee_id, c.agent_type, c.agent_session_id,
                        c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
-                       c.agent_metadata, c.project_id, psr.provider AS runtime_provider,
+                       c.agent_metadata, c.project_id, c.privileged,
+                       c.counsel_direction, psr.provider AS runtime_provider,
                        {case} AS derived_kind
                 FROM conversations c
                 LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
@@ -423,7 +436,8 @@ pub async fn list_conversations(
                         THEN COALESCE(agent_type, runtime_provider)
                         ELSE agent_type END AS agent_type,
                    agent_session_id, agent_cwd, agent_model_id,
-                   agent_permission_mode, agent_metadata, project_id
+                   agent_permission_mode, agent_metadata, project_id,
+                   privileged, counsel_direction
             FROM derived
             WHERE is_archived = 0
               AND (?1 IS NULL OR derived_kind = ?1)
@@ -458,6 +472,8 @@ pub async fn list_conversations(
                     agent_permission_mode: row.get(13)?,
                     agent_metadata: row.get(14)?,
                     project_id: row.get(15)?,
+                    privileged: row.get::<_, i32>(16)? != 0,
+                    counsel_direction: row.get(17)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -478,7 +494,8 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                     CASE WHEN ({case}) = 'chat'
                          THEN COALESCE(c.selected_provider, psr.provider)
                          ELSE c.selected_provider END AS selected_provider,
-                    c.project_root, c.is_archived, c.employee_id
+                    c.project_root, c.is_archived, c.employee_id,
+                    c.privileged, c.counsel_direction
              FROM conversations c
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
              WHERE c.id = ?1
@@ -498,6 +515,8 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                     project_root: row.get(5)?,
                     is_archived: row.get::<_, i32>(6)? != 0,
                     employee_id: row.get(7)?,
+                    privileged: row.get::<_, i32>(8)? != 0,
+                    counsel_direction: row.get(9)?,
                 })
             })
             .optional()?;
@@ -543,6 +562,45 @@ pub async fn update_conversation(
     })
     .await?;
     refresh_conversation_index_meta_best_effort(app, index_id, index_title, None).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_conversation_privileged(
+    app: AppHandle,
+    id: String,
+    privileged: bool,
+    counsel_direction: Option<String>,
+) -> Result<(), String> {
+    let index_id = id.clone();
+    let normalized_direction = counsel_direction
+        .as_deref()
+        .map(str::trim)
+        .filter(|direction| !direction.is_empty())
+        .map(str::to_string);
+    run_db(app.clone(), move |conn| {
+        let changed = conn.execute(
+            "UPDATE conversations
+             SET privileged = ?1, counsel_direction = ?2
+             WHERE id = ?3",
+            params![i32::from(privileged), normalized_direction, id],
+        )?;
+        if changed == 0 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
+        if privileged {
+            stamp_existing_privileged_messages(conn, &id)?;
+        }
+        mark_sync_upsert(conn, "conversations", &id)?;
+        Ok(())
+    })
+    .await?;
+
+    // Remove chunks created before the flag was enabled. Subsequent message
+    // writes are also blocked by `IndexableMessage::is_privileged`.
+    if privileged {
+        delete_conversation_index_best_effort(&app, &index_id);
+    }
     Ok(())
 }
 
@@ -661,6 +719,8 @@ pub(crate) async fn create_agent_conversation_record(
         project_id: project_id.clone(),
         project_root: normalized_project_root.clone(),
         is_archived: false,
+        privileged: false,
+        counsel_direction: None,
     };
 
     let persisted_convo = convo.clone();
@@ -1416,7 +1476,8 @@ pub async fn get_agent_conversation(
                          ELSE c.agent_type END AS agent_type,
                     c.agent_session_id,
                     c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
-                    c.agent_metadata, c.project_id, c.project_root, c.is_archived
+                    c.agent_metadata, c.project_id, c.project_root, c.is_archived,
+                    c.privileged, c.counsel_direction
              FROM conversations c
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
              WHERE c.id = ?1
@@ -1440,6 +1501,8 @@ pub async fn get_agent_conversation(
                     project_id: row.get(9)?,
                     project_root: row.get(10)?,
                     is_archived: row.get::<_, i32>(11)? != 0,
+                    privileged: row.get::<_, i32>(12)? != 0,
+                    counsel_direction: row.get(13)?,
                 })
             })
             .optional()?;
@@ -1920,7 +1983,7 @@ pub async fn save_message(
         save_message_record(conn, &message)?;
         let meta = load_indexable_message_meta(conn, &message.conversation_id)?;
         Ok(meta.map(
-            |(kind, title, agent_type, project_root, is_archived)| IndexableMessage {
+            |(kind, title, agent_type, project_root, is_archived, is_privileged)| IndexableMessage {
                 message_id: message.id,
                 conversation_id: message.conversation_id,
                 kind,
@@ -1929,6 +1992,7 @@ pub async fn save_message(
                 agent_type,
                 project_root,
                 is_archived,
+                is_privileged,
                 timestamp: message.timestamp,
                 content: message.content,
             },
@@ -2694,6 +2758,8 @@ mod tests {
             project_id: None,
             project_root: None,
             is_archived: false,
+            privileged: false,
+            counsel_direction: None,
         };
         assert!(upsert_agent_conversation_in_db(&conn, &late).unwrap());
 
@@ -2833,6 +2899,8 @@ mod tests {
             project_id: Some("/synthetic/project".to_string()),
             project_root: Some("/synthetic/project".to_string()),
             is_archived: false,
+            privileged: false,
+            counsel_direction: None,
         };
 
         assert!(!upsert_agent_conversation_in_db(&conn, &conversation).unwrap());

--- a/src-tauri/src/commands/conversation_search.rs
+++ b/src-tauri/src/commands/conversation_search.rs
@@ -132,10 +132,11 @@ pub async fn backfill_conversation_fts(app: AppHandle) -> Result<usize, String> 
                          THEN COALESCE(c.agent_type, psr.provider)
                          ELSE c.agent_type END AS agent_type,
                     COALESCE(c.project_root, c.agent_cwd, c.project_id) AS project_root,
-                    c.is_archived, m.timestamp, m.content
+                    c.is_archived, c.privileged, m.timestamp, m.content
              FROM messages m
              JOIN conversations c ON c.id = m.conversation_id
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+             WHERE c.privileged = 0
              ORDER BY m.timestamp ASC",
             case = DERIVED_KIND_CASE_SQL,
         );
@@ -150,8 +151,9 @@ pub async fn backfill_conversation_fts(app: AppHandle) -> Result<usize, String> 
                 agent_type: row.get(5)?,
                 project_root: row.get(6)?,
                 is_archived: row.get::<_, i32>(7)? != 0,
-                timestamp: row.get(8)?,
-                content: row.get(9)?,
+                is_privileged: row.get::<_, i32>(8)? != 0,
+                timestamp: row.get(9)?,
+                content: row.get(10)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1107,6 +1107,7 @@ pub fn run() {
             commands::chat::list_conversations,
             commands::chat::get_conversation,
             commands::chat::update_conversation,
+            commands::chat::set_conversation_privileged,
             commands::chat::archive_conversation,
             commands::chat::delete_conversation,
             commands::chat::delete_conversations_by_employee,

--- a/src-tauri/src/services/conversation_index.rs
+++ b/src-tauri/src/services/conversation_index.rs
@@ -47,6 +47,10 @@ pub struct IndexableMessage {
     pub agent_type: Option<String>,
     pub project_root: Option<String>,
     pub is_archived: bool,
+    /// Privileged conversations must never create local search chunks. The
+    /// write path deletes any stale chunks before returning so a later edit or
+    /// backfill cannot resurrect searchable content.
+    pub is_privileged: bool,
     pub timestamp: i64,
     pub content: String,
 }
@@ -247,6 +251,10 @@ fn delete_message_chunks_tx(tx: &Connection, message_id: &str) -> Result<()> {
 pub fn reindex_message(conn: &Connection, msg: &IndexableMessage) -> Result<()> {
     let tx = conn.unchecked_transaction()?;
     delete_message_chunks_tx(&tx, &msg.message_id)?;
+    if msg.is_privileged {
+        tx.commit()?;
+        return Ok(());
+    }
     let chunks = chunk_message(&msg.content);
     let now = now_ms();
     for chunk in &chunks {
@@ -560,6 +568,7 @@ mod tests {
             },
             project_root: Some("/repo".into()),
             is_archived: false,
+            is_privileged: false,
             timestamp: 1000,
             content: content.to_string(),
         }
@@ -619,6 +628,26 @@ mod tests {
         let hits = search_fts(&conn, "release", &SearchFilters::default(), 10).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].message_id, "m1");
+    }
+
+    #[test]
+    fn privileged_conversation_does_not_create_conv_chunks() {
+        let conn = test_conn();
+        let mut privileged = msg(
+            "privileged-message",
+            "privileged-conversation",
+            "chat",
+            "user",
+            "privileged work product",
+        );
+        privileged.is_privileged = true;
+
+        reindex_message(&conn, &privileged).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM conv_chunks", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
     }
 
     #[test]

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -33,6 +33,12 @@ pub struct PersistedMessage {
     pub provider: Option<String>,
 }
 
+/// Durable designation applied to every message persisted for a Privileged
+/// Matter conversation. Keeping this at the database persistence chokepoint
+/// covers renderer, agent-runtime, and orchestrator writes alike.
+pub const PRIVILEGED_MATTER_STAMP: &str =
+    "Privileged & Confidential — Prepared in Anticipation of Litigation";
+
 pub const WAL_AUTOCHECKPOINT_PAGES: u32 = 200;
 const WAL_CHECKPOINT_INTERVAL_SECS: u64 = 10;
 
@@ -270,7 +276,63 @@ pub fn start_wal_checkpoint_task(app: &AppHandle) {
     }
 }
 
+fn stamp_privileged_message_metadata(
+    conn: &Connection,
+    conversation_id: &str,
+    metadata: &Option<String>,
+) -> Result<Option<String>> {
+    let privileged = conn
+        .query_row(
+            "SELECT privileged, counsel_direction FROM conversations WHERE id = ?1",
+            rusqlite::params![conversation_id],
+            |row| Ok((row.get::<_, i32>(0)? != 0, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+    let Some((true, counsel_direction)) = privileged else {
+        return Ok(metadata.clone());
+    };
+
+    let mut object = match metadata.as_deref() {
+        Some(raw) => match serde_json::from_str::<serde_json::Value>(raw) {
+            Ok(serde_json::Value::Object(object)) => object,
+            Ok(value) => {
+                let mut object = serde_json::Map::new();
+                object.insert("legacy_metadata".to_string(), value);
+                object
+            }
+            Err(_) => {
+                let mut object = serde_json::Map::new();
+                object.insert(
+                    "legacy_metadata_raw".to_string(),
+                    serde_json::Value::String(raw.to_string()),
+                );
+                object
+            }
+        },
+        None => serde_json::Map::new(),
+    };
+    object.insert(
+        "privileged_matter_stamp".to_string(),
+        serde_json::Value::String(PRIVILEGED_MATTER_STAMP.to_string()),
+    );
+    if let Some(direction) = counsel_direction
+        .as_deref()
+        .map(str::trim)
+        .filter(|direction| !direction.is_empty())
+    {
+        object.insert(
+            "counsel_direction".to_string(),
+            serde_json::Value::String(direction.to_string()),
+        );
+    }
+    serde_json::to_string(&serde_json::Value::Object(object))
+        .map(Some)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))
+}
+
 pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Result<()> {
+    let metadata =
+        stamp_privileged_message_metadata(conn, &message.conversation_id, &message.metadata)?;
     if let Err(err) = conn.execute(
         "INSERT INTO messages (
             id, conversation_id, role, content, model, timestamp, metadata,
@@ -295,7 +357,7 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
             message.content,
             message.model,
             message.timestamp,
-            message.metadata,
+            metadata.as_deref(),
             message.provider
         ],
     ) {
@@ -327,7 +389,7 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
             event_id,
             message.conversation_id,
             message.id,
-            message.metadata,
+            metadata.as_deref(),
             message.timestamp
         ],
     )?;
@@ -378,6 +440,38 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
         )?;
     }
 
+    Ok(())
+}
+
+/// Stamp messages that were already present when a conversation is switched
+/// into Privileged Matter Mode. Future writes flow through `save_message_record`;
+/// this closes the retroactive gap without duplicating stamp logic in callers.
+pub fn stamp_existing_privileged_messages(
+    conn: &Connection,
+    conversation_id: &str,
+) -> Result<()> {
+    let messages = {
+        let mut stmt = conn.prepare(
+            "SELECT id, metadata FROM messages
+             WHERE conversation_id = ?1 AND deleted_at IS NULL",
+        )?;
+        stmt.query_map(rusqlite::params![conversation_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })?
+        .collect::<Result<Vec<_>>>()?
+    };
+
+    for (message_id, previous_metadata) in messages {
+        let metadata =
+            stamp_privileged_message_metadata(conn, conversation_id, &previous_metadata)?;
+        if metadata != previous_metadata {
+            conn.execute(
+                "UPDATE messages SET metadata = ?1 WHERE id = ?2",
+                rusqlite::params![metadata, message_id],
+            )?;
+            mark_sync_upsert(conn, "messages", &message_id)?;
+        }
+    }
     Ok(())
 }
 
@@ -657,7 +751,9 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             agent_metadata TEXT,
             project_id TEXT,
             project_root TEXT,
-            employee_id TEXT
+            employee_id TEXT,
+            privileged INTEGER NOT NULL DEFAULT 0,
+            counsel_direction TEXT
         )",
         [],
     )?;
@@ -971,6 +1067,29 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
         .is_ok();
     if !has_employee_id {
         conn.execute("ALTER TABLE conversations ADD COLUMN employee_id TEXT", [])?;
+    }
+
+    // Privileged Matter Mode is persisted with the conversation so Rust-side
+    // index and message-stamping gates do not depend on renderer state. Each
+    // probe keeps this migration safe for both fresh and pre-existing DBs.
+    let has_privileged: bool = conn
+        .prepare("SELECT privileged FROM conversations LIMIT 1")
+        .is_ok();
+    if !has_privileged {
+        conn.execute(
+            "ALTER TABLE conversations ADD COLUMN privileged INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+
+    let has_counsel_direction: bool = conn
+        .prepare("SELECT counsel_direction FROM conversations LIMIT 1")
+        .is_ok();
+    if !has_counsel_direction {
+        conn.execute(
+            "ALTER TABLE conversations ADD COLUMN counsel_direction TEXT",
+            [],
+        )?;
     }
 
     // Backfill project context for existing agent conversations.
@@ -1442,6 +1561,100 @@ mod tests {
             )
             .unwrap();
         assert_eq!(event_count, 2);
+    }
+
+    #[test]
+    fn save_message_record_stamps_all_privileged_persistence_paths() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, privileged, counsel_direction)
+             VALUES ('privileged', 'Matter', 1000, 1, 'Counsel-directed review')",
+            [],
+        )
+        .unwrap();
+
+        save_message_record(
+            &conn,
+            &PersistedMessage {
+                id: "m-privileged".to_string(),
+                conversation_id: "privileged".to_string(),
+                role: "assistant".to_string(),
+                content: "work product".to_string(),
+                model: None,
+                timestamp: 2000,
+                metadata: Some(r#"{"origin":"orchestrator"}"#.to_string()),
+                provider: None,
+            },
+        )
+        .unwrap();
+
+        for table in ["messages", "message_events"] {
+            let metadata: String = conn
+                .query_row(
+                    &format!("SELECT metadata FROM {table} WHERE conversation_id = 'privileged'"),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+            assert_eq!(
+                metadata["privileged_matter_stamp"],
+                PRIVILEGED_MATTER_STAMP
+            );
+            assert_eq!(metadata["counsel_direction"], "Counsel-directed review");
+            assert_eq!(metadata["origin"], "orchestrator");
+        }
+    }
+
+    #[test]
+    fn marking_a_conversation_privileged_stamps_existing_messages() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at)
+             VALUES ('retroactive', 'Matter', 1000)",
+            [],
+        )
+        .unwrap();
+        save_message_record(
+            &conn,
+            &PersistedMessage {
+                id: "m-retroactive".to_string(),
+                conversation_id: "retroactive".to_string(),
+                role: "assistant".to_string(),
+                content: "existing work product".to_string(),
+                model: None,
+                timestamp: 2000,
+                metadata: Some(r#"{"origin":"before-toggle"}"#.to_string()),
+                provider: None,
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "UPDATE conversations
+             SET privileged = 1, counsel_direction = 'Counsel-directed review'
+             WHERE id = 'retroactive'",
+            [],
+        )
+        .unwrap();
+        stamp_existing_privileged_messages(&conn, "retroactive").unwrap();
+
+        let metadata: String = conn
+            .query_row(
+                "SELECT metadata FROM messages WHERE id = 'm-retroactive'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+        assert_eq!(
+            metadata["privileged_matter_stamp"],
+            PRIVILEGED_MATTER_STAMP
+        );
+        assert_eq!(metadata["counsel_direction"], "Counsel-directed review");
+        assert_eq!(metadata["origin"], "before-toggle");
     }
 
     #[test]
@@ -2386,6 +2599,64 @@ mod tests {
             )
             .unwrap();
         assert_eq!(mode, Some("plan".to_string()));
+    }
+
+    #[test]
+    fn migration_adds_privileged_matter_columns_to_pre_existing_db() {
+        // Start from the legacy schema shape before Privileged Matter Mode.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                selected_model TEXT,
+                selected_provider TEXT,
+                is_archived INTEGER DEFAULT 0,
+                kind TEXT NOT NULL DEFAULT 'chat',
+                agent_type TEXT,
+                agent_session_id TEXT,
+                agent_cwd TEXT,
+                agent_model_id TEXT,
+                agent_metadata TEXT,
+                project_id TEXT,
+                project_root TEXT
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                model TEXT,
+                timestamp INTEGER NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        setup_schema(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, privileged, counsel_direction)
+             VALUES ('p1', 'Privileged', 1000, 1, 'Counsel-directed review')",
+            [],
+        )
+        .unwrap();
+        let values: (i64, Option<String>) = conn
+            .query_row(
+                "SELECT privileged, counsel_direction FROM conversations WHERE id = 'p1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(values, (1, Some("Counsel-directed review".to_string())));
+
+        // Re-running setup remains idempotent once both columns exist.
+        setup_schema(&conn).unwrap();
     }
 
     #[test]

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -50,6 +50,10 @@ import {
   pickAndReadAttachments,
 } from "@/lib/images/attachments";
 import { scrollMessageIntoView } from "@/lib/message-scroll";
+import {
+  formatPrivilegedMatterStamp,
+  prependPrivilegedMatterStamp,
+} from "@/lib/privileged-matter";
 import type { Attachment } from "@/lib/providers/types";
 import {
   getModelDisplayName,
@@ -87,6 +91,7 @@ import {
 import { readDocument } from "@/services/docreader";
 import {
   type AgentType,
+  assertPrivilegedConversationProvider,
   type DiffEvent,
   launchLogin,
   supportsConversationFork,
@@ -95,6 +100,7 @@ import {
 import { skills } from "@/services/skills";
 import { type AgentMessage, agentStore } from "@/stores/agent.store";
 import { fileTreeState } from "@/stores/fileTree";
+import { privacyStore } from "@/stores/privacy.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
@@ -249,6 +255,24 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     if (thread?.kind !== "agent") return null;
     return thread;
   });
+  const isPrivilegedConversation = () =>
+    privacyStore.isPrivileged(activeAgentThread()?.id);
+  const counselDirection = () => {
+    const id = activeAgentThread()?.id;
+    return id
+      ? privacyStore.getConversationPrivacy(id).counselDirection
+      : undefined;
+  };
+  const assertPrivilegedThreadProvider = () => {
+    const thread = activeAgentThread();
+    if (!thread) return;
+    assertPrivilegedConversationProvider(
+      thread.id,
+      privacyStore.isPrivileged(thread.id),
+      thread.agentType,
+      { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+    );
+  };
 
   // Per-thread composer draft (#1631) — persisted to SQLite so an app crash
   // before submit doesn't lose the user's typed text. Write is debounced to
@@ -706,6 +730,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       return;
     }
     try {
+      assertPrivilegedThreadProvider();
+    } catch (error) {
+      setCommandStatus(error instanceof Error ? error.message : String(error));
+      setTimeout(() => setCommandStatus(null), 5000);
+      return;
+    }
+    try {
       const sessionId = await agentStore.resumeAgentConversation(thread.id);
       verboseRuntimeConsole.debug("[AgentChat] Session resumed:", sessionId);
     } catch (error) {
@@ -780,9 +811,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       return;
     }
 
-    const markdown = formatChatHistoryMarkdown(messages, {
-      header: "# Agent Chat History",
-    });
+    const markdown = isPrivilegedConversation()
+      ? prependPrivilegedMatterStamp(
+          formatChatHistoryMarkdown(messages, {
+            header: "# Agent Chat History",
+          }),
+          counselDirection(),
+        )
+      : formatChatHistoryMarkdown(messages, {
+          header: "# Agent Chat History",
+        });
 
     try {
       await navigator.clipboard.writeText(markdown);
@@ -797,6 +835,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   const downloadChatHistory = async () => {
     if (isSaving()) return;
+    if (isPrivilegedConversation()) {
+      alert("Cloud Notes export is disabled for Privileged Matter Mode.");
+      return;
+    }
     const messages = threadMessages();
     if (!hasExportableMessages(messages)) return;
 
@@ -894,6 +936,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     // bubble + dots appear before the first stream chunk arrives. Resuming
     // preserves persisted history and provider context after Login → Dismiss.
     const thread = activeAgentThread();
+    try {
+      assertPrivilegedThreadProvider();
+    } catch (error) {
+      setCommandStatus(error instanceof Error ? error.message : String(error));
+      setTimeout(() => setCommandStatus(null), 5000);
+      return;
+    }
     if (!hasSession()) {
       if (!trimmed) {
         console.warn(
@@ -1681,6 +1730,22 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       {/* Plan Header */}
       <PlanHeader />
 
+      <Show when={isPrivilegedConversation()}>
+        <aside
+          class="shrink-0 border-b border-amber-400/30 bg-[linear-gradient(110deg,rgba(180,116,27,0.18),rgba(45,29,12,0.42))] px-4 py-2.5 text-amber-100"
+          data-testid="privileged-matter-banner"
+          aria-label="Privileged Matter Mode enabled"
+        >
+          <p class="m-0 text-xs font-semibold tracking-wide">
+            {formatPrivilegedMatterStamp(counselDirection())}
+          </p>
+          <p class="m-0 mt-1 text-[11px] leading-relaxed text-amber-100/75">
+            Memory, history sync, cloud Notes export, local search indexing, and
+            non-local providers are blocked for this conversation.
+          </p>
+        </aside>
+      </Show>
+
       {/* Paired workflow header — thread title + compact active stage (#2368) */}
       <Show when={isPairedThread()}>
         <div
@@ -1748,8 +1813,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             type="button"
             class="bg-transparent border border-border text-muted-foreground p-1.5 rounded text-xs cursor-pointer transition-all hover:bg-surface-2 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={downloadChatHistory}
-            disabled={isSaving()}
-            title="Download chat history"
+            disabled={isSaving() || isPrivilegedConversation()}
+            title={
+              isPrivilegedConversation()
+                ? "Cloud Notes export is disabled for Privileged Matter Mode"
+                : "Download chat history"
+            }
           >
             <svg
               class="w-3.5 h-3.5"

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -51,6 +51,10 @@ import { pickAndReadAttachments } from "@/lib/images/attachments";
 import { scrollMessageIntoView } from "@/lib/message-scroll";
 import { isPaymentError } from "@/lib/payment-errors";
 import {
+  formatPrivilegedMatterStamp,
+  prependPrivilegedMatterStamp,
+} from "@/lib/privileged-matter";
+import {
   computeProviderBoundaries,
   providerDisplayName,
 } from "@/lib/provider-boundaries";
@@ -98,12 +102,14 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
+import { assertPrivilegedConversationProvider } from "@/services/providers";
 import { skills } from "@/services/skills";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { editorStore } from "@/stores/editor.store";
 import { fileTreeState } from "@/stores/fileTree";
+import { privacyStore } from "@/stores/privacy.store";
 import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
@@ -225,6 +231,21 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
   );
   const conversationId = () =>
     props.threadId ?? conversationStore.activeConversationId;
+  const isPrivilegedConversation = () => {
+    const id = conversationId();
+    return (
+      privacyStore.isPrivileged(id) ||
+      conversationStore.conversations.find(
+        (conversation) => conversation.id === id,
+      )?.privileged === true
+    );
+  };
+  const counselDirection = () => {
+    const id = conversationId();
+    return id
+      ? privacyStore.getConversationPrivacy(id).counselDirection
+      : undefined;
+  };
   const clearRecordedSession = () => {
     releaseRecordedSessionArtifacts?.();
     releaseRecordedSessionArtifacts = undefined;
@@ -1143,6 +1164,20 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       return;
     }
 
+    try {
+      assertPrivilegedConversationProvider(
+        id,
+        isPrivilegedConversation(),
+        activeThreadProvider(),
+        { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+      );
+    } catch (error) {
+      conversationStore.setError(
+        error instanceof Error ? error.message : String(error),
+      );
+      return;
+    }
+
     // Set loading synchronously before any await. orchestrate() also sets
     // this, but only after we yield on persistMessage — a window wide
     // enough for a fast user submission to slip past `conversationIsLoading()`
@@ -1244,6 +1279,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       const retryProvider =
         (activeConvo?.selectedProvider as ProviderId | undefined) ??
         providerStore.activeProvider;
+      assertPrivilegedConversationProvider(
+        id,
+        isPrivilegedConversation(),
+        retryProvider,
+        { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+      );
       const content = await sendMessageWithRetry(
         message.request.prompt,
         message.modelId ?? chatStore.selectedModel,
@@ -1312,7 +1353,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       return;
     }
 
-    const markdown = formatChatHistoryMarkdown(messages);
+    const markdown = isPrivilegedConversation()
+      ? prependPrivilegedMatterStamp(
+          formatChatHistoryMarkdown(messages),
+          counselDirection(),
+        )
+      : formatChatHistoryMarkdown(messages);
 
     try {
       await navigator.clipboard.writeText(markdown);
@@ -1327,6 +1373,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
 
   const downloadChatHistory = async () => {
     if (isSaving()) return;
+    if (isPrivilegedConversation()) {
+      alert("Cloud Notes export is disabled for Privileged Matter Mode.");
+      return;
+    }
     const messages = conversationMessages();
     if (!hasExportableMessages(messages)) return;
 
@@ -1470,8 +1520,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 type="button"
                 class="bg-transparent border border-border text-muted-foreground p-1.5 rounded text-xs cursor-pointer transition-all hover:bg-surface-2 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={downloadChatHistory}
-                disabled={isSaving()}
-                title="Download chat history"
+                disabled={isSaving() || isPrivilegedConversation()}
+                title={
+                  isPrivilegedConversation()
+                    ? "Cloud Notes export is disabled for Privileged Matter Mode"
+                    : "Download chat history"
+                }
               >
                 <svg
                   class="w-3.5 h-3.5"
@@ -1515,6 +1569,22 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
             </div>
           </div>
         </header>
+
+        <Show when={isPrivilegedConversation()}>
+          <aside
+            class="shrink-0 border-b border-amber-400/30 bg-[linear-gradient(110deg,rgba(180,116,27,0.18),rgba(45,29,12,0.42))] px-4 py-2.5 text-amber-100"
+            data-testid="privileged-matter-banner"
+            aria-label="Privileged Matter Mode enabled"
+          >
+            <p class="m-0 text-xs font-semibold tracking-wide">
+              {formatPrivilegedMatterStamp(counselDirection())}
+            </p>
+            <p class="m-0 mt-1 text-[11px] leading-relaxed text-amber-100/75">
+              Memory, history sync, cloud Notes export, local search indexing,
+              and non-local providers are blocked for this conversation.
+            </p>
+          </aside>
+        </Show>
 
         <div
           class="flex-1 min-h-0 overflow-y-auto pb-4 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-surface-2 [&::-webkit-scrollbar-thumb]:rounded"

--- a/src/components/chat/DataDestinationsPanel.tsx
+++ b/src/components/chat/DataDestinationsPanel.tsx
@@ -29,6 +29,15 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
 
   const destinationState = createMemo<Destination[]>(() => [
     {
+      label: "Privileged Matter Mode",
+      detail: () =>
+        privacyStore.isPrivileged(props.conversationId)
+          ? "Memory, history sync, cloud Notes export, and non-local providers are blocked"
+          : "Off — turn it on only for counsel-directed work product",
+      control: "Conversation controls",
+      enabled: () => privacyStore.isPrivileged(props.conversationId),
+    },
+    {
       label: "Inference provider",
       detail: () => {
         const provider = conversation()?.provider ?? "selected provider";
@@ -111,6 +120,20 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
     privacyStore.setConversationPrivacy(id, { [key]: checked });
   };
 
+  const updatePrivileged = (checked: boolean) => {
+    const id = props.conversationId;
+    if (!id) return;
+    privacyStore.setConversationPrivacy(id, { privileged: checked });
+  };
+
+  const updateCounselDirection = (value: string) => {
+    const id = props.conversationId;
+    if (!id) return;
+    privacyStore.setConversationPrivacy(id, {
+      counselDirection: value.trim() || undefined,
+    });
+  };
+
   return (
     <section
       class="w-full max-w-[560px] overflow-hidden rounded-xl border border-[#293438] bg-[#101719] text-[#e8f0ef] shadow-[0_18px_50px_rgba(0,0,0,0.24)]"
@@ -178,11 +201,57 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
             Conversation controls
           </p>
           <div class="mt-2 grid gap-2 sm:grid-cols-2">
+            <div class="sm:col-span-2 rounded-lg border border-[#805f35] bg-[linear-gradient(110deg,rgba(171,117,49,0.17),rgba(28,23,18,0.5))] px-3 py-2.5 shadow-[inset_3px_0_0_rgba(220,171,95,0.8)]">
+              <label class="flex cursor-pointer items-start gap-2">
+                <input
+                  type="checkbox"
+                  class="mt-0.5 accent-[#dcae66]"
+                  checked={privacyStore.isPrivileged(props.conversationId)}
+                  onChange={(event) =>
+                    updatePrivileged(event.currentTarget.checked)
+                  }
+                  aria-label="Enable Privileged Matter Mode"
+                />
+                <span class="min-w-0">
+                  <span class="block text-xs font-semibold text-[#f3d6a1]">
+                    Privileged Matter Mode
+                  </span>
+                  <span class="mt-0.5 block text-[11px] leading-relaxed text-[#cbb89a]">
+                    Applies a privileged-and-confidential stamp and blocks
+                    memory, history sync, cloud Notes export, local search
+                    indexing, and providers that are not explicitly
+                    confidential-safe.
+                  </span>
+                </span>
+              </label>
+              <Show when={privacyStore.isPrivileged(props.conversationId)}>
+                <label class="mt-2 block">
+                  <span class="block text-[10px] font-semibold uppercase tracking-[0.12em] text-[#cbb89a]">
+                    Counsel direction (optional)
+                  </span>
+                  <input
+                    type="text"
+                    class="mt-1 w-full rounded border border-[#805f35] bg-[#15110d] px-2.5 py-1.5 text-xs text-[#f3e7d4] outline-none placeholder:text-[#8a7963] focus:border-[#dcae66]"
+                    value={
+                      privacyStore.getConversationPrivacy(
+                        props.conversationId ?? "",
+                      ).counselDirection ?? ""
+                    }
+                    placeholder="e.g. Counsel-directed review"
+                    onChange={(event) =>
+                      updateCounselDirection(event.currentTarget.value)
+                    }
+                    aria-label="Counsel direction"
+                  />
+                </label>
+              </Show>
+            </div>
             <label class="flex cursor-pointer items-start gap-2 rounded-lg border border-[#293438] px-3 py-2 transition-colors hover:border-[#4a6a5e]">
               <input
                 type="checkbox"
-                class="mt-0.5 accent-[#76ddb0]"
+                class="mt-0.5 accent-[#76ddb0] disabled:cursor-not-allowed"
                 checked={privacyStore.isMemoryExcluded(props.conversationId)}
+                disabled={privacyStore.isPrivileged(props.conversationId)}
                 onChange={(event) =>
                   updatePrivacy("excludeMemory", event.currentTarget.checked)
                 }
@@ -195,10 +264,11 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
             <label class="flex cursor-pointer items-start gap-2 rounded-lg border border-[#293438] px-3 py-2 transition-colors hover:border-[#4a6a5e]">
               <input
                 type="checkbox"
-                class="mt-0.5 accent-[#76ddb0]"
+                class="mt-0.5 accent-[#76ddb0] disabled:cursor-not-allowed"
                 checked={privacyStore.isHistorySyncExcluded(
                   props.conversationId,
                 )}
+                disabled={privacyStore.isPrivileged(props.conversationId)}
                 onChange={(event) =>
                   updatePrivacy(
                     "excludeHistorySync",
@@ -214,7 +284,8 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
           </div>
           <p class="m-0 mt-2 text-[10px] leading-relaxed text-[#71817e]">
             Exclusion takes effect before the next capture or sync drain; queued
-            history remains local until you include it again.
+            history remains local until you include it again. Privileged Matter
+            Mode locks both exclusions on for this conversation.
           </p>
         </div>
       </Show>

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -29,14 +29,19 @@ import {
   type SwitchBlockedReason,
   switchChatProvider,
 } from "@/services/provider-bindings";
-import type { AgentType } from "@/services/providers";
+import {
+  type AgentType,
+  isConfidentialSafeProvider,
+} from "@/services/providers";
 import { agentDisplayName, agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import type { Conversation as ChatConversation } from "@/stores/chat.store";
 import { chatStore } from "@/stores/chat.store";
 import type { Conversation as StoreConversation } from "@/stores/conversation.store";
 import { conversationStore } from "@/stores/conversation.store";
+import { privacyStore } from "@/stores/privacy.store";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
+import { settingsStore } from "@/stores/settings.store";
 
 interface ModelSelectorProps {
   threadId?: string | null;
@@ -69,6 +74,29 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
     props.threadId ??
     conversationStore.activeConversationId ??
     chatStore.activeConversationId;
+  const isPrivilegedConversation = () => {
+    const id = activeThreadId();
+    return (
+      privacyStore.isPrivileged(id) ||
+      conversationStore.conversations.find(
+        (conversation) => conversation.id === id,
+      )?.privileged === true ||
+      chatStore.conversations.find((conversation) => conversation.id === id)
+        ?.privileged === true
+    );
+  };
+  const isProviderAllowedForConversation = (providerId: string) =>
+    !isPrivilegedConversation() ||
+    isConfidentialSafeProvider(providerId, {
+      lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl"),
+    });
+  const privilegedProviderMessage =
+    "Privileged Matter Mode only permits LM Studio on a local loopback endpoint.";
+  const rejectUnsafeProvider = (providerId: string): boolean => {
+    if (isProviderAllowedForConversation(providerId)) return false;
+    conversationStore.setError(privilegedProviderMessage);
+    return true;
+  };
   const activeConversation = (): PickerConversation | null => {
     const id = activeThreadId();
     if (!id) return null;
@@ -297,6 +325,10 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
   const selectModel = (modelId: string) => {
     const conversationId = activeThreadId();
     const targetProvider = currentProvider();
+    if (rejectUnsafeProvider(targetProvider)) {
+      setIsOpen(false);
+      return;
+    }
     if (!conversationId) {
       providerStore.setActiveProvider(targetProvider);
       providerStore.setActiveModel(modelId);
@@ -330,6 +362,7 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
    * fetched asynchronously (clicking the chip triggers the load).
    */
   const selectProvider = (providerId: ProviderId) => {
+    if (rejectUnsafeProvider(providerId)) return;
     setDraftProvider(providerId);
     setSearchQuery("");
   };
@@ -350,6 +383,7 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
       );
       return;
     }
+    if (rejectUnsafeProvider(agentType)) return;
 
     const blocked = evaluateChatSwitchGuard(conversationId);
     if (blocked) {
@@ -469,7 +503,8 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                   <button
                     type="button"
                     aria-pressed={providerId === currentProvider()}
-                    class="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs cursor-pointer transition-colors no-underline border"
+                    disabled={!isProviderAllowedForConversation(providerId)}
+                    class="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs cursor-pointer transition-colors no-underline border disabled:cursor-not-allowed disabled:opacity-45"
                     classList={{
                       "bg-primary text-primary-foreground border-primary font-medium":
                         providerId === currentProvider(),
@@ -477,7 +512,11 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                         providerId !== currentProvider(),
                     }}
                     onClick={() => selectProvider(providerId)}
-                    title={PROVIDER_CONFIGS[providerId].name}
+                    title={
+                      isProviderAllowedForConversation(providerId)
+                        ? PROVIDER_CONFIGS[providerId].name
+                        : privilegedProviderMessage
+                    }
                   >
                     <ProviderIcon provider={providerId} size={14} />
                     <span class="whitespace-nowrap">
@@ -488,6 +527,13 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
               )}
             </For>
           </div>
+
+          <Show when={isPrivilegedConversation()}>
+            <p class="m-0 border-b border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-200/80">
+              Privileged Matter Mode restricts this conversation to local LM
+              Studio. Remote chat providers are intentionally unavailable.
+            </p>
+          </Show>
 
           {/* External-agent rail: clicking switches the active thread to a
               native-agent provider. The cross-category machinery in
@@ -512,9 +558,14 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                   <Show when={agent.available}>
                     <button
                       type="button"
-                      class="flex items-center gap-1 px-2.5 py-1.5 bg-transparent border border-transparent rounded text-xs text-muted-foreground cursor-pointer transition-all no-underline hover:bg-border hover:text-foreground"
+                      disabled={!isProviderAllowedForConversation(agent.type)}
+                      class="flex items-center gap-1 px-2.5 py-1.5 bg-transparent border border-transparent rounded text-xs text-muted-foreground cursor-pointer transition-all no-underline hover:bg-border hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
                       onClick={() => selectAgentProvider(agent.type)}
-                      title={`Switch to ${agentDisplayName(agent.type)} — opens an external agent session for this thread`}
+                      title={
+                        isProviderAllowedForConversation(agent.type)
+                          ? `Switch to ${agentDisplayName(agent.type)} — opens an external agent session for this thread`
+                          : privilegedProviderMessage
+                      }
                     >
                       <ProviderIcon provider={agent.type} size={14} />
                       <span class="max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap">
@@ -533,7 +584,8 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
             <Show when={!isPrivateChat() && !searchQuery()}>
               <button
                 type="button"
-                class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border border-b border-b-surface-3 ${committedAutoModel() ? "bg-success/15" : ""}`}
+                disabled={!isProviderAllowedForConversation(currentProvider())}
+                class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border border-b border-b-surface-3 disabled:cursor-not-allowed disabled:opacity-45 ${committedAutoModel() ? "bg-success/15" : ""}`}
                 onClick={() => selectModel(AUTO_MODEL_ID)}
               >
                 <div class="flex flex-col gap-0.5 min-w-0 flex-1">
@@ -567,7 +619,10 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                 {(model) => (
                   <button
                     type="button"
-                    class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border ${model.id === committedModel() ? "bg-primary/[0.12]" : ""}`}
+                    disabled={
+                      !isProviderAllowedForConversation(currentProvider())
+                    }
+                    class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border disabled:cursor-not-allowed disabled:opacity-45 ${model.id === committedModel() ? "bg-primary/[0.12]" : ""}`}
                     onClick={() => selectModel(model.id)}
                   >
                     <div class="flex flex-col gap-0.5 min-w-0 flex-1">

--- a/src/lib/privileged-matter.ts
+++ b/src/lib/privileged-matter.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Shared presentation helpers for the per-conversation Privileged Matter Mode.
+// ABOUTME: Keeps the user-visible stamp identical across chat, agent, and export surfaces.
+
+export const PRIVILEGED_MATTER_STAMP =
+  "Privileged & Confidential — Prepared in Anticipation of Litigation";
+
+export function formatPrivilegedMatterStamp(
+  counselDirection?: string | null,
+): string {
+  const direction = counselDirection?.trim();
+  return direction
+    ? `${PRIVILEGED_MATTER_STAMP}\nCounsel direction: ${direction}`
+    : PRIVILEGED_MATTER_STAMP;
+}
+
+/** Prefix allowed local exports so the work-product designation travels with them. */
+export function prependPrivilegedMatterStamp(
+  content: string,
+  counselDirection?: string | null,
+): string {
+  return `${formatPrivilegedMatterStamp(counselDirection)}\n\n---\n\n${content}`;
+}

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -675,6 +675,8 @@ export interface Conversation {
   project_root: string | null;
   is_archived: boolean;
   employee_id: string | null;
+  privileged: boolean;
+  counsel_direction: string | null;
 }
 
 /**
@@ -699,6 +701,8 @@ export interface AgentConversation {
   project_id: string | null;
   project_root: string | null;
   is_archived: boolean;
+  privileged: boolean;
+  counsel_direction: string | null;
 }
 
 /**
@@ -724,6 +728,8 @@ export interface UnifiedConversationRow {
   agent_permission_mode: string | null;
   agent_metadata: string | null;
   project_id: string | null;
+  privileged: boolean;
+  counsel_direction: string | null;
 }
 
 /**
@@ -823,6 +829,26 @@ export async function updateConversation(
     title,
     selectedModel,
     selectedProvider,
+  });
+}
+
+/**
+ * Persist Privileged Matter Mode so Rust-side indexing and metadata gates
+ * remain active even if renderer state is restarted.
+ */
+export async function setConversationPrivileged(
+  id: string,
+  privileged: boolean,
+  counselDirection?: string | null,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  await invoke("set_conversation_privileged", {
+    id,
+    privileged,
+    counselDirection: counselDirection ?? null,
   });
 }
 

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -40,11 +40,13 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
+import { assertPrivilegedConversationProvider } from "@/services/providers";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { fileTreeState } from "@/stores/fileTree";
+import { privacyStore } from "@/stores/privacy.store";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
@@ -192,6 +194,32 @@ export async function orchestrate(
   prompt: string,
   images?: Attachment[],
 ): Promise<void> {
+  const conv = conversationStore.conversations.find(
+    (c) => c.id === conversationId,
+  );
+  const isPrivilegedConversation =
+    conv?.privileged === true || privacyStore.isPrivileged(conversationId);
+  // Privileged Matter Mode must be checked before either the employee-cloud
+  // escape hatch or the normal provider route has a chance to receive prompt
+  // content. Unknown and remote providers fail closed here.
+  const selectedProvider = conv?.employeeId
+    ? "organization-cloud-run"
+    : ((conv?.selectedProvider as string | undefined) ??
+      providerStore.activeProvider);
+  try {
+    assertPrivilegedConversationProvider(
+      conversationId,
+      isPrivilegedConversation,
+      selectedProvider,
+      { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+    );
+  } catch (error) {
+    conversationStore.setError(
+      error instanceof Error ? error.message : String(error),
+    );
+    return;
+  }
+
   // Show loading indicator immediately so the user sees feedback right
   // after hitting Enter — before history, memory, and skill context load.
   conversationStore.setLoading(true, conversationId);
@@ -208,9 +236,6 @@ export async function orchestrate(
   // agent owns its own system_prompt, model_policy, tool_presets, and
   // approval policy - we just hand it the user message and surface the
   // reply.
-  const conv = conversationStore.conversations.find(
-    (c) => c.id === conversationId,
-  );
   if (conv?.employeeId) {
     await runEmployeeTurn(conversationId, conv.employeeId, prompt);
     return;
@@ -235,7 +260,12 @@ export async function orchestrate(
 
   let answerMemory: UnifiedMessage["memory"] | undefined;
   // Inject typed memory context for the default orchestrator path.
-  if (settingsStore.get("memoryEnabled") && authStore.isAuthenticated) {
+  if (
+    !isPrivilegedConversation &&
+    !privacyStore.isMemoryExcluded(conversationId) &&
+    settingsStore.get("memoryEnabled") &&
+    authStore.isAuthenticated
+  ) {
     try {
       const memoryContext = await bootstrapMemoryContextDetails();
       if (memoryContext?.prompt) {
@@ -271,8 +301,7 @@ export async function orchestrate(
   // on another. Threads with no recorded selection fall back to the
   // user's globally-active default.
   await skillsStore.ensureContextLoaded(fileTreeState.rootPath, conversationId);
-  const threadProvider = ((conv?.selectedProvider as ProviderId | undefined) ??
-    providerStore.activeProvider) as ProviderId;
+  const threadProvider = selectedProvider as ProviderId;
   const threadModel = conv?.selectedModel ?? providerStore.activeModel;
   const capabilities = buildCapabilities(
     conversationId,

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -33,6 +33,70 @@ export type AgentType =
   | "lmstudio";
 export type UnlistenFn = () => void;
 
+/**
+ * Explicit P0 allowlist for Privileged Matter Mode. Unknown providers are
+ * denied rather than inferred safe from a display name or marketing claim.
+ */
+export const CONFIDENTIAL_SAFE_PROVIDERS = [
+  // LM Studio is a local process only when its configured endpoint resolves to
+  // loopback. The settings UI also permits remote URLs, so the runtime check in
+  // `isConfidentialSafeProvider` is required in addition to this static entry.
+  "lmstudio",
+] as const;
+
+type ConfidentialSafeProvider = (typeof CONFIDENTIAL_SAFE_PROVIDERS)[number];
+
+export interface ConfidentialProviderOptions {
+  lmStudioBaseUrl?: string | null;
+}
+
+function isLoopbackUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl.trim()).hostname.toLowerCase();
+    return ["localhost", "localhost.", "127.0.0.1", "::1", "[::1]"].includes(
+      hostname,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true only for an explicitly reviewed provider in a configuration
+ * that keeps inference on the user's device. This remains intentionally
+ * static until a registry can provide verifiable retention and training terms.
+ */
+export function isConfidentialSafeProvider(
+  providerId: string | null | undefined,
+  options: ConfidentialProviderOptions = {},
+): providerId is ConfidentialSafeProvider {
+  if (
+    !providerId ||
+    !CONFIDENTIAL_SAFE_PROVIDERS.includes(
+      providerId as ConfidentialSafeProvider,
+    )
+  ) {
+    return false;
+  }
+  if (providerId === "lmstudio") {
+    return isLoopbackUrl(options.lmStudioBaseUrl ?? "http://localhost:1234");
+  }
+  return false;
+}
+
+/** Throw before a privileged conversation crosses a provider boundary. */
+export function assertPrivilegedConversationProvider(
+  conversationId: string,
+  privileged: boolean,
+  providerId: string | null | undefined,
+  options: ConfidentialProviderOptions = {},
+): void {
+  if (!privileged || isConfidentialSafeProvider(providerId, options)) return;
+  throw new Error(
+    `Privileged Matter Mode blocks ${providerId ?? "this provider"} for conversation ${conversationId}. Choose a local LM Studio endpoint instead.`,
+  );
+}
+
 export type ProviderOrigin = "desktop" | "remote";
 
 /** Roles inside a paired `claude-codex` thread (#2368). */

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -672,6 +672,7 @@ import {
   oauthConnectionsRevision,
   oauthSelectionsRevision,
 } from "@/stores/oauth-account.store";
+import { privacyStore } from "@/stores/privacy.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -2279,6 +2280,8 @@ function unifiedRowToAgent(row: UnifiedConversationRow): DbAgentConversation {
     project_id: row.project_id,
     project_root: row.project_root,
     is_archived: row.is_archived,
+    privileged: row.privileged,
+    counsel_direction: row.counsel_direction,
   };
 }
 
@@ -3507,9 +3510,17 @@ export const agentStore = {
         projectRoot: cwd,
         limit,
       });
+      const agentConversations = rows.map(unifiedRowToAgent);
+      for (const conversation of agentConversations) {
+        privacyStore.hydrateConversationPrivilege(
+          conversation.id,
+          conversation.privileged,
+          conversation.counsel_direction,
+        );
+      }
       setState(
         "recentAgentConversations",
-        happyArchiveFence.filterVisible(rows.map(unifiedRowToAgent)),
+        happyArchiveFence.filterVisible(agentConversations),
       );
     } catch (error) {
       console.error("Failed to load agent conversation history:", error);
@@ -3536,6 +3547,11 @@ export const agentStore = {
    */
   upsertAgentConversationFromDb(row: DbAgentConversation) {
     if (happyArchiveFence.isArchived(row.id)) return;
+    privacyStore.hydrateConversationPrivilege(
+      row.id,
+      row.privileged,
+      row.counsel_direction,
+    );
     setState("recentAgentConversations", (rows) => {
       const without = rows.filter((r) => r.id !== row.id);
       return [row, ...without];
@@ -3559,6 +3575,14 @@ export const agentStore = {
       const localRows = happyArchiveFence.filterVisible(
         rawLocalRows.map(unifiedRowToAgent),
       );
+
+      for (const conversation of localRows) {
+        privacyStore.hydrateConversationPrivilege(
+          conversation.id,
+          conversation.privileged,
+          conversation.counsel_direction,
+        );
+      }
 
       setState("recentAgentConversations", localRows);
       const titleOverrides = new Map(
@@ -3665,6 +3689,17 @@ export const agentStore = {
     // lease is created. Providers echo this id back as their session handle,
     // which lets one teardown path revoke the exact key used by the child.
     const localSessionId = opts?.localSessionId ?? crypto.randomUUID();
+    try {
+      providerService.assertPrivilegedConversationProvider(
+        localSessionId,
+        privacyStore.isPrivileged(localSessionId),
+        resolvedAgentType,
+        { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+      );
+    } catch (error) {
+      setState("error", error instanceof Error ? error.message : String(error));
+      return null;
+    }
     const resumeAgentSessionId = opts?.resumeAgentSessionId;
     const happyArchiveOwnerConversationId =
       opts?.archiveOwnerConversationId ?? localSessionId;
@@ -3732,7 +3767,10 @@ export const agentStore = {
       // spawns including post-compaction spawns. Best-effort; a failure here
       // must not block the spawn (#1625).
       let memoryContext: string | undefined;
-      if (settingsStore.settings.memoryEnabled) {
+      if (
+        settingsStore.settings.memoryEnabled &&
+        !privacyStore.isMemoryExcluded(localSessionId)
+      ) {
         try {
           const bootstrapped = await bootstrapMemoryContext();
           if (bootstrapped && bootstrapped.trim().length > 0) {
@@ -4630,6 +4668,27 @@ export const agentStore = {
       } catch {
         // Non-fatal — the runtime is the source of truth for the live session.
       }
+      if (convo?.privileged) {
+        privacyStore.hydrateConversationPrivilege(
+          convo.id,
+          true,
+          convo.counsel_direction,
+        );
+        try {
+          providerService.assertPrivilegedConversationProvider(
+            conversationId,
+            true,
+            liveInfo.agentType,
+            { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+          );
+        } catch (error) {
+          setState(
+            "error",
+            error instanceof Error ? error.message : String(error),
+          );
+          return false;
+        }
+      }
       const agentType = liveInfo.agentType;
       const runtimeModelId =
         liveInfo.currentModelId ?? convo?.agent_model_id ?? undefined;
@@ -4857,6 +4916,11 @@ export const agentStore = {
       setState("error", "Agent conversation not found");
       return null;
     }
+    privacyStore.hydrateConversationPrivilege(
+      convo.id,
+      convo.privileged,
+      convo.counsel_direction,
+    );
     const agentType: AgentType =
       convo.agent_type === "codex" ||
       convo.agent_type === "claude-code" ||
@@ -5141,7 +5205,11 @@ export const agentStore = {
       ];
     }
 
-    if (settingsStore.settings.memoryEnabled && promptForBudget?.trim()) {
+    if (
+      settingsStore.settings.memoryEnabled &&
+      !privacyStore.isMemoryExcluded(session.conversationId) &&
+      promptForBudget?.trim()
+    ) {
       try {
         const recall = await recallMemoryContext(promptForBudget);
         if (recall) {
@@ -6607,6 +6675,24 @@ export const agentStore = {
     // Derive the thread id early so turnInFlight / turnError operate on the
     // right key across cold-start, promotion, and crash-recovery paths. #1631.
     const threadId = session?.conversationId;
+
+    if (threadId && session) {
+      try {
+        providerService.assertPrivilegedConversationProvider(
+          threadId,
+          privacyStore.isPrivileged(threadId),
+          session.info.agentType,
+          { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+        );
+      } catch (error) {
+        this.setTurnError(
+          threadId,
+          "privileged_provider_blocked",
+          error instanceof Error ? error.message : String(error),
+        );
+        return;
+      }
+    }
 
     if (threadId) {
       this.setTurnInFlight(threadId, true);

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -98,6 +98,8 @@ export interface Conversation {
   selectedModel: string;
   selectedProvider: ProviderId | AgentType | null;
   isArchived: boolean;
+  privileged?: boolean;
+  counselDirection?: string | null;
   compactedSummary?: CompactedSummary;
   /** Reasoning effort level: "minimal" | "low" | "medium" | "high" | "xhigh". */
   reasoningEffort?: string;
@@ -155,6 +157,8 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     selectedModel: row.selected_model ?? DEFAULT_MODEL,
     selectedProvider: (row.selected_provider as ProviderId | AgentType) ?? null,
     isArchived: row.is_archived,
+    privileged: row.privileged,
+    counselDirection: row.counsel_direction,
   };
 }
 

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -17,6 +17,7 @@ import {
   updateConversation as updateConversationDb,
 } from "@/lib/tauri-bridge";
 import type { AgentType } from "@/services/providers";
+import { privacyStore } from "@/stores/privacy.store";
 import type { UnifiedMessage } from "@/types/conversation";
 import { deserializeMetadata, serializeMetadata } from "@/types/conversation";
 
@@ -32,6 +33,8 @@ export interface Conversation {
   projectRoot: string | null;
   isArchived: boolean;
   employeeId: string | null;
+  privileged?: boolean;
+  counselDirection?: string | null;
 }
 
 interface ConversationState {
@@ -98,6 +101,8 @@ function dbToConversation(db: DbConversation): Conversation {
     projectRoot: db.project_root ?? null,
     isArchived: db.is_archived,
     employeeId: db.employee_id ?? null,
+    privileged: db.privileged,
+    counselDirection: db.counsel_direction,
   };
 }
 
@@ -111,6 +116,8 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     projectRoot: row.project_root,
     isArchived: row.is_archived,
     employeeId: row.employee_id,
+    privileged: row.privileged,
+    counselDirection: row.counsel_direction,
   };
 }
 
@@ -663,6 +670,14 @@ export const conversationStore = {
     try {
       const rows = await listConversations({ kind: "chat" });
       const conversations = rows.map(unifiedRowToConversation);
+
+      for (const conversation of conversations) {
+        privacyStore.hydrateConversationPrivilege(
+          conversation.id,
+          conversation.privileged === true,
+          conversation.counselDirection,
+        );
+      }
 
       setState("conversations", conversations);
 

--- a/src/stores/privacy.store.ts
+++ b/src/stores/privacy.store.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Persists exclusion choices through the same Tauri/browser settings boundary as app settings.
 
 import { createStore } from "solid-js/store";
-import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { isTauriRuntime, setConversationPrivileged } from "@/lib/tauri-bridge";
 
 const PRIVACY_STORE = "privacy.json";
 const CONVERSATIONS_KEY = "conversations";
@@ -11,6 +11,10 @@ const BROWSER_PRIVACY_KEY = "seren_conversation_privacy";
 export interface ConversationPrivacy {
   excludeMemory: boolean;
   excludeHistorySync: boolean;
+  /** Privileged conversations deny memory, history sync, notes export, and unsafe providers. */
+  privileged: boolean;
+  /** Optional direction supplied by counsel and mirrored into the local chat DB. */
+  counselDirection?: string;
 }
 
 interface PrivacyState {
@@ -43,6 +47,12 @@ function normalizeConversations(
     normalized[id] = {
       excludeMemory: candidate.excludeMemory === true,
       excludeHistorySync: candidate.excludeHistorySync === true,
+      privileged: candidate.privileged === true,
+      counselDirection:
+        typeof candidate.counselDirection === "string" &&
+        candidate.counselDirection.trim().length > 0
+          ? candidate.counselDirection.trim()
+          : undefined,
     };
   }
   return normalized;
@@ -102,6 +112,7 @@ function flagsFor(id: string): ConversationPrivacy {
     privacyState.conversations[id] ?? {
       excludeMemory: false,
       excludeHistorySync: false,
+      privileged: false,
     }
   );
 }
@@ -112,11 +123,37 @@ export const privacyStore = {
   },
 
   isMemoryExcluded(id: string | null | undefined): boolean {
-    return id ? flagsFor(id).excludeMemory : false;
+    return id ? flagsFor(id).privileged || flagsFor(id).excludeMemory : false;
   },
 
   isHistorySyncExcluded(id: string | null | undefined): boolean {
-    return id ? flagsFor(id).excludeHistorySync : false;
+    return id
+      ? flagsFor(id).privileged || flagsFor(id).excludeHistorySync
+      : false;
+  },
+
+  isPrivileged(id: string | null | undefined): boolean {
+    return id ? flagsFor(id).privileged : false;
+  },
+
+  /**
+   * Merge the durable SQLite flag into renderer state without writing it back.
+   * A stale or unavailable privacy.json must never make a persisted privileged
+   * conversation eligible for egress after an app restart.
+   */
+  hydrateConversationPrivilege(
+    id: string,
+    privileged: boolean,
+    counselDirection?: string | null,
+  ): void {
+    if (!id || !privileged) return;
+    const current = flagsFor(id);
+    setPrivacyState("conversations", id, {
+      ...current,
+      privileged: true,
+      counselDirection:
+        counselDirection?.trim() || current.counselDirection || undefined,
+    });
   },
 
   setConversationPrivacy(
@@ -130,11 +167,23 @@ export const privacyStore = {
     };
     setPrivacyState("conversations", id, next);
     void saveStoredPrivacy();
+    if ("privileged" in updates || "counselDirection" in updates) {
+      void setConversationPrivileged(
+        id,
+        next.privileged,
+        next.counselDirection ?? null,
+      ).catch((error) => {
+        console.warn(
+          "[Privacy] Failed to persist Privileged Matter Mode to the chat DB:",
+          error,
+        );
+      });
+    }
   },
 
   excludedHistorySyncIds(): string[] {
     return Object.entries(privacyState.conversations)
-      .filter(([, flags]) => flags.excludeHistorySync)
+      .filter(([, flags]) => flags.privileged || flags.excludeHistorySync)
       .map(([id]) => id);
   },
 };

--- a/tests/unit/privileged-matter-mode.test.ts
+++ b/tests/unit/privileged-matter-mode.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Verifies Privileged Matter Mode composes the existing local egress exclusions.
+// ABOUTME: Ensures a privileged conversation never reaches memory capture.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, setConversationPrivilegedMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  setConversationPrivilegedMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => false,
+  setConversationPrivileged: setConversationPrivilegedMock,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: { isAuthenticated: true, user: { id: "user-1" } },
+}));
+
+vi.mock("@/stores/project.store", () => ({
+  projectStore: { activeProject: { id: "project-1" } },
+}));
+
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) =>
+      key === "memoryEnabled" || key === "sourceRetentionEnabled",
+  },
+}));
+
+import { processAssistantResponseMemory } from "@/services/memory";
+import { privacyStore } from "@/stores/privacy.store";
+
+describe("Privileged Matter Mode", () => {
+  const conversationId = "privileged-matter-mode-test";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    privacyStore.setConversationPrivacy(conversationId, {
+      excludeMemory: false,
+      excludeHistorySync: false,
+      privileged: true,
+      counselDirection: "Counsel-directed analysis",
+    });
+  });
+
+  it("makes privileged conversations memory and history-sync excluded", () => {
+    expect(privacyStore.isPrivileged(conversationId)).toBe(true);
+    expect(privacyStore.isMemoryExcluded(conversationId)).toBe(true);
+    expect(privacyStore.isHistorySyncExcluded(conversationId)).toBe(true);
+    expect(privacyStore.excludedHistorySyncIds()).toContain(conversationId);
+  });
+
+  it("honors the durable database privilege flag before privacy settings reload", () => {
+    const restoredConversationId = "privileged-matter-restored-test";
+    privacyStore.hydrateConversationPrivilege(
+      restoredConversationId,
+      true,
+      "Counsel-directed analysis",
+    );
+
+    expect(privacyStore.isPrivileged(restoredConversationId)).toBe(true);
+    expect(privacyStore.isMemoryExcluded(restoredConversationId)).toBe(true);
+    expect(privacyStore.isHistorySyncExcluded(restoredConversationId)).toBe(
+      true,
+    );
+  });
+
+  it("does not invoke process_conversation for a privileged conversation", async () => {
+    await expect(
+      processAssistantResponseMemory("Privileged response", {
+        conversationId,
+        userQuery: "Privileged prompt",
+        sourceExternalId: "desktop:conversation:privileged",
+      }),
+    ).resolves.toBeNull();
+
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "memory_process_conversation",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/privileged-provider-gate.test.ts
+++ b/tests/unit/privileged-provider-gate.test.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Pins the static provider boundary used by Privileged Matter Mode.
+// ABOUTME: Covers the deny-by-default helper plus selector and send-path references.
+
+import { describe, expect, it, vi } from "vitest";
+import { readSource } from "./source-text";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/lib/browser-local-runtime", () => ({
+  isLocalProviderRuntime: () => false,
+  onRuntimeEvent: vi.fn(),
+  runtimeInvoke: vi.fn(),
+}));
+
+vi.mock("@/lib/runtime", () => ({
+  runtimeHasCapability: () => false,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => false,
+}));
+
+import {
+  CONFIDENTIAL_SAFE_PROVIDERS,
+  assertPrivilegedConversationProvider,
+  isConfidentialSafeProvider,
+} from "@/services/providers";
+
+describe("Privileged Matter provider gate", () => {
+  it("denies non-allowlisted providers and permits only loopback LM Studio", () => {
+    expect(CONFIDENTIAL_SAFE_PROVIDERS).toEqual(["lmstudio"]);
+    expect(
+      isConfidentialSafeProvider("lmstudio", {
+        lmStudioBaseUrl: "http://localhost:1234",
+      }),
+    ).toBe(true);
+    expect(
+      isConfidentialSafeProvider("lmstudio", {
+        lmStudioBaseUrl: "https://remote.example.invalid",
+      }),
+    ).toBe(false);
+    expect(() =>
+      assertPrivilegedConversationProvider("p1", true, "openai"),
+    ).toThrow("Privileged Matter Mode blocks openai");
+    expect(() =>
+      assertPrivilegedConversationProvider("p1", true, "lmstudio", {
+        lmStudioBaseUrl: "http://127.0.0.1:1234",
+      }),
+    ).not.toThrow();
+  });
+
+  it("uses the same static allowlist in selector and send paths", () => {
+    expect(readSource("src/components/chat/ModelSelector.tsx")).toContain(
+      "isConfidentialSafeProvider",
+    );
+    expect(readSource("src/services/orchestrator.ts")).toContain(
+      "assertPrivilegedConversationProvider",
+    );
+    expect(readSource("src/components/chat/ChatContent.tsx")).toContain(
+      "assertPrivilegedConversationProvider",
+    );
+    expect(readSource("src/stores/agent.store.ts")).toContain(
+      "assertPrivilegedConversationProvider",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements the P0 foundation for per-conversation Privileged Matter Mode.

### Audit trace
- Persists `conversations.privileged` and `counsel_direction` with an idempotent SQLite migration, then exposes `set_conversation_privileged` through the Tauri bridge.
- Composes the existing privacy gates so a privileged conversation is denied memory capture, history sync, cloud Notes export, and local conversation indexing.
- Stamps persisted work product and allowed local exports with `Privileged & Confidential — Prepared in Anticipation of Litigation`, including counsel direction when supplied.
- Adds a persistent chat warning, a per-conversation control, and provider restrictions at both the selector and send/runtime chokepoints.

### Deny-by-default design
A privileged designation is durable and immediately implies memory and history-sync exclusion. Existing index chunks are removed and future indexing is skipped. Provider selection and send paths reject every provider not on the static confidential-safe allowlist; unknown providers are unsafe.

### Static allowlist basis
The initial allowlist contains only loopback `lmstudio`. LM Studio documents its local server as a localhost API and separately documents that serving on a local network makes it reachable beyond localhost: [local server](https://lmstudio.ai/docs/developer/core/server), [network exposure](https://lmstudio.ai/docs/developer/core/server/serve-on-network). The implementation therefore verifies a loopback endpoint. Hosted “private” routes lack a source-verified retention/training basis in this codebase, and Ollama is not an available desktop agent provider, so both remain denied pending the registry-driven P1 allowlist.

### Networked path
No new outbound calls. This change suppresses existing memory, history-sync, and cloud Notes egress for privileged conversations and restricts existing provider dispatch to an explicit local allowlist.

### Verification
- `cargo test --manifest-path src-tauri/Cargo.toml --lib privileged -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml --lib -q`
- `pnpm vitest run tests/unit/privileged-matter-mode.test.ts tests/unit/privileged-provider-gate.test.ts tests/unit/memory-exclusion.test.ts tests/unit/memory-source-retention.test.ts`
- `pnpm check`
- `pnpm build`

### Follow-up
The registry-driven provider allowlist and signed-in live functional verification remain P1/residual. serenorg/seren-memory#24 remains the dependency for cascade-deleting retained sources that predate a retroactive privileged designation.

Refs serenorg/seren-desktop#3195

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com