### PR TITLE
fix(memory): keep session scope on memories queued during cloud failures

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "seren-memory-sdk"
 version = "0.1.0"
-source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#0133c145953bcf133b1d4d76bdbee4d4183607f"
+source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#b256cbc618667d8e480fbf1c84d90af07af85fc1"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -13,7 +13,7 @@ use tauri::State;
 use seren_memory_sdk::bootstrap::BootstrapOrchestrator;
 use seren_memory_sdk::cache::LocalCache;
 use seren_memory_sdk::client::MemoryClient;
-use seren_memory_sdk::models::{CachedMemory, ContextSource, SessionContext};
+use seren_memory_sdk::models::{CachedMemory, ContextSource, MemoryScope, SessionContext};
 use seren_memory_sdk::sync::SyncEngine;
 
 const AUTH_STORE: &str = "auth.json";
@@ -414,6 +414,9 @@ pub async fn memory_remember(
     let org_uuid = org_id
         .as_deref()
         .and_then(|value| uuid::Uuid::parse_str(value).ok());
+    let session_uuid = session_id
+        .as_deref()
+        .and_then(|value| uuid::Uuid::parse_str(value).ok());
     state.ensure_cache()?;
     let cached = CachedMemory {
         id: local_id,
@@ -432,7 +435,10 @@ pub async fn memory_remember(
         let guard = state.cache.lock().map_err(|e| e.to_string())?;
         if let Some(cache) = guard.as_ref() {
             cache
-                .insert_memory_scoped(&cached, project_uuid, org_uuid)
+                .insert_memory_scoped(
+                    &cached,
+                    MemoryScope::new(project_uuid, org_uuid, session_uuid),
+                )
                 .ok();
         }
     }


### PR DESCRIPTION
Closes serenorg/seren-desktop#3181

## Problem

`memory_remember` accepts a `session_id` and forwards it to the cloud `remember` call, but the local cache write dropped it — `insert_memory_scoped` only took project and org.

That matters precisely on the fallback path this code exists for. When the cloud call fails, the record is kept locally and pushed later; by then the session scope is gone, so the deferred push can never carry it. This is the "cloud failure followed by deferred sync necessarily loses that scope" gap called out in serenorg/seren-desktop#3181.

## Change

- `session_id` is parsed and passed into `insert_memory_scoped`, so a record captured during an outage keeps the scope it was captured with.
- Cargo.lock moves to seren-memory-sdk `b256cbc` (serenorg/seren-memory-sdk#17), which adds `session_id` to the cache schema, `PendingUpload`, and `PushMemoryRequest`, and preserves `created_at` / `relevance_score` under a reserved `seren_origin` metadata key.

The lock bump is a one-line SHA edit rather than `cargo update`, because full re-resolution currently fails on an unrelated pre-existing conflict (`serenity` wants `reqwest`'s `rustls-tls`, which newer `reqwest` renamed). Same approach as serenorg/seren-desktop#3199.

## Service contract, verified live

Checked the `remember` tool schema on the live `seren-memory` publisher rather than assuming. It accepts `session_id` as a first-class field, and has **no** field for `relevance_score` (f64) or `created_at` — the service stamps its own creation time, and `importance` is int16 with different semantics. Those two therefore travel in `metadata`, which is free-form and echoed back on `list_memories`.

## Tests

Regression coverage lives in the SDK, where the data was being lost: `push_carries_session_scope_and_origin_stamp` asserts a queued record reaches the wire with `session_id` set and both origin values inside metadata. Mutation-checked — it fails when the origin stamp is dropped, fails again when `session_id` is also dropped, and passes when restored.

- SDK: 47 tests green.
- Desktop: 996 passed. One unrelated flake, `pdf::tests::write_pdf_from_html_produces_valid_pdf_header`, which shells out to a PDF converter; it passes in isolation on both this branch and main.

## Live walkthrough (no mocks)

Ran the merged SDK against `https://memory.serendb.com` with the real stored credential:

- Local cache retains the session id on a record staged for deferred sync — **confirmed**.
- Production pending queue, measured read-only from a copy: **101 rows, 0 carrying a session id** (they predate this fix).
- Cloud round-trip **could not be completed**. The service's write path is returning `internal error`. This is not caused by this change: a bare `content` + `memory_type` call fails identically, and `create_memory`, `learn_from_error`, `recall`, and `session_bootstrap` fail the same way while `list_memories` and `/health` succeed. Filed as serenorg/seren-memory#21.

Queue drain and the cloud round-trip stay open against serenorg/seren-memory#21 and the next release validation.
