### PR TITLE
fix(sandbox): resolve the agent launch spec in trusted code

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -14,6 +14,7 @@ import {
   buildProviderMcpConfig,
   resolveBrokeredSerenCredential,
 } from "./mcp-config.mjs";
+import { resolveSandboxLaunchSpec } from "./sandbox-spec.mjs";
 import { composeWindowsShellCommand } from "./windows-shell-args.mjs";
 
 // Agent runtimes are loaded in isolation (#2457). Each runtime module is
@@ -1736,7 +1737,26 @@ export function createProviderHandlers({
     }
   }
 
-  async function spawnOwnedSession(params) {
+  async function spawnOwnedSession(callerParams) {
+    // Every provider_spawn caller reaches this one function — the desktop
+    // renderer, a paired role's inner spawn, an orchestrator one-shot, and the
+    // Happy mobile bridge. Discard whatever launch spec the caller sent and
+    // resolve the real one from the trusted app binary, so no caller can widen
+    // or replace the boundary and no caller has to know how to build it. #3230.
+    const { sandboxProfile: _callerSuppliedSpec, ...sanitizedParams } =
+      callerParams;
+    const params = {
+      ...sanitizedParams,
+      sandboxProfile:
+        sanitizedParams.agentType === "claude-code"
+          ? resolveSandboxLaunchSpec({
+              sandboxMode: sanitizedParams.sandboxMode,
+              cwd: sanitizedParams.cwd,
+              networkEnabled: sanitizedParams.networkEnabled,
+            })
+          : null,
+    };
+
     const {
       agentType,
       cwd,

--- a/bin/browser-local/sandbox-spec.mjs
+++ b/bin/browser-local/sandbox-spec.mjs
@@ -1,0 +1,112 @@
+// ABOUTME: Resolves a bounded session's OS sandbox launch spec from the trusted app binary.
+// ABOUTME: A provider_spawn caller can never supply or widen the spec; failure blocks the launch.
+
+import { execFileSync } from "node:child_process";
+
+const SPEC_ARGUMENT = "__seren-sandbox-spec";
+const SPEC_TIMEOUT_MS = 15_000;
+
+/** A full-access session is an explicit user opt-in and carries no OS profile. */
+function isFullAccess(sandboxMode) {
+  return sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+}
+
+/**
+ * The runtime only accepts the three shapes the Rust builder emits. Anything
+ * else — including a hand-written profile that would widen the boundary — is
+ * rejected rather than passed through to the launcher.
+ */
+function assertKnownSpecShape(spec) {
+  const nonEmpty = (value) =>
+    typeof value === "string" && value.trim().length > 0;
+
+  if (spec?.kind === "seatbelt" && nonEmpty(spec.profile)) return;
+  if (
+    (spec?.kind === "linux-launcher" || spec?.kind === "windows-launcher") &&
+    nonEmpty(spec.launcherPath) &&
+    nonEmpty(spec.policyBase64)
+  ) {
+    return;
+  }
+
+  throw new Error(
+    "the app binary returned an unrecognized sandbox launch spec.",
+  );
+}
+
+/**
+ * Ask the signed app binary for this session's launch spec. Every bounded local
+ * agent spawn resolves here regardless of which caller issued provider_spawn —
+ * the desktop renderer, a paired role, an orchestrator one-shot, or the Happy
+ * mobile bridge. #3230.
+ *
+ * Returns null only for full-access sessions. Any other failure throws so the
+ * caller fails closed instead of launching unconfined.
+ */
+export function resolveSandboxLaunchSpec({
+  sandboxMode,
+  cwd,
+  networkEnabled,
+} = {}) {
+  if (isFullAccess(sandboxMode)) return null;
+
+  const specBinary = process.env.SEREN_SANDBOX_SPEC_BIN;
+  if (typeof specBinary !== "string" || specBinary.trim().length === 0) {
+    throw new Error(
+      "Agent launch blocked: the trusted sandbox spec binary is unavailable.",
+    );
+  }
+
+  if (typeof cwd !== "string" || cwd.trim().length === 0) {
+    throw new Error(
+      "Agent launch blocked: a bounded session requires a project root.",
+    );
+  }
+
+  let stdout;
+  try {
+    stdout = execFileSync(
+      specBinary,
+      [
+        SPEC_ARGUMENT,
+        sandboxMode ?? "workspace-write",
+        networkEnabled === false ? "false" : "true",
+        cwd,
+      ],
+      {
+        encoding: "utf8",
+        timeout: SPEC_TIMEOUT_MS,
+        maxBuffer: 4 * 1024 * 1024,
+        // Capture stderr instead of letting it reach the runtime's own stream;
+        // the reason belongs in the thrown error, not in an unattributed log.
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (error) {
+    // stderr carries the Rust builder's reason (bad mode, unresolvable root,
+    // unavailable backend); surface it so the failure is diagnosable.
+    const detail =
+      (typeof error?.stderr === "string" ? error.stderr.trim() : "") ||
+      (error instanceof Error ? error.message : String(error));
+    throw new Error(
+      `Agent launch blocked: the trusted sandbox launch spec failed: ${detail}`,
+    );
+  }
+
+  let spec;
+  try {
+    spec = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(
+      "Agent launch blocked: the trusted sandbox launch spec was not valid JSON.",
+    );
+  }
+
+  try {
+    assertKnownSpecShape(spec);
+  } catch (error) {
+    throw new Error(`Agent launch blocked: ${error.message}`);
+  }
+
+  return spec;
+}

--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -1,6 +1,7 @@
-// ABOUTME: Tauri command that returns the verified OS provider sandbox launch spec.
+// ABOUTME: Builds the verified OS provider sandbox launch spec and exposes it to trusted callers.
 // ABOUTME: Credential-store paths are denied before the policy crosses into the child runtime.
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -47,13 +48,82 @@ pub enum AgentSandboxLaunchSpec {
     },
 }
 
+/// Hidden app-binary subcommand that prints the launch spec as JSON on stdout.
+///
+/// The provider runtime shells out to this so a bounded session's real launcher
+/// is produced by the signed app binary rather than handed in by whichever
+/// caller issued `provider_spawn`. #3230.
+pub const SANDBOX_SPEC_ARGUMENT: &str = "__seren-sandbox-spec";
+
+const BAD_ARGUMENTS_EXIT: i32 = 64;
+const SPEC_FAILURE_EXIT: i32 = 70;
+
 #[tauri::command]
 pub fn agent_sandbox_profile(
     mode: String,
     project_root: String,
     network_enabled: Option<bool>,
 ) -> Result<AgentSandboxLaunchSpec, String> {
-    let mode = SandboxMode::from_str(&mode).map_err(|error| error.to_string())?;
+    build_launch_spec(&mode, &project_root, network_enabled.unwrap_or(true))
+}
+
+/// Entry point for `<app-binary> __seren-sandbox-spec <mode> <network> <root>`.
+///
+/// Runs before Tauri starts, so no window is created. Success writes one JSON
+/// line to stdout; every failure writes the reason to stderr and exits non-zero
+/// so the caller fails closed instead of launching unconfined.
+pub fn sandbox_spec_main(args: Vec<String>) -> ! {
+    let rest = args.into_iter().skip(1).collect::<Vec<_>>();
+    if rest.len() != 4 || rest[0] != SANDBOX_SPEC_ARGUMENT {
+        exit_with(
+            BAD_ARGUMENTS_EXIT,
+            format!("usage: {SANDBOX_SPEC_ARGUMENT} <mode> <network-enabled> <project-root>"),
+        );
+    }
+
+    let network_enabled = match rest[2].trim() {
+        "true" => true,
+        "false" => false,
+        other => exit_with(
+            BAD_ARGUMENTS_EXIT,
+            format!("invalid network-enabled value: {other}"),
+        ),
+    };
+
+    let spec = match build_launch_spec(&rest[1], &rest[3], network_enabled) {
+        Ok(spec) => spec,
+        Err(error) => exit_with(SPEC_FAILURE_EXIT, error),
+    };
+
+    match serde_json::to_string(&spec) {
+        Ok(encoded) => {
+            let mut stdout = std::io::stdout();
+            if writeln!(stdout, "{encoded}")
+                .and_then(|()| stdout.flush())
+                .is_err()
+            {
+                exit_with(SPEC_FAILURE_EXIT, "could not write the sandbox launch spec");
+            }
+            std::process::exit(0);
+        }
+        Err(error) => exit_with(
+            SPEC_FAILURE_EXIT,
+            format!("could not serialize the sandbox launch spec: {error}"),
+        ),
+    }
+}
+
+fn exit_with(code: i32, message: impl std::fmt::Display) -> ! {
+    eprintln!("Seren sandbox spec: {message}");
+    std::process::exit(code);
+}
+
+fn build_launch_spec(
+    mode: &str,
+    project_root: &str,
+    network_enabled: bool,
+) -> Result<AgentSandboxLaunchSpec, String> {
+    let mode = SandboxMode::from_str(mode).map_err(|error| error.to_string())?;
     if mode == SandboxMode::FullAccess {
         return Err("No sandbox profile is generated for full-access mode.".to_string());
     }
@@ -75,7 +145,7 @@ pub fn agent_sandbox_profile(
         mode,
         vec![PathBuf::from(project_root)],
         deny_read,
-        network_enabled.unwrap_or(true),
+        network_enabled,
     )
     .map_err(|error| error.to_string())?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,5 +12,10 @@ fn main() {
     {
         seren_desktop_lib::sandbox::sandbox_run_main(args);
     }
+    if args.get(1).is_some_and(|argument| {
+        argument == seren_desktop_lib::commands::sandbox::SANDBOX_SPEC_ARGUMENT
+    }) {
+        seren_desktop_lib::commands::sandbox::sandbox_spec_main(args);
+    }
     seren_desktop_lib::run()
 }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -479,6 +479,22 @@ fn spawn_node_process(
     // the per-CLI config JSON / TOML.
     command.env("SEREN_EMBEDDED_NODE_BIN", node_bin);
 
+    // serenorg/seren-desktop#3230 — a bounded agent's launch spec is produced by
+    // this binary's `__seren-sandbox-spec` subcommand, not by whichever caller
+    // issued provider_spawn. Without this path the runtime has no trusted source
+    // for the spec and every bounded launch fails closed.
+    match std::env::current_exe() {
+        Ok(app_binary) => {
+            command.env("SEREN_SANDBOX_SPEC_BIN", app_binary);
+        }
+        Err(err) => {
+            log::error!(
+                "[ProviderRuntime] Could not resolve the app binary for sandbox specs: {}",
+                err
+            );
+        }
+    }
+
     crate::embedded_runtime::sanitize_spawn_env(&mut command);
 
     command

--- a/src-tauri/tests/sandbox_spec_dispatch.rs
+++ b/src-tauri/tests/sandbox_spec_dispatch.rs
@@ -1,0 +1,82 @@
+// ABOUTME: Critical guard for #3230 — the app binary is the only source of a sandbox launch spec.
+// ABOUTME: Runs the real binary's hidden subcommand; every rejected input must fail closed.
+
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn spec_command(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_Seren"))
+        .arg("__seren-sandbox-spec")
+        .args(args)
+        .output()
+        .expect("run the sandbox spec subcommand")
+}
+
+#[test]
+fn spec_dispatch_emits_a_launch_spec_for_a_bounded_session() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let root = workspace.path().to_string_lossy().into_owned();
+
+    let output = spec_command(&["workspace-write", "false", &root]);
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let spec: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("spec is a single JSON document");
+    let kind = spec["kind"].as_str().expect("spec carries a kind");
+    assert!(
+        matches!(kind, "seatbelt" | "linux-launcher" | "windows-launcher"),
+        "unexpected launch spec kind: {kind}"
+    );
+}
+
+#[test]
+fn spec_dispatch_refuses_full_access() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let root = workspace.path().to_string_lossy().into_owned();
+
+    let output = spec_command(&["full-access", "true", &root]);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn spec_dispatch_refuses_an_unknown_mode() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let root = workspace.path().to_string_lossy().into_owned();
+
+    let output = spec_command(&["allow-everything", "true", &root]);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn spec_dispatch_refuses_a_root_that_does_not_resolve() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let missing = workspace.path().join("absent");
+
+    let output = spec_command(&[
+        "workspace-write",
+        "true",
+        &missing.to_string_lossy().into_owned(),
+    ]);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn spec_dispatch_refuses_a_malformed_network_flag() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let root = workspace.path().to_string_lossy().into_owned();
+
+    let output = spec_command(&["workspace-write", "yes", &root]);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -104,19 +104,6 @@ export interface AgentInfo {
   unavailableReason?: string;
 }
 
-export type SandboxLaunchSpec =
-  | { kind: "seatbelt"; profile: string }
-  | {
-      kind: "linux-launcher";
-      launcherPath: string;
-      policyBase64: string;
-    }
-  | {
-      kind: "windows-launcher";
-      launcherPath: string;
-      policyBase64: string;
-    };
-
 // Remote sessions (provider runtime listSessions capability)
 export interface RemoteSessionInfo {
   sessionId: string;
@@ -538,27 +525,10 @@ export async function spawnAgent(
   lmStudioApiKey?: string,
   autoApproveReads?: boolean,
 ): Promise<AgentSessionInfo> {
-  const fullAccess =
-    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
-  const isMacOsDesktop =
-    typeof navigator !== "undefined" &&
-    /Macintosh|Mac OS X/i.test(navigator.userAgent);
-  const isLinuxDesktop =
-    typeof navigator !== "undefined" && /Linux/i.test(navigator.userAgent);
-  const isWindowsDesktop =
-    typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent);
-  const sandboxProfile =
-    agentType === "claude-code" &&
-    isTauriRuntime() &&
-    (isMacOsDesktop || isLinuxDesktop || isWindowsDesktop) &&
-    !fullAccess
-      ? await invoke<SandboxLaunchSpec>("agent_sandbox_profile", {
-          mode: sandboxMode ?? "workspace-write",
-          projectRoot: cwd,
-          networkEnabled: networkEnabled !== false,
-        })
-      : null;
-
+  // The OS sandbox launch spec is deliberately absent here. The provider
+  // runtime resolves it from the trusted app binary for every spawn path, so a
+  // renderer-supplied spec could neither be trusted nor kept in sync with the
+  // paths that never reach this function. #3230.
   return invokeProvider<AgentSessionInfo>(
     "provider_spawn",
     {
@@ -567,7 +537,6 @@ export async function spawnAgent(
       localSessionId: localSessionId ?? null,
       resumeAgentSessionId: resumeAgentSessionId ?? null,
       sandboxMode: sandboxMode ?? null,
-      sandboxProfile,
       serenCapability: serenCredential?.capability ?? null,
       serenMcpUrl: serenCredential?.mcpUrl ?? null,
       serenApiBaseUrl: serenCredential?.apiBaseUrl ?? null,

--- a/tests/unit/sandbox-launch-spec.test.ts
+++ b/tests/unit/sandbox-launch-spec.test.ts
@@ -1,0 +1,107 @@
+// ABOUTME: Critical guard for #3230 — the sandbox launch spec comes from the trusted app binary only.
+// ABOUTME: Runs the real resolver against a real child process; a caller can never supply the spec.
+
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/sandbox-spec.mjs",
+  import.meta.url,
+).href;
+const { resolveSandboxLaunchSpec } = await import(
+  /* @vite-ignore */ modulePath
+);
+
+const originalSpecBin = process.env.SEREN_SANDBOX_SPEC_BIN;
+
+/**
+ * Stand in for the app binary. The resolver's contract is "execute this
+ * program with the spec subcommand and read one JSON line from stdout", so a
+ * real executable exercises the same argv, exit-code, and stdout path the
+ * shipped binary uses. The Rust builder itself is covered by the Rust tests.
+ */
+function installSpecBinary(body: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "seren-spec-"));
+  const binary = path.join(dir, "spec-binary.sh");
+  writeFileSync(binary, `#!/bin/sh\n${body}\n`, "utf8");
+  chmodSync(binary, 0o755);
+  process.env.SEREN_SANDBOX_SPEC_BIN = binary;
+  return binary;
+}
+
+describe("trusted sandbox launch spec (#3230)", () => {
+  afterEach(() => {
+    if (originalSpecBin === undefined) {
+      delete process.env.SEREN_SANDBOX_SPEC_BIN;
+    } else {
+      process.env.SEREN_SANDBOX_SPEC_BIN = originalSpecBin;
+    }
+  });
+
+  it("passes the requested mode, network flag, and root to the binary", () => {
+    installSpecBinary(
+      'printf \'{"kind":"seatbelt","profile":"mode=%s network=%s root=%s"}\\n\' "$2" "$3" "$4"',
+    );
+
+    expect(
+      resolveSandboxLaunchSpec({
+        sandboxMode: "read-only",
+        cwd: "/tmp/project",
+        networkEnabled: false,
+      }),
+    ).toEqual({
+      kind: "seatbelt",
+      profile: "mode=read-only network=false root=/tmp/project",
+    });
+  });
+
+  it("blocks the launch when the trusted binary is unavailable", () => {
+    delete process.env.SEREN_SANDBOX_SPEC_BIN;
+
+    expect(() =>
+      resolveSandboxLaunchSpec({
+        sandboxMode: "workspace-write",
+        cwd: "/tmp/project",
+        networkEnabled: false,
+      }),
+    ).toThrow(/trusted sandbox spec binary is unavailable/);
+  });
+
+  it("blocks the launch when the trusted binary fails", () => {
+    installSpecBinary('echo "unsupported sandbox mode" >&2\nexit 70');
+
+    expect(() =>
+      resolveSandboxLaunchSpec({
+        sandboxMode: "workspace-write",
+        cwd: "/tmp/project",
+        networkEnabled: true,
+      }),
+    ).toThrow(/unsupported sandbox mode/);
+  });
+
+  it("rejects a spec shape the Rust builder never emits", () => {
+    installSpecBinary('printf \'{"kind":"anything-goes"}\\n\'');
+
+    expect(() =>
+      resolveSandboxLaunchSpec({
+        sandboxMode: "workspace-write",
+        cwd: "/tmp/project",
+        networkEnabled: true,
+      }),
+    ).toThrow(/unrecognized sandbox launch spec/);
+  });
+
+  it("leaves full-access sessions without a spec", () => {
+    installSpecBinary('echo "the binary must not be consulted" >&2\nexit 70');
+
+    expect(
+      resolveSandboxLaunchSpec({
+        sandboxMode: "full-access",
+        cwd: "/tmp/project",
+        networkEnabled: true,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3230.

## Problem

The bounded OS sandbox launch spec was produced in the **renderer**
(`src/services/providers.ts` → `invoke("agent_sandbox_profile")`) and relayed to the Node
provider runtime as an ordinary `provider_spawn` parameter. Rust was never in that request
path, which broke availability and security at the same time:

- **Availability.** Every spawn path that does not originate in the renderer sent no
  `sandboxProfile`, so `buildClaudeSpawnInvocation` fail-closed and the session could not
  start: paired Claude+Codex roles, orchestrator one-shots (`provider_worker.rs`), and Happy
  mobile remote sessions.
- **Security.** Any `provider_spawn` caller could supply an allow-everything profile and the
  runtime used it verbatim, defeating the boundary #3192 was built to create.

## Fix

The app binary owns the spec.

- `src-tauri/src/commands/sandbox.rs` — the spec builder is extracted to `build_launch_spec`,
  shared by the existing `agent_sandbox_profile` Tauri command and a new hidden
  `__seren-sandbox-spec` subcommand that prints the spec as one JSON line on stdout. Every
  rejected input writes its reason to stderr and exits non-zero.
- `src-tauri/src/main.rs` — dispatches the subcommand before Tauri starts, alongside the
  existing `__seren-sandbox-run`.
- `src-tauri/src/provider_runtime.rs` — `spawn_node_process` passes the app-binary path to the
  runtime as `SEREN_SANDBOX_SPEC_BIN`.
- `bin/browser-local/sandbox-spec.mjs` — new resolver: runs the trusted binary, validates the
  returned shape against the three kinds Rust emits, and throws otherwise.
- `bin/browser-local/providers.mjs` — `spawnOwnedSession` is the single choke point every
  `provider_spawn` caller reaches. It discards any caller-supplied `sandboxProfile` and
  resolves the real one there, so paired inner spawns, one-shots, and Happy remote sessions
  are all covered without each caller learning how to build a spec.
- `src/services/providers.ts` — stops producing and sending the spec.

Full-access sessions are unchanged: they are an explicit user opt-in and carry no profile.
Missing or failed resolution still blocks the launch.

## Validation — live, no mocks

Reproduced first on `main` against the real `bin/provider-runtime.mjs`, then re-run on this
branch. Local paths and the machine's account name are elided below.

**Before (on `main`)**

| Caller input | Result |
| --- | --- |
| no `sandboxProfile` (one-shot / paired / Happy shape) | `Claude Code launch blocked: the verified macOS sandbox profile is missing.` |
| `sandboxProfile: {kind:"seatbelt", profile:"(version 1)(allow default)"}` | `status: ready`, live PID — session running under the caller's unconfined profile |

**After (this branch)**

| Caller input | Result |
| --- | --- |
| no `sandboxProfile` | `status: ready` — availability defect fixed |
| allow-all profile, no trusted binary reachable | `Agent launch blocked: the trusted sandbox spec binary is unavailable.` — the exact input that spawned an unconfined process before is now refused |
| allow-all profile, trusted binary reachable | spawns under the trusted profile |

**Trusted subcommand, run directly against the built app binary**

Emits a valid seatbelt profile for `workspace-write` and `read-only`; `read-only` emits no
`file-write*` grant; `network false` emits `(deny network*)`. Fails closed with a non-empty
stderr reason and empty stdout for `full-access` (exit 70), an unknown mode (70), an
unresolvable project root (70), a malformed network flag (64), and wrong arity (64).

**The emitted profile is real containment**

Under the trusted profile a child is denied reading a canary in `$HOME` and listing `~/.ssh`,
and denied writing outside the workspace, while reads inside the workspace succeed. Under the
caller's `(version 1)(allow default)` all of those are permitted.

**Real in-app run**

Launched the actual Tauri app (isolated validation instance) and confirmed its provider-runtime
child receives `SEREN_SANDBOX_SPEC_BIN` pointing at the app binary. Driving `provider_spawn`
through that live in-app runtime:

- renderer shape (no spec) → launch reached `sandbox-exec` and was denied `execvp ... Operation
  not permitted` for a Claude binary sitting outside the workspace root.
- hostile caller sending `(version 1)(allow default)` → **identical** denial.
- control: that same binary runs fine under `(version 1)(allow default)` directly
  (`2.1.218 (Claude Code)`).

The caller's profile would have permitted the exec; the launch was denied instead, so the
trusted profile — not the caller's — governed the in-app session.

## Tests

- `tests/unit/sandbox-launch-spec.test.ts` — the resolver against a real child process: argv
  passthrough, no-binary block, non-zero-exit block, unknown-shape rejection, full-access null.
- `src-tauri/tests/sandbox_spec_dispatch.rs` — the real app binary's subcommand: emits a valid
  spec, and fails closed on full-access, unknown mode, unresolvable root, malformed flag.

`pnpm test` 2692 passed / 15 skipped. `cargo test` 997 + 6 seatbelt canaries + 5 new, 0 failed.
`pnpm check` clean.

## Networked paths

None. This change adds no publisher or Gateway API call. The spec is produced locally by the
app binary and consumed by the local provider runtime over the existing loopback WebSocket.

## Note for review

Two things deliberately left alone, both pre-existing and out of this ticket's scope:

1. `sandboxMode` is still caller-supplied, so a `provider_spawn` caller can still request
   `full-access` (which by design carries no profile). This issue scoped the fix to the spec.
   Worth a follow-up if we want the mode itself to be Rust-owned.
2. `agent_sandbox_profile` is kept and still registered, per the ticket's stated fix direction
   of sharing one builder, but the renderer no longer calls it. Happy to delete it if you'd
   rather not carry the unused IPC surface.
