### PR TITLE
fix(auth): stop a model flag from injecting the desktop key anywhere

### DIFF
--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -652,8 +652,14 @@ fn read_stored_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<St
     }
 }
 
+/// `command` is a free-form string the model authors, and
+/// `inject_seren_credentials` is a model-supplied tool argument. An opt-in may
+/// therefore confirm the skill-path detection but must never widen it —
+/// otherwise `env` or a curl could carry the desktop key out of the machine.
+/// Skill binaries that legitimately need the key go through `run_skill_script`,
+/// which validates the slug and cwd instead of trusting a command string. #3240
 fn should_inject_seren_credentials(command: &str, requested: Option<bool>) -> bool {
-    requested.unwrap_or_else(|| command_targets_seren_skill(command))
+    requested != Some(false) && command_targets_seren_skill(command)
 }
 
 fn command_targets_seren_skill(command: &str) -> bool {
@@ -808,8 +814,11 @@ mod tests {
         assert!(wrapped.contains(r#""C:\Users\test\script.py""#));
     }
 
+    /// The model authors both the command and the flag, so an opt-in on an
+    /// arbitrary command must not produce a credential. This previously
+    /// asserted the opposite. See #3240.
     #[tokio::test]
-    async fn execute_shell_command_injects_stored_seren_credentials_when_requested() {
+    async fn execute_shell_command_refuses_credentials_for_a_non_skill_command() {
         let app = mock_app_with_api_key(Some("seren_test_shell_key"));
 
         let result = execute_shell_command(
@@ -822,10 +831,45 @@ mod tests {
         .expect("command succeeds");
 
         assert_eq!(result.exit_code, Some(0));
-        assert_eq!(
-            result.stdout.trim(),
-            "seren_test_shell_key|seren_test_shell_key"
+        assert!(
+            !result.stdout.contains("seren_test_shell_key"),
+            "a model-supplied opt-in must not widen credential injection"
         );
+    }
+
+    /// The skill path is the one the opt-in exists for, and it has to keep
+    /// working: the command names an installed skill directory.
+    #[tokio::test]
+    async fn execute_shell_command_still_injects_for_a_skill_path_command() {
+        let app = mock_app_with_api_key(Some("seren_test_shell_key"));
+        let command = format!(
+            "cd ~/.config/seren/skills/example 2>/dev/null; {}",
+            print_seren_key_env_command()
+        );
+
+        let result = execute_shell_command(app.handle().clone(), command, Some(5), Some(true))
+            .await
+            .expect("command succeeds");
+
+        assert_eq!(result.exit_code, Some(0));
+        assert!(
+            result.stdout.contains("seren_test_shell_key"),
+            "skill-path commands must keep receiving desktop auth"
+        );
+    }
+
+    #[test]
+    fn seren_credential_gate_lets_the_model_suppress_but_never_grant() {
+        let skill = "python3 ~/.config/seren/skills/example/run.py";
+        let ordinary = "env";
+
+        // An opt-in cannot grant on a command that is not a skill path.
+        assert!(!should_inject_seren_credentials(ordinary, Some(true)));
+        assert!(!should_inject_seren_credentials(ordinary, None));
+        // It can still suppress on one that is.
+        assert!(!should_inject_seren_credentials(skill, Some(false)));
+        assert!(should_inject_seren_credentials(skill, Some(true)));
+        assert!(should_inject_seren_credentials(skill, None));
     }
 
     #[tokio::test]

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -364,9 +364,9 @@ export const FILE_TOOLS: ToolDefinition[] = [
           inject_seren_credentials: {
             type: "boolean",
             description:
-              "Set true only for Seren-owned skill scripts or publisher clients that need Desktop auth. " +
-              "This injects the logged-in user's SEREN_API_KEY and API_KEY into the subprocess. " +
-              "Do not set for ordinary user-requested shell commands.",
+              "Set false to withhold Desktop auth from a Seren skill script that would otherwise receive it. " +
+              "Setting true does not grant anything: SEREN_API_KEY and API_KEY are injected only when the " +
+              "command targets an installed Seren skill path, regardless of this flag.",
           },
         },
         required: ["command"],


### PR DESCRIPTION
Closes #3240. Found while re-verifying serenorg/seren-core#222 for #3194.

## The gap

`execute_command` offers `inject_seren_credentials` as a **model-supplied** boolean, and the gate honoured it:

```rust
requested.unwrap_or_else(|| command_targets_seren_skill(command))
```

The command string is model-authored too, so a model could set the flag on `env`, a `curl`, or anything else and receive the stored desktop `publisher:*` key as `SEREN_API_KEY` and `API_KEY`. The only thing discouraging it was prose in the tool definition — guidance, not a boundary, and useless against prompt injection.

This is the #3194 acceptance criterion that was still failing: *"`env`, process inspection, provider debug output, and **model-run shell commands** cannot recover a real Seren or upstream credential."*

## Why the blast radius is large

The injected key is the desktop wildcard. Verified live today against `api.serendb.com`: an API key can still reach `/organizations/**`, so that key mints a **non-expiring** `publisher:*` key in one request and can revoke other keys. One model-authored command therefore becomes a permanent organization credential that survives logout and outlives every lease. Tracked upstream as serenorg/seren-core#222.

The broker from #3233 does not cover this path — it brokers provider/MCP traffic, while `shell.rs` hands the raw key straight to the subprocess.

## The fix

```rust
requested != Some(false) && command_targets_seren_skill(command)
```

The flag can now suppress but never grant. Injection depends on the command actually targeting an installed Seren skill path.

`run_skill_script` is deliberately untouched: it validates the skill slug and cwd and executes the skill's own binary rather than a free-form string, so skills keep their auth through the path that was designed for it.

The tool description no longer advertises a grant it cannot make.

## Tests

`execute_shell_command_injects_stored_seren_credentials_when_requested` pinned the vulnerable behaviour as correct — it ran `printf '%s|%s' "${SEREN_API_KEY:-}" "${API_KEY:-}"` with the flag set and asserted the real key came back. Rather than delete it, its assertion is inverted and renamed, and a skill-path counterpart is added so both directions are covered:

- `execute_shell_command_refuses_credentials_for_a_non_skill_command` — real shell, real store, flag set, key must not appear.
- `execute_shell_command_still_injects_for_a_skill_path_command` — real shell, skill-path command, key must still appear.
- `seren_credential_gate_lets_the_model_suppress_but_never_grant` — the truth table.

Both shell tests spawn the actual subprocess against the actual store; nothing is mocked.

1014 Rust lib tests pass, 2703 frontend tests pass.

## What this does not fix

Installed skills still receive the wildcard key directly, and that cannot be brokered client-side without a skills migration: of the 38 installed skills, 166 files read `SEREN_API_KEY` and 82 hardcode `api.serendb.com`, against only 16 that honour a base-URL env var. Handing those a broker base URL would be ignored by most of them. seren-core#222 is the cheap fix for that surface, and it is the right one.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
