### PR TITLE
feat(sandbox): report the verified effective sandbox in settings

### DIFF
--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -48,6 +48,20 @@ pub enum AgentSandboxLaunchSpec {
     },
 }
 
+/// A truthful renderer-facing summary of the sandbox that will be used for a
+/// local agent launch. This reports whether the trusted backend can build a
+/// launch specification; it does not claim a child is already confined.
+#[derive(Debug, Serialize)]
+pub struct AgentSandboxStatus {
+    pub backend: String,
+    pub spec_available: bool,
+    pub enforced_at_launch: bool,
+    pub fail_closed: bool,
+    pub effective_mode: String,
+    pub network_enabled: bool,
+    pub detail: String,
+}
+
 /// Hidden app-binary subcommand that prints the launch spec as JSON on stdout.
 ///
 /// The provider runtime shells out to this so a bounded session's real launcher
@@ -65,6 +79,60 @@ pub fn agent_sandbox_profile(
     network_enabled: Option<bool>,
 ) -> Result<AgentSandboxLaunchSpec, String> {
     build_launch_spec(&mode, &project_root, network_enabled.unwrap_or(true))
+}
+
+/// Reports the effective sandbox posture from the Rust policy layer instead of
+/// echoing the renderer's requested mode. Bounded modes fail closed when a
+/// launch specification cannot be built; full access is deliberately shown as
+/// unconfined rather than as a failed sandbox.
+#[tauri::command]
+pub fn agent_sandbox_status(
+    mode: String,
+    project_root: String,
+    network_enabled: Option<bool>,
+) -> AgentSandboxStatus {
+    let network_enabled = network_enabled.unwrap_or(true);
+    let parsed_mode = SandboxMode::from_str(&mode);
+    let is_full_access = matches!(&parsed_mode, Ok(SandboxMode::FullAccess));
+    let effective_mode = match &parsed_mode {
+        Ok(SandboxMode::ReadOnly) => "read-only".to_string(),
+        Ok(SandboxMode::WorkspaceWrite) => "workspace-write".to_string(),
+        Ok(SandboxMode::FullAccess) => "full-access".to_string(),
+        Err(_) => mode.trim().to_string(),
+    };
+
+    if is_full_access {
+        return AgentSandboxStatus {
+            backend: "unconfined".to_string(),
+            spec_available: false,
+            enforced_at_launch: false,
+            fail_closed: false,
+            effective_mode: "full-access".to_string(),
+            network_enabled,
+            detail: "No OS sandbox — the agent runs unconfined.".to_string(),
+        };
+    }
+
+    match build_launch_spec(&mode, &project_root, network_enabled) {
+        Ok(_) => AgentSandboxStatus {
+            backend: resolve_backend_kind().to_string(),
+            spec_available: true,
+            enforced_at_launch: true,
+            fail_closed: true,
+            effective_mode,
+            network_enabled,
+            detail: launch_enforcement_detail().to_string(),
+        },
+        Err(error) => AgentSandboxStatus {
+            backend: resolve_backend_kind().to_string(),
+            spec_available: false,
+            enforced_at_launch: false,
+            fail_closed: true,
+            effective_mode,
+            network_enabled,
+            detail: error,
+        },
+    }
 }
 
 /// Entry point for `<app-binary> __seren-sandbox-spec <mode> <network> <root>`.
@@ -116,6 +184,50 @@ pub fn sandbox_spec_main(args: Vec<String>) -> ! {
 fn exit_with(code: i32, message: impl std::fmt::Display) -> ! {
     eprintln!("Seren sandbox spec: {message}");
     std::process::exit(code);
+}
+
+fn resolve_backend_kind() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        return "seatbelt";
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return "linux-landlock";
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return "windows-restricted-token";
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        "unsupported"
+    }
+}
+
+fn launch_enforcement_detail() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        return "Seatbelt enforcement is applied when the agent process launches.";
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return "Landlock support is checked when the agent launches; a missing kernel primitive fails the bounded session closed.";
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return "Restricted-token support is checked when the agent launches; a missing OS primitive fails the bounded session closed.";
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        "No supported OS sandbox backend is available on this platform."
+    }
 }
 
 fn build_launch_spec(
@@ -186,5 +298,50 @@ fn build_launch_spec(
     {
         let _ = policy;
         Err("The provider sandbox backend is unavailable on this platform.".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_access_status_reports_unconfined() {
+        let status = agent_sandbox_status("full-access".to_string(), String::new(), Some(true));
+
+        assert_eq!(status.backend, "unconfined");
+        assert!(!status.spec_available);
+        assert!(!status.enforced_at_launch);
+        assert!(!status.fail_closed);
+        assert_eq!(status.effective_mode, "full-access");
+        assert!(status.detail.contains("unconfined"));
+    }
+
+    #[test]
+    fn workspace_write_status_reports_a_launchable_fail_closed_spec() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let status = agent_sandbox_status(
+            "workspace-write".to_string(),
+            workspace.path().display().to_string(),
+            Some(false),
+        );
+
+        assert_eq!(status.backend, resolve_backend_kind());
+        assert!(status.spec_available, "{}", status.detail);
+        assert!(status.enforced_at_launch);
+        assert!(status.fail_closed);
+        assert_eq!(status.effective_mode, "workspace-write");
+        assert!(!status.network_enabled);
+    }
+
+    #[test]
+    fn empty_project_root_reports_an_unavailable_spec() {
+        let status =
+            agent_sandbox_status("workspace-write".to_string(), "   ".to_string(), Some(true));
+
+        assert!(!status.spec_available);
+        assert!(!status.enforced_at_launch);
+        assert!(status.fail_closed);
+        assert!(!status.detail.is_empty());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1073,6 +1073,7 @@ pub fn run() {
             commands::history_sync::history_sync_run_now,
             commands::history_sync::history_sync_wipe_remote,
             commands::sandbox::agent_sandbox_profile,
+            commands::sandbox::agent_sandbox_status,
             commands::credential_lease::credential_lease_create,
             commands::credential_lease::credential_lease_revoke,
             commands::credential_lease::credential_lease_revoke_all,

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -27,6 +27,10 @@ import {
   wipeHistorySyncRemote,
 } from "@/services/historySync";
 import { allowsSerenPublicModels } from "@/services/organization-policy";
+import {
+  type AgentSandboxStatus,
+  getAgentSandboxStatus,
+} from "@/services/providers";
 import { telemetry } from "@/services/telemetry";
 import {
   appearanceState,
@@ -42,6 +46,7 @@ import {
 import { authStore } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { cryptoWalletStore } from "@/stores/crypto-wallet.store";
+import { fileTreeState } from "@/stores/fileTree";
 import { resetAllKeybindings } from "@/stores/keybindings.store";
 import { providerStore } from "@/stores/provider.store";
 import {
@@ -117,6 +122,12 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
   const [historySyncSummary, setHistorySyncSummary] =
     createSignal<HistorySyncSummary | null>(null);
   const [historySyncWipeConfirm, setHistorySyncWipeConfirm] = createSignal("");
+  const [agentSandboxStatus, setAgentSandboxStatus] =
+    createSignal<AgentSandboxStatus | null>(null);
+  const [agentSandboxStatusError, setAgentSandboxStatusError] = createSignal<
+    string | null
+  >(null);
+  let agentSandboxStatusRequest = 0;
 
   const refreshClaudeMemoryStatus = async () => {
     try {
@@ -125,6 +136,32 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       setClaudeMemoryWatchingRoot(status.watching_root);
     } catch (err) {
       console.warn("[ClaudeMemory] status read failed", err);
+    }
+  };
+
+  const refreshAgentSandboxStatus = async (
+    mode: string,
+    projectRoot: string,
+    networkEnabled: boolean,
+  ) => {
+    const request = ++agentSandboxStatusRequest;
+    setAgentSandboxStatusError(null);
+    try {
+      const status = await getAgentSandboxStatus(
+        mode,
+        projectRoot,
+        networkEnabled,
+      );
+      if (request === agentSandboxStatusRequest) {
+        setAgentSandboxStatus(status);
+      }
+    } catch (error) {
+      if (request === agentSandboxStatusRequest) {
+        setAgentSandboxStatus(null);
+        setAgentSandboxStatusError(
+          `Could not verify the effective sandbox: ${String(error)}`,
+        );
+      }
     }
   };
 
@@ -430,6 +467,13 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     if (visible.some((section) => section.id === activeSection())) return;
     const firstVisible = visible[0];
     if (firstVisible) selectSection(firstVisible.id);
+  });
+
+  createEffect(() => {
+    const mode = settingsState.app.agentSandboxMode;
+    const networkEnabled = settingsState.app.agentNetworkEnabled;
+    const projectRoot = fileTreeState.rootPath ?? "";
+    void refreshAgentSandboxStatus(mode, projectRoot, networkEnabled);
   });
 
   const handleOpenSection = (event: Event) => {
@@ -1326,6 +1370,117 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                   )}
                 </For>
               </div>
+            </div>
+
+            <div class="py-3 border-b border-border">
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Verified effective sandbox
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Reported by the trusted Rust sandbox module for the current
+                    project and network settings.
+                  </span>
+                </div>
+                <Show
+                  when={agentSandboxStatus()}
+                  fallback={
+                    <span class="text-[0.75rem] text-muted-foreground">
+                      Checking…
+                    </span>
+                  }
+                >
+                  {(status) => (
+                    <span
+                      class={`shrink-0 rounded-full border px-2 py-1 text-[0.72rem] font-medium ${
+                        status().effective_mode === "full-access"
+                          ? "border-destructive/40 bg-destructive/10 text-destructive"
+                          : status().enforced_at_launch
+                            ? "border-accent/40 bg-primary/10 text-foreground"
+                            : "border-warning/40 bg-warning/10 text-warning"
+                      }`}
+                    >
+                      {status().effective_mode === "full-access"
+                        ? "Unconfined"
+                        : status().enforced_at_launch
+                          ? "Enforced at launch"
+                          : "Unavailable"}
+                    </span>
+                  )}
+                </Show>
+              </div>
+
+              <Show when={agentSandboxStatus()}>
+                {(status) => (
+                  <div class="mt-3 flex flex-col gap-2 text-[0.8rem]">
+                    <Show when={status().effective_mode === "full-access"}>
+                      <div
+                        class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive"
+                        role="alert"
+                      >
+                        <span class="font-medium">
+                          Unconfined — no OS sandbox
+                        </span>
+                        <span class="ml-1">
+                          The agent runs outside the trusted sandbox boundary.
+                        </span>
+                      </div>
+                    </Show>
+                    <div class="grid grid-cols-2 gap-x-4 gap-y-1 rounded-md bg-surface-3/50 px-3 py-2 text-muted-foreground">
+                      <span>
+                        Backend:{" "}
+                        <strong class="font-medium text-foreground">
+                          {status().backend}
+                        </strong>
+                      </span>
+                      <span>
+                        Effective mode:{" "}
+                        <strong class="font-medium text-foreground">
+                          {status().effective_mode}
+                        </strong>
+                      </span>
+                      <span>
+                        Network:{" "}
+                        <strong class="font-medium text-foreground">
+                          {status().network_enabled ? "Enabled" : "Disabled"}
+                        </strong>
+                      </span>
+                      <span>
+                        Launch state:{" "}
+                        <strong class="font-medium text-foreground">
+                          {status().enforced_at_launch
+                            ? "Enforced"
+                            : "Not enforced"}
+                        </strong>
+                      </span>
+                    </div>
+                    <p class="m-0 text-muted-foreground leading-normal">
+                      {status().detail}
+                    </p>
+                    <Show when={!status().spec_available}>
+                      <p
+                        class="m-0 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-warning"
+                        role="alert"
+                      >
+                        A bounded agent session would be blocked until this
+                        sandbox specification can be prepared.
+                      </p>
+                    </Show>
+                  </div>
+                )}
+              </Show>
+
+              <Show when={agentSandboxStatusError()}>
+                {(error) => (
+                  <p
+                    class="m-0 mt-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-[0.8rem] text-warning"
+                    role="alert"
+                  >
+                    {error()}
+                  </p>
+                )}
+              </Show>
             </div>
 
             <Show

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -537,6 +537,17 @@ export interface BrokeredSerenCredential {
   apiBaseUrl: string;
 }
 
+/** Truthful sandbox posture returned by the trusted Rust sandbox module. */
+export interface AgentSandboxStatus {
+  backend: string;
+  spec_available: boolean;
+  enforced_at_launch: boolean;
+  fail_closed: boolean;
+  effective_mode: string;
+  network_enabled: boolean;
+  detail: string;
+}
+
 async function invokeProvider<T>(
   command: string,
   args?: Record<string, unknown>,
@@ -556,6 +567,23 @@ async function invokeProvider<T>(
 // ============================================================================
 // Tauri Command Wrappers
 // ============================================================================
+
+/**
+ * Read the sandbox posture that the trusted host can actually prepare for an
+ * agent launch. This is intentionally separate from the requested settings
+ * mode, which is not proof that a platform backend can build its spec.
+ */
+export async function getAgentSandboxStatus(
+  mode: string,
+  projectRoot: string,
+  networkEnabled: boolean,
+): Promise<AgentSandboxStatus> {
+  return invoke<AgentSandboxStatus>("agent_sandbox_status", {
+    mode,
+    projectRoot,
+    networkEnabled,
+  });
+}
 
 /**
  * Spawn a new agent runtime session.

--- a/tests/unit/sandbox-status-bridge.test.ts
+++ b/tests/unit/sandbox-status-bridge.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Pins the renderer's read-only bridge to the trusted sandbox status command.
+// ABOUTME: Keeps Settings from inferring effective confinement from its requested mode.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/lib/browser-local-runtime", () => ({
+  isLocalProviderRuntime: () => false,
+  onRuntimeEvent: vi.fn(),
+  runtimeInvoke: vi.fn(),
+}));
+
+vi.mock("@/lib/runtime", () => ({
+  runtimeHasCapability: () => false,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
+
+import { getAgentSandboxStatus } from "@/services/providers";
+
+describe("agent sandbox status renderer bridge", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("returns the Rust-sourced effective status shape", async () => {
+    const expected = {
+      backend: "seatbelt",
+      spec_available: true,
+      enforced_at_launch: true,
+      fail_closed: true,
+      effective_mode: "workspace-write",
+      network_enabled: false,
+      detail: "Seatbelt enforcement is applied when the agent process launches.",
+    };
+    invokeMock.mockResolvedValue(expected);
+
+    await expect(
+      getAgentSandboxStatus("workspace-write", "/workspace", false),
+    ).resolves.toEqual(expected);
+    expect(invokeMock).toHaveBeenCalledWith("agent_sandbox_status", {
+      mode: "workspace-write",
+      projectRoot: "/workspace",
+      networkEnabled: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a Rust-owned `agent_sandbox_status` command that reports the launch posture the trusted sandbox module can prepare.
- Registers a typed renderer wrapper and shows the returned backend, effective mode, network posture, and launch state in Settings.
- Makes Full Access explicit: **Unconfined — no OS sandbox**. Bounded-mode specification failures surface the reason a session would be blocked.

## Audit trace

The prior Settings sandbox section displayed only the requested mode. This change reads the status from `src-tauri/src/commands/sandbox.rs`, where the existing launch-spec builder remains the source of truth. `src/services/providers.ts` is the sole renderer bridge; the component does not call Tauri directly.

## Truthful reporting design

This is a pre-launch capability report, not a claim that a child is already confined. Bounded modes report an enforced-at-launch posture only when Rust can build a platform launch spec, and retain fail-closed status when it cannot. Full Access reports `unconfined` with `enforced_at_launch: false`.

Networked path: none — the status is produced locally by the trusted sandbox module; no publisher or Gateway API call is added.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml sandbox -- --nocapture`
- `pnpm vitest run tests/unit/sandbox-status-bridge.test.ts --reporter=verbose`
- `pnpm check`
- `pnpm build`

Refs #3192

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com