### PR TITLE
docs(auth): correct stale per-publisher scope justification

### DIFF
--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -18,9 +18,14 @@ const DEFAULT_ORG_API_KEYS_PATH: &str = "/organizations/default/api-keys";
 const LEASE_STORE: &str = "credential-leases.json";
 const LEASE_LEDGER_KEY: &str = "orphaned_leases";
 const LEASE_EXPIRY_DAYS: u8 = 1;
-// The public OpenAPI schema accepts scopes but does not publish a narrower
-// accepted grammar. Keep this to the only live-verified scope until the API
-// exposes per-publisher scope syntax. See #3194.
+// Core now publishes and enforces a per-publisher scope grammar
+// (`publisher:*`, `publisher:<slug>`, `publisher:<slug>:operation:<id>`; see
+// seren-core#222). The lease stays `publisher:*` because a general agent
+// session does not know its publisher set at spawn — the Seren MCP catalog is
+// dynamic — so narrowing needs a per-publisher capability minted at first use,
+// not a scope-string change. One residual on the wildcard is tracked in
+// seren-core#224: for a user key it still authorizes destructive
+// seren-passwords operations. See #3194.
 const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*"];
 
 /// What the renderer and provider runtime are allowed to see. The real key is


### PR DESCRIPTION
## Summary

Comment-only fix for #3243. The `VERIFIED_LEASE_SCOPES` justification in `src-tauri/src/credential_lease.rs` claimed the API does not publish a narrower accepted scope grammar. That is no longer true: **seren-core#222** shipped and now enforces `publisher:*`, `publisher:<slug>`, and `publisher:<slug>:operation:<id>` (verified live — a `publisher:seren-notes` key is denied every other publisher with 403 and cannot reach org key-management routes).

The comment now records the *actual* reason the lease stays `publisher:*`: a general agent session does not know its publisher set at spawn (the Seren MCP catalog is dynamic), so narrowing requires a per-publisher capability minted at first use — a design change, not a scope-string edit. It also links the tracked residual, **seren-core#224** (a user-key wildcard still authorizes destructive `seren-passwords` operations).

## Scope

- Comment-only. `VERIFIED_LEASE_SCOPES` is unchanged (`["publisher:*"]`).
- **No behavior change**, no functional/network path affected.

## Validation

- `cargo check` (comment-only; cannot alter compilation or runtime behavior).

Closes #3243

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com