### PR TITLE
docs(auth): correct the lease-scope comment now that scopes are enforced

### DIFF
--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -18,9 +18,14 @@ const DEFAULT_ORG_API_KEYS_PATH: &str = "/organizations/default/api-keys";
 const LEASE_STORE: &str = "credential-leases.json";
 const LEASE_LEDGER_KEY: &str = "orphaned_leases";
 const LEASE_EXPIRY_DAYS: u8 = 1;
-// The public OpenAPI schema accepts scopes but does not publish a narrower
-// accepted grammar. Keep this to the only live-verified scope until the API
-// exposes per-publisher scope syntax. See #3194.
+// Core now publishes and enforces a per-publisher scope grammar
+// (`publisher:*`, `publisher:<slug>`, `publisher:<slug>:operation:<id>`; see
+// seren-core#222). The lease stays `publisher:*` because a general agent
+// session does not know its publisher set at spawn — the Seren MCP catalog is
+// dynamic — so narrowing needs a per-publisher capability minted at first use,
+// not a scope-string change. One residual on the wildcard is tracked in
+// seren-core#224: for a user key it still authorizes destructive
+// seren-passwords operations. See #3194.
 const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*"];
 
 /// What the renderer and provider runtime are allowed to see. The real key is


### PR DESCRIPTION
Closes #3243. Comment-only.

The lease-scope comment justified `publisher:*` by claiming the API published no narrower scope grammar. serenorg/seren-core#222 shipped and I verified it live: the grammar (`publisher:*`, `publisher:<slug>`, `publisher:<slug>:operation:<id>`) is now published and enforced — a `publisher:seren-notes` key is denied every other publisher (403) and cannot reach `/organizations/**`.

The comment now states the real reason the lease stays `publisher:*` — a general agent session does not know its publisher set at spawn, so narrowing needs a per-publisher capability minted at first use, not a scope-string edit — and links the tracked residual (serenorg/seren-core#224: the user-key wildcard still authorizes destructive `seren-passwords` operations, while installed skills only need read).

`VERIFIED_LEASE_SCOPES` is unchanged. No behavior change, so no test change; `cargo check` and a full lib build pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com