### PR TITLE
fix(tools): classify tool approvals by structural verb, not dead path patterns

### DIFF
--- a/src/lib/tools/approval-config.ts
+++ b/src/lib/tools/approval-config.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Configuration for Gateway publisher tool approval requirements.
-// ABOUTME: Defines which operations need user approval before execution.
+// ABOUTME: Classifies Gateway/built-in tool operations for the renderer authorization gate.
+// ABOUTME: Uses the operation's structural verb token, not hardcoded per-publisher path patterns.
 
 /**
  * Approval requirement for a specific operation.
@@ -7,7 +7,7 @@
 export interface ApprovalRequirement {
   /** Publisher slug (e.g., "gmail") */
   publisherSlug: string;
-  /** Tool/endpoint name (e.g., "messages/{id}/delete") */
+  /** Tool/operation name (the Gateway operationId, e.g. "delete_messages_by_message_id") */
   toolPattern: string;
   /** Human-readable description of what this operation does */
   description: string;
@@ -27,78 +27,164 @@ interface OperationPattern {
 }
 
 /**
- * Explicit high-risk operations that always require one-shot approval.
- * Operations absent from both this list and TRUSTED_READ_OPERATIONS are
- * unclassified and must be escalated before their first use in a session.
+ * Explicit high-risk operations that carry a specific approval description.
+ *
+ * These are matched against the Gateway's real operationId tool names. Structural
+ * classification (see classifyGatewayOperation) already escalates deletes and sends,
+ * so this list exists to enrich the approval prompt, not to be the only defense.
  */
 export const APPROVAL_REQUIREMENTS: ApprovalRequirement[] = [
-  // Gmail - Modify operations
   {
     publisherSlug: "gmail",
-    toolPattern: "messages/*/delete",
+    toolPattern: "delete_messages_by_message_id",
     description: "Permanently delete email",
     isDestructive: true,
   },
   {
     publisherSlug: "gmail",
-    toolPattern: "messages/*/trash",
-    description: "Move email to trash",
-  },
-  {
-    publisherSlug: "gmail",
-    toolPattern: "messages/*/modify",
-    description: "Modify email labels",
-  },
-  {
-    publisherSlug: "gmail",
-    toolPattern: "threads/*/trash",
-    description: "Move thread to trash",
-  },
-  {
-    publisherSlug: "gmail",
-    toolPattern: "labels",
-    description: "Create label",
-  },
-  {
-    publisherSlug: "gmail",
-    toolPattern: "labels/*/delete",
+    toolPattern: "delete_labels_by_label_id",
     description: "Delete label",
     isDestructive: true,
   },
   {
     publisherSlug: "gmail",
-    toolPattern: "drafts/*/send",
-    description: "Send draft email",
+    toolPattern: "post_send",
+    description: "Send email",
   },
   {
     publisherSlug: "gmail",
-    toolPattern: "messages/send",
-    description: "Send email",
+    toolPattern: "post_messages_send",
+    description: "Send email (raw RFC 2822)",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "post_drafts_by_draft_id_send",
+    description: "Send draft email",
   },
 ];
 
 /**
- * Positively identified read-only operations that may execute silently.
- * Keep this list narrow: verb-shaped names and undiscovered publishers do not
- * become trusted merely because they look like reads.
+ * Publisher-scoped read trust. Reads (safe verb tokens, see READ_VERBS) for these
+ * publishers execute silently. Reads for any other publisher stay unclassified —
+ * we do not assume an unknown or dynamically discovered publisher's reads are safe.
+ */
+export const TRUSTED_READ_PUBLISHERS: ReadonlySet<string> = new Set(["gmail"]);
+
+/**
+ * Positively identified read-only operations for publishers not covered by
+ * TRUSTED_READ_PUBLISHERS. Keep this list narrow: verb-shaped names and
+ * undiscovered publishers do not become trusted merely because they look like reads.
  */
 export const TRUSTED_READ_OPERATIONS: readonly OperationPattern[] = [
-  { publisherSlug: "gmail", toolPattern: "messages" },
-  { publisherSlug: "gmail", toolPattern: "messages/*" },
-  { publisherSlug: "gmail", toolPattern: "threads" },
-  { publisherSlug: "gmail", toolPattern: "threads/*" },
-  { publisherSlug: "gmail", toolPattern: "labels/list" },
-  { publisherSlug: "gmail", toolPattern: "get_messages" },
-  { publisherSlug: "gmail", toolPattern: "get_message" },
-  { publisherSlug: "gmail", toolPattern: "get_thread" },
-  { publisherSlug: "gmail", toolPattern: "list_messages" },
-  { publisherSlug: "gmail", toolPattern: "list_threads" },
-  { publisherSlug: "gmail", toolPattern: "list_labels" },
   { publisherSlug: "seren", toolPattern: "list_projects" },
   { publisherSlug: "seren", toolPattern: "get_project" },
   { publisherSlug: "seren", toolPattern: "search_projects" },
   { publisherSlug: "seren", toolPattern: "get_status" },
 ];
+
+/**
+ * Leading verb tokens that denote a side-effect-free read. Gateway operationIds
+ * are `{httpMethod}_{path}`, so a `get_`/`head_` prefix is a genuine HTTP GET/HEAD.
+ * The remaining verbs cover CRUD-style and RPC-style read names.
+ */
+const READ_VERBS: ReadonlySet<string> = new Set([
+  "get",
+  "head",
+  "list",
+  "search",
+  "describe",
+  "read",
+  "fetch",
+  "query",
+  "count",
+  "find",
+  "lookup",
+  "check",
+  "view",
+  "show",
+  "poll",
+  "status",
+  "info",
+  "ping",
+  "health",
+  "has",
+  "is",
+  "exists",
+]);
+
+/**
+ * Tokens that mark an operation as high-risk: irreversible, monetary, outbound,
+ * or credential/security sensitive. Matched as whole underscore/space-delimited
+ * tokens so `get_messages` is never flagged by the word "messages" — only real
+ * verbs like `send`, `delete`, `transfer`, or `order` count.
+ */
+const HIGH_RISK_TOKENS: ReadonlySet<string> = new Set([
+  // irreversible / destructive
+  "delete",
+  "destroy",
+  "drop",
+  "purge",
+  "terminate",
+  "wipe",
+  "erase",
+  "remove",
+  "revoke",
+  // monetary / trading
+  "pay",
+  "payment",
+  "payout",
+  "withdraw",
+  "withdrawal",
+  "deposit",
+  "transfer",
+  "remit",
+  "trade",
+  "order",
+  "buy",
+  "sell",
+  "charge",
+  "refund",
+  "settle",
+  "settlement",
+  "swap",
+  "mint",
+  "burn",
+  "bet",
+  "wager",
+  "stake",
+  // outbound
+  "send",
+  "email",
+  "sms",
+  "notify",
+  "dispatch",
+  "broadcast",
+  // credential / security / execution
+  "credential",
+  "secret",
+  "password",
+  "sign",
+  "execute",
+  "deploy",
+]);
+
+function isHighRiskToken(token: string): boolean {
+  if (HIGH_RISK_TOKENS.has(token)) return true;
+  // Light singularization so plurals like "orders" or "transfers" still match
+  // "order" / "transfer".
+  return token.endsWith("s") && HIGH_RISK_TOKENS.has(token.slice(0, -1));
+}
+
+function operationTokens(toolName: string): string[] {
+  return toolName
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function leadingVerb(toolName: string): string {
+  return operationTokens(toolName)[0] ?? "";
+}
 
 function matchesOperation(
   requirement: OperationPattern,
@@ -107,8 +193,9 @@ function matchesOperation(
 ): boolean {
   if (requirement.publisherSlug !== publisherSlug) return false;
 
-  // Simple wildcard matching: "messages/*/delete" matches
-  // "messages/123/delete" without allowing a wildcard to span a path segment.
+  // Simple wildcard matching: "messages/*/delete" matches "messages/123/delete"
+  // without allowing a wildcard to span a path segment. Live operationIds are
+  // literal (path parameters are call arguments), so most patterns match exactly.
   const pattern = requirement.toolPattern
     .split("*")
     .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
@@ -117,8 +204,28 @@ function matchesOperation(
 }
 
 /**
- * Classify an operation only when it has an explicit policy entry.
- * Everything else is deliberately unclassified rather than implicitly safe.
+ * Whether the operation is a read. Reads are never high-risk: the read verb gates
+ * the high-risk token scan so an operation like `get_transfers` (reading transfers)
+ * is not mistaken for a money movement.
+ */
+export function isReadOperation(toolName: string): boolean {
+  return READ_VERBS.has(leadingVerb(toolName));
+}
+
+/**
+ * Escalate operations whose verb marks them irreversible, monetary, outbound, or
+ * credential-sensitive. This only adds approvals; it never grants access, and it
+ * never fires for a read operation.
+ */
+export function isHighRiskOperation(toolName: string): boolean {
+  if (isReadOperation(toolName)) return false;
+  return operationTokens(toolName).some(isHighRiskToken);
+}
+
+/**
+ * Classify an operation by its structural verb token plus explicit policy entries.
+ * Precedence is deny-safe: high-risk is decided before trusted-read, and anything
+ * unrecognized stays unclassified rather than implicitly safe.
  */
 export function classifyGatewayOperation(
   publisherSlug: string,
@@ -132,25 +239,20 @@ export function classifyGatewayOperation(
     return "high-risk";
   }
 
-  if (
+  if (isHighRiskOperation(toolName)) {
+    return "high-risk";
+  }
+
+  const trustedRead =
+    (TRUSTED_READ_PUBLISHERS.has(publisherSlug) && isReadOperation(toolName)) ||
     TRUSTED_READ_OPERATIONS.some((operation) =>
       matchesOperation(operation, publisherSlug, toolName),
-    )
-  ) {
+    );
+  if (trustedRead) {
     return "trusted-read";
   }
 
   return "unclassified";
-}
-
-/**
- * Escalate recognizably high-risk names even before their publisher supplies
- * trusted metadata. This helper only adds prompts; it never grants access.
- */
-export function isHighRiskVerb(toolName: string): boolean {
-  return /send|delete|remove|pay|transfer|trade|execute|credential|revoke/i.test(
-    toolName,
-  );
 }
 
 /**
@@ -160,10 +262,7 @@ export function requiresApproval(
   publisherSlug: string,
   toolName: string,
 ): boolean {
-  return (
-    classifyGatewayOperation(publisherSlug, toolName) === "high-risk" ||
-    isHighRiskVerb(toolName)
-  );
+  return classifyGatewayOperation(publisherSlug, toolName) === "high-risk";
 }
 
 /**

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -20,7 +20,7 @@ import type { OperationClass } from "./approval-config";
 import {
   classifyGatewayOperation,
   getApprovalRequirement,
-  isHighRiskVerb,
+  isHighRiskOperation,
 } from "./approval-config";
 import {
   hasSessionDenial,
@@ -230,7 +230,8 @@ async function authorizeToolOperation(
   const operationClass =
     options?.operationClass ??
     classifyGatewayOperation(publisherSlug, toolName);
-  const highRisk = operationClass === "high-risk" || isHighRiskVerb(toolName);
+  const highRisk =
+    operationClass === "high-risk" || isHighRiskOperation(toolName);
 
   if (operationClass === "trusted-read" && !highRisk) {
     return { approved: true };

--- a/tests/unit/approval-config.test.ts
+++ b/tests/unit/approval-config.test.ts
@@ -1,101 +1,132 @@
-// Unit tests for Gateway tool approval configuration
+// Unit tests for Gateway tool approval classification.
+//
+// Tool names below are the REAL operationIds the Gateway exposes (verified against
+// the live publisher listing), not REST-path placeholders. The prior suite asserted
+// against synthetic `messages/123/delete`-style inputs that never occur in production,
+// which hid a classifier that matched nothing on the real names.
 
 import { describe, expect, it } from "vitest";
 import {
   classifyGatewayOperation,
   getApprovalRequirement,
-  isHighRiskVerb,
+  isHighRiskOperation,
+  isReadOperation,
   requiresApproval,
 } from "@/lib/tools/approval-config";
 
 describe("approval-config", () => {
-  describe("requiresApproval", () => {
-    it("should require approval for Gmail delete operations", () => {
-      expect(requiresApproval("gmail", "messages/123/delete")).toBe(true);
+  describe("Gmail reads are silent (regression: they used to prompt)", () => {
+    it("classifies real Gmail read operationIds as trusted-read", () => {
+      for (const tool of [
+        "get_messages",
+        "get_messages_by_message_id",
+        "get_threads",
+        "get_threads_by_thread_id",
+        "get_labels",
+        "get_labels_by_label_id",
+        "get_profile",
+        "get_drafts",
+        "get_health",
+      ]) {
+        expect(classifyGatewayOperation("gmail", tool)).toBe("trusted-read");
+        expect(requiresApproval("gmail", tool)).toBe(false);
+      }
+    });
+  });
+
+  describe("Gmail high-risk mutations require one-shot approval", () => {
+    it("escalates permanent deletes and outbound sends", () => {
+      for (const tool of [
+        "delete_messages_by_message_id",
+        "delete_labels_by_label_id",
+        "post_send",
+        "post_messages_send",
+        "post_drafts_by_draft_id_send",
+      ]) {
+        expect(classifyGatewayOperation("gmail", tool)).toBe("high-risk");
+        expect(requiresApproval("gmail", tool)).toBe(true);
+      }
+    });
+  });
+
+  describe("Gmail reversible writes are session-grantable, not one-shot", () => {
+    it("leaves trash/modify/create-label unclassified (approve once, then grant)", () => {
+      for (const tool of [
+        "post_messages_by_message_id_trash",
+        "post_messages_by_message_id_modify",
+        "post_threads_by_thread_id_trash",
+        "post_labels",
+      ]) {
+        expect(classifyGatewayOperation("gmail", tool)).toBe("unclassified");
+        expect(requiresApproval("gmail", tool)).toBe(false);
+      }
+    });
+  });
+
+  describe("structural classification is publisher-agnostic", () => {
+    it("escalates monetary, trading, transfer, and destructive operations on any publisher", () => {
+      expect(requiresApproval("alpaca", "post_orders")).toBe(true);
+      expect(requiresApproval("some-dex", "post_swap")).toBe(true);
+      expect(requiresApproval("some-wallet", "post_transfers")).toBe(true);
+      expect(requiresApproval("some-bank", "post_withdrawals")).toBe(true);
+      expect(requiresApproval("attio", "delete_records_by_id")).toBe(true);
     });
 
-    it("should require approval for Gmail trash operations", () => {
-      expect(requiresApproval("gmail", "messages/456/trash")).toBe(true);
-      expect(requiresApproval("gmail", "threads/789/trash")).toBe(true);
+    it("treats an ordinary write on an unknown publisher as a session-grantable mutation", () => {
+      expect(classifyGatewayOperation("attio", "post_notes")).toBe(
+        "unclassified",
+      );
+      expect(requiresApproval("attio", "post_notes")).toBe(false);
     });
 
-    it("should require approval for Gmail modify operations", () => {
-      expect(requiresApproval("gmail", "messages/123/modify")).toBe(true);
-    });
-
-    it("should require approval for label operations", () => {
-      expect(requiresApproval("gmail", "labels")).toBe(true);
-      expect(requiresApproval("gmail", "labels/123/delete")).toBe(true);
-    });
-
-    it("should require approval for sending emails", () => {
-      expect(requiresApproval("gmail", "messages/send")).toBe(true);
-      expect(requiresApproval("gmail", "drafts/123/send")).toBe(true);
-    });
-
-    it("should NOT require approval for read operations", () => {
-      expect(requiresApproval("gmail", "messages")).toBe(false);
-      expect(requiresApproval("gmail", "messages/123")).toBe(false);
-      expect(requiresApproval("gmail", "threads")).toBe(false);
-      expect(requiresApproval("gmail", "threads/456")).toBe(false);
-      expect(requiresApproval("gmail", "labels/list")).toBe(false);
-    });
-
-    it("requires approval for destructive-looking operations on non-Gmail publishers", () => {
-      expect(requiresApproval("other-publisher", "messages/123/delete")).toBe(
-        true,
+    it("does not auto-trust reads for an unknown publisher", () => {
+      expect(classifyGatewayOperation("attio", "get_records")).toBe(
+        "unclassified",
       );
     });
   });
 
-  describe("classifyGatewayOperation", () => {
-    it("classifies explicitly configured Gmail mutations as high-risk", () => {
-      expect(classifyGatewayOperation("gmail", "messages/123/delete")).toBe(
-        "high-risk",
-      );
+  describe("read verbs gate the high-risk token scan", () => {
+    it("never escalates a read even when its name contains a money-shaped noun", () => {
+      expect(isReadOperation("get_transfers")).toBe(true);
+      expect(requiresApproval("some-publisher", "get_transfers")).toBe(false);
+      expect(requiresApproval("some-publisher", "list_orders")).toBe(false);
+      expect(requiresApproval("some-publisher", "search_payments")).toBe(false);
     });
+  });
 
-    it("classifies only explicit known reads as trusted", () => {
-      expect(classifyGatewayOperation("gmail", "get_messages")).toBe(
-        "trusted-read",
-      );
+  describe("isHighRiskOperation", () => {
+    it("flags irreversible/monetary/outbound verbs and ignores reads and inspects", () => {
+      expect(isHighRiskOperation("delete_record")).toBe(true);
+      expect(isHighRiskOperation("post_transfers")).toBe(true);
+      expect(isHighRiskOperation("execute_wallet_transfer")).toBe(true);
+      expect(isHighRiskOperation("inspect_records")).toBe(false);
+      expect(isHighRiskOperation("get_transfers")).toBe(false);
+    });
+  });
+
+  describe("seren built-in reads stay trusted", () => {
+    it("keeps the explicit built-in read allowlist", () => {
       expect(classifyGatewayOperation("seren", "list_projects")).toBe(
         "trusted-read",
       );
-    });
-
-    it("leaves a never-seen publisher and tool unclassified", () => {
       expect(classifyGatewayOperation("new-publisher", "inspect_records")).toBe(
         "unclassified",
       );
     });
-
-    it("escalates high-risk verbs without using them as an allowlist", () => {
-      expect(isHighRiskVerb("delete_record")).toBe(true);
-      expect(isHighRiskVerb("inspect_records")).toBe(false);
-    });
   });
 
   describe("getApprovalRequirement", () => {
-    it("should return requirement for matching operations", () => {
-      const req = getApprovalRequirement("gmail", "messages/123/delete");
+    it("returns the description for a matching high-risk operationId", () => {
+      const req = getApprovalRequirement("gmail", "delete_messages_by_message_id");
       expect(req).not.toBeNull();
       expect(req?.publisherSlug).toBe("gmail");
       expect(req?.description).toBe("Permanently delete email");
       expect(req?.isDestructive).toBe(true);
     });
 
-    it("should return null for non-matching operations", () => {
-      const req = getApprovalRequirement("gmail", "messages");
-      expect(req).toBeNull();
-    });
-
-    it("should match wildcard patterns correctly", () => {
-      const req1 = getApprovalRequirement("gmail", "messages/abc123/trash");
-      expect(req1?.description).toBe("Move email to trash");
-
-      const req2 = getApprovalRequirement("gmail", "threads/xyz789/trash");
-      expect(req2?.description).toBe("Move thread to trash");
+    it("returns null for a read operation", () => {
+      expect(getApprovalRequirement("gmail", "get_messages")).toBeNull();
     });
   });
 });

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -85,13 +85,13 @@ describe("tool executor OAuth account routing", () => {
       id: "tool-call-1",
       type: "function",
       function: {
-        name: "gateway__gmail__messages",
+        name: "gateway__gmail__get_messages",
         arguments: JSON.stringify({ q: "from:example" }),
       },
     });
 
     expect(result.is_error).toBe(false);
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "messages", {
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "get_messages", {
       q: "from:example",
       connection_id: "conn-google-personal",
     });
@@ -123,7 +123,7 @@ describe("tool executor OAuth account routing", () => {
         id: "tool-call-owning",
         type: "function",
         function: {
-          name: "gateway__gmail__messages",
+          name: "gateway__gmail__get_messages",
           arguments: JSON.stringify({ q: "from:example" }),
         },
       },
@@ -131,7 +131,7 @@ describe("tool executor OAuth account routing", () => {
     );
 
     expect(result.is_error).toBe(false);
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "messages", {
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "get_messages", {
       q: "from:example",
       connection_id: "conn-google-personal",
     });
@@ -152,7 +152,7 @@ describe("tool executor OAuth account routing", () => {
       id: "tool-call-2",
       type: "function",
       function: {
-        name: "gateway__gmail__messages",
+        name: "gateway__gmail__get_messages",
         arguments: JSON.stringify({ q: "from:example" }),
       },
     });
@@ -174,7 +174,7 @@ describe("tool executor OAuth account routing", () => {
       id: "tool-call-unavailable",
       type: "function",
       function: {
-        name: "gateway__gmail__messages",
+        name: "gateway__gmail__get_messages",
         arguments: JSON.stringify({ q: "safe-read" }),
       },
     });
@@ -215,7 +215,7 @@ describe("tool executor OAuth account routing", () => {
         id: "tool-call-paid",
         type: "function",
         function: {
-          name: "gateway__gmail__messages",
+          name: "gateway__gmail__get_messages",
           arguments: JSON.stringify({ q: "safe-read" }),
         },
       },
@@ -226,7 +226,7 @@ describe("tool executor OAuth account routing", () => {
     expect(mocks.callGatewayTool).toHaveBeenNthCalledWith(
       1,
       "gmail",
-      "messages",
+      "get_messages",
       {
         q: "safe-read",
         connection_id: "conn-google-personal",
@@ -235,7 +235,7 @@ describe("tool executor OAuth account routing", () => {
     expect(mocks.callGatewayTool).toHaveBeenNthCalledWith(
       2,
       "gmail",
-      "messages",
+      "get_messages",
       {
         q: "safe-read",
         connection_id: "conn-google-personal",


### PR DESCRIPTION
## Summary

Fixes #3249. The renderer authorization classifier (`src/lib/tools/approval-config.ts`) matched **REST-path-style patterns** (`messages/*/delete`, `messages/send`, `get_message`, `labels/list`) that **never match the Gateway's real operationId tool names** (`delete_messages_by_message_id`, `post_send`, `get_messages_by_message_id`, `post_messages_by_message_id_trash`, …). The shipped Stage-1 containment (#3216) therefore misclassified live operations in both directions.

This is a renderer-side **containment refinement**, not the trusted Rust boundary #3193 ultimately requires. It does not close #3193.

## What was broken

- **Reads prompted the user.** `gateway__gmail__get_messages_by_message_id` (read one email) matched no trusted-read pattern → `unclassified` → first-use approval prompt on a pure read.
- **Mutations relied on a leaky substring regex.** `isHighRiskVerb` (`send|delete|remove|pay|transfer|trade|execute|credential|revoke`) missed real monetary/trading operations like `alpaca post_orders` (place a trade) → they got a reusable session grant after one prompt instead of one-shot approval.
- **Tests validated a fiction.** `tests/unit/approval-config.test.ts` asserted against synthetic `messages/123/delete` inputs that never occur in production, so the suite was green against names the app never sees. `tool-executor-oauth-account.test.ts` similarly relied on a non-existent `gmail messages` tool.

## The fix

Classify by the operation's **structural verb token** — which every OpenAPI-derived publisher tool carries as its `{httpMethod}_{path}` operationId — instead of hardcoded per-publisher path patterns:

| Signal | Class | Behavior |
|---|---|---|
| read verb (`get`/`head`/`list`/`search`/…) | trusted-read (for read-trusted publishers) or unclassified | never high-risk; a read verb gates the high-risk token scan so `get_transfers` is not mistaken for a money movement |
| irreversible/monetary/outbound/credential verb (`delete`/`transfer`/`order`/`send`/`sign`/…) | high-risk | one-shot approval every call, on **any** publisher |
| other write (`post`/`put`/`patch` create/update) | unclassified | approve once, then session-grant (per the ticket's usability goal) |

Publisher-scoped read trust (`TRUSTED_READ_PUBLISHERS`) silences known-safe reads (Gmail) structurally, resilient to endpoint drift. Reads for unknown/dynamically discovered publishers stay unclassified — we do not assume an unknown publisher's reads are safe. `isHighRiskOperation` also now applies to local stdio MCP tools (previously forced-unclassified), so a local `delete_*`/`transfer_*` tool is caught too.

## Verification

- `pnpm vitest run` — **2701 passed, 15 skipped** (full frontend suite).
- New regression tests assert against the **real** operationId names: Gmail reads are silent, permanent deletes/sends are one-shot, trash/modify/create-label are session-grantable, and `post_orders`/`post_swap`/`post_transfers`/`delete_records_by_id` escalate on arbitrary publishers.
- Biome clean on changed files. No new `tsc` errors introduced (repo has unrelated pre-existing baseline errors).

## Networked path

No new outbound calls. No change to transport (`callGatewayTool`/`mcpClient`), OAuth routing, x402, or the Rust path — this only changes the client-side classification decision before the existing dispatch. Verified the Gmail operationId naming against the live Gateway publisher listing (143 publishers).

## Scope / follow-ups (tracked under #3193, not this PR)

- The enforcement boundary is still the renderer, not a trusted Rust gate.
- Reads for non-Gmail publishers still prompt once (conservative posture, by design).
- No capability leases/budgets, blocked-state task machine, approval inbox, or E2E capability test.

Refs #3193
