### PR TITLE
fix(oauth): resolve latent src type errors (approval render crash + 2)

### DIFF
--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -364,10 +364,10 @@ export const GatewayToolApproval: Component = () => {
                         {(connection) => (
                           <span class="flex items-center gap-3 text-base text-foreground bg-surface-1 px-3 py-2 rounded-md border border-border min-h-[46px]">
                             <span class="w-7 h-7 rounded-full bg-accent text-primary-foreground flex items-center justify-center text-xs font-semibold shrink-0">
-                              {connectionInitial(connection())}
+                              {connectionInitial(connection)}
                             </span>
                             <span class="truncate">
-                              {formatOAuthConnectionLabel(connection())}
+                              {formatOAuthConnectionLabel(connection)}
                             </span>
                           </span>
                         )}

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -346,6 +346,12 @@ export async function setDefaultOAuthConnection(
     );
   }
 
+  if (!data?.connection) {
+    throw new Error(
+      `Failed to set default connection ${connectionId}: response contained no connection`,
+    );
+  }
+
   markOAuthConnectionsChanged();
   return data.connection as OAuthConnection;
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2165,7 +2165,8 @@ export type ErrorKind =
   | "binary_missing"
   | "crash_ceiling"
   | "summary_call_failed"
-  | "seed_failed";
+  | "seed_failed"
+  | "privileged_provider_blocked";
 
 export interface TurnError {
   kind: ErrorKind;


### PR DESCRIPTION
## What

Fixes three latent TypeScript errors in shipped `src/` code that `tsc --noEmit` surfaces but no CI gate catches (CI runs Biome + `vite build`/esbuild, neither of which type-checks).

## Defects fixed

1. **Render crash — `GatewayToolApproval.tsx`** (high). The single-connection branch is a `keyed` `<Show>`, so its callback receives the resolved `OAuthConnection` **value**, not an accessor. The code called `connection()` — invoking a plain object as a function → `TypeError: connection is not a function` **during render**, whenever a publisher has exactly one valid OAuth connection and the compact "From:" display renders. In SolidJS a render-time throw hits the error boundary and breaks the approval dialog. Fixed by using `connection` directly. (The non-keyed sibling `<Show when={selectedConnection()}>` correctly keeps `connection()`.)

2. **Missing `ErrorKind` member — `agent.store.ts`** (low). `sendPrompt` calls `setTurnError(threadId, "privileged_provider_blocked", …)`, but that kind was never added to the `ErrorKind` union. No runtime misbehavior today (`TurnError.retryable` is unread), but the union must stay authoritative. Added the member.

3. **Null-deref — `publisher-oauth.ts`** (low). `return data.connection` ran without guarding `data`, which the generated client types as optionally present; a 2xx-with-no-body response would throw an opaque `TypeError`. Added an explicit guard.

## Root cause

No `tsc` runs anywhere in CI or `package.json`. Type errors — including a real render crash — accumulate in production code unseen.

## Test plan

- `node_modules/.bin/tsc --noEmit` → **0 non-test errors** after the fix (was 4 in `src/`).
- `pnpm biome check` clean on all 3 changed files.
- Affected suites pass: `agent-turn-error`, `publisher-oauth-reconnect`, `oauth-account-switcher-load`, `tool-executor-oauth-account`, `agent-oauth-routing`, `agent-terminal-send-failure`, `agent-session-died-mid-prompt` (56 tests).

## No new test — rationale

The render-crash fix is **type-enforced**: `tsc` flags `connection()` on a `keyed` `<Show>` as `TS2349`, so any regression is caught by a typecheck. CLAUDE.md prohibits testing UI components and mocked behavior, and this repo has no SolidJS render harness (the nearest test does source-string assertions). A source-text guard can't robustly distinguish the correct non-keyed `connection()` from the buggy keyed one. The durable systemic guard for this whole class is a `tsc` CI gate — proposed separately, not bolted onto this bugfix.

## Follow-up (separate decision)

`tsc --noEmit` also reports ~104 errors in `tests/` (missing declarations for the intentionally-untyped `bin/**/*.mjs` modules, unused `@ts-expect-error`). Not runtime bugs; Vitest runs those suites fine. Whether to clean them up and add a `typecheck` CI gate is a distinct call, deliberately out of scope here.

Fixes #3252
