### PR TITLE
fix(gateway): repair keyed Show crash + latent src type errors (#3252)

### DIFF
--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -364,10 +364,10 @@ export const GatewayToolApproval: Component = () => {
                         {(connection) => (
                           <span class="flex items-center gap-3 text-base text-foreground bg-surface-1 px-3 py-2 rounded-md border border-border min-h-[46px]">
                             <span class="w-7 h-7 rounded-full bg-accent text-primary-foreground flex items-center justify-center text-xs font-semibold shrink-0">
-                              {connectionInitial(connection())}
+                              {connectionInitial(connection)}
                             </span>
                             <span class="truncate">
-                              {formatOAuthConnectionLabel(connection())}
+                              {formatOAuthConnectionLabel(connection)}
                             </span>
                           </span>
                         )}

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -346,6 +346,12 @@ export async function setDefaultOAuthConnection(
     );
   }
 
+  if (!data?.connection) {
+    throw new Error(
+      `Failed to set default connection ${connectionId}: response contained no connection`,
+    );
+  }
+
   markOAuthConnectionsChanged();
   return data.connection as OAuthConnection;
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2165,7 +2165,8 @@ export type ErrorKind =
   | "binary_missing"
   | "crash_ceiling"
   | "summary_call_failed"
-  | "seed_failed";
+  | "seed_failed"
+  | "privileged_provider_blocked";
 
 export interface TurnError {
   kind: ErrorKind;

--- a/tests/unit/src-type-safety-3252.test.ts
+++ b/tests/unit/src-type-safety-3252.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Regression guard for #3252 — keeps the three fixed src files tsc-clean.
+// ABOUTME: The render crash in GatewayToolApproval was a type error no other gate catches.
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const TSC = resolve(REPO_ROOT, "node_modules/.bin/tsc");
+
+// The three production files fixed in #3252. Biome (not type-aware), vite build
+// (esbuild strips types), and Vitest (esbuild) all shipped these type errors
+// unnoticed — only tsc catches them, so this guard runs the real compiler.
+const GUARDED_FILES = [
+  "src/components/gateway/GatewayToolApproval.tsx",
+  "src/services/publisher-oauth.ts",
+  "src/stores/agent.store.ts",
+];
+
+function runTsc(): string {
+  try {
+    return execFileSync(TSC, ["--noEmit"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // tsc exits non-zero when ANY file has errors — including the ~104
+    // out-of-scope test-file errors #3252 explicitly deferred. Diagnostics
+    // still land on stdout, so read them back and filter to the guarded files.
+    return (err as { stdout?: Buffer | string }).stdout?.toString() ?? "";
+  }
+}
+
+describe("#3252 — shipped src/ type errors (render crash + latent defects)", () => {
+  it("reports zero tsc errors in the three fixed files", () => {
+    const offending = runTsc()
+      .split("\n")
+      .filter((line) => GUARDED_FILES.some((file) => line.startsWith(file)));
+
+    expect(
+      offending,
+      `tsc reported errors in files fixed by #3252:\n${offending.join("\n")}`,
+    ).toEqual([]);
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #3252.

## What

Fixes the 4 shipped `src/` type errors surfaced by `tsc --noEmit` (3 files). None are caught by CI today — Biome is not type-aware, and `vite build` / Vitest use esbuild, which strips types without checking.

### 1. Render crash — `GatewayToolApproval.tsx:367,370`
The single-connection compact "From:" branch is a `keyed` `<Show>`, so its children callback receives the **resolved `OAuthConnection` value**, not an accessor. Calling `connection()` invoked a plain object as a function → `TypeError` during render, tripping the error boundary on a security-sensitive approval surface (single-account users). Fix: pass `connection` directly.

### 2. `ErrorKind` union drift — `agent.store.ts:2161`
`sendPrompt` sets the turn-error kind `"privileged_provider_blocked"`, which was not a member of the `ErrorKind` union. Runtime impact is low (`retryable` is not consumed by any component today), but the closed union must stay authoritative. Fix: add the member.

### 3. Null-deref — `publisher-oauth.ts:350`
`setDefaultOAuthConnection` dereferenced the optionally-present response body (`data.connection`). A 2xx-with-no-body reaches the deref and throws. Fix: guard `data.connection` and throw a clear error before returning.

## Regression guard

`tests/unit/src-type-safety-3252.test.ts` runs the **real** `tsc --noEmit` over the three fixed files and asserts zero errors — the only gate that catches this class of bug. Verified **red** with the bug reintroduced, **green** with the fix.

## Networked path

- Defects #1 and #2 touch no outbound request (render-only / type-only).
- Defect #3 guards the response of an existing call — `PUT /oauth/connections/{connection_id}/default` (seren-core Gateway, bearer). The request slug/method/path is unchanged and verified against the openapi spec.

## Validation

- `tsc --noEmit`: **0 errors** across `src/` after the fix.
- `pnpm biome check` clean on the 3 changed src files.
- Affected suites green: `agent-turn-error`, `privileged-provider-gate`, `publisher-oauth-reconnect`, `tool-executor-oauth-account`, `tool-executor-approval`, `oauth-account-switcher-load`, `agent-oauth-routing`, plus the new guard (41 tests).

## Out of scope

The ~104 `tsc` errors in `tests/` (missing decls for intentionally-untyped `bin/**/*.mjs`, unused `@ts-expect-error`) and a project-wide `typecheck` CI gate — a separate, larger decision per the issue.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com