### PR TITLE
refactor(agent): extract Happy-archive seam from agent.store (#3250)

### DIFF
--- a/src/lib/agent/happy-archive.ts
+++ b/src/lib/agent/happy-archive.ts
@@ -1,0 +1,188 @@
+// ABOUTME: Pure Happy-origin archive fencing and invalidation planning helpers.
+// ABOUTME: Behavior-preserving extraction from agent.store; no store state closure.
+
+/**
+ * Monotonic fence for Happy-origin archives. Async list/spawn/reattach work
+ * captures an epoch before it starts and may only commit while that epoch is
+ * still current and the conversation is not tombstoned.
+ */
+export class HappyArchiveFence {
+  private readonly entries = new Map<
+    string,
+    { generation: number; archived: boolean }
+  >();
+
+  capture(conversationId: string): number {
+    return this.entries.get(conversationId)?.generation ?? 0;
+  }
+
+  archive(conversationId: string): number {
+    const current = this.entries.get(conversationId);
+    if (current?.archived) return current.generation;
+    const generation = (current?.generation ?? 0) + 1;
+    this.entries.set(conversationId, { generation, archived: true });
+    return generation;
+  }
+
+  isArchived(conversationId: string): boolean {
+    return this.entries.get(conversationId)?.archived === true;
+  }
+
+  allows(conversationId: string, capturedGeneration: number): boolean {
+    const current = this.entries.get(conversationId);
+    return (
+      (current?.generation ?? 0) === capturedGeneration &&
+      current?.archived !== true
+    );
+  }
+
+  filterVisible<T extends { id: string }>(rows: T[]): T[] {
+    return rows.filter((row) => !this.isArchived(row.id));
+  }
+}
+
+/**
+ * Invalidate the frontend immediately after Rust archives an agent
+ * conversation. A conversation may own more than one runtime session while a
+ * predictive-compaction standby is warming, so every matching session must be
+ * removed and tombstoned before a late runtime event can reach the UI.
+ */
+export function planHappyArchiveInvalidation(
+  sessions: Record<
+    string,
+    {
+      conversationId: string;
+      role: "serving" | "standby";
+      archiveOwnerConversationId?: string;
+      standbySessionId?: string | null;
+    }
+  >,
+  activeSessionId: string | null,
+  conversationId: string,
+): { archivedSessionIds: string[]; nextActiveSessionId: string | null } {
+  const archivedSessionIdSet = new Set(
+    Object.entries(sessions)
+      .filter(
+        ([, session]) =>
+          session.conversationId === conversationId ||
+          session.archiveOwnerConversationId === conversationId,
+      )
+      .map(([sessionId]) => sessionId),
+  );
+  // Include a registered warm standby even if it predates the explicit owner
+  // field. The serving pointer is the durable sibling relationship until
+  // promotion copies the persisted conversation id onto the standby.
+  for (const sessionId of [...archivedSessionIdSet]) {
+    const standbySessionId = sessions[sessionId]?.standbySessionId;
+    if (standbySessionId && sessions[standbySessionId]) {
+      archivedSessionIdSet.add(standbySessionId);
+    }
+  }
+  const archivedSessionIds = [...archivedSessionIdSet];
+  const nextActiveSessionId =
+    activeSessionId && archivedSessionIdSet.has(activeSessionId)
+      ? (Object.entries(sessions).find(
+          ([sessionId, session]) =>
+            !archivedSessionIdSet.has(sessionId) && session.role === "serving",
+        )?.[0] ?? null)
+      : activeSessionId;
+  return { archivedSessionIds, nextActiveSessionId };
+}
+
+/**
+ * Release the app-wide predictive-compaction mutex only when the archived
+ * conversation owns the in-flight warmup. Clearing it for an unrelated
+ * archive could allow a second compaction to start concurrently.
+ */
+export interface HappyArchivedSiblingRetirementResult {
+  fenced: boolean;
+  retired: boolean;
+  forceKilled: boolean;
+  lastError?: unknown;
+}
+
+/**
+ * Retire a sibling of the Happy row archived on mobile. The durable local
+ * fence is attempted before process teardown, and the PID-guarded Rust kill is
+ * the immediate fallback when the provider runtime cannot service termination.
+ */
+export async function retireHappyArchivedSiblingProvider(
+  sessionId: string,
+  pid: number | null | undefined,
+  operations: {
+    fence: (sessionId: string) => Promise<void>;
+    terminate: (sessionId: string) => Promise<void>;
+    forceKill: (pid: number) => Promise<boolean>;
+  },
+): Promise<HappyArchivedSiblingRetirementResult> {
+  let fenced = false;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2 && !fenced; attempt += 1) {
+    try {
+      await operations.fence(sessionId);
+      fenced = true;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  try {
+    await operations.terminate(sessionId);
+    return { fenced, retired: true, forceKilled: false, lastError };
+  } catch (error) {
+    lastError = error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("not found")) {
+      return { fenced, retired: true, forceKilled: false, lastError };
+    }
+  }
+
+  if (pid != null) {
+    try {
+      const forceKilled = await operations.forceKill(pid);
+      if (forceKilled) {
+        return { fenced, retired: true, forceKilled: true, lastError };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  return { fenced, retired: false, forceKilled: false, lastError };
+}
+
+export function planHappyProviderArchiveInvalidation(
+  sessions: Record<
+    string,
+    {
+      role: "serving" | "standby";
+      standbySessionId?: string | null;
+    }
+  >,
+  activeSessionId: string | null,
+  targetProviderSessionId: string,
+): {
+  archivedSessionIds: string[];
+  linkedServingSessionIds: string[];
+  nextActiveSessionId: string | null;
+} {
+  const linkedServingSessionIds = Object.entries(sessions)
+    .filter(
+      ([sessionId, session]) =>
+        sessionId !== targetProviderSessionId &&
+        session.role === "serving" &&
+        session.standbySessionId === targetProviderSessionId,
+    )
+    .map(([sessionId]) => sessionId);
+  const nextActiveSessionId =
+    activeSessionId === targetProviderSessionId
+      ? (Object.entries(sessions).find(
+          ([sessionId, session]) =>
+            sessionId !== targetProviderSessionId && session.role === "serving",
+        )?.[0] ?? null)
+      : activeSessionId;
+  return {
+    archivedSessionIds: [targetProviderSessionId],
+    linkedServingSessionIds,
+    nextActiveSessionId,
+  };
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5,6 +5,12 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createEffect, createRoot } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import {
+  HappyArchiveFence,
+  planHappyArchiveInvalidation,
+  planHappyProviderArchiveInvalidation,
+  retireHappyArchivedSiblingProvider,
+} from "@/lib/agent/happy-archive";
+import {
   extractEvidenceFromAgentMessages,
   type FinalizationEvidence,
   type FinalOutputValidationReport,
@@ -45,6 +51,16 @@ import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 
+// Happy-archive fencing/invalidation helpers live in @/lib/agent/happy-archive.
+// Re-exported so existing importers keep the unchanged public surface.
+export {
+  type HappyArchivedSiblingRetirementResult,
+  HappyArchiveFence,
+  planHappyArchiveInvalidation,
+  planHappyProviderArchiveInvalidation,
+  retireHappyArchivedSiblingProvider,
+} from "@/lib/agent/happy-archive";
+
 /** Per-session ready promises — resolved when backend emits "ready" status */
 const sessionReadyPromises = new Map<
   string,
@@ -63,46 +79,6 @@ const reattachingConversations = new Map<string, Promise<boolean>>();
  *  drops events for these IDs to prevent stale errors from dead sessions leaking
  *  into new/live sessions. Cleared when the global subscriber is torn down. */
 const terminatedSessionIds = new Set<string>();
-
-/**
- * Monotonic fence for Happy-origin archives. Async list/spawn/reattach work
- * captures an epoch before it starts and may only commit while that epoch is
- * still current and the conversation is not tombstoned.
- */
-export class HappyArchiveFence {
-  private readonly entries = new Map<
-    string,
-    { generation: number; archived: boolean }
-  >();
-
-  capture(conversationId: string): number {
-    return this.entries.get(conversationId)?.generation ?? 0;
-  }
-
-  archive(conversationId: string): number {
-    const current = this.entries.get(conversationId);
-    if (current?.archived) return current.generation;
-    const generation = (current?.generation ?? 0) + 1;
-    this.entries.set(conversationId, { generation, archived: true });
-    return generation;
-  }
-
-  isArchived(conversationId: string): boolean {
-    return this.entries.get(conversationId)?.archived === true;
-  }
-
-  allows(conversationId: string, capturedGeneration: number): boolean {
-    const current = this.entries.get(conversationId);
-    return (
-      (current?.generation ?? 0) === capturedGeneration &&
-      current?.archived !== true
-    );
-  }
-
-  filterVisible<T extends { id: string }>(rows: T[]): T[] {
-    return rows.filter((row) => !this.isArchived(row.id));
-  }
-}
 
 const happyArchiveFence = new HappyArchiveFence();
 
@@ -902,152 +878,6 @@ function subscribeToProviderRuntimeRestarted(): void {
       }
     },
   );
-}
-
-/**
- * Invalidate the frontend immediately after Rust archives an agent
- * conversation. A conversation may own more than one runtime session while a
- * predictive-compaction standby is warming, so every matching session must be
- * removed and tombstoned before a late runtime event can reach the UI.
- */
-export function planHappyArchiveInvalidation(
-  sessions: Record<
-    string,
-    {
-      conversationId: string;
-      role: "serving" | "standby";
-      archiveOwnerConversationId?: string;
-      standbySessionId?: string | null;
-    }
-  >,
-  activeSessionId: string | null,
-  conversationId: string,
-): { archivedSessionIds: string[]; nextActiveSessionId: string | null } {
-  const archivedSessionIdSet = new Set(
-    Object.entries(sessions)
-      .filter(
-        ([, session]) =>
-          session.conversationId === conversationId ||
-          session.archiveOwnerConversationId === conversationId,
-      )
-      .map(([sessionId]) => sessionId),
-  );
-  // Include a registered warm standby even if it predates the explicit owner
-  // field. The serving pointer is the durable sibling relationship until
-  // promotion copies the persisted conversation id onto the standby.
-  for (const sessionId of [...archivedSessionIdSet]) {
-    const standbySessionId = sessions[sessionId]?.standbySessionId;
-    if (standbySessionId && sessions[standbySessionId]) {
-      archivedSessionIdSet.add(standbySessionId);
-    }
-  }
-  const archivedSessionIds = [...archivedSessionIdSet];
-  const nextActiveSessionId =
-    activeSessionId && archivedSessionIdSet.has(activeSessionId)
-      ? (Object.entries(sessions).find(
-          ([sessionId, session]) =>
-            !archivedSessionIdSet.has(sessionId) && session.role === "serving",
-        )?.[0] ?? null)
-      : activeSessionId;
-  return { archivedSessionIds, nextActiveSessionId };
-}
-
-/**
- * Release the app-wide predictive-compaction mutex only when the archived
- * conversation owns the in-flight warmup. Clearing it for an unrelated
- * archive could allow a second compaction to start concurrently.
- */
-export interface HappyArchivedSiblingRetirementResult {
-  fenced: boolean;
-  retired: boolean;
-  forceKilled: boolean;
-  lastError?: unknown;
-}
-
-/**
- * Retire a sibling of the Happy row archived on mobile. The durable local
- * fence is attempted before process teardown, and the PID-guarded Rust kill is
- * the immediate fallback when the provider runtime cannot service termination.
- */
-export async function retireHappyArchivedSiblingProvider(
-  sessionId: string,
-  pid: number | null | undefined,
-  operations: {
-    fence: (sessionId: string) => Promise<void>;
-    terminate: (sessionId: string) => Promise<void>;
-    forceKill: (pid: number) => Promise<boolean>;
-  },
-): Promise<HappyArchivedSiblingRetirementResult> {
-  let fenced = false;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 2 && !fenced; attempt += 1) {
-    try {
-      await operations.fence(sessionId);
-      fenced = true;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  try {
-    await operations.terminate(sessionId);
-    return { fenced, retired: true, forceKilled: false, lastError };
-  } catch (error) {
-    lastError = error;
-    const message = error instanceof Error ? error.message : String(error);
-    if (message.includes("not found")) {
-      return { fenced, retired: true, forceKilled: false, lastError };
-    }
-  }
-
-  if (pid != null) {
-    try {
-      const forceKilled = await operations.forceKill(pid);
-      if (forceKilled) {
-        return { fenced, retired: true, forceKilled: true, lastError };
-      }
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  return { fenced, retired: false, forceKilled: false, lastError };
-}
-
-export function planHappyProviderArchiveInvalidation(
-  sessions: Record<
-    string,
-    {
-      role: "serving" | "standby";
-      standbySessionId?: string | null;
-    }
-  >,
-  activeSessionId: string | null,
-  targetProviderSessionId: string,
-): {
-  archivedSessionIds: string[];
-  linkedServingSessionIds: string[];
-  nextActiveSessionId: string | null;
-} {
-  const linkedServingSessionIds = Object.entries(sessions)
-    .filter(
-      ([sessionId, session]) =>
-        sessionId !== targetProviderSessionId &&
-        session.role === "serving" &&
-        session.standbySessionId === targetProviderSessionId,
-    )
-    .map(([sessionId]) => sessionId);
-  const nextActiveSessionId =
-    activeSessionId === targetProviderSessionId
-      ? (Object.entries(sessions).find(
-          ([sessionId, session]) =>
-            sessionId !== targetProviderSessionId && session.role === "serving",
-        )?.[0] ?? null)
-      : activeSessionId;
-  return {
-    archivedSessionIds: [targetProviderSessionId],
-    linkedServingSessionIds,
-    nextActiveSessionId,
-  };
 }
 
 function subscribeToAgentConversationArchived(): void {


### PR DESCRIPTION
## What

First incremental, behavior-preserving extraction from the 9.5k-line `agent.store.ts` god-file tracked by #3250.

Moves the **Happy-archive fencing seam** (issue seam #7) into a co-located module `src/lib/agent/happy-archive.ts`:

- `HappyArchiveFence` (class)
- `planHappyArchiveInvalidation`
- `planHappyProviderArchiveInvalidation`
- `retireHappyArchivedSiblingProvider`
- `HappyArchivedSiblingRetirementResult` (type)

These are **pure** functions/classes — all inputs are parameters, no closure over `state`/`setState` — so this is a straight relocation.

## Why this seam first

The issue mandates moving pure helpers and self-contained handlers into sibling modules first (lowest risk), then the larger stateful clusters, and that the first PR establishes the pattern. This seam is the cleanest such cluster: already module-level, already exported, and directly test-pinned. It sets up the `src/lib/agent/` co-location directory (mirroring the existing `src/lib/compaction/`) that subsequent seam PRs will follow.

## Public surface unchanged

- The store keeps the `happyArchiveFence` singleton and **every call site unchanged** (25 internal references intact).
- Moved symbols are **re-exported** from `@/stores/agent.store`, so external importers — including `tests/unit/agent-conversation-archive-invalidation.test.ts`, which both imports these symbols and asserts on the store source text — resolve identically.
- `agent.store.ts`: **9644 to 9474 lines**.

## Non-goals (per issue)

No behavior, IPC-contract, or persistence-schema change. No new features. No dependency additions. No big-bang — one seam only.

## Validation

- Full unit suite green: **380 files / 2714 tests passed**, 0 failures.
- Pinned tests unchanged and passing: `agent-history-persistence.test.ts` (#3247), `agent-conversation-archive-invalidation.test.ts` (source-text + behavior assertions).
- `biome check`: both changed files clean.
- `tsc --noEmit`: neither changed file appears in the (pre-existing, repo-wide) error baseline — the extraction is type-clean.

No new test added: this is a pure relocation already comprehensively pinned by the existing archive-invalidation test; adding coverage would duplicate it.

Refs #3250

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
