### PR TITLE
feat(privacy): one-shot 'Erase all local conversation data' with per-target report (#3197 item 4)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -8,10 +8,11 @@ use crate::services::database::{
     DbPool, PersistedMessage, WalCheckpointMode, checkpoint_wal, enqueue_sync_tombstone, init_db,
     mark_sync_upsert, save_message_record, stamp_existing_privileged_messages,
 };
+use crate::commands::memory::MemoryState;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 fn load_indexable_message_meta(
     conn: &Connection,
@@ -2224,6 +2225,128 @@ pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
     .await?;
     clear_conversation_index_best_effort(&app);
     Ok(())
+}
+
+/// Outcome of erasing one conversation-data target in the erase-all flow.
+/// `status` is one of `ok`, `failed`, `delegated`, or `unsupported`.
+#[derive(Serialize)]
+pub struct EraseTargetReport {
+    pub target: String,
+    pub status: String,
+    pub detail: Option<String>,
+}
+
+impl EraseTargetReport {
+    fn new(target: &str, status: &str, detail: Option<String>) -> Self {
+        Self {
+            target: target.to_string(),
+            status: status.to_string(),
+            detail,
+        }
+    }
+}
+
+/// Erase every local conversation-data target in one flow and return a
+/// per-target success/failure report. Each target is best-effort and isolated:
+/// a failure in one is recorded and the remaining targets still run.
+///
+/// Remote targets this flow does not perform are reported honestly rather than
+/// omitted — `remote_history_schema` and `claude_agent_preferences` are
+/// delegated to their own controls, and `cloud_memories` is unsupported because
+/// the memory service exposes no source/bulk delete (tracked in #3198).
+#[tauri::command]
+pub async fn erase_all_conversation_data(
+    app: AppHandle,
+    memory_state: State<'_, MemoryState>,
+) -> Result<Vec<EraseTargetReport>, String> {
+    let mut reports = Vec::new();
+
+    // Local chat.db: capture each agent conversation's transcript identity
+    // before the rows are deleted, then run the thorough per-conversation
+    // delete for every conversation, followed by VACUUM + WAL truncate.
+    let chat_result = run_db(app.clone(), move |conn| {
+        let conversation_ids = conn
+            .prepare("SELECT id FROM conversations")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<String>>>()?;
+        let targets = collect_agent_transcript_targets(conn, &conversation_ids)?;
+        delete_conversation_records(conn, &conversation_ids)?;
+        vacuum_database(conn)?;
+        Ok((conversation_ids.len(), targets))
+    })
+    .await;
+
+    let transcript_targets = match chat_result {
+        Ok((count, targets)) => {
+            reports.push(EraseTargetReport::new(
+                "local_chat_db",
+                "ok",
+                Some(format!("{count} conversation(s) removed; VACUUM + WAL truncate")),
+            ));
+            targets
+        }
+        Err(err) => {
+            reports.push(EraseTargetReport::new("local_chat_db", "failed", Some(err)));
+            Vec::new()
+        }
+    };
+
+    // Conversation index: clear all chunks and reclaim the freed pages.
+    let index_result = open_index_db(&app).and_then(|conn| {
+        conversation_index::clear_all_chunks(&conn)?;
+        vacuum_database(&conn)?;
+        Ok(())
+    });
+    match index_result {
+        Ok(()) => reports.push(EraseTargetReport::new("conversation_index", "ok", None)),
+        Err(err) => reports.push(EraseTargetReport::new(
+            "conversation_index",
+            "failed",
+            Some(err.to_string()),
+        )),
+    }
+
+    // CLI transcripts: best-effort file removal (failures are logged per file).
+    let transcript_count = transcript_targets.len();
+    delete_agent_transcripts_best_effort(&transcript_targets);
+    reports.push(EraseTargetReport::new(
+        "cli_transcripts",
+        "ok",
+        Some(format!(
+            "{transcript_count} agent session transcript(s) targeted"
+        )),
+    ));
+
+    // Local cloud-memory cache: drop the connection and remove the files.
+    match memory_state.wipe_local_cache() {
+        Ok(()) => reports.push(EraseTargetReport::new("memory_cache_db", "ok", None)),
+        Err(err) => reports.push(EraseTargetReport::new(
+            "memory_cache_db",
+            "failed",
+            Some(err),
+        )),
+    }
+
+    // Remote / blocked targets — reported so "erase all" is not misleading.
+    reports.push(EraseTargetReport::new(
+        "remote_history_schema",
+        "delegated",
+        Some(
+            "Use \"Wipe Remote Copy\" — needs the SerenDB project/branch and a typed database-name confirmation.".to_string(),
+        ),
+    ));
+    reports.push(EraseTargetReport::new(
+        "cloud_memories",
+        "unsupported",
+        Some("The memory service exposes no source or bulk delete (tracked in #3198).".to_string()),
+    ));
+    reports.push(EraseTargetReport::new(
+        "claude_agent_preferences",
+        "delegated",
+        Some("Remote SerenDB memory preferences are cleared through the Claude memory tools.".to_string()),
+    ));
+
+    Ok(reports)
 }
 
 // ============================================================================

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -95,6 +95,35 @@ impl MemoryState {
         Ok(())
     }
 
+    /// Erase the entire local memory cache from disk. Drops the open connection
+    /// first so the file handles are released, then removes `memory_cache.db`
+    /// and its `-wal`/`-shm` companions. The next cache access lazily reopens an
+    /// empty database via `ensure_cache`. Used by the erase-all-data flow.
+    pub fn wipe_local_cache(&self) -> Result<(), String> {
+        {
+            let mut guard = self.cache.lock().map_err(|e| e.to_string())?;
+            *guard = None;
+        }
+        let file_name = self
+            .cache_path
+            .file_name()
+            .map(|name| name.to_os_string())
+            .unwrap_or_default();
+        for suffix in ["", "-wal", "-shm"] {
+            let mut sibling = file_name.clone();
+            sibling.push(suffix);
+            let path = self.cache_path.with_file_name(&sibling);
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(format!("failed to remove {}: {err}", path.display()));
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn call_memory_tool(
         &self,
         app: &tauri::AppHandle,
@@ -767,6 +796,35 @@ pub async fn memory_sync(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wipe_local_cache_removes_db_and_sidecar_files() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cache_path = tmp.path().join("memory_cache.db");
+        let state = MemoryState::new("https://memory.example".to_string(), cache_path.clone());
+
+        // Open a real cache so the primary DB file exists on disk, then stage
+        // the WAL/SHM sidecars the removal loop must also clear.
+        state.ensure_cache().expect("open cache");
+        assert!(cache_path.exists(), "cache db should be created");
+        let wal = tmp.path().join("memory_cache.db-wal");
+        let shm = tmp.path().join("memory_cache.db-shm");
+        std::fs::write(&wal, b"wal").unwrap();
+        std::fs::write(&shm, b"shm").unwrap();
+
+        state.wipe_local_cache().expect("wipe");
+
+        assert!(!cache_path.exists(), "db removed");
+        assert!(!wal.exists(), "wal removed");
+        assert!(!shm.exists(), "shm removed");
+
+        // A wipe with nothing on disk is a no-op, not an error.
+        state.wipe_local_cache().expect("idempotent wipe");
+
+        // The cache lazily reopens empty after a wipe.
+        state.ensure_cache().expect("reopen cache");
+        assert!(cache_path.exists(), "cache db recreated on next use");
+    }
 
     #[test]
     fn exposes_all_live_memory_mcp_tools() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1148,6 +1148,7 @@ pub fn run() {
             commands::chat::get_messages,
             commands::chat::clear_conversation_history,
             commands::chat::clear_all_history,
+            commands::chat::erase_all_conversation_data,
             // Model context-window cache
             commands::model_context_cache::get_model_context_window,
             commands::model_context_cache::record_model_context_window,

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,10 @@ import {
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
 import { isWindowsPlatform } from "@/lib/platform";
+import {
+  type EraseTargetReport,
+  eraseAllConversationData,
+} from "@/lib/tauri-bridge";
 import { type BuildInfo, getBuildInfo } from "@/services/buildInfo";
 import {
   getClaudeMemoryStatus,
@@ -122,6 +126,11 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
   const [historySyncSummary, setHistorySyncSummary] =
     createSignal<HistorySyncSummary | null>(null);
   const [historySyncWipeConfirm, setHistorySyncWipeConfirm] = createSignal("");
+  const [eraseAllConfirm, setEraseAllConfirm] = createSignal("");
+  const [eraseAllBusy, setEraseAllBusy] = createSignal(false);
+  const [eraseAllReports, setEraseAllReports] = createSignal<
+    EraseTargetReport[] | null
+  >(null);
   const [agentSandboxStatus, setAgentSandboxStatus] =
     createSignal<AgentSandboxStatus | null>(null);
   const [agentSandboxStatusError, setAgentSandboxStatusError] = createSignal<
@@ -284,6 +293,27 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       console.error("[HistorySync] remote wipe failed", err);
     } finally {
       setHistorySyncBusy(false);
+    }
+  };
+
+  const handleEraseAllData = async () => {
+    setEraseAllBusy(true);
+    setEraseAllReports(null);
+    // Stop scheduled sync ticks so nothing re-uploads mid-erase.
+    handleBooleanChange("historySyncEnabled", false);
+    stopHistorySync();
+    try {
+      const reports = await eraseAllConversationData();
+      setEraseAllReports(reports);
+      setEraseAllConfirm("");
+      setHistorySyncSummary(null);
+    } catch (err) {
+      setEraseAllReports([
+        { target: "erase_all", status: "failed", detail: String(err) },
+      ]);
+      console.error("[EraseAll] erase all conversation data failed", err);
+    } finally {
+      setEraseAllBusy(false);
     }
   };
 
@@ -2420,6 +2450,73 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 {historySyncMessage()}
               </p>
             </Show>
+
+            <div class="py-3 border-b border-border">
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-col gap-0.5 flex-1">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Erase All Local Conversation Data
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Type{" "}
+                    <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                      ERASE
+                    </code>{" "}
+                    to permanently delete local chat history, the search index,
+                    the memory cache, and CLI session transcripts. Remote and
+                    cloud-memory copies are not removed here — see the report.
+                  </span>
+                </div>
+                <div class="flex items-center gap-2 shrink-0">
+                  <input
+                    type="text"
+                    value={eraseAllConfirm()}
+                    onInput={(e) => setEraseAllConfirm(e.currentTarget.value)}
+                    placeholder="ERASE"
+                    class="w-[14rem] px-2.5 py-1.5 rounded-md border border-border bg-surface text-[0.82rem] text-foreground outline-none focus:border-accent"
+                  />
+                  <button
+                    type="button"
+                    disabled={eraseAllBusy() || eraseAllConfirm() !== "ERASE"}
+                    class="px-3 py-1.5 text-[0.8rem] rounded-md border border-destructive/60 bg-destructive/10 text-destructive hover:bg-destructive/15 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={handleEraseAllData}
+                  >
+                    Erase
+                  </button>
+                </div>
+              </div>
+
+              <Show when={eraseAllReports()}>
+                <ul class="m-0 mt-3 flex flex-col gap-1 list-none p-0">
+                  <For each={eraseAllReports() ?? []}>
+                    {(report) => (
+                      <li class="flex items-baseline gap-2 text-[0.78rem]">
+                        <span
+                          class="font-medium shrink-0"
+                          classList={{
+                            "text-emerald-500": report.status === "ok",
+                            "text-destructive": report.status === "failed",
+                            "text-muted-foreground":
+                              report.status === "delegated" ||
+                              report.status === "unsupported",
+                          }}
+                        >
+                          {report.status.toUpperCase()}
+                        </span>
+                        <span class="text-foreground shrink-0">
+                          {report.target}
+                        </span>
+                        <Show when={report.detail}>
+                          <span class="text-muted-foreground">
+                            — {report.detail}
+                          </span>
+                        </Show>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </Show>
+            </div>
           </section>
         </Show>
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -1157,6 +1157,26 @@ export async function clearAllHistory(): Promise<void> {
   await invoke("clear_all_history");
 }
 
+/** Outcome of erasing one conversation-data target in the erase-all flow. */
+export interface EraseTargetReport {
+  target: string;
+  status: "ok" | "failed" | "delegated" | "unsupported";
+  detail?: string | null;
+}
+
+/**
+ * Erase every local conversation-data target (chat.db, conversation index,
+ * memory cache, and CLI transcripts) and return a per-target success/failure
+ * report. Remote and blocked targets are reported, not performed.
+ */
+export async function eraseAllConversationData(): Promise<EraseTargetReport[]> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Message operations require Tauri runtime");
+  }
+  return invoke<EraseTargetReport[]>("erase_all_conversation_data");
+}
+
 // ============================================================================
 // Runtime Session Operations
 // ============================================================================


### PR DESCRIPTION
## What

Closes #3257. Completes the local scope of #3197 (True deletion) — outstanding item 4.

Adds a single `erase_all_conversation_data` flow so a user can erase every **local** conversation-data target at once and see exactly what was cleared. Previously `clear_all_history` deleted `chat.db` rows but never reclaimed free pages, the conversation index, the local cloud-memory cache, or the CLI transcripts — and reported nothing.

## Change

New `#[tauri::command] erase_all_conversation_data` runs each local target independently (a failure in one is recorded, the rest still run) and returns a per-target report:

| target | action |
| --- | --- |
| `local_chat_db` | delete all conversations via the thorough `delete_conversation_records` path (all related tables + sync tombstones), then `VACUUM` + WAL truncate |
| `conversation_index` | clear all chunks + `VACUUM` |
| `memory_cache_db` | new `MemoryState::wipe_local_cache` drops the SDK cache connection and removes `memory_cache.db` (+ `-wal`/`-shm`); next access lazily reopens empty |
| `cli_transcripts` | remove every agent conversation's `~/.claude` / `~/.codex` transcript (reuses the #3248 helper); targets captured **before** the rows are deleted |

Targets this flow does **not** perform are reported honestly (not omitted) so "erase all" is not misleading:

- `remote_history_schema` → **delegated** to the existing "Wipe Remote Copy" control (needs SerenDB project/branch + typed DB-name confirmation).
- `cloud_memories` → **unsupported**: the memory service exposes no source/bulk delete (#3198).
- `claude_agent_preferences` → **delegated** (remote SerenDB memory prefs).

A Settings control (typed `ERASE` confirmation, mirroring the "Wipe Remote Copy" pattern) triggers it and renders the per-target report with status coloring.

## Networked paths

None added. The command performs only local filesystem/SQLite operations. The remote/cloud targets are explicitly *reported as not performed* here and delegated to their existing controls; no new outbound publisher/API calls are introduced.

## Validation (live, no mocks)

- `cargo test --lib` — **1022 passed, 0 failed, 2 ignored**.
- New test `wipe_local_cache_removes_db_and_sidecar_files` exercises the **real** SDK `LocalCache`: opens a real cache DB, stages real `-wal`/`-shm` sidecars, wipes, asserts all removed, asserts idempotency, and asserts the cache lazily reopens empty.
- The command composes already-tested primitives — `delete_conversation_records`, `collect_agent_transcript_targets` + `remove_agent_transcripts` (from #3248, real-filesystem tested), `vacuum_database`, `conversation_index::clear_all_chunks`, and the new `wipe_local_cache`.
- Frontend: Biome clean; adds **zero** new `tsc` errors (the changed files are type-clean).

**Validation boundary (stated honestly):** the destructive end-to-end was not run against real user data (it erases everything). The failing layer — filesystem/SQLite removal — is covered by the real-resource tests above; the Settings control is thin wiring over the validated command.

## Scope

Local targets only, by design. The two remote gaps are tracked separately: cloud-memory cascade (#3198, verified blocked at the service) and `memory_cache.db` per-conversation delete (#3256, needs a `seren-memory-sdk` scope delete). This PR's whole-cache wipe is the clean local counterpart.
