### PR TITLE
refactor(agent): extract message-metadata helpers (#3250)

### DIFF
--- a/src/lib/agent/message-metadata.ts
+++ b/src/lib/agent/message-metadata.ts
@@ -1,0 +1,150 @@
+// ABOUTME: Pure (de)serialization between persisted SQLite rows and AgentMessage.
+// ABOUTME: Behavior-preserving extraction from agent.store; no store state closure.
+
+import type { StoredMessage } from "@/lib/tauri-bridge";
+import type {
+  DiffEvent,
+  PairedSpawnConfig,
+  ToolCallEvent,
+} from "@/services/providers";
+import type { AgentMessage } from "@/stores/agent.store";
+
+export interface AgentConversationMetadata {
+  pendingBootstrapPromptContext?: string;
+  pendingBootstrapMessages?: AgentMessage[];
+  /** Pinned Planner/Executor model + effort choices for paired threads. */
+  pairedConfig?: PairedSpawnConfig;
+}
+
+export function parseAgentConversationMetadata(
+  raw: string | null | undefined,
+): AgentConversationMetadata {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as AgentConversationMetadata;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function serializeAgentConversationMetadata(
+  metadata: AgentConversationMetadata,
+): string | null {
+  return metadata.pendingBootstrapPromptContext ||
+    (metadata.pendingBootstrapMessages &&
+      metadata.pendingBootstrapMessages.length > 0) ||
+    metadata.pairedConfig
+    ? JSON.stringify(metadata)
+    : null;
+}
+
+/**
+ * Metadata shape for a persisted non-prose turn block (#3247). A `tool` or
+ * `diff` message rides in the `messages` table as a `role: "assistant"` row;
+ * `block_type` plus the serialized payload let `reconstructStoredAgentMessage`
+ * rebuild the original `AgentMessage.type`/`toolCall`/`diff` on read.
+ */
+export interface PersistedBlockMetadata {
+  block_type?: "tool" | "diff";
+  tool_call?: ToolCallEvent;
+  diff?: DiffEvent;
+}
+
+export function parsePersistedBlockMetadata(
+  raw: string | null | undefined,
+): PersistedBlockMetadata | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistedBlockMetadata;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function serializeAgentMessageMetadata(
+  msg: AgentMessage,
+): string | null {
+  if (msg.type === "handoff") {
+    return JSON.stringify({ v: 1, paired_handoff: true });
+  }
+  // Tool calls and file diffs carry their payload in metadata so the full
+  // claude-code turn — not just its final answer — survives reload, export,
+  // and sync (#3247). The transient live stdout buffer (`partialResult`) is
+  // dropped by the final status upsert, so it never lands here.
+  if (msg.type === "tool" && msg.toolCall) {
+    return JSON.stringify({
+      v: 1,
+      block_type: "tool",
+      tool_call: msg.toolCall,
+    });
+  }
+  if (msg.type === "diff" && msg.diff) {
+    return JSON.stringify({ v: 1, block_type: "diff", diff: msg.diff });
+  }
+  if (!msg.finalOutputValidation) return null;
+  return JSON.stringify({
+    v: 1,
+    final_output_validation: msg.finalOutputValidation,
+  });
+}
+
+/**
+ * Rebuild an `AgentMessage` from a persisted SQLite row. Tool/diff blocks
+ * (#3247) reconstruct their `type` and payload from `block_type` metadata;
+ * everything else maps to user/handoff/assistant as before. Pure and exported
+ * for round-trip regression coverage.
+ */
+export function reconstructStoredAgentMessage(m: StoredMessage): AgentMessage {
+  if (m.role === "user") {
+    return {
+      id: m.id,
+      type: "user",
+      content: m.content,
+      timestamp: m.timestamp,
+    };
+  }
+  const block = parsePersistedBlockMetadata(m.metadata);
+  if (block?.block_type === "tool" && block.tool_call) {
+    return {
+      id: m.id,
+      type: "tool",
+      content: m.content,
+      timestamp: m.timestamp,
+      toolCallId: block.tool_call.toolCallId,
+      toolCall: block.tool_call,
+      provider: m.provider ?? undefined,
+    };
+  }
+  if (block?.block_type === "diff" && block.diff) {
+    return {
+      id: m.id,
+      type: "diff",
+      content: m.content,
+      timestamp: m.timestamp,
+      toolCallId: block.diff.toolCallId,
+      diff: block.diff,
+      provider: m.provider ?? undefined,
+    };
+  }
+  return {
+    id: m.id,
+    type: isPairedHandoffMetadata(m.metadata) ? "handoff" : "assistant",
+    content: m.content,
+    timestamp: m.timestamp,
+    provider: m.provider ?? undefined,
+  };
+}
+
+function isPairedHandoffMetadata(metadata: string | null | undefined): boolean {
+  if (!metadata) return false;
+  try {
+    return JSON.parse(metadata)?.paired_handoff === true;
+  } catch {
+    return false;
+  }
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -11,6 +11,13 @@ import {
   retireHappyArchivedSiblingProvider,
 } from "@/lib/agent/happy-archive";
 import {
+  parseAgentConversationMetadata,
+  parsePersistedBlockMetadata,
+  reconstructStoredAgentMessage,
+  serializeAgentConversationMetadata,
+  serializeAgentMessageMetadata,
+} from "@/lib/agent/message-metadata";
+import {
   extractEvidenceFromAgentMessages,
   type FinalizationEvidence,
   type FinalOutputValidationReport,
@@ -60,6 +67,12 @@ export {
   planHappyProviderArchiveInvalidation,
   retireHappyArchivedSiblingProvider,
 } from "@/lib/agent/happy-archive";
+// Message (de)serialization helpers live in @/lib/agent/message-metadata.
+// Re-exported so existing importers keep the unchanged public surface.
+export {
+  reconstructStoredAgentMessage,
+  serializeAgentMessageMetadata,
+} from "@/lib/agent/message-metadata";
 
 /** Per-session ready promises — resolved when backend emits "ready" status */
 const sessionReadyPromises = new Map<
@@ -594,7 +607,6 @@ import {
   getAgentConversation,
   getMessages,
   listConversations,
-  type StoredMessage,
   saveMessage,
   setAgentConversationMetadata as setAgentConversationMetadataDb,
   setAgentConversationModelId as setAgentConversationModelIdDb,
@@ -1284,13 +1296,6 @@ export interface AgentCompactedSummary {
   lineage?: SummaryLineage;
 }
 
-interface AgentConversationMetadata {
-  pendingBootstrapPromptContext?: string;
-  pendingBootstrapMessages?: AgentMessage[];
-  /** Pinned Planner/Executor model + effort choices for paired threads. */
-  pairedConfig?: PairedSpawnConfig;
-}
-
 export interface AgentMessage {
   id: string;
   type:
@@ -1816,139 +1821,6 @@ async function buildDroppedPromptRecoverySnapshot(
     ) ?? undefined;
 
   return { restoredMessages, bootstrapPromptContext };
-}
-
-function parseAgentConversationMetadata(
-  raw: string | null | undefined,
-): AgentConversationMetadata {
-  if (!raw) {
-    return {};
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as AgentConversationMetadata;
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-function serializeAgentConversationMetadata(
-  metadata: AgentConversationMetadata,
-): string | null {
-  return metadata.pendingBootstrapPromptContext ||
-    (metadata.pendingBootstrapMessages &&
-      metadata.pendingBootstrapMessages.length > 0) ||
-    metadata.pairedConfig
-    ? JSON.stringify(metadata)
-    : null;
-}
-
-/**
- * Metadata shape for a persisted non-prose turn block (#3247). A `tool` or
- * `diff` message rides in the `messages` table as a `role: "assistant"` row;
- * `block_type` plus the serialized payload let `reconstructStoredAgentMessage`
- * rebuild the original `AgentMessage.type`/`toolCall`/`diff` on read.
- */
-interface PersistedBlockMetadata {
-  block_type?: "tool" | "diff";
-  tool_call?: ToolCallEvent;
-  diff?: DiffEvent;
-}
-
-function parsePersistedBlockMetadata(
-  raw: string | null | undefined,
-): PersistedBlockMetadata | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as PersistedBlockMetadata;
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-export function serializeAgentMessageMetadata(
-  msg: AgentMessage,
-): string | null {
-  if (msg.type === "handoff") {
-    return JSON.stringify({ v: 1, paired_handoff: true });
-  }
-  // Tool calls and file diffs carry their payload in metadata so the full
-  // claude-code turn — not just its final answer — survives reload, export,
-  // and sync (#3247). The transient live stdout buffer (`partialResult`) is
-  // dropped by the final status upsert, so it never lands here.
-  if (msg.type === "tool" && msg.toolCall) {
-    return JSON.stringify({
-      v: 1,
-      block_type: "tool",
-      tool_call: msg.toolCall,
-    });
-  }
-  if (msg.type === "diff" && msg.diff) {
-    return JSON.stringify({ v: 1, block_type: "diff", diff: msg.diff });
-  }
-  if (!msg.finalOutputValidation) return null;
-  return JSON.stringify({
-    v: 1,
-    final_output_validation: msg.finalOutputValidation,
-  });
-}
-
-/**
- * Rebuild an `AgentMessage` from a persisted SQLite row. Tool/diff blocks
- * (#3247) reconstruct their `type` and payload from `block_type` metadata;
- * everything else maps to user/handoff/assistant as before. Pure and exported
- * for round-trip regression coverage.
- */
-export function reconstructStoredAgentMessage(m: StoredMessage): AgentMessage {
-  if (m.role === "user") {
-    return {
-      id: m.id,
-      type: "user",
-      content: m.content,
-      timestamp: m.timestamp,
-    };
-  }
-  const block = parsePersistedBlockMetadata(m.metadata);
-  if (block?.block_type === "tool" && block.tool_call) {
-    return {
-      id: m.id,
-      type: "tool",
-      content: m.content,
-      timestamp: m.timestamp,
-      toolCallId: block.tool_call.toolCallId,
-      toolCall: block.tool_call,
-      provider: m.provider ?? undefined,
-    };
-  }
-  if (block?.block_type === "diff" && block.diff) {
-    return {
-      id: m.id,
-      type: "diff",
-      content: m.content,
-      timestamp: m.timestamp,
-      toolCallId: block.diff.toolCallId,
-      diff: block.diff,
-      provider: m.provider ?? undefined,
-    };
-  }
-  return {
-    id: m.id,
-    type: isPairedHandoffMetadata(m.metadata) ? "handoff" : "assistant",
-    content: m.content,
-    timestamp: m.timestamp,
-    provider: m.provider ?? undefined,
-  };
-}
-
-function isPairedHandoffMetadata(metadata: string | null | undefined): boolean {
-  if (!metadata) return false;
-  try {
-    return JSON.parse(metadata)?.paired_handoff === true;
-  } catch {
-    return false;
-  }
 }
 
 /**


### PR DESCRIPTION
## What

Second incremental, behavior-preserving extraction from the `agent.store.ts` god-file tracked by #3250 (follows #3258).

Moves the pure **DB-row ↔ `AgentMessage` (de)serialization seam** (issue seam #6, persistence subset) into a co-located module `src/lib/agent/message-metadata.ts`:

- `parseAgentConversationMetadata` / `serializeAgentConversationMetadata`
- `parsePersistedBlockMetadata`
- `serializeAgentMessageMetadata`
- `reconstructStoredAgentMessage`
- `isPairedHandoffMetadata`
- `AgentConversationMetadata` / `PersistedBlockMetadata` types

These are **pure** — they operate only on their arguments, JSON, and imported types, with no closure over `state`/`setState`.

## Public surface unchanged

- `AgentMessage` is **type-only** back-imported from the store (erased at runtime → no import cycle).
- The store keeps **every call site unchanged** (11 references intact), drops the now-unused `StoredMessage` import, and **re-exports** `serializeAgentMessageMetadata` and `reconstructStoredAgentMessage` so `@/stores/agent.store`'s public surface is identical. `AgentConversationMetadata` was previously un-exported and has no external importer, so moving it changes nothing observable.
- `agent.store.ts`: **9474 → 9346 lines**.

## Non-goals (per issue)

No behavior, IPC-contract, or persistence-schema change. No new features. No dependency additions. One seam only.

## Validation

- Full unit suite green: **380 files / 2714 tests passed**, 0 failures.
- The #3247 pinned test `agent-history-persistence.test.ts` — which round-trips these helpers via `serializeAgentMessageMetadata`/`reconstructStoredAgentMessage` **and** asserts on `loadPersistedAgentHistory` source text (call-sites that stay in the store) — unchanged and passing.
- `biome check`: both changed files clean.
- `tsc --noEmit`: neither changed file appears in the (pre-existing, repo-wide) error baseline.

No new test added: the extracted functions are already round-trip-pinned by the existing history-persistence test.

## Networked-path trace (per workflow)

No outbound Gateway publisher/API path. These are pure in-process JSON transforms between SQLite rows and in-memory messages; nothing to verify against the live publisher list.

Refs #3250

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
