### PR TITLE
refactor(agent): extract shared store runtime into src/lib/agent (#3250)

### DIFF
--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Shared mutable runtime state for the agent store and its seams.
+// ABOUTME: Owns the SolidJS store instance plus cross-cutting coordination maps.
+
+import { createStore } from "solid-js/store";
+import { HappyArchiveFence } from "@/lib/agent/happy-archive";
+import type { AgentEvent } from "@/services/providers";
+import type { AgentState } from "@/stores/agent.store";
+
+/** Per-session ready promises — resolved when backend emits "ready" status */
+export const sessionReadyPromises = new Map<
+  string,
+  { promise: Promise<void>; resolve: () => void }
+>();
+
+/** Conversations with a spawn currently in progress. Prevents double-spawn
+ *  when selectThread fires twice before the first spawn registers the session. */
+export const spawningConversations = new Set<string>();
+
+/** Conversations with a live-session re-attach currently in progress.
+ *  Multiple resume triggers can race before the adopted session reaches state. */
+export const reattachingConversations = new Map<string, Promise<boolean>>();
+
+/** Session IDs that have been explicitly terminated. The global event subscriber
+ *  drops events for these IDs to prevent stale errors from dead sessions leaking
+ *  into new/live sessions. Cleared when the global subscriber is torn down. */
+export const terminatedSessionIds = new Set<string>();
+
+export const happyArchiveFence = new HappyArchiveFence();
+
+/** Exact provider sessions archived before a conversation owner was durable.
+ * Kept separate from conversation fences so an unowned standby cannot evict
+ * its healthy serving sibling. */
+export const happyProviderArchiveTombstones = new Set<string>();
+
+/** Session IDs that the agent store just terminated programmatically. The
+ *  runtime emits "Session terminated before request completed." (and other
+ *  death-string `provider://error` events) when in-flight control requests
+ *  reject during a programmatic kill — those are self-inflicted and must
+ *  not surface as user-visible chat errors. The error handler short-circuits
+ *  death-string events for ids in this set. Cleared at the end of
+ *  terminateSession after the IPC kill completes. #1852. */
+export const expectedTerminateSessionIds = new Set<string>();
+
+/** Lightweight context for sessions that are mid-spawn (IPC call in flight).
+ *  Populated before providerService.spawnAgent and cleaned up after the session
+ *  is registered in state.sessions. The global event logger consults this map
+ *  so early events show the correct agent type and conversation ID. */
+export const spawnContextMap = new Map<
+  string,
+  { agentType: string; conversationId?: string }
+>();
+
+/**
+ * Per-thread restart-timer handles. Cleared when the turn produces its
+ * first stream chunk or when a terminal error flips the bubble. #1631.
+ */
+export const restartTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export const [state, setState] = createStore<AgentState>({
+  availableAgents: [],
+  sessions: {},
+  threadStates: {},
+  persistedMessages: {},
+  activeSessionId: null,
+  selectedAgentType: "claude-code",
+  recentAgentConversations: [],
+  remoteSessions: [],
+  remoteSessionsNextCursor: null,
+  remoteSessionsLoading: false,
+  remoteSessionsError: null,
+  isLoading: false,
+  error: null,
+  installStatus: null,
+  cliScanRejection: null,
+  cliUpdateActionRequired: null,
+  pendingPermissions: [],
+  pendingDiffProposals: [],
+  agentModeEnabled: false,
+});
+
+export const agentOAuthRoutingRefreshes = new Map<string, Promise<boolean>>();
+export const agentOAuthRoutingAvailability = new Map<string, boolean>();
+export const agentOAuthRoutingDelivery = new Map<string, boolean>();
+export const agentOAuthRoutingRevisions = new Map<string, string>();
+export const agentOAuthRoutingSelectionThreads = new Map<string, string>();
+
+export const pendingSessionEvents = new Map<string, AgentEvent[]>();
+
+/** Guard against concurrent auto-recovery spawns in sendPrompt (per-session). */
+export const recoveryInFlightMap = new Map<string, Promise<string | null>>();
+
+export const messagePersistQueues = new Map<string, Promise<void>>();
+
+/** Last pairedConfig JSON written per conversation, to skip no-op DB writes. */
+export const pairedConfigPersisted = new Map<string, string>();
+
+export const spawnFailureTimestamps = new Map<string, number[]>();

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3,9 +3,8 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createEffect, createRoot } from "solid-js";
-import { createStore, produce } from "solid-js/store";
+import { produce } from "solid-js/store";
 import {
-  HappyArchiveFence,
   planHappyArchiveInvalidation,
   planHappyProviderArchiveInvalidation,
   retireHappyArchivedSiblingProvider,
@@ -17,6 +16,29 @@ import {
   serializeAgentConversationMetadata,
   serializeAgentMessageMetadata,
 } from "@/lib/agent/message-metadata";
+import {
+  agentOAuthRoutingAvailability,
+  agentOAuthRoutingDelivery,
+  agentOAuthRoutingRefreshes,
+  agentOAuthRoutingRevisions,
+  agentOAuthRoutingSelectionThreads,
+  expectedTerminateSessionIds,
+  happyArchiveFence,
+  happyProviderArchiveTombstones,
+  messagePersistQueues,
+  pairedConfigPersisted,
+  pendingSessionEvents,
+  reattachingConversations,
+  recoveryInFlightMap,
+  restartTimers,
+  sessionReadyPromises,
+  setState,
+  spawnContextMap,
+  spawnFailureTimestamps,
+  spawningConversations,
+  state,
+  terminatedSessionIds,
+} from "@/lib/agent/runtime";
 import {
   extractEvidenceFromAgentMessages,
   type FinalizationEvidence,
@@ -74,41 +96,6 @@ export {
   serializeAgentMessageMetadata,
 } from "@/lib/agent/message-metadata";
 
-/** Per-session ready promises — resolved when backend emits "ready" status */
-const sessionReadyPromises = new Map<
-  string,
-  { promise: Promise<void>; resolve: () => void }
->();
-
-/** Conversations with a spawn currently in progress. Prevents double-spawn
- *  when selectThread fires twice before the first spawn registers the session. */
-const spawningConversations = new Set<string>();
-
-/** Conversations with a live-session re-attach currently in progress.
- *  Multiple resume triggers can race before the adopted session reaches state. */
-const reattachingConversations = new Map<string, Promise<boolean>>();
-
-/** Session IDs that have been explicitly terminated. The global event subscriber
- *  drops events for these IDs to prevent stale errors from dead sessions leaking
- *  into new/live sessions. Cleared when the global subscriber is torn down. */
-const terminatedSessionIds = new Set<string>();
-
-const happyArchiveFence = new HappyArchiveFence();
-
-/** Exact provider sessions archived before a conversation owner was durable.
- * Kept separate from conversation fences so an unowned standby cannot evict
- * its healthy serving sibling. */
-const happyProviderArchiveTombstones = new Set<string>();
-
-/** Session IDs that the agent store just terminated programmatically. The
- *  runtime emits "Session terminated before request completed." (and other
- *  death-string `provider://error` events) when in-flight control requests
- *  reject during a programmatic kill — those are self-inflicted and must
- *  not surface as user-visible chat errors. The error handler short-circuits
- *  death-string events for ids in this set. Cleared at the end of
- *  terminateSession after the IPC kill completes. #1852. */
-const expectedTerminateSessionIds = new Set<string>();
-
 /** Lazy getter for the user's current navigation target, registered by
  *  thread.store. `getIdleClaudeSessionIds` consults this so a parallel spawn's
  *  preemptive idle-reclaim never targets the conversation the user is viewing —
@@ -121,15 +108,6 @@ export function registerActiveNavigationThreadIdGetter(
 ): void {
   activeNavigationThreadIdGetter = getter;
 }
-
-/** Lightweight context for sessions that are mid-spawn (IPC call in flight).
- *  Populated before providerService.spawnAgent and cleaned up after the session
- *  is registered in state.sessions. The global event logger consults this map
- *  so early events show the correct agent type and conversation ID. */
-const spawnContextMap = new Map<
-  string,
-  { agentType: string; conversationId?: string }
->();
 
 /** Max time to wait for a session to become ready before giving up */
 const SESSION_READY_TIMEOUT_MS = 30_000;
@@ -215,12 +193,6 @@ export class PredictiveCompactMutex {
  * cross the threshold in the same promptComplete tick. #1631.
  */
 const predictiveCompactMutex = new PredictiveCompactMutex();
-
-/**
- * Per-thread restart-timer handles. Cleared when the turn produces its
- * first stream chunk or when a terminal error flips the bubble. #1631.
- */
-const restartTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /** Invisibility-budget constants per restart-dependent scenario (#1631). */
 export const BUDGET_COLD_START_MS = 60_000;
@@ -2006,7 +1978,7 @@ export interface ThreadRuntimeState {
   lastPromptDocNames?: string[];
 }
 
-interface AgentState {
+export interface AgentState {
   /** Available agents and their status */
   availableAgents: AgentInfo[];
   /** Active sessions keyed by session ID */
@@ -2098,28 +2070,6 @@ function unifiedRowToAgent(row: UnifiedConversationRow): DbAgentConversation {
   };
 }
 
-const [state, setState] = createStore<AgentState>({
-  availableAgents: [],
-  sessions: {},
-  threadStates: {},
-  persistedMessages: {},
-  activeSessionId: null,
-  selectedAgentType: "claude-code",
-  recentAgentConversations: [],
-  remoteSessions: [],
-  remoteSessionsNextCursor: null,
-  remoteSessionsLoading: false,
-  remoteSessionsError: null,
-  isLoading: false,
-  error: null,
-  installStatus: null,
-  cliScanRejection: null,
-  cliUpdateActionRequired: null,
-  pendingPermissions: [],
-  pendingDiffProposals: [],
-  agentModeEnabled: false,
-});
-
 /** Kill a provider that completed after its owning Happy conversation was
  * archived. This path can run before the session was ever registered in the
  * Solid store, so it must call the provider directly rather than delegate to
@@ -2197,12 +2147,6 @@ async function discardLateArchivedProviderSession(
     }),
   );
 }
-
-const agentOAuthRoutingRefreshes = new Map<string, Promise<boolean>>();
-const agentOAuthRoutingAvailability = new Map<string, boolean>();
-const agentOAuthRoutingDelivery = new Map<string, boolean>();
-const agentOAuthRoutingRevisions = new Map<string, string>();
-const agentOAuthRoutingSelectionThreads = new Map<string, string>();
 
 function currentAgentOAuthRoutingRevision(): string {
   return `${oauthConnectionsRevision()}:${oauthSelectionsRevision()}`;
@@ -2288,15 +2232,7 @@ createRoot(() => {
 });
 
 let globalUnsubscribe: UnlistenFn | null = null;
-const pendingSessionEvents = new Map<string, AgentEvent[]>();
-
-/** Guard against concurrent auto-recovery spawns in sendPrompt (per-session). */
-const recoveryInFlightMap = new Map<string, Promise<string | null>>();
 const LEGACY_CLAUDE_LOCAL_SESSION_ID_RE = /^session-\d+$/;
-const messagePersistQueues = new Map<string, Promise<void>>();
-
-/** Last pairedConfig JSON written per conversation, to skip no-op DB writes. */
-const pairedConfigPersisted = new Map<string, string>();
 
 // Chunk accumulation buffers — plain JS, not reactive.
 // Flushed to the SolidJS store at CHUNK_FLUSH_MS intervals to reduce
@@ -2482,7 +2418,6 @@ const MAX_CLAUDE_INIT_RETRIES = 3;
 /** Spawn cascade guard: track recent failures per conversation to prevent infinite loops. */
 const SPAWN_CASCADE_WINDOW_MS = 30_000;
 const SPAWN_CASCADE_MAX_FAILURES = 3;
-const spawnFailureTimestamps = new Map<string, number[]>();
 
 function recordSpawnFailure(conversationId: string): void {
   const now = Date.now();

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -17,6 +17,11 @@ const agentStoreSource = readFileSync(
   "utf-8",
 );
 
+const agentRuntimeSource = readFileSync(
+  resolve("src/lib/agent/runtime.ts"),
+  "utf-8",
+);
+
 const agentChatSource = readFileSync(
   resolve("src/components/chat/AgentChat.tsx"),
   "utf-8",
@@ -297,7 +302,7 @@ describe("#2499 — agent thread transcript must fall back to durable history wh
     expect(agentStoreSource).toContain(
       "persistedMessages: Record<string, AgentMessage[]>;",
     );
-    expect(agentStoreSource).toContain("persistedMessages: {},");
+    expect(agentRuntimeSource).toContain("persistedMessages: {},");
   });
 
   it("hydratePersistedHistory loads from SQLite, respects live-session precedence, and re-reads fresh", () => {

--- a/tests/unit/agent-session-events.test.ts
+++ b/tests/unit/agent-session-events.test.ts
@@ -9,10 +9,14 @@ const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const agentRuntimeSource = readFileSync(
+  resolve("src/lib/agent/runtime.ts"),
+  "utf-8",
+);
 
 describe("stale event filtering for terminated sessions", () => {
   it("maintains a terminatedSessionIds set", () => {
-    expect(agentStoreSource).toContain(
+    expect(agentRuntimeSource).toContain(
       "const terminatedSessionIds = new Set<string>()",
     );
   });
@@ -54,8 +58,8 @@ describe("stale event filtering for terminated sessions", () => {
 
 describe("spawn context map for diagnostic logging", () => {
   it("maintains a spawnContextMap with agent type and conversation ID", () => {
-    expect(agentStoreSource).toContain("const spawnContextMap = new Map<");
-    expect(agentStoreSource).toContain(
+    expect(agentRuntimeSource).toContain("const spawnContextMap = new Map<");
+    expect(agentRuntimeSource).toContain(
       "{ agentType: string; conversationId?: string }",
     );
   });

--- a/tests/unit/agent-streaming-draft-persistence.test.ts
+++ b/tests/unit/agent-streaming-draft-persistence.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { readSource } from "./source-text";
 
 const agentStoreSource = readSource("src/stores/agent.store.ts");
+const agentRuntimeSource = readSource("src/lib/agent/runtime.ts");
 
 describe("#2333 — live assistant stream drafts are recoverable after reload", () => {
   it("flushChunkBuf checkpoints visible live assistant text to SQLite", () => {
@@ -50,7 +51,7 @@ describe("#2333 — live assistant stream drafts are recoverable after reload", 
   });
 
   it("serializes draft and final saves for the same assistant message id", () => {
-    expect(agentStoreSource).toContain(
+    expect(agentRuntimeSource).toContain(
       "const messagePersistQueues = new Map<string, Promise<void>>()",
     );
 

--- a/tests/unit/idle-reclaim-race-1852.test.ts
+++ b/tests/unit/idle-reclaim-race-1852.test.ts
@@ -9,6 +9,10 @@ const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const agentRuntimeSource = readFileSync(
+  resolve("src/lib/agent/runtime.ts"),
+  "utf-8",
+);
 const threadStoreSource = readFileSync(
   resolve("src/stores/thread.store.ts"),
   "utf-8",
@@ -44,7 +48,7 @@ describe("#1852 — Fix 2: idle-reclaim honours navigation intent", () => {
 
 describe("#1852 — Fix 3: self-inflicted terminates do not surface in chat", () => {
   it("declares an expectedTerminateSessionIds set", () => {
-    expect(agentStoreSource).toMatch(
+    expect(agentRuntimeSource).toMatch(
       /const expectedTerminateSessionIds\s*=\s*new Set<string>\(\)/,
     );
   });

--- a/tests/unit/resume-reattach-live-session-2675.test.ts
+++ b/tests/unit/resume-reattach-live-session-2675.test.ts
@@ -9,6 +9,10 @@ const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const agentRuntimeSource = readFileSync(
+  resolve("src/lib/agent/runtime.ts"),
+  "utf-8",
+);
 const providerServiceSource = readFileSync(
   resolve("src/services/providers.ts"),
   "utf-8",
@@ -40,7 +44,7 @@ describe("#2675 — live re-attach restores runtime state", () => {
   });
 
   it("reattachLiveSession serializes concurrent adoption for one conversation", () => {
-    expect(agentStoreSource).toContain("const reattachingConversations");
+    expect(agentRuntimeSource).toContain("const reattachingConversations");
     expect(reattachBody).toContain(
       "const inFlight = reattachingConversations.get(conversationId)",
     );


### PR DESCRIPTION
## What

**Foundational PR** for the `agent.store.ts` decomposition (#3250), following the approach agreed after #3258/#3260: relocate the SolidJS **store instance** and the **cross-cutting coordination state** into a co-located module `src/lib/agent/runtime.ts`.

This is the keystone that unblocks the *big* seam PRs: once `state`/`setState` and shared maps live in `runtime.ts`, each seam (streaming ~1,670 lines, compaction, prompt-queue…) can be extracted into its own module importing shared state **directly** — instead of importing from `@/stores/agent.store`, which would create an import cycle.

## Moved into `runtime.ts`

- The store: `const [state, setState] = createStore<AgentState>({…})` + its initial literal. `AgentState` stays in `agent.store.ts` and is now `export`ed so `runtime.ts` **type-imports** it (type-only → erased at runtime → no cycle).
- Cross-cutting coordination holders: `sessionReadyPromises`, `spawningConversations`, `reattachingConversations`, `terminatedSessionIds`, `happyArchiveFence`, `happyProviderArchiveTombstones`, `expectedTerminateSessionIds`, `spawnContextMap`, `restartTimers`, the five `agentOAuthRouting*` maps, `pendingSessionEvents`, `recoveryInFlightMap`, `messagePersistQueues`, `pairedConfigPersisted`, `spawnFailureTimestamps`.

## Deliberately left in place

- **Reassigned `let` bindings** (listener handles, `sessionResetGeneration`, `globalUnsubscribe`) — imported bindings are read-only, so these can't move without refactoring their reassignment; they stay.
- **Seam-local streaming buffers** (`chunkBufs`, `chunkFlushTimers`, `thinkingMarkupStreamStates`, `toolEventBufs`, `toolEventFlushTimers`, `PendingToolEvent`) — these travel *with* the streaming seam in its own PR, so `runtime.ts` stays free of streaming-only types.

## Public surface + call sites unchanged

Every call site is untouched; the store now does `import { state, setState, … } from "@/lib/agent/runtime"`. `agent.store.ts`: **9346 → 9281 lines** (the reduction is modest by design — this PR moves *plumbing above* the god-object; the large method-cluster seams land next, now that they can import from `runtime.ts`).

## Test changes (transparency)

Five existing tests pin these declarations **by source text** (`expect(agentStoreSource).toContain("const <map> = new …")`). Since the declarations legitimately moved, those specific assertions are **repointed to the `runtime.ts` source** where the declaration now lives — **same fact, same type asserted, zero weakening**. The behavioral call-site assertions (`.get`/`.set`/`.add`/`.has`) stay pointed at `agent.store.ts`, where that logic remains. No test was deleted or loosened.

- `resume-reattach-live-session-2675` — `reattachingConversations` decl
- `agent-session-events` — `terminatedSessionIds`, `spawnContextMap` decls
- `idle-reclaim-race-1852` — `expectedTerminateSessionIds` decl
- `agent-streaming-draft-persistence` — `messagePersistQueues` decl
- `agent-history-persistence` — `persistedMessages: {}` initial literal (the `AgentState` interface-field assertion stays on the store)

## Validation

- Full unit suite green: **380 files / 2714 tests passed**, 0 failures.
- `biome check`: both source files clean (`tests/` is outside Biome's config).
- `tsc --noEmit`: all changed files type-clean.

## Non-goals

No behavior, IPC-contract, or persistence-schema change. No new features. No dependency additions.

Refs #3250

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
