### PR TITLE
test(security): prove authorization decisions survive an on-disk reopen

### DIFF
--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -779,4 +779,38 @@ mod tests {
         assert!(ToolRoute::parse("web").is_ok());
         assert!(ToolRoute::parse("bogus").is_err());
     }
+
+    /// The `:memory:` tests above prove the SQL; this proves the headline
+    /// property that decisions are durable host-side. A grant recorded through
+    /// one state must survive a fresh state opened against the same file — the
+    /// on-disk equivalent of an app restart.
+    #[test]
+    fn decisions_survive_reopening_the_on_disk_store() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("tool_authorization.db");
+
+        {
+            let first = ToolAuthorizationState::new(db_path.clone());
+            first
+                .record_decision(
+                    ToolRoute::Gateway,
+                    "new-publisher",
+                    "inspect_records",
+                    "conv-a",
+                    true,
+                )
+                .unwrap();
+        }
+        assert!(db_path.exists(), "store should be written to disk");
+
+        // A brand-new state (no shared connection) at the same path.
+        let second = ToolAuthorizationState::new(db_path);
+        let decision = second
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+            .unwrap();
+        assert_eq!(
+            decision.decision, "allow",
+            "the recorded grant must survive reopening the store"
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #3267 (slice A of #3193).

The merged gate tests use an in-memory SQLite database, which proves the SQL but not the headline acceptance property **"Authorization decisions persist host-side"**. This adds a real on-disk regression test: record a grant through one `ToolAuthorizationState`, drop it, then open a fresh state at the same file path (the on-disk equivalent of an app restart) and assert the grant still resolves to `allow`.

No production code change — test-only hardening of the persistence guarantee.

## Verification
- `cargo test --lib tool_authorization` — **19 passed** (was 18), including the new `decisions_survive_reopening_the_on_disk_store` against a real temp-file database.

Refs #3261, #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com