### PR TITLE
refactor(agent): extract pure compaction helpers (#3250)

### DIFF
--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -1,0 +1,203 @@
+// ABOUTME: Pure compaction helpers — mutex, prune/prepend transforms, window defaults.
+// ABOUTME: Behavior-preserving extraction from agent.store; no store state closure.
+
+import type { PrunableMessage } from "@/lib/compaction/prune";
+import type { AgentMessage } from "@/stores/agent.store";
+
+/** Owner-aware global cap for predictive compaction. An archived run can
+ * release its own slot immediately, but a stale completion from that run must
+ * never release a newer thread's slot. */
+export class PredictiveCompactMutex {
+  private owner: { sessionId: string; generation: number } | null = null;
+  private nextGeneration = 0;
+
+  tryAcquire(
+    sessionId: string,
+  ): Readonly<{ sessionId: string; generation: number }> | null {
+    if (this.owner !== null) return null;
+    this.nextGeneration += 1;
+    this.owner = { sessionId, generation: this.nextGeneration };
+    return this.owner;
+  }
+
+  release(lease: Readonly<{ sessionId: string; generation: number }>): boolean {
+    if (
+      this.owner?.sessionId !== lease.sessionId ||
+      this.owner.generation !== lease.generation
+    ) {
+      return false;
+    }
+    this.owner = null;
+    return true;
+  }
+
+  releaseCurrentForAny(sessionIds: Iterable<string>): boolean {
+    if (!this.owner) return false;
+    for (const sessionId of sessionIds) {
+      if (this.owner.sessionId === sessionId) {
+        this.owner = null;
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Outcome of an auto-compaction attempt. Callers use this to decide whether
+ * to fall back to Seren Chat. Only `failed_catastrophic` fires the fallback;
+ * transient or "no-op" outcomes keep the user inside the agent session.
+ *
+ * - `retried`: compaction succeeded AND the user's last prompt was re-sent.
+ *   Returned by `compactAndRetry` only — `compactAgentConversation` never
+ *   retries; that responsibility lives with the caller.
+ * - `succeeded`: compaction succeeded, no prompt to retry.
+ * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
+ *   the session was already too small to compact. Usually means a single
+ *   message is gigantic — Chat fallback would not help.
+ * - `cancelled`: a Stop / predictive-promotion teardown / other graceful
+ *   cancel propagated up as "Task cancelled" while compaction or the
+ *   retry was in flight. Not a defect — the error event handler's
+ *   graceful-cancel branch already restores UI state. Chat fallback would
+ *   be wrong, since the user's intent was to stop, not to switch modes.
+ * - `failed_catastrophic`: unrecoverable failure (spawn failed, summary API
+ *   threw after refresh, agent runtime broken). Chat fallback is correct.
+ */
+export type CompactionOutcome =
+  | "retried"
+  | "succeeded"
+  | "skipped_nothing_to_compact"
+  | "cancelled"
+  | "failed_catastrophic";
+
+/**
+ * Return shape of `compactAgentConversation`. The new session id is plumbed
+ * back to callers so they don't have to re-derive it by searching
+ * `state.sessions` for a matching `conversationId` — that lookup falsely
+ * fails for agents like Codex where `sessionId === conversationId` (#1757).
+ *
+ * `newSessionId` is set on reactive success (the post-compaction serving
+ * session). On predictive success the standby id is stored on the parent
+ * via `standbySessionId`; predictive callers consult that pointer instead.
+ */
+export type CompactAgentResult = {
+  outcome: Exclude<CompactionOutcome, "retried">;
+  newSessionId?: string;
+};
+
+export function prunableAgentMessage(m: AgentMessage): PrunableMessage {
+  return {
+    id: m.id,
+    role:
+      m.type === "user" || m.type === "assistant" || m.type === "tool"
+        ? m.type
+        : "other",
+    content: m.content,
+    toolResult: m.toolCall?.result,
+    toolName: m.toolCall?.title,
+    toolArgs: m.toolCall?.parameters
+      ? JSON.stringify(m.toolCall.parameters)
+      : undefined,
+  };
+}
+
+export function applyPrunedAgentMessages(
+  messages: AgentMessage[],
+  pruned: PrunableMessage[],
+): AgentMessage[] {
+  return messages.map((m, i) => {
+    const p = pruned[i];
+    if (!p) return m;
+    const next: AgentMessage = { ...m, content: p.content };
+    if (m.toolCall) {
+      let parameters = m.toolCall.parameters;
+      if (p.toolArgs !== undefined) {
+        try {
+          parameters = JSON.parse(p.toolArgs) as Record<string, unknown>;
+        } catch {
+          parameters = m.toolCall.parameters;
+        }
+      }
+      next.toolCall = {
+        ...m.toolCall,
+        parameters,
+        ...(p.toolResult !== undefined ? { result: p.toolResult } : {}),
+      };
+    }
+    return next;
+  });
+}
+
+export function buildAgentCompactionPrepend(
+  summary: string,
+  toPreserve: AgentMessage[],
+): string {
+  // Tool messages can be enormous file contents / JSON dumps; user and
+  // assistant text keep the original ceiling used by the long-standing
+  // post-compaction prepend path.
+  const MAX_MSG_CHARS = 2000;
+  const MAX_TOOL_CHARS = 500;
+  const preservedContext = toPreserve
+    .map((m) => {
+      if (m.type === "user" || m.type === "assistant") {
+        const content =
+          m.content.length > MAX_MSG_CHARS
+            ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
+            : m.content;
+        if (m.type === "user") {
+          return `<prior_user>${content}</prior_user>`;
+        }
+        return `<prior_assistant>${content}</prior_assistant>`;
+      }
+      if (m.type === "tool" && m.toolCall?.result) {
+        const title = (m.toolCall.title || "tool").replace(/"/g, "'");
+        const result = m.toolCall.result;
+        const trimmed =
+          result.length > MAX_TOOL_CHARS
+            ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
+            : result;
+        return `<prior_tool name="${title}">${trimmed}</prior_tool>`;
+      }
+      return null;
+    })
+    .filter((s): s is string => s !== null)
+    .join("\n\n");
+  return preservedContext
+    ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
+    : `Prior work summary:\n${summary}`;
+}
+
+/** Claude Code model IDs that ship a 1M-token context tier behind the
+ * `[1m]` suffix. Bare IDs default to 200K — Anthropic gates the 1M tier on
+ * the suffix, which the CLI translates into a `context-1m-2025-08-07` beta
+ * header. The first promptComplete still upserts the CLI-reported window via
+ * recordModelContextWindow, so this is just the cold-start default. #1761. */
+const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
+  "claude-opus-4-5",
+  "claude-opus-4-6",
+  "claude-opus-4-7",
+  "claude-opus-4-8",
+  "claude-sonnet-4-5",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-7",
+]);
+
+export function defaultContextWindowFor(
+  agentType: string,
+  modelId?: string,
+): number {
+  if (agentType === "codex") return 1_000_000;
+  if (agentType === "gemini") return 1_000_000;
+  if (agentType === "grok") return 1_000_000;
+  if (agentType === "lmstudio") return 128_000;
+  // Paired threads gauge against the planner (Claude defaults to the 1M
+  // tier); the runtime-reported contextWindow corrects this per turn.
+  if (agentType === "claude-codex") return 1_000_000;
+  if (agentType === "claude-code" && modelId) {
+    if (/\[1m\]$/i.test(modelId)) {
+      const stripped = modelId.replace(/\[1m\]$/i, "").replace(/-\d{8}$/, "");
+      if (CLAUDE_1M_TIER_CAPABLE_MODELS.has(stripped)) return 1_000_000;
+    }
+  }
+  return 200_000;
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5,6 +5,15 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createEffect, createRoot } from "solid-js";
 import { produce } from "solid-js/store";
 import {
+  applyPrunedAgentMessages,
+  buildAgentCompactionPrepend,
+  type CompactAgentResult,
+  type CompactionOutcome,
+  defaultContextWindowFor,
+  PredictiveCompactMutex,
+  prunableAgentMessage,
+} from "@/lib/agent/compaction";
+import {
   planHappyArchiveInvalidation,
   planHappyProviderArchiveInvalidation,
   retireHappyArchivedSiblingProvider,
@@ -80,6 +89,12 @@ import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 
+// Compaction helpers live in @/lib/agent/compaction.
+// Re-exported so existing importers keep the unchanged public surface.
+export {
+  type CompactionOutcome,
+  PredictiveCompactMutex,
+} from "@/lib/agent/compaction";
 // Happy-archive fencing/invalidation helpers live in @/lib/agent/happy-archive.
 // Re-exported so existing importers keep the unchanged public surface.
 export {
@@ -147,45 +162,6 @@ const SUMMARY_PRIMARY_MODEL = "anthropic/claude-sonnet-4";
 // rejected by the gateway, dead-ending the fallback tier before the
 // deterministic local summary. #2111.
 const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"];
-
-/** Owner-aware global cap for predictive compaction. An archived run can
- * release its own slot immediately, but a stale completion from that run must
- * never release a newer thread's slot. */
-export class PredictiveCompactMutex {
-  private owner: { sessionId: string; generation: number } | null = null;
-  private nextGeneration = 0;
-
-  tryAcquire(
-    sessionId: string,
-  ): Readonly<{ sessionId: string; generation: number }> | null {
-    if (this.owner !== null) return null;
-    this.nextGeneration += 1;
-    this.owner = { sessionId, generation: this.nextGeneration };
-    return this.owner;
-  }
-
-  release(lease: Readonly<{ sessionId: string; generation: number }>): boolean {
-    if (
-      this.owner?.sessionId !== lease.sessionId ||
-      this.owner.generation !== lease.generation
-    ) {
-      return false;
-    }
-    this.owner = null;
-    return true;
-  }
-
-  releaseCurrentForAny(sessionIds: Iterable<string>): boolean {
-    if (!this.owner) return false;
-    for (const sessionId of sessionIds) {
-      if (this.owner.sessionId === sessionId) {
-        this.owner = null;
-        return true;
-      }
-    }
-    return false;
-  }
-}
 
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
@@ -307,48 +283,6 @@ function waitForSessionReady(sessionId: string): Promise<void> {
   ]);
 }
 
-/**
- * Outcome of an auto-compaction attempt. Callers use this to decide whether
- * to fall back to Seren Chat. Only `failed_catastrophic` fires the fallback;
- * transient or "no-op" outcomes keep the user inside the agent session.
- *
- * - `retried`: compaction succeeded AND the user's last prompt was re-sent.
- *   Returned by `compactAndRetry` only — `compactAgentConversation` never
- *   retries; that responsibility lives with the caller.
- * - `succeeded`: compaction succeeded, no prompt to retry.
- * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
- *   the session was already too small to compact. Usually means a single
- *   message is gigantic — Chat fallback would not help.
- * - `cancelled`: a Stop / predictive-promotion teardown / other graceful
- *   cancel propagated up as "Task cancelled" while compaction or the
- *   retry was in flight. Not a defect — the error event handler's
- *   graceful-cancel branch already restores UI state. Chat fallback would
- *   be wrong, since the user's intent was to stop, not to switch modes.
- * - `failed_catastrophic`: unrecoverable failure (spawn failed, summary API
- *   threw after refresh, agent runtime broken). Chat fallback is correct.
- */
-export type CompactionOutcome =
-  | "retried"
-  | "succeeded"
-  | "skipped_nothing_to_compact"
-  | "cancelled"
-  | "failed_catastrophic";
-
-/**
- * Return shape of `compactAgentConversation`. The new session id is plumbed
- * back to callers so they don't have to re-derive it by searching
- * `state.sessions` for a matching `conversationId` — that lookup falsely
- * fails for agents like Codex where `sessionId === conversationId` (#1757).
- *
- * `newSessionId` is set on reactive success (the post-compaction serving
- * session). On predictive success the standby id is stored on the parent
- * via `standbySessionId`; predictive callers consult that pointer instead.
- */
-type CompactAgentResult = {
-  outcome: Exclude<CompactionOutcome, "retried">;
-  newSessionId?: string;
-};
-
 /** Maximum time sendPrompt waits for a predictive standby's seed prompt to
  * complete when the serving session is at critical context usage (#1675). */
 const STANDBY_SEED_WAIT_MS = 5_000;
@@ -388,88 +322,6 @@ function consumeCompactionPrepend(sessionId: string, prompt: string): string {
   if (!prepend) return prompt;
   setState("sessions", sessionId, "pendingCompactionPrepend", undefined);
   return `[Auto-compaction restored prior context]\n${prepend}\n\n---\n\n${prompt}`;
-}
-
-function prunableAgentMessage(m: AgentMessage): PrunableMessage {
-  return {
-    id: m.id,
-    role:
-      m.type === "user" || m.type === "assistant" || m.type === "tool"
-        ? m.type
-        : "other",
-    content: m.content,
-    toolResult: m.toolCall?.result,
-    toolName: m.toolCall?.title,
-    toolArgs: m.toolCall?.parameters
-      ? JSON.stringify(m.toolCall.parameters)
-      : undefined,
-  };
-}
-
-function applyPrunedAgentMessages(
-  messages: AgentMessage[],
-  pruned: PrunableMessage[],
-): AgentMessage[] {
-  return messages.map((m, i) => {
-    const p = pruned[i];
-    if (!p) return m;
-    const next: AgentMessage = { ...m, content: p.content };
-    if (m.toolCall) {
-      let parameters = m.toolCall.parameters;
-      if (p.toolArgs !== undefined) {
-        try {
-          parameters = JSON.parse(p.toolArgs) as Record<string, unknown>;
-        } catch {
-          parameters = m.toolCall.parameters;
-        }
-      }
-      next.toolCall = {
-        ...m.toolCall,
-        parameters,
-        ...(p.toolResult !== undefined ? { result: p.toolResult } : {}),
-      };
-    }
-    return next;
-  });
-}
-
-function buildAgentCompactionPrepend(
-  summary: string,
-  toPreserve: AgentMessage[],
-): string {
-  // Tool messages can be enormous file contents / JSON dumps; user and
-  // assistant text keep the original ceiling used by the long-standing
-  // post-compaction prepend path.
-  const MAX_MSG_CHARS = 2000;
-  const MAX_TOOL_CHARS = 500;
-  const preservedContext = toPreserve
-    .map((m) => {
-      if (m.type === "user" || m.type === "assistant") {
-        const content =
-          m.content.length > MAX_MSG_CHARS
-            ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
-            : m.content;
-        if (m.type === "user") {
-          return `<prior_user>${content}</prior_user>`;
-        }
-        return `<prior_assistant>${content}</prior_assistant>`;
-      }
-      if (m.type === "tool" && m.toolCall?.result) {
-        const title = (m.toolCall.title || "tool").replace(/"/g, "'");
-        const result = m.toolCall.result;
-        const trimmed =
-          result.length > MAX_TOOL_CHARS
-            ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
-            : result;
-        return `<prior_tool name="${title}">${trimmed}</prior_tool>`;
-      }
-      return null;
-    })
-    .filter((s): s is string => s !== null)
-    .join("\n\n");
-  return preservedContext
-    ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
-    : `Prior work summary:\n${summary}`;
 }
 
 /**
@@ -515,38 +367,6 @@ function drainStandbyQueueIfPending(
   setTimeout(() => {
     void doSendPrompt(nextPrompt, undefined, undefined, drainTarget);
   }, 0);
-}
-
-/** Claude Code model IDs that ship a 1M-token context tier behind the
- * `[1m]` suffix. Bare IDs default to 200K — Anthropic gates the 1M tier on
- * the suffix, which the CLI translates into a `context-1m-2025-08-07` beta
- * header. The first promptComplete still upserts the CLI-reported window via
- * recordModelContextWindow, so this is just the cold-start default. #1761. */
-const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
-  "claude-opus-4-5",
-  "claude-opus-4-6",
-  "claude-opus-4-7",
-  "claude-opus-4-8",
-  "claude-sonnet-4-5",
-  "claude-sonnet-4-6",
-  "claude-sonnet-4-7",
-]);
-
-function defaultContextWindowFor(agentType: string, modelId?: string): number {
-  if (agentType === "codex") return 1_000_000;
-  if (agentType === "gemini") return 1_000_000;
-  if (agentType === "grok") return 1_000_000;
-  if (agentType === "lmstudio") return 128_000;
-  // Paired threads gauge against the planner (Claude defaults to the 1M
-  // tier); the runtime-reported contextWindow corrects this per turn.
-  if (agentType === "claude-codex") return 1_000_000;
-  if (agentType === "claude-code" && modelId) {
-    if (/\[1m\]$/i.test(modelId)) {
-      const stripped = modelId.replace(/\[1m\]$/i, "").replace(/-\d{8}$/, "");
-      if (CLAUDE_1M_TIER_CAPABLE_MODELS.has(stripped)) return 1_000_000;
-    }
-  }
-  return 200_000;
 }
 
 import {

--- a/tests/unit/claude-runtime-1m-tier.test.ts
+++ b/tests/unit/claude-runtime-1m-tier.test.ts
@@ -20,8 +20,8 @@ const {
   _resolveSpawnShell: resolveSpawnShell,
 } = await import(/* @vite-ignore */ modulePath);
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
+const compactionSource = readFileSync(
+  resolve("src/lib/agent/compaction.ts"),
   "utf-8",
 );
 
@@ -173,7 +173,7 @@ describe("augmentWithLegacyOpus — picker exposes 1M-tier variants", () => {
     ];
     expect(oneMBareIds).toEqual(expectedOneMBareIds);
     expect(
-      extractQuotedSetValues(agentStoreSource, "CLAUDE_1M_TIER_CAPABLE_MODELS"),
+      extractQuotedSetValues(compactionSource, "CLAUDE_1M_TIER_CAPABLE_MODELS"),
     ).toEqual(expectedOneMBareIds);
   });
 

--- a/tests/unit/compact-retry-codex.test.ts
+++ b/tests/unit/compact-retry-codex.test.ts
@@ -10,6 +10,10 @@ const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const compactionSource = readFileSync(
+  resolve("src/lib/agent/compaction.ts"),
+  "utf-8",
+);
 
 function functionBody(anchor: string): string {
   const start = agentStoreSource.indexOf(anchor);
@@ -25,7 +29,7 @@ function functionBody(anchor: string): string {
 
 describe("#1757 — compactAgentConversation returns the new sessionId", () => {
   it("declares the CompactAgentResult shape with newSessionId on the type", () => {
-    expect(agentStoreSource).toMatch(
+    expect(compactionSource).toMatch(
       /type CompactAgentResult\s*=\s*\{[\s\S]*?outcome:\s*Exclude<CompactionOutcome,\s*"retried">[\s\S]*?newSessionId\?:\s*string[\s\S]*?\}/,
     );
   });

--- a/tests/unit/compaction-prepend-format.test.ts
+++ b/tests/unit/compaction-prepend-format.test.ts
@@ -6,8 +6,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
+const compactionSource = readFileSync(
+  resolve("src/lib/agent/compaction.ts"),
   "utf-8",
 );
 
@@ -18,15 +18,15 @@ function preservedContextBlock(): string {
   // summarization request, not a continuation request — different codepath,
   // not the bleed source. Anchor on the formatter's variable name so
   // assertions are scoped to the bug surface.
-  const start = agentStoreSource.indexOf("const preservedContext = toPreserve");
+  const start = compactionSource.indexOf("const preservedContext = toPreserve");
   if (start < 0) {
-    throw new Error("preservedContext formatter not found in agent.store.ts");
+    throw new Error("preservedContext formatter not found in compaction.ts");
   }
-  const end = agentStoreSource.indexOf("const userTurnCount", start);
+  const end = compactionSource.indexOf("/** Claude Code model IDs", start);
   if (end < 0) {
     throw new Error("could not find prepend-wrapper end");
   }
-  return agentStoreSource.slice(start, end);
+  return compactionSource.slice(start, end);
 }
 
 describe("#1941 — preserved-context format does not mimic Claude Code stream-json", () => {

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -25,6 +25,10 @@ const agentStoreTs = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const compactionTs = readFileSync(
+  resolve("src/lib/agent/compaction.ts"),
+  "utf-8",
+);
 const threadStoreTs = readFileSync(
   resolve("src/stores/thread.store.ts"),
   "utf-8",
@@ -149,12 +153,12 @@ describe("Gemini Agent — agent.store.ts wiring (#1471)", () => {
     // #1749: this default now lives in defaultContextWindowFor; the spawn
     // block delegates via that helper. Assert the helper still maps gemini
     // to 1M.
-    const helperStart = agentStoreTs.indexOf(
+    const helperStart = compactionTs.indexOf(
       "function defaultContextWindowFor(",
     );
     expect(helperStart, "defaultContextWindowFor must exist").toBeGreaterThan(0);
-    const helperEnd = agentStoreTs.indexOf("\n}\n", helperStart);
-    const helperBody = agentStoreTs.slice(helperStart, helperEnd);
+    const helperEnd = compactionTs.indexOf("\n}\n", helperStart);
+    const helperBody = compactionTs.slice(helperStart, helperEnd);
     expect(helperBody).toMatch(
       /agentType\s*===\s*"gemini"\)?\s*return\s*1_000_000/,
     );

--- a/tests/unit/predictive-compact-race.test.ts
+++ b/tests/unit/predictive-compact-race.test.ts
@@ -5,6 +5,7 @@ import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
 const agentStoreSource = readSource("src/stores/agent.store.ts");
+const compactionSource = readSource("src/lib/agent/compaction.ts");
 
 describe("#1749 — sendPrompt enqueues instead of dispatching when predictive compact is in flight", () => {
   it("guard fires when predictiveCompactInFlight=true, no standby yet, and usage >= autoCompactThreshold", () => {
@@ -126,12 +127,12 @@ describe("#1749 — defaultContextWindowFor recognises 1M Claude variants at spa
   });
 
   it("the helper maps known 1M Claude IDs to 1_000_000 and unknowns to 200_000", () => {
-    const helperStart = agentStoreSource.indexOf(
+    const helperStart = compactionSource.indexOf(
       "function defaultContextWindowFor(",
     );
     expect(helperStart, "defaultContextWindowFor must exist").toBeGreaterThan(0);
-    const helperEnd = agentStoreSource.indexOf("\n}\n", helperStart);
-    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+    const helperEnd = compactionSource.indexOf("\n}\n", helperStart);
+    const helperBody = compactionSource.slice(helperStart, helperEnd);
 
     // Codex / Gemini cases must still return their existing defaults.
     expect(helperBody).toContain('agentType === "codex"');
@@ -141,8 +142,8 @@ describe("#1749 — defaultContextWindowFor recognises 1M Claude variants at spa
     // Claude 1M models must be enumerated explicitly so a brand-new install
     // hits the right window on the very first turn (before the CLI's
     // meta.contextWindow has had a chance to upsert).
-    expect(agentStoreSource).toContain('"claude-opus-4-7"');
-    expect(agentStoreSource).toContain('"claude-sonnet-4-6"');
+    expect(compactionSource).toContain('"claude-opus-4-7"');
+    expect(compactionSource).toContain('"claude-sonnet-4-6"');
     // Default for anything unknown is still 200_000.
     expect(helperBody).toContain("200_000");
   });
@@ -152,11 +153,11 @@ describe("#1749 — defaultContextWindowFor recognises 1M Claude variants at spa
     // (`claude-opus-4-7[1m]`); both the bare ID and the bracketed form
     // must hit the 1M branch so a fresh session does not start at 200K
     // and trigger premature auto-compaction.
-    const helperStart = agentStoreSource.indexOf(
+    const helperStart = compactionSource.indexOf(
       "function defaultContextWindowFor(",
     );
-    const helperEnd = agentStoreSource.indexOf("\n}\n", helperStart);
-    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+    const helperEnd = compactionSource.indexOf("\n}\n", helperStart);
+    const helperBody = compactionSource.slice(helperStart, helperEnd);
     expect(helperBody).toContain("\\[1m\\]");
   });
 });

--- a/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
+++ b/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
@@ -10,18 +10,26 @@ const agentStoreSource = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
 );
+const compactionSource = readFileSync(
+  resolve("src/lib/agent/compaction.ts"),
+  "utf-8",
+);
 
 /**
  * Slice a fixed-size window forward from a unique anchor. The two fixes in
  * #1858 each live in a tightly localized region, so a windowed slice keeps
  * the assertions immune to drift in unrelated code below.
  */
-function regionAfter(anchor: string, len: number): string {
-  const start = agentStoreSource.indexOf(anchor);
+function regionAfter(
+  anchor: string,
+  len: number,
+  source: string = agentStoreSource,
+): string {
+  const start = source.indexOf(anchor);
   if (start < 0) {
-    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+    throw new Error(`anchor not found: ${anchor}`);
   }
-  return agentStoreSource.slice(start, start + len);
+  return source.slice(start, start + len);
 }
 
 describe("#1858 Defect 1 — setModel updates contextWindowSize on mid-session model swap", () => {
@@ -77,7 +85,7 @@ describe("#1858 Defect 2 — passive prepend preserves tool-result content", () 
   // prepend formatting region only — not the toCompact serialization nor the
   // post-prepend spawn flows below.
   const prependRegion = () =>
-    regionAfter("function buildAgentCompactionPrepend", 2500);
+    regionAfter("function buildAgentCompactionPrepend", 2500, compactionSource);
 
   it("prepend builder includes m.type === \"tool\" alongside user/assistant", () => {
     // The filter must allow tool messages through. Pre-fix shape was a literal


### PR DESCRIPTION
## What

Behavior-preserving extraction of the **pure compaction cluster** from `agent.store.ts` (#3250) into a co-located module `src/lib/agent/compaction.ts`. Same low-risk profile as #3258 / #3260: module-level code, **zero `this.`**, relocation + re-export.

Moved (pure — no `this.`, no closure over store `state`/`setState`):
- `PredictiveCompactMutex` (class)
- `prunableAgentMessage`, `applyPrunedAgentMessages`, `buildAgentCompactionPrepend`
- `defaultContextWindowFor` (+ its now-private `CLAUDE_1M_TIER_CAPABLE_MODELS` set)
- `CompactionOutcome`, `CompactAgentResult` (types)

## Public surface + call sites unchanged

- `AgentMessage` / `PrunableMessage` are **type-only** imports (erased at runtime → no cycle).
- The `predictiveCompactMutex` **singleton stays in the store** (instantiates the imported class).
- The store **re-exports** `PredictiveCompactMutex` and `CompactionOutcome` so `@/stores/agent.store`'s public surface is identical.
- **Left in the store on purpose:** the scalar constants (`BUDGET_*`, `SUMMARY_*`, `AGGRESSIVE_RETRY_*`, `PREDICTIVE_*` — one-liners, heavily source-text-pinned) and the three **state-closing** helpers (`consumeCompactionPrepend`, `waitForStandbySeed`, `drainStandbyQueueIfPending`).
- `agent.store.ts`: **9281 → 9101 lines**.

## Test changes (transparency)

Six tests pin the moved declarations **by source text** (`readFileSync`/`readSource` of `agent.store.ts`). Those specific assertions are **repointed to the `compaction.ts` source** where the code now lives — **same fact, same type/body asserted, zero weakening**. Behavioral call-site assertions on the compaction *methods* that remain in the store stay pointed at `agent.store.ts`. No test deleted or loosened.

- `claude-runtime-1m-tier` — `CLAUDE_1M_TIER_CAPABLE_MODELS` set values
- `compact-retry-codex` — `CompactAgentResult` type shape
- `compaction-prepend-format` — `buildAgentCompactionPrepend` body
- `gemini-agent`, `predictive-compact-race` — `defaultContextWindowFor` body + 1M-tier IDs
- `setmodel-context-window-and-prepend-tool-results` — `buildAgentCompactionPrepend` body

## Validation

- Full unit suite green: **380 files / 2714 tests passed**, 0 failures.
- `biome check`: both source files clean (`tests/` is outside Biome's config).
- `tsc --noEmit`: all changed files (source + tests) type-clean.

No new test added: these helpers are already round-trip/source-pinned by the existing compaction tests.

## Non-goals

No behavior, IPC-contract, or persistence-schema change. No new features. No dependency additions. No outbound network path touched (pure in-process helpers).

Refs #3250

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
