### PR TITLE
feat(security): capability leases with predicates + budgets (#3262)

### DIFF
--- a/src-tauri/src/capability_lease.rs
+++ b/src-tauri/src/capability_lease.rs
@@ -1,0 +1,879 @@
+// ABOUTME: Task/session capability-lease model + deterministic matcher for the host authorization gate.
+// ABOUTME: A lease pre-approves a bounded envelope (predicates + budgets) so work runs silently without per-call prompts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::tool_authorization::{OperationClass, ToolRoute};
+
+/// A shell/skill command the lease pre-approves, identified by its leading
+/// executable token (e.g. `cargo`, `pnpm`, `git`). Arguments may vary — the
+/// point of a lease is that a build/test/format command runs without a fresh
+/// prompt for every invocation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandRule {
+    /// Lowercased program name, matched against the command's first token.
+    pub program: String,
+}
+
+/// A publisher/operation predicate. `publisher_slug` may be `*` to cover any
+/// publisher. `allow_high_risk` gates whether the rule extends to operations the
+/// classifier flags high-risk (destructive/monetary/outbound/credential); a
+/// coding lease leaves it false so a `post_send` still needs an exact one-shot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublisherRule {
+    pub publisher_slug: String,
+    #[serde(default)]
+    pub allow_high_risk: bool,
+    /// Resource/account/connection this rule is scoped to. `None` means any
+    /// target; `Some(id)` means the call's target must match exactly, so a lease
+    /// for one repository/account does not silently cover another.
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+/// An explicit deny predicate. Any field left `None` is a wildcard. A single
+/// matching exclusion denies the call regardless of what any allow-predicate
+/// says — this is how `deny > prompt > allow` is enforced within a lease.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Exclusion {
+    #[serde(default)]
+    pub route: Option<String>,
+    #[serde(default)]
+    pub publisher_slug: Option<String>,
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub program: Option<String>,
+}
+
+/// The predicate surface a lease pre-approves. Only the dimensions the gate's
+/// live routes evaluate are modeled here: command rules (shell/skill), network
+/// hosts (web), and publisher operations with a resource constraint
+/// (gateway/seren/mcp). Filesystem-root enforcement stays in
+/// `orchestrator/file_access_policy.rs`; model-originated file tools never reach
+/// this gate.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeasePredicates {
+    #[serde(default)]
+    pub command_rules: Vec<CommandRule>,
+    #[serde(default)]
+    pub network_hosts: Vec<String>,
+    #[serde(default)]
+    pub publisher_ops: Vec<PublisherRule>,
+    #[serde(default)]
+    pub exclusions: Vec<Exclusion>,
+}
+
+/// Consumable limits. A lease is bounded by predicates *and* budgets: even a
+/// covered call is escalated once a budget is exhausted, producing a single
+/// scope-escalation request rather than silently running unbounded work.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaseBudgets {
+    /// Total call count across every route the lease covers. `None` = unmetered.
+    #[serde(default)]
+    pub max_calls: Option<u64>,
+    #[serde(default)]
+    pub calls_used: u64,
+    /// Monetary ceiling in micro-units of `asset` (e.g. USDC micros). `None` =
+    /// no monetary allowance; any priced call escalates.
+    #[serde(default)]
+    pub max_spend_micros: Option<u64>,
+    #[serde(default)]
+    pub spend_used_micros: u64,
+    #[serde(default)]
+    pub asset: Option<String>,
+}
+
+impl LeaseBudgets {
+    /// Whether charging `cost_micros` for one more call stays within budget.
+    fn admits(&self, cost_micros: u64) -> bool {
+        if let Some(max) = self.max_calls
+            && self.calls_used.saturating_add(1) > max
+        {
+            return false;
+        }
+        if cost_micros > 0 {
+            match self.max_spend_micros {
+                // A priced call with no monetary allowance is not covered.
+                None => return false,
+                Some(max) => {
+                    if self.spend_used_micros.saturating_add(cost_micros) > max {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// A persisted, thread-scoped capability lease. Bound to a conversation (the only
+/// local task/session identifier), a start/expiry window, and a revocation flag.
+/// The model may *request* one but never mint it: leases are created only by the
+/// host-side grant command a user's approval invokes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityLease {
+    pub id: String,
+    /// Thread binding — matches the gate's decision store key.
+    pub conversation_id: String,
+    /// Human-readable summary of the approved envelope, shown at review time.
+    pub label: String,
+    pub created_at: String,
+    /// RFC3339 UTC instant after which the lease no longer matches.
+    pub expires_at: String,
+    #[serde(default)]
+    pub revoked: bool,
+    pub predicates: LeasePredicates,
+    pub budgets: LeaseBudgets,
+}
+
+impl CapabilityLease {
+    /// Active = bound to this conversation, not revoked, not expired at `now`.
+    /// `now` and `expires_at` are RFC3339 UTC strings; lexicographic comparison
+    /// is a correct time ordering for that fixed format.
+    pub fn is_active(&self, conversation_id: &str, now: &str) -> bool {
+        !self.revoked && self.conversation_id == conversation_id && self.expires_at.as_str() > now
+    }
+}
+
+/// The normalized call the matcher evaluates. The renderer supplies the route,
+/// publisher/tool identity, and the small argument slice a predicate needs; the
+/// host owns classification (`class`).
+#[derive(Clone, Debug)]
+pub struct OperationRequest {
+    pub route: ToolRoute,
+    pub class: OperationClass,
+    pub publisher_slug: String,
+    pub tool_name: String,
+    /// Shell/skill command line; its first token is matched against command rules.
+    pub command: Option<String>,
+    /// Web-fetch host (already extracted from the URL by the caller).
+    pub host: Option<String>,
+    /// Publisher resource/account/connection identifier, if the call names one.
+    pub target: Option<String>,
+    /// Declared monetary cost of this call in micro-units. 0 when free/unknown.
+    pub cost_micros: u64,
+}
+
+/// The matcher's verdict for one call against the active lease set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LeaseOutcome {
+    /// A lease's exclusion matched — deny outright, beating every allow.
+    Deny,
+    /// A lease covers the call and its budget admits it; `String` is the lease id
+    /// to charge.
+    Allow(String),
+    /// No active lease covers the call, or the only covering lease is out of
+    /// budget. The caller escalates (prompts) exactly once.
+    Escalate,
+}
+
+/// Leading executable token of a command line, lowercased. Mirrors the gate's
+/// operation tokenizer so `"cargo build --release"` → `"cargo"`.
+pub fn command_program(command: &str) -> Option<String> {
+    command
+        .split_whitespace()
+        .next()
+        .map(|token| {
+            // Strip a path prefix so `/usr/bin/git` matches a `git` rule.
+            token
+                .rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(token)
+                .to_lowercase()
+        })
+        .filter(|program| !program.is_empty())
+}
+
+/// Host suffix match: an entry `example.com` covers `example.com` and
+/// `api.example.com`, but not `notexample.com`. Case-insensitive.
+fn host_matches(rule: &str, host: &str) -> bool {
+    let rule = rule.trim().trim_start_matches('.').to_lowercase();
+    let host = host.trim().to_lowercase();
+    if rule.is_empty() {
+        return false;
+    }
+    host == rule || host.ends_with(&format!(".{rule}"))
+}
+
+fn exclusion_matches(exclusion: &Exclusion, req: &OperationRequest) -> bool {
+    // Every specified field must match; an all-`None` exclusion is ignored rather
+    // than denying everything (that would be a footgun, not a policy).
+    let mut constrained = false;
+    if let Some(route) = &exclusion.route {
+        constrained = true;
+        if !route.eq_ignore_ascii_case(req.route.as_wire()) {
+            return false;
+        }
+    }
+    if let Some(publisher) = &exclusion.publisher_slug {
+        constrained = true;
+        if publisher != &req.publisher_slug {
+            return false;
+        }
+    }
+    if let Some(tool) = &exclusion.tool_name {
+        constrained = true;
+        if tool != &req.tool_name {
+            return false;
+        }
+    }
+    if let Some(host) = &exclusion.host {
+        constrained = true;
+        match &req.host {
+            Some(req_host) if host_matches(host, req_host) => {}
+            _ => return false,
+        }
+    }
+    if let Some(program) = &exclusion.program {
+        constrained = true;
+        let matched = req
+            .command
+            .as_deref()
+            .and_then(command_program)
+            .is_some_and(|actual| actual == program.to_lowercase());
+        if !matched {
+            return false;
+        }
+    }
+    constrained
+}
+
+/// Whether a lease's predicates cover this call. Coverage is route-specific and
+/// deliberately conservative: an unmatched route/predicate is never covered.
+fn predicates_cover(lease: &CapabilityLease, req: &OperationRequest) -> bool {
+    match req.route {
+        ToolRoute::Shell | ToolRoute::Skill => {
+            let Some(program) = req.command.as_deref().and_then(command_program) else {
+                return false;
+            };
+            lease
+                .predicates
+                .command_rules
+                .iter()
+                .any(|rule| rule.program.to_lowercase() == program)
+        }
+        ToolRoute::Web => {
+            let Some(host) = req.host.as_deref() else {
+                return false;
+            };
+            lease
+                .predicates
+                .network_hosts
+                .iter()
+                .any(|entry| host_matches(entry, host))
+        }
+        ToolRoute::Gateway | ToolRoute::Seren | ToolRoute::Mcp => {
+            lease.predicates.publisher_ops.iter().any(|rule| {
+                let publisher_ok =
+                    rule.publisher_slug == "*" || rule.publisher_slug == req.publisher_slug;
+                let risk_ok = req.class != OperationClass::HighRisk || rule.allow_high_risk;
+                let target_ok = match &rule.target {
+                    None => true,
+                    Some(target) => req.target.as_deref() == Some(target.as_str()),
+                };
+                publisher_ok && risk_ok && target_ok
+            })
+        }
+    }
+}
+
+/// Evaluate one call against the leases bound to `conversation_id` with
+/// `deny > allow` resolution.
+///
+/// Deny wins: if any active lease excludes the call, the verdict is `Deny` even
+/// when another predicate would allow it. Otherwise the first covering lease
+/// whose budget admits the call yields `Allow`; if a lease covers but is out of
+/// budget and nothing else covers, the verdict is `Escalate` (one
+/// scope-escalation request), never a silent allow.
+pub fn evaluate_for_conversation(
+    leases: &[CapabilityLease],
+    req: &OperationRequest,
+    conversation_id: &str,
+    now: &str,
+) -> LeaseOutcome {
+    let active: Vec<&CapabilityLease> = leases
+        .iter()
+        .filter(|lease| lease.is_active(conversation_id, now))
+        .collect();
+
+    // Deny beats everything: one matching exclusion on any active lease wins.
+    for lease in &active {
+        if lease
+            .predicates
+            .exclusions
+            .iter()
+            .any(|exclusion| exclusion_matches(exclusion, req))
+        {
+            return LeaseOutcome::Deny;
+        }
+    }
+
+    // First lease that both covers the call and has budget for it.
+    for lease in &active {
+        if predicates_cover(lease, req) && lease.budgets.admits(req.cost_micros) {
+            return LeaseOutcome::Allow(lease.id.clone());
+        }
+    }
+
+    LeaseOutcome::Escalate
+}
+
+// ============================================================================
+// Capability-bundle derivation
+//
+// At task start the host derives a *proposed* bundle the user reviews once. This
+// produces the proposal only — it never grants authority. The model may request
+// a bundle this way but cannot approve or widen it; only a human-invoked grant
+// persists a lease.
+// ============================================================================
+
+/// The default shell programs a coding task needs: this project's documented
+/// build/test/format/VCS toolchain. Anything outside this set escalates once, so
+/// a coding lease does not silently cover arbitrary shell execution.
+const CODING_COMMAND_PROGRAMS: &[&str] = &["cargo", "pnpm", "npm", "node", "git"];
+
+/// Default call ceiling for a derived coding bundle. Sized so an ordinary
+/// long-running coding task (edits, searches, builds, tests) completes under one
+/// lease, per the acceptance criteria, while still bounding runaway loops.
+const CODING_DEFAULT_MAX_CALLS: u64 = 500;
+
+/// The task profile the (slice-D) approval UI selects, plus any plan-specific
+/// predicates it wants folded into the proposal. Derivation is pure: it maps this
+/// request to concrete predicates and default budgets for review.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleRequest {
+    /// `"coding"` seeds the workspace toolchain; any other value seeds nothing and
+    /// relies solely on the explicit predicates below.
+    #[serde(default)]
+    pub profile: String,
+    /// Extra shell programs to pre-approve beyond the profile defaults.
+    #[serde(default)]
+    pub extra_commands: Vec<String>,
+    /// Publisher operations (with optional resource/account constraints) the plan
+    /// needs — e.g. issue/PR operations scoped to one repository.
+    #[serde(default)]
+    pub publisher_ops: Vec<PublisherRule>,
+    /// Hosts to pre-approve for web fetches (package registries, docs).
+    #[serde(default)]
+    pub network_hosts: Vec<String>,
+    /// Explicit exclusions carried straight into the proposal.
+    #[serde(default)]
+    pub exclusions: Vec<Exclusion>,
+    /// Requested lifetime; the grant command stamps the real expiry.
+    #[serde(default)]
+    pub duration_secs: i64,
+    /// Overrides the default call ceiling when set.
+    #[serde(default)]
+    pub max_calls: Option<u64>,
+    #[serde(default)]
+    pub max_spend_micros: Option<u64>,
+    #[serde(default)]
+    pub asset: Option<String>,
+}
+
+/// A reviewable, editable proposal. Carries no id, timestamps, or grant — those
+/// are minted only when a user approves it via the grant command.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposedBundle {
+    pub label: String,
+    pub duration_secs: i64,
+    pub predicates: LeasePredicates,
+    pub budgets: LeaseBudgets,
+}
+
+/// Turn a task profile into a concrete, editable capability proposal. Pure and
+/// side-effect-free.
+pub fn derive_bundle(request: &BundleRequest) -> ProposedBundle {
+    let mut programs: Vec<String> = Vec::new();
+    if request.profile == "coding" {
+        programs.extend(CODING_COMMAND_PROGRAMS.iter().map(|p| p.to_string()));
+    }
+    for extra in &request.extra_commands {
+        let normalized = extra.trim().to_lowercase();
+        if !normalized.is_empty() && !programs.contains(&normalized) {
+            programs.push(normalized);
+        }
+    }
+    let command_rules = programs
+        .into_iter()
+        .map(|program| CommandRule { program })
+        .collect();
+
+    let predicates = LeasePredicates {
+        command_rules,
+        network_hosts: request.network_hosts.clone(),
+        publisher_ops: request.publisher_ops.clone(),
+        exclusions: request.exclusions.clone(),
+    };
+
+    let budgets = LeaseBudgets {
+        max_calls: Some(request.max_calls.unwrap_or(CODING_DEFAULT_MAX_CALLS)),
+        calls_used: 0,
+        max_spend_micros: request.max_spend_micros,
+        spend_used_micros: 0,
+        asset: request.asset.clone(),
+    };
+
+    let label = if request.profile == "coding" {
+        "Coding task capability lease".to_string()
+    } else {
+        "Task capability lease".to_string()
+    };
+
+    ProposedBundle {
+        label,
+        duration_secs: request.duration_secs,
+        predicates,
+        budgets,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: &str = "2026-07-24T00:00:00Z";
+    const LATER: &str = "2026-07-24T04:00:00Z";
+    const PAST: &str = "2026-07-23T00:00:00Z";
+
+    fn lease(predicates: LeasePredicates, budgets: LeaseBudgets) -> CapabilityLease {
+        CapabilityLease {
+            id: "lease-1".to_string(),
+            conversation_id: "conv-a".to_string(),
+            label: "test lease".to_string(),
+            created_at: NOW.to_string(),
+            expires_at: LATER.to_string(),
+            revoked: false,
+            predicates,
+            budgets,
+        }
+    }
+
+    fn shell_req(command: &str) -> OperationRequest {
+        OperationRequest {
+            route: ToolRoute::Shell,
+            class: OperationClass::HighRisk,
+            publisher_slug: "seren".to_string(),
+            tool_name: "execute_command".to_string(),
+            command: Some(command.to_string()),
+            host: None,
+            target: None,
+            cost_micros: 0,
+        }
+    }
+
+    fn gateway_req(publisher: &str, tool: &str, class: OperationClass) -> OperationRequest {
+        OperationRequest {
+            route: ToolRoute::Gateway,
+            class,
+            publisher_slug: publisher.to_string(),
+            tool_name: tool.to_string(),
+            command: None,
+            host: None,
+            target: None,
+            cost_micros: 0,
+        }
+    }
+
+    fn eval(leases: &[CapabilityLease], req: &OperationRequest, now: &str) -> LeaseOutcome {
+        evaluate_for_conversation(leases, req, "conv-a", now)
+    }
+
+    // ---- command tokenizing ---------------------------------------------
+
+    #[test]
+    fn command_program_strips_paths_and_lowercases() {
+        assert_eq!(command_program("cargo build").as_deref(), Some("cargo"));
+        assert_eq!(command_program("/usr/bin/GIT status").as_deref(), Some("git"));
+        assert_eq!(command_program("   pnpm   test  ").as_deref(), Some("pnpm"));
+        assert_eq!(command_program("").as_deref(), None);
+    }
+
+    // ---- command-rule coverage (the 500-call coding task) ---------------
+
+    #[test]
+    fn command_lease_covers_matching_program_regardless_of_args() {
+        let l = lease(
+            LeasePredicates {
+                command_rules: vec![
+                    CommandRule { program: "cargo".to_string() },
+                    CommandRule { program: "pnpm".to_string() },
+                    CommandRule { program: "git".to_string() },
+                ],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        for command in [
+            "cargo build --release",
+            "cargo test --manifest-path src-tauri/Cargo.toml",
+            "pnpm check",
+            "git status",
+        ] {
+            assert_eq!(
+                eval(&[l.clone()], &shell_req(command), NOW),
+                LeaseOutcome::Allow("lease-1".to_string()),
+                "{command} should be covered"
+            );
+        }
+    }
+
+    #[test]
+    fn command_lease_escalates_an_unlisted_program() {
+        let l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        assert_eq!(eval(&[l], &shell_req("rm -rf /"), NOW), LeaseOutcome::Escalate);
+    }
+
+    // ---- publisher + resource coverage ----------------------------------
+
+    #[test]
+    fn publisher_lease_covers_unclassified_ops_but_not_high_risk_by_default() {
+        let l = lease(
+            LeasePredicates {
+                publisher_ops: vec![PublisherRule {
+                    publisher_slug: "attio".to_string(),
+                    allow_high_risk: false,
+                    target: None,
+                }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(100), ..Default::default() },
+        );
+        assert_eq!(
+            eval(&[l.clone()], &gateway_req("attio", "post_notes", OperationClass::Unclassified), NOW),
+            LeaseOutcome::Allow("lease-1".to_string()),
+        );
+        // A high-risk op on the same publisher is not covered without opt-in.
+        assert_eq!(
+            eval(&[l], &gateway_req("attio", "delete_records", OperationClass::HighRisk), NOW),
+            LeaseOutcome::Escalate,
+        );
+    }
+
+    #[test]
+    fn publisher_lease_target_constraint_scopes_to_one_resource() {
+        let l = lease(
+            LeasePredicates {
+                publisher_ops: vec![PublisherRule {
+                    publisher_slug: "github".to_string(),
+                    allow_high_risk: true,
+                    target: Some("serenorg/seren-desktop".to_string()),
+                }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(100), ..Default::default() },
+        );
+        let mut in_scope = gateway_req("github", "post_issues", OperationClass::Unclassified);
+        in_scope.target = Some("serenorg/seren-desktop".to_string());
+        assert_eq!(eval(&[l.clone()], &in_scope, NOW), LeaseOutcome::Allow("lease-1".to_string()));
+
+        let mut other_repo = gateway_req("github", "post_issues", OperationClass::Unclassified);
+        other_repo.target = Some("serenorg/other".to_string());
+        assert_eq!(eval(&[l], &other_repo, NOW), LeaseOutcome::Escalate);
+    }
+
+    // ---- deny > allow ----------------------------------------------------
+
+    #[test]
+    fn exclusion_denies_even_when_a_predicate_would_allow() {
+        let l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "git".to_string() }],
+                exclusions: vec![Exclusion { program: Some("git".to_string()), ..Default::default() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        assert_eq!(eval(&[l], &shell_req("git push"), NOW), LeaseOutcome::Deny);
+    }
+
+    #[test]
+    fn deny_from_one_lease_beats_allow_from_another() {
+        let allow = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "git".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(10), ..Default::default() },
+        );
+        let mut deny = lease(LeasePredicates::default(), LeaseBudgets::default());
+        deny.id = "lease-2".to_string();
+        deny.predicates.exclusions = vec![Exclusion {
+            route: Some("shell".to_string()),
+            ..Default::default()
+        }];
+        // Order independent: deny wins whichever lease is scanned first.
+        assert_eq!(eval(&[allow.clone(), deny.clone()], &shell_req("git status"), NOW), LeaseOutcome::Deny);
+        assert_eq!(eval(&[deny, allow], &shell_req("git status"), NOW), LeaseOutcome::Deny);
+    }
+
+    // ---- budgets ---------------------------------------------------------
+
+    #[test]
+    fn call_budget_exhaustion_escalates() {
+        let mut l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(2), calls_used: 2, ..Default::default() },
+        );
+        l.budgets.calls_used = 2;
+        assert_eq!(eval(&[l], &shell_req("cargo build"), NOW), LeaseOutcome::Escalate);
+    }
+
+    #[test]
+    fn priced_call_requires_monetary_budget() {
+        let base = LeasePredicates {
+            publisher_ops: vec![PublisherRule {
+                publisher_slug: "*".to_string(),
+                allow_high_risk: true,
+                target: None,
+            }],
+            ..Default::default()
+        };
+        // No monetary allowance → a priced call escalates.
+        let free_only = lease(base.clone(), LeaseBudgets { max_calls: Some(100), ..Default::default() });
+        let mut priced = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        priced.cost_micros = 5_000_000;
+        assert_eq!(eval(&[free_only], &priced, NOW), LeaseOutcome::Escalate);
+
+        // With allowance the same call is covered.
+        let funded = lease(
+            base,
+            LeaseBudgets {
+                max_calls: Some(100),
+                max_spend_micros: Some(10_000_000),
+                asset: Some("USDC".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(eval(&[funded], &priced, NOW), LeaseOutcome::Allow("lease-1".to_string()));
+    }
+
+    #[test]
+    fn monetary_budget_overrun_escalates() {
+        let l = lease(
+            LeasePredicates {
+                publisher_ops: vec![PublisherRule {
+                    publisher_slug: "*".to_string(),
+                    allow_high_risk: true,
+                    target: None,
+                }],
+                ..Default::default()
+            },
+            LeaseBudgets {
+                max_calls: Some(100),
+                max_spend_micros: Some(10_000_000),
+                spend_used_micros: 8_000_000,
+                asset: Some("USDC".to_string()),
+                ..Default::default()
+            },
+        );
+        let mut priced = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        priced.cost_micros = 5_000_000; // 8M + 5M > 10M
+        assert_eq!(eval(&[l], &priced, NOW), LeaseOutcome::Escalate);
+    }
+
+    // ---- lifetime binding ------------------------------------------------
+
+    #[test]
+    fn expired_lease_does_not_match() {
+        let l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        // now == LATER means the window has closed (expires_at is exclusive).
+        assert_eq!(eval(&[l.clone()], &shell_req("cargo build"), LATER), LeaseOutcome::Escalate);
+        // and clearly after.
+        assert_eq!(eval(&[l], &shell_req("cargo build"), "2026-07-25T00:00:00Z"), LeaseOutcome::Escalate);
+    }
+
+    #[test]
+    fn revoked_lease_does_not_match() {
+        let mut l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        l.revoked = true;
+        assert_eq!(eval(&[l], &shell_req("cargo build"), NOW), LeaseOutcome::Escalate);
+    }
+
+    #[test]
+    fn lease_for_another_conversation_does_not_match() {
+        let l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        assert_eq!(
+            evaluate_for_conversation(&[l], &shell_req("cargo build"), "conv-b", NOW),
+            LeaseOutcome::Escalate,
+        );
+    }
+
+    #[test]
+    fn host_lease_covers_subdomains_only() {
+        let l = lease(
+            LeasePredicates {
+                network_hosts: vec!["example.com".to_string()],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(50), ..Default::default() },
+        );
+        let mut allowed = OperationRequest {
+            route: ToolRoute::Web,
+            class: OperationClass::Unclassified,
+            publisher_slug: "seren".to_string(),
+            tool_name: "web_fetch".to_string(),
+            command: None,
+            host: Some("api.example.com".to_string()),
+            target: None,
+            cost_micros: 0,
+        };
+        assert_eq!(eval(&[l.clone()], &allowed, NOW), LeaseOutcome::Allow("lease-1".to_string()));
+        allowed.host = Some("notexample.com".to_string());
+        assert_eq!(eval(&[l], &allowed, NOW), LeaseOutcome::Escalate);
+    }
+
+    // ---- bundle derivation ----------------------------------------------
+
+    #[test]
+    fn coding_profile_seeds_the_toolchain_and_a_bounded_budget() {
+        let bundle = derive_bundle(&BundleRequest {
+            profile: "coding".to_string(),
+            duration_secs: 4 * 3600,
+            ..Default::default()
+        });
+        let programs: Vec<&str> = bundle
+            .predicates
+            .command_rules
+            .iter()
+            .map(|rule| rule.program.as_str())
+            .collect();
+        assert!(programs.contains(&"cargo"));
+        assert!(programs.contains(&"pnpm"));
+        assert!(programs.contains(&"git"));
+        assert_eq!(bundle.budgets.max_calls, Some(500));
+        // Derivation grants no money by default.
+        assert_eq!(bundle.budgets.max_spend_micros, None);
+    }
+
+    #[test]
+    fn derivation_folds_in_plan_predicates_and_dedupes_extra_commands() {
+        let bundle = derive_bundle(&BundleRequest {
+            profile: "coding".to_string(),
+            extra_commands: vec!["cargo".to_string(), "Rg".to_string()],
+            publisher_ops: vec![PublisherRule {
+                publisher_slug: "github".to_string(),
+                allow_high_risk: true,
+                target: Some("serenorg/seren-desktop".to_string()),
+            }],
+            network_hosts: vec!["registry.npmjs.org".to_string()],
+            duration_secs: 3600,
+            max_calls: Some(1000),
+            ..Default::default()
+        });
+        let cargo_rules = bundle
+            .predicates
+            .command_rules
+            .iter()
+            .filter(|rule| rule.program == "cargo")
+            .count();
+        assert_eq!(cargo_rules, 1, "extra command must not duplicate a profile default");
+        assert!(bundle.predicates.command_rules.iter().any(|rule| rule.program == "rg"));
+        assert_eq!(bundle.predicates.publisher_ops.len(), 1);
+        assert_eq!(bundle.predicates.network_hosts, vec!["registry.npmjs.org".to_string()]);
+        assert_eq!(bundle.budgets.max_calls, Some(1000));
+    }
+
+    #[test]
+    fn non_coding_profile_only_uses_explicit_predicates() {
+        let bundle = derive_bundle(&BundleRequest {
+            profile: "custom".to_string(),
+            duration_secs: 3600,
+            ..Default::default()
+        });
+        assert!(bundle.predicates.command_rules.is_empty());
+        assert_eq!(bundle.label, "Task capability lease");
+    }
+
+    #[test]
+    fn past_created_lease_is_not_spuriously_expired() {
+        // Guards the string-time comparison: a lease created in the past but
+        // expiring in the future is active now.
+        let mut l = lease(
+            LeasePredicates {
+                command_rules: vec![CommandRule { program: "cargo".to_string() }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(500), ..Default::default() },
+        );
+        l.created_at = PAST.to_string();
+        assert_eq!(eval(&[l], &shell_req("cargo build"), NOW), LeaseOutcome::Allow("lease-1".to_string()));
+    }
+
+    // ---- wire contract ---------------------------------------------------
+
+    /// The predicates/budgets cross the Tauri command boundary as camelCase JSON.
+    /// A field rename that broke that contract would silently make the grant
+    /// command reject the renderer's payload; pin it.
+    #[test]
+    fn predicates_and_budgets_use_the_camel_case_wire_contract() {
+        let predicates: LeasePredicates = serde_json::from_value(serde_json::json!({
+            "commandRules": [{ "program": "cargo" }],
+            "networkHosts": ["registry.npmjs.org"],
+            "publisherOps": [{
+                "publisherSlug": "github",
+                "allowHighRisk": true,
+                "target": "serenorg/seren-desktop"
+            }],
+            "exclusions": [{ "program": "rm" }],
+        }))
+        .expect("camelCase predicates deserialize");
+        assert_eq!(predicates.command_rules.len(), 1);
+        assert!(predicates.publisher_ops[0].allow_high_risk);
+        assert_eq!(predicates.exclusions[0].program.as_deref(), Some("rm"));
+
+        let budgets: LeaseBudgets = serde_json::from_value(serde_json::json!({
+            "maxCalls": 500,
+            "maxSpendMicros": 10_000_000,
+            "asset": "USDC",
+        }))
+        .expect("camelCase budgets deserialize");
+        assert_eq!(budgets.max_calls, Some(500));
+        assert_eq!(budgets.max_spend_micros, Some(10_000_000));
+
+        // A lease serializes back to camelCase for inspection/listing.
+        let value = serde_json::to_value(lease(predicates, budgets)).expect("lease serializes");
+        assert!(value.get("conversationId").is_some());
+        assert!(value.get("expiresAt").is_some());
+        assert!(value["budgets"].get("maxCalls").is_some());
+        assert!(value["predicates"].get("commandRules").is_some());
+    }
+}

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2364,12 +2364,12 @@ pub async fn erase_all_conversation_data(
         )),
     }
 
-    // Tool authorization decisions: conversation-scoped grants/denials.
+    // Tool authorization: conversation-scoped grants/denials and capability leases.
     match authorization_state.wipe() {
         Ok(count) => reports.push(EraseTargetReport::new(
             "tool_authorization_db",
             "ok",
-            Some(format!("{count} decision(s) removed")),
+            Some(format!("{count} authorization record(s) removed")),
         )),
         Err(err) => reports.push(EraseTargetReport::new(
             "tool_authorization_db",

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -3,11 +3,21 @@
 
 use tauri::State;
 
-use crate::tool_authorization::{AuthorizationDecision, ToolAuthorizationState, ToolRoute};
+use crate::capability_lease::{
+    BundleRequest, CapabilityLease, LeaseBudgets, LeasePredicates, ProposedBundle, derive_bundle,
+};
+use crate::tool_authorization::{
+    AuthorizationDecision, OperationContext, ToolAuthorizationState, ToolRoute,
+};
 
 /// Classify a model-originated tool call and return the host's decision. The
 /// renderer honors `allow`/`deny` directly and, on `prompt`, runs the matching
 /// approval UI. Passing through the gate never itself prompts the user.
+///
+/// `context` carries the small argument slice a capability-lease predicate needs
+/// (command, host, resource target, monetary cost). It is optional so callers
+/// that have nothing to contribute pass nothing; a predicate that needs a field
+/// simply will not match a call that omits it.
 #[tauri::command]
 pub fn authorize_tool_operation(
     state: State<'_, ToolAuthorizationState>,
@@ -15,9 +25,11 @@ pub fn authorize_tool_operation(
     publisher_slug: String,
     tool_name: String,
     conversation_id: String,
+    context: Option<OperationContext>,
 ) -> Result<AuthorizationDecision, String> {
     let route = ToolRoute::parse(&route)?;
-    state.authorize(route, &publisher_slug, &tool_name, &conversation_id)
+    let context = context.unwrap_or_default();
+    state.authorize(route, &publisher_slug, &tool_name, &conversation_id, &context)
 }
 
 /// Persist a prompt outcome host-side. Classification is re-derived here, so a
@@ -34,4 +46,49 @@ pub fn record_tool_operation_decision(
 ) -> Result<(), String> {
     let route = ToolRoute::parse(&route)?;
     state.record_decision(route, &publisher_slug, &tool_name, &conversation_id, approved)
+}
+
+/// Derive a *proposed* capability bundle for a task. This is read-only: it grants
+/// nothing. The model may request a bundle this way, but only a human-approved
+/// `grant_capability_lease` call persists authority — model output can never mint
+/// or widen a lease.
+#[tauri::command]
+pub fn propose_capability_bundle(request: BundleRequest) -> Result<ProposedBundle, String> {
+    Ok(derive_bundle(&request))
+}
+
+/// Persist a user-approved capability lease bound to a conversation. Invoked by
+/// the approval UI after the user reviews (and optionally edits) a proposed
+/// bundle — never by a model tool call. The host owns the lease id, timestamps,
+/// and expiry; the caller supplies only the reviewed envelope.
+#[tauri::command]
+pub fn grant_capability_lease(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+    label: String,
+    duration_secs: i64,
+    predicates: LeasePredicates,
+    budgets: LeaseBudgets,
+) -> Result<CapabilityLease, String> {
+    state.grant_lease(&conversation_id, &label, duration_secs, predicates, budgets)
+}
+
+/// Every capability lease bound to a conversation, newest first. Backs inspection
+/// and the revocation surface.
+#[tauri::command]
+pub fn list_capability_leases(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+) -> Result<Vec<CapabilityLease>, String> {
+    state.list_leases(&conversation_id)
+}
+
+/// Revoke a capability lease immediately. Idempotent — returns whether a lease
+/// was actually revoked by this call.
+#[tauri::command]
+pub fn revoke_capability_lease(
+    state: State<'_, ToolAuthorizationState>,
+    lease_id: String,
+) -> Result<bool, String> {
+    state.revoke_lease(&lease_id)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub mod sandbox;
 
 pub mod audio;
 mod auth;
+pub mod capability_lease;
 pub mod credential_broker;
 pub mod credential_lease;
 // Public so the headless `claude_memory_sync` example can drive the
@@ -1088,6 +1089,10 @@ pub fn run() {
             commands::credential_lease::credential_lease_revoke_all,
             commands::tool_authorization::authorize_tool_operation,
             commands::tool_authorization::record_tool_operation_decision,
+            commands::tool_authorization::propose_capability_bundle,
+            commands::tool_authorization::grant_capability_lease,
+            commands::tool_authorization::list_capability_leases,
+            commands::tool_authorization::revoke_capability_lease,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -5,7 +5,29 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use rusqlite::Connection;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+use crate::capability_lease::{
+    self, CapabilityLease, LeaseBudgets, LeaseOutcome, LeasePredicates, OperationRequest,
+};
+
+/// The small argument slice the gate needs to evaluate lease predicates for a
+/// call. Extracted from the tool arguments by the renderer per route: `command`
+/// for shell/skill, `host` for web fetch, `target` (resource/account/connection)
+/// and `cost_micros` for publisher operations. All optional — a call with no
+/// context simply cannot match a predicate that requires it.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationContext {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub cost_micros: Option<u64>,
+}
 
 /// Which executor route the renderer is asking about. The route decides how a
 /// call is classified: publisher routes use the operationId verb grammar, while
@@ -37,6 +59,19 @@ impl ToolRoute {
             "skill" => Ok(Self::Skill),
             "web" => Ok(Self::Web),
             other => Err(format!("Unknown tool route: {other}")),
+        }
+    }
+
+    /// The lowercase wire token for this route. Kept in sync with `parse` so an
+    /// exclusion predicate can name a route by the same string the renderer sends.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Gateway => "gateway",
+            Self::Seren => "seren",
+            Self::Mcp => "mcp",
+            Self::Shell => "shell",
+            Self::Skill => "skill",
+            Self::Web => "web",
         }
     }
 }
@@ -444,21 +479,48 @@ impl ToolAuthorizationState {
         })
     }
 
-    /// The gate: classify, then resolve against the persisted store. High-risk
-    /// operations always prompt (one-shot) and are never persisted; trusted reads
-    /// run silently; unclassified operations reuse a stored grant/denial or prompt
-    /// once for a session decision.
+    /// The gate: classify, evaluate any task-scoped capability lease, then fall
+    /// back to the per-tool decision store.
+    ///
+    /// Order enforces `deny > prompt > allow`:
+    /// 1. Trusted reads run silently.
+    /// 2. An active lease is consulted next. A lease exclusion denies outright;
+    ///    a covered call inside budget runs silently (and the budget is charged),
+    ///    letting a long-running task proceed without per-call prompts. This is
+    ///    what lets an otherwise one-shot high-risk shell command run under an
+    ///    approved command-rule lease.
+    /// 3. If no lease covers the call, the Stage-1 posture is preserved: high-risk
+    ///    prompts one-shot; unclassified reuses a stored grant/denial or prompts
+    ///    once for a session decision. A new host/account/root/operation class or
+    ///    an exhausted budget therefore surfaces as a single scope-escalation.
     pub fn authorize(
         &self,
         route: ToolRoute,
         publisher_slug: &str,
         tool_name: &str,
         conversation_id: &str,
+        context: &OperationContext,
     ) -> Result<AuthorizationDecision, String> {
         let class = classify_for_route(route, publisher_slug, tool_name);
 
         if class == OperationClass::TrustedRead {
             return Ok(AuthorizationDecision::allow(class));
+        }
+
+        let request = OperationRequest {
+            route,
+            class,
+            publisher_slug: publisher_slug.to_string(),
+            tool_name: tool_name.to_string(),
+            command: context.command.clone(),
+            host: context.host.clone(),
+            target: context.target.clone(),
+            cost_micros: context.cost_micros.unwrap_or(0),
+        };
+        match self.evaluate_and_charge_leases(conversation_id, &request)? {
+            LeaseOutcome::Deny => return Ok(AuthorizationDecision::deny(class)),
+            LeaseOutcome::Allow(_) => return Ok(AuthorizationDecision::allow(class)),
+            LeaseOutcome::Escalate => {}
         }
 
         if class == OperationClass::HighRisk {
@@ -488,6 +550,114 @@ impl ToolAuthorizationState {
         }
     }
 
+    /// Read the active leases for a conversation, evaluate the call, and — when a
+    /// lease covers it — charge that lease's budget, all under one connection lock
+    /// so the read/decrement is atomic and two concurrent calls cannot both spend
+    /// the last unit of a budget.
+    fn evaluate_and_charge_leases(
+        &self,
+        conversation_id: &str,
+        request: &OperationRequest,
+    ) -> Result<LeaseOutcome, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let leases = read_leases(conn, conversation_id)?;
+            let outcome = capability_lease::evaluate_for_conversation(
+                &leases,
+                request,
+                conversation_id,
+                &now,
+            );
+            if let LeaseOutcome::Allow(lease_id) = &outcome
+                && let Some(mut lease) = leases.into_iter().find(|lease| &lease.id == lease_id)
+            {
+                lease.budgets.calls_used = lease.budgets.calls_used.saturating_add(1);
+                if request.cost_micros > 0 {
+                    lease.budgets.spend_used_micros = lease
+                        .budgets
+                        .spend_used_micros
+                        .saturating_add(request.cost_micros);
+                }
+                write_lease(conn, &lease)?;
+            }
+            Ok(outcome)
+        })
+    }
+
+    /// Persist a user-approved lease. Called only from the host-side grant command
+    /// a human approval invokes — never from a model tool call — so model output
+    /// can never mint or widen a lease. The host owns the id, timestamps, and
+    /// expiry; the caller supplies only the reviewed predicates, budgets, label,
+    /// and requested duration.
+    pub fn grant_lease(
+        &self,
+        conversation_id: &str,
+        label: &str,
+        duration_secs: i64,
+        predicates: LeasePredicates,
+        budgets: LeaseBudgets,
+    ) -> Result<CapabilityLease, String> {
+        if duration_secs <= 0 {
+            return Err("A capability lease needs a positive duration.".to_string());
+        }
+        let lease_id = uuid::Uuid::new_v4().to_string();
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let expires_at = timestamp_plus_seconds(conn, duration_secs)?;
+            let lease = CapabilityLease {
+                id: lease_id.clone(),
+                conversation_id: conversation_id.to_string(),
+                label: label.to_string(),
+                created_at: now,
+                expires_at,
+                revoked: false,
+                predicates: predicates.clone(),
+                budgets: budgets.clone(),
+            };
+            write_lease(conn, &lease)?;
+            Ok(lease)
+        })
+    }
+
+    /// Every lease bound to a conversation, newest first. Backs inspection and the
+    /// (slice-D) revocation UI.
+    pub fn list_leases(&self, conversation_id: &str) -> Result<Vec<CapabilityLease>, String> {
+        self.with_conn(|conn| read_leases(conn, conversation_id))
+    }
+
+    /// Mark a lease revoked. Idempotent: revoking an unknown or already-revoked
+    /// lease is a no-op that reports whether this call changed anything.
+    ///
+    /// The stored `lease_json` blob is the source of truth the matcher reads, so
+    /// revocation must flip the flag *inside the blob* — updating only the
+    /// `revoked` column would leave the matcher still honoring the lease.
+    pub fn revoke_lease(&self, lease_id: &str) -> Result<bool, String> {
+        self.with_conn(|conn| {
+            let json: Option<String> = conn
+                .query_row(
+                    "SELECT lease_json FROM capability_leases WHERE id = ?1",
+                    rusqlite::params![lease_id],
+                    |row| row.get(0),
+                )
+                .map(Some)
+                .or_else(|err| match err {
+                    rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                    other => Err(other.to_string()),
+                })?;
+            let Some(json) = json else {
+                return Ok(false);
+            };
+            let mut lease: CapabilityLease = serde_json::from_str(&json)
+                .map_err(|e| format!("Capability lease was unreadable: {e}"))?;
+            if lease.revoked {
+                return Ok(false);
+            }
+            lease.revoked = true;
+            write_lease(conn, &lease)?;
+            Ok(true)
+        })
+    }
+
     /// Record a prompt outcome. Re-derives classification host-side so a renderer
     /// cannot persist a grant for a high-risk (one-shot) or trusted-read (silent)
     /// operation — only unclassified session decisions are durable.
@@ -511,14 +681,92 @@ impl ToolAuthorizationState {
         self.persist_decision(conversation_id, publisher_slug, tool_name, decision)
     }
 
-    /// Erase every stored decision. Backs the one-shot "erase all local
-    /// conversation data" flow; the next access lazily reopens an empty store.
+    /// Erase every stored decision and capability lease. Backs the one-shot
+    /// "erase all local conversation data" flow; the next access lazily reopens an
+    /// empty store. Returns the total number of rows removed across both tables.
     pub fn wipe(&self) -> Result<usize, String> {
         self.with_conn(|conn| {
-            conn.execute("DELETE FROM tool_decisions", [])
-                .map_err(|e| e.to_string())
+            let decisions = conn
+                .execute("DELETE FROM tool_decisions", [])
+                .map_err(|e| e.to_string())?;
+            let leases = conn
+                .execute("DELETE FROM capability_leases", [])
+                .map_err(|e| e.to_string())?;
+            Ok(decisions + leases)
         })
     }
+}
+
+/// SQLite's clock, formatted to match `created_at`/`updated_at` in the store, so
+/// lease lifetime comparisons use one time source rather than mixing Rust and DB
+/// clocks.
+fn current_timestamp(conn: &Connection) -> Result<String, String> {
+    conn.query_row(
+        "SELECT strftime('%Y-%m-%dT%H:%M:%fZ','now')",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// `now + duration_secs` in the same format. Used to stamp a lease's expiry
+/// host-side from a reviewed duration.
+fn timestamp_plus_seconds(conn: &Connection, duration_secs: i64) -> Result<String, String> {
+    conn.query_row(
+        "SELECT strftime('%Y-%m-%dT%H:%M:%fZ','now', ?1)",
+        rusqlite::params![format!("{duration_secs} seconds")],
+        |row| row.get(0),
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn read_leases(conn: &Connection, conversation_id: &str) -> Result<Vec<CapabilityLease>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT lease_json FROM capability_leases \
+             WHERE conversation_id = ?1 ORDER BY created_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(rusqlite::params![conversation_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|e| e.to_string())?;
+    let mut leases = Vec::new();
+    for row in rows {
+        let json = row.map_err(|e| e.to_string())?;
+        // A single corrupt row must not blind the gate to every other lease, but
+        // it also must not silently vanish — log and skip.
+        match serde_json::from_str::<CapabilityLease>(&json) {
+            Ok(lease) => leases.push(lease),
+            Err(err) => log::warn!("[tool-authorization] Skipping unreadable lease row: {err}"),
+        }
+    }
+    Ok(leases)
+}
+
+fn write_lease(conn: &Connection, lease: &CapabilityLease) -> Result<(), String> {
+    let json = serde_json::to_string(lease)
+        .map_err(|e| format!("Capability lease could not be encoded: {e}"))?;
+    conn.execute(
+        "INSERT INTO capability_leases \
+           (id, conversation_id, expires_at, revoked, lease_json, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(id) DO UPDATE SET \
+           expires_at = excluded.expires_at, \
+           revoked = excluded.revoked, \
+           lease_json = excluded.lease_json",
+        rusqlite::params![
+            lease.id,
+            lease.conversation_id,
+            lease.expires_at,
+            lease.revoked as i64,
+            json,
+            lease.created_at,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 fn init_schema(conn: &Connection) -> Result<(), String> {
@@ -531,6 +779,28 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
             updated_at      TEXT NOT NULL,
             PRIMARY KEY (conversation_id, publisher_slug, tool_name)
         )",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    // Capability leases (#3193-B). The full lease is stored as JSON (the source
+    // of truth for predicates + mutable budget counters); the columns exist only
+    // to index by conversation and to prune by expiry/revocation without parsing
+    // every blob.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS capability_leases (
+            id              TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            expires_at      TEXT NOT NULL,
+            revoked         INTEGER NOT NULL DEFAULT 0,
+            lease_json      TEXT NOT NULL,
+            created_at      TEXT NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_capability_leases_conversation \
+         ON capability_leases(conversation_id)",
         [],
     )
     .map_err(|e| e.to_string())?;
@@ -547,6 +817,45 @@ mod tests {
         // Force the connection open against :memory: by touching the store.
         s.with_conn(|_| Ok(())).unwrap();
         s
+    }
+
+    // No lease context: the classification/decision-store tests exercise the
+    // path where no argument predicate applies.
+    fn ctx() -> OperationContext {
+        OperationContext::default()
+    }
+
+    fn cmd_ctx(command: &str) -> OperationContext {
+        OperationContext {
+            command: Some(command.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn target_ctx(target: &str) -> OperationContext {
+        OperationContext {
+            target: Some(target.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn command_rules(programs: &[&str]) -> LeasePredicates {
+        LeasePredicates {
+            command_rules: programs
+                .iter()
+                .map(|p| capability_lease::CommandRule {
+                    program: p.to_string(),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn call_budget(max: u64) -> LeaseBudgets {
+        LeaseBudgets {
+            max_calls: Some(max),
+            ..Default::default()
+        }
     }
 
     // ---- classification --------------------------------------------------
@@ -672,7 +981,7 @@ mod tests {
     fn trusted_read_allows_silently() {
         let s = state();
         let decision = s
-            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a")
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "allow");
         assert_eq!(decision.prompt_kind, None);
@@ -683,7 +992,7 @@ mod tests {
         let s = state();
         for _ in 0..2 {
             let decision = s
-                .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a")
+                .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx())
                 .unwrap();
             assert_eq!(decision.decision, "prompt");
             assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
@@ -700,7 +1009,7 @@ mod tests {
         )
         .unwrap();
         let decision = s
-            .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a")
+            .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "prompt", "still one-shot after a recorded approval");
     }
@@ -709,7 +1018,7 @@ mod tests {
     fn unclassified_prompts_once_then_reuses_the_grant() {
         let s = state();
         let first = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
         assert_eq!(first.decision, "prompt");
         assert_eq!(first.prompt_kind.as_deref(), Some("session"));
@@ -722,7 +1031,7 @@ mod tests {
             .unwrap();
 
         let second = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
         assert_eq!(second.decision, "allow");
     }
@@ -730,12 +1039,12 @@ mod tests {
     #[test]
     fn unclassified_denial_is_durable() {
         let s = state();
-        s.authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+        s.authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
         s.record_decision(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", false)
             .unwrap();
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "deny");
     }
@@ -747,7 +1056,7 @@ mod tests {
             .unwrap();
         // A different conversation does not inherit the grant.
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-b")
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-b", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -756,7 +1065,7 @@ mod tests {
     fn a_newly_seen_publisher_is_never_silently_allowed() {
         let s = state();
         let decision = s
-            .authorize(ToolRoute::Gateway, "never-seen", "inspect_everything", "conv-a")
+            .authorize(ToolRoute::Gateway, "never-seen", "inspect_everything", "conv-a", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -768,7 +1077,7 @@ mod tests {
             .unwrap();
         assert_eq!(s.wipe().unwrap(), 1);
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a")
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -778,5 +1087,274 @@ mod tests {
         assert!(ToolRoute::parse("gateway").is_ok());
         assert!(ToolRoute::parse("web").is_ok());
         assert!(ToolRoute::parse("bogus").is_err());
+    }
+
+    // ---- capability-lease integration (real store + matcher + budgets) ---
+
+    /// The headline acceptance criterion: a 500-call coding task runs under one
+    /// approved lease with zero recurring prompts, and the budget is consumed.
+    #[test]
+    fn granted_command_lease_runs_a_500_call_task_silently() {
+        let s = state();
+        let lease = s
+            .grant_lease(
+                "conv-a",
+                "coding",
+                4 * 3600,
+                command_rules(&["cargo", "pnpm", "git"]),
+                call_budget(500),
+            )
+            .unwrap();
+
+        for i in 0..500 {
+            let command = match i % 3 {
+                0 => "cargo test --manifest-path src-tauri/Cargo.toml",
+                1 => "pnpm check",
+                _ => "git status --porcelain",
+            };
+            let decision = s
+                .authorize(
+                    ToolRoute::Shell,
+                    "seren",
+                    "execute_command",
+                    "conv-a",
+                    &cmd_ctx(command),
+                )
+                .unwrap();
+            assert_eq!(
+                decision.decision, "allow",
+                "call {i} ({command}) should run silently under the lease"
+            );
+        }
+
+        let updated = s
+            .list_leases("conv-a")
+            .unwrap()
+            .into_iter()
+            .find(|l| l.id == lease.id)
+            .unwrap();
+        assert_eq!(updated.budgets.calls_used, 500);
+
+        // The 501st call exhausts the budget: exactly one scope-escalation.
+        let decision = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("cargo build"),
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+    }
+
+    /// A shell command outside the lease's command rules is not covered and
+    /// escalates once, rather than silently running.
+    #[test]
+    fn shell_command_outside_the_lease_escalates() {
+        let s = state();
+        s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
+            .unwrap();
+        let decision = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("curl https://example.com/pay"),
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+    }
+
+    /// deny > allow: a lease exclusion denies a command its own command rule
+    /// would otherwise allow.
+    #[test]
+    fn lease_exclusion_denies_over_a_command_grant() {
+        let s = state();
+        let mut predicates = command_rules(&["git"]);
+        predicates.exclusions = vec![capability_lease::Exclusion {
+            program: Some("git".to_string()),
+            ..Default::default()
+        }];
+        s.grant_lease("conv-a", "coding", 3600, predicates, call_budget(50))
+            .unwrap();
+        let decision = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("git push origin main"),
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "deny");
+    }
+
+    /// Repeated publisher operations inside one resource/account constraint run
+    /// silently; a different account is out of scope and escalates.
+    #[test]
+    fn publisher_lease_covers_repeated_ops_within_one_target() {
+        let s = state();
+        let predicates = LeasePredicates {
+            publisher_ops: vec![capability_lease::PublisherRule {
+                publisher_slug: "attio".to_string(),
+                allow_high_risk: false,
+                target: Some("conn-123".to_string()),
+            }],
+            ..Default::default()
+        };
+        s.grant_lease("conv-a", "crm", 3600, predicates, call_budget(100))
+            .unwrap();
+
+        for tool in ["post_notes", "post_records", "patch_records_by_id"] {
+            let decision = s
+                .authorize(ToolRoute::Gateway, "attio", tool, "conv-a", &target_ctx("conn-123"))
+                .unwrap();
+            assert_eq!(decision.decision, "allow", "{tool} should be covered");
+        }
+
+        // A different connection/account is not covered — one escalation.
+        let decision = s
+            .authorize(ToolRoute::Gateway, "attio", "post_notes", "conv-a", &target_ctx("conn-999"))
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+    }
+
+    /// A high-risk publisher op is not silently covered by a lease that did not
+    /// opt into high-risk, even on the approved target.
+    #[test]
+    fn publisher_lease_without_high_risk_still_escalates_destructive_ops() {
+        let s = state();
+        let predicates = LeasePredicates {
+            publisher_ops: vec![capability_lease::PublisherRule {
+                publisher_slug: "attio".to_string(),
+                allow_high_risk: false,
+                target: Some("conn-123".to_string()),
+            }],
+            ..Default::default()
+        };
+        s.grant_lease("conv-a", "crm", 3600, predicates, call_budget(100))
+            .unwrap();
+        let decision = s
+            .authorize(
+                ToolRoute::Gateway,
+                "attio",
+                "delete_records_by_id",
+                "conv-a",
+                &target_ctx("conn-123"),
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+    }
+
+    /// Revoking a lease immediately stops its silent coverage; revocation is
+    /// idempotent.
+    #[test]
+    fn revoking_a_lease_stops_silent_coverage() {
+        let s = state();
+        let lease = s
+            .grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
+            .unwrap();
+        assert_eq!(
+            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+                .unwrap()
+                .decision,
+            "allow"
+        );
+        assert!(s.revoke_lease(&lease.id).unwrap());
+        assert_eq!(
+            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+                .unwrap()
+                .decision,
+            "prompt"
+        );
+        assert!(!s.revoke_lease(&lease.id).unwrap(), "second revoke is a no-op");
+    }
+
+    /// A lease granted for one conversation never covers another.
+    #[test]
+    fn lease_does_not_leak_across_conversations() {
+        let s = state();
+        s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
+            .unwrap();
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-b", &cmd_ctx("cargo build"))
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+    }
+
+    #[test]
+    fn grant_lease_rejects_nonpositive_duration() {
+        let s = state();
+        assert!(
+            s.grant_lease("conv-a", "x", 0, LeasePredicates::default(), LeaseBudgets::default())
+                .is_err()
+        );
+    }
+
+    /// A lease and its consumed budget survive the store being closed and
+    /// reopened on the same on-disk database — real file I/O, no in-memory shim.
+    #[test]
+    fn leases_persist_across_store_reopen_on_disk() {
+        let dir = std::env::temp_dir().join(format!("seren-authz-{}", uuid::Uuid::new_v4()));
+        let db = dir.join("tool_authorization.db");
+        {
+            let s = ToolAuthorizationState::new(db.clone());
+            s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
+                .unwrap();
+            assert_eq!(
+                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+                    .unwrap()
+                    .decision,
+                "allow"
+            );
+        }
+        {
+            // A fresh state reopens the same file, re-inits the schema, and honors
+            // the persisted lease and its already-charged budget.
+            let s = ToolAuthorizationState::new(db.clone());
+            let leases = s.list_leases("conv-a").unwrap();
+            assert_eq!(leases.len(), 1);
+            assert_eq!(leases[0].budgets.calls_used, 1, "budget spend persisted to disk");
+            assert_eq!(
+                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo test"))
+                    .unwrap()
+                    .decision,
+                "allow"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The renderer sends the operation context as camelCase; pin `costMicros`.
+    #[test]
+    fn operation_context_deserializes_camel_case() {
+        let context: OperationContext = serde_json::from_value(serde_json::json!({
+            "command": "cargo build",
+            "host": "example.com",
+            "target": "conn-1",
+            "costMicros": 5,
+        }))
+        .expect("camelCase context deserializes");
+        assert_eq!(context.command.as_deref(), Some("cargo build"));
+        assert_eq!(context.cost_micros, Some(5));
+    }
+
+    /// The erase-all flow removes leases too, not just per-tool decisions.
+    #[test]
+    fn wipe_clears_capability_leases() {
+        let s = state();
+        s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
+            .unwrap();
+        assert!(s.wipe().unwrap() >= 1);
+        assert!(s.list_leases("conv-a").unwrap().is_empty());
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
     }
 }

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -66,6 +66,47 @@ const DENY_DECISION: AuthorizationDecision = {
 };
 
 /**
+ * The small argument slice the host gate needs to evaluate a capability-lease
+ * predicate for this call. Keep in sync with `OperationContext` in
+ * `src-tauri/src/tool_authorization.rs`. Every field is optional: a call that
+ * omits one simply cannot match a predicate that requires it.
+ */
+interface OperationContext {
+  command?: string;
+  host?: string;
+  target?: string;
+  costMicros?: number;
+}
+
+/**
+ * Extract the lease-predicate context from a publisher-style call's arguments.
+ * The resource/account/connection constraint keys off `connection_id` — the
+ * OAuth account identity this codebase already resolves — and a web fetch keys
+ * off its URL host.
+ */
+function contextForPublisherRoute(
+  route: ToolRoute,
+  args: Record<string, unknown>,
+): OperationContext {
+  const context: OperationContext = {};
+  if (route === "web") {
+    const url = typeof args.url === "string" ? args.url : undefined;
+    if (url) {
+      try {
+        context.host = new URL(url).host;
+      } catch {
+        // A malformed URL yields no host; the call cannot match a host predicate.
+      }
+    }
+    return context;
+  }
+  if (typeof args.connection_id === "string" && args.connection_id.length > 0) {
+    context.target = args.connection_id;
+  }
+  return context;
+}
+
+/**
  * Ask the host gate to classify a model-originated call. Passing through the
  * gate never itself prompts the user; it returns allow/deny/prompt.
  */
@@ -74,6 +115,7 @@ async function consultAuthorizationGate(
   publisherSlug: string,
   toolName: string,
   conversationId: string,
+  context: OperationContext,
 ): Promise<AuthorizationDecision> {
   try {
     return await invoke<AuthorizationDecision>("authorize_tool_operation", {
@@ -81,6 +123,7 @@ async function consultAuthorizationGate(
       publisherSlug,
       toolName,
       conversationId,
+      context,
     });
   } catch (err) {
     console.error("[Tool Executor] Authorization gate unavailable:", err);
@@ -295,6 +338,7 @@ async function authorizeToolOperation(
     publisherSlug,
     toolName,
     sessionId,
+    contextForPublisherRoute(route, args),
   );
 
   if (decision.decision === "allow") {
@@ -337,6 +381,7 @@ async function authorizeToolOperation(
 async function authorizeSubprocess(
   route: "shell" | "skill",
   toolName: string,
+  command: string,
   conversationId: string | null,
   runApprovalUi: () => Promise<boolean>,
 ): Promise<boolean> {
@@ -345,6 +390,7 @@ async function authorizeSubprocess(
     "seren",
     toolName,
     sessionConversationId(conversationId),
+    { command },
   );
   if (decision.decision === "deny") {
     return false;
@@ -595,6 +641,7 @@ export async function executeTool(
         const approved = await authorizeSubprocess(
           "shell",
           "execute_command",
+          command,
           conversationId,
           () => requestShellApproval(command, timeoutSecs),
         );
@@ -650,9 +697,12 @@ export async function executeTool(
         }
         const timeoutSecs = (args.timeout_secs as number) ?? 30;
         const preview = `${cwd}> ${argv.map((item) => JSON.stringify(item)).join(" ")}`;
+        // The lease's command rules match the skill's leading program token, so
+        // pass the raw argv (not the cwd-prefixed preview) as the command.
         const approved = await authorizeSubprocess(
           "skill",
           "run_skill_script",
+          argv.join(" "),
           conversationId,
           () => requestShellApproval(preview, timeoutSecs),
         );


### PR DESCRIPTION
## Summary

Slice **B** of #3193 (does **not** close it). Builds on the slice-A host gate (#3267). Gives the Rust authorization gate a **task/session capability lease** so approved long-running work proceeds silently inside a bounded, pre-approved envelope — replacing the per-call shell prompt and the per-tool in-memory grant with predicates + budgets.

## What landed

- **`src-tauri/src/capability_lease.rs` (new)** — pure lease model + deterministic matcher:
  - Predicates the gate's live routes actually evaluate: **command rules** (shell/skill), **network hosts** (web), **publisher operations + resource/account target** (gateway/seren/mcp), and explicit **exclusions**.
  - **Budgets**: call-count and monetary (micro-units of an asset), with decrement + exhaustion.
  - Resolution is **`deny > allow`**: a matching exclusion denies outright; otherwise the first covering lease with budget allows; a covered-but-out-of-budget or uncovered call yields `Escalate`.
  - **Bundle derivation** (`derive_bundle`) turns a task profile into a *reviewable* proposal — it grants nothing.
- **`src-tauri/src/tool_authorization.rs`** — persists leases in the slice-A `tool_authorization.db` (the store slice A said B would extend). `authorize()` now evaluates + charges a covering lease **before** the Stage-1 fallthrough, so Stage-1 behavior is unchanged when no lease exists. `wipe()` clears leases too. `grant_lease` / `list_leases` / `revoke_lease` added. Revocation flips the flag inside the source-of-truth `lease_json` blob (not just an index column).
- **`src-tauri/src/commands/tool_authorization.rs`** — `authorize_tool_operation` takes an optional predicate `context`; new `propose_capability_bundle` (read-only), `grant_capability_lease`, `list_capability_leases`, `revoke_capability_lease`. The model may *request* a bundle but only a **human-approved grant** persists authority — model output never creates a persistent rule.
- **`src/lib/tools/executor.ts`** — threads the predicate context (command / host / target) through the gate per route.

## Acceptance criteria (slice B)

- [x] A task-scoped capability bundle can be reviewed and approved once (`propose_capability_bundle` → `grant_capability_lease`).
- [x] A lease uses **predicates + budgets**, not an exact argument hash.
- [x] Exact tool+argument binding stays limited to one-shot / high-risk (unchanged Stage-1 path).
- [x] A **500-call coding task** completes under one approved lease without recurring prompts (`granted_command_lease_runs_a_500_call_task_silently`).
- [x] Repeated approved publisher ops within one resource/account run without prompts (`publisher_lease_covers_repeated_ops_within_one_target`).
- [x] A new host / account / publisher-op class / exceeded budget → one scope-escalation (matcher `Escalate` → gate prompt).
- [x] Policy conflicts resolve **deny > prompt > allow**; model output never mints a persistent rule.

Filesystem-root escalation stays enforced by the existing `orchestrator/file_access_policy.rs` seam (model file tools never reach this gate); not duplicated here.

## Out of scope (later slices)

Blocked-state task machine + `approval_pending` continuations (slice C, #3263); approval inbox / audit / revocation **UI** (slice D, #3264). Live monetary metering via the x402 cost path is modeled + unit-tested here; wiring the live per-call cost is a follow-up.

## Networked-path trace

**No new outbound path.** The gate, lease store, matcher, budgets, and all four commands are entirely local (SQLite + Tauri IPC, in-process). The `target` predicate keys off the existing local `connection_id` OAuth-routing concept — not a new API slug. The gate only *decides* whether an existing downstream publisher call proceeds; it issues no request itself.

## Evidence (live, no mocks)

Exercised against **real rusqlite** (in-memory and on-disk), the real matcher, and the real serde wire contract:

- `capability_lease`: 20 tests — matcher, budgets, deny>allow, expiry/revocation, derivation, camelCase wire contract.
- `tool_authorization`: 29 tests — incl. the **500-call** lease run, budget exhaustion → escalation, publisher+target coverage, exclusion-denies-over-grant, revoke stops coverage, per-conversation isolation, **on-disk persist + reopen** (budget spend survives), `wipe` clears leases, camelCase `OperationContext`.
- Full `cargo test --lib` green; `cargo clippy --lib` clean on the new/changed files; Biome + `tsc` clean on `executor.ts`.

A real bug was found and fixed during the live loop: `revoke_lease` had updated the `revoked` column while the matcher read the `lease_json` blob, so revocation didn't take effect — the `revoking_a_lease_stops_silent_coverage` test caught it.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
