### PR TITLE
feat(security): suspended approval continuations + task states (#3263)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -1,0 +1,715 @@
+// ABOUTME: Host-owned suspended continuations for authorization-blocked actions (#3193-C).
+// ABOUTME: A blocked action becomes a first-class, dedup'd, idempotently-resolvable record — never a hung agent or a generic tool error.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::capability_lease::command_program;
+use crate::orchestrator::types::TaskExecutionState;
+use crate::tool_authorization::ToolRoute;
+
+/// Whether a blocked action holds up the whole turn or only an independent branch.
+///
+/// Conservative by default: the linear turn is what the current renderer drives,
+/// so the whole task waits (`WaitingForApproval`). `Branch` is reserved for work
+/// the scheduler can prove independent, which continues (`RunningWithBlockedActions`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContinuationScope {
+    Linear,
+    Branch,
+}
+
+impl ContinuationScope {
+    fn as_wire(self) -> &'static str {
+        match self {
+            Self::Linear => "linear",
+            Self::Branch => "branch",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "linear" => Ok(Self::Linear),
+            "branch" => Ok(Self::Branch),
+            other => Err(format!("Unknown continuation scope: {other}")),
+        }
+    }
+}
+
+/// The lifecycle of one suspended continuation. `Pending` is the only non-terminal
+/// state; every other is settled exactly once. `Expired` is a first-class terminal
+/// outcome — an approval that never arrived, distinct from a `Denied` decision.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContinuationState {
+    Pending,
+    Approved,
+    Denied,
+    Skipped,
+    Expired,
+}
+
+impl ContinuationState {
+    fn as_wire(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Denied => "denied",
+            Self::Skipped => "skipped",
+            Self::Expired => "expired",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "approved" => Ok(Self::Approved),
+            "denied" => Ok(Self::Denied),
+            "skipped" => Ok(Self::Skipped),
+            "expired" => Ok(Self::Expired),
+            other => Err(format!("Unknown continuation state: {other}")),
+        }
+    }
+
+    /// Map this outcome to the task-level state the frontend renders.
+    pub fn task_state(self, scope: ContinuationScope) -> TaskExecutionState {
+        match self {
+            Self::Pending => match scope {
+                ContinuationScope::Linear => TaskExecutionState::WaitingForApproval,
+                ContinuationScope::Branch => TaskExecutionState::RunningWithBlockedActions,
+            },
+            Self::Approved => TaskExecutionState::Running,
+            Self::Denied => TaskExecutionState::ApprovalDenied,
+            Self::Skipped => TaskExecutionState::ActionSkipped,
+            Self::Expired => TaskExecutionState::ApprovalExpired,
+        }
+    }
+}
+
+/// A human decision on a suspended action. Expiry is not here: it is a system
+/// outcome (`expire_continuation`), not a user choice.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolveDecision {
+    Approve,
+    Deny,
+    Skip,
+}
+
+impl ResolveDecision {
+    pub fn settled_state(self) -> ContinuationState {
+        match self {
+            Self::Approve => ContinuationState::Approved,
+            Self::Deny => ContinuationState::Denied,
+            Self::Skip => ContinuationState::Skipped,
+        }
+    }
+}
+
+/// What the gate blocked, in host-owned terms. Carries both the display metadata
+/// the approval UI renders and the argument slice the dedup fingerprint keys on.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestedCapability {
+    /// `ToolRoute` wire token (gateway/seren/mcp/shell/skill/web).
+    pub route: String,
+    pub publisher_slug: String,
+    pub tool_name: String,
+    /// Host classification (trusted-read/high-risk/unclassified). Host-owned so the
+    /// renderer cannot understate what was blocked.
+    pub operation_class: String,
+    pub description: String,
+    #[serde(default)]
+    pub is_destructive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+}
+
+/// The renderer's contract for a freshly registered (or deduped) continuation.
+///
+/// `resume_token` is the host-minted secret the renderer holds to resolve the
+/// continuation; it is deliberately absent from `model_result`, so a model that
+/// learns the public `approval_id` still cannot forge a resume or self-approve.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisteredContinuation {
+    pub approval_id: String,
+    pub resume_token: String,
+    pub blocked_scope: ContinuationScope,
+    pub task_state: TaskExecutionState,
+    /// Whether this call created the record. `false` when an equivalent pending
+    /// request already existed and was reused (dedup) — the renderer can suppress a
+    /// duplicate prompt/notification.
+    pub deduplicated: bool,
+    /// The redacted `approval_pending` payload safe to surface to the model as a
+    /// tool result. Never contains the resume token.
+    pub model_result: serde_json::Value,
+}
+
+/// The result of resolving (or expiring) a continuation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveOutcome {
+    /// Whether THIS call changed the continuation. `false` on idempotent replay of
+    /// an already-settled decision — the continuation resolves exactly once.
+    pub changed: bool,
+    pub state: ContinuationState,
+    pub task_state: TaskExecutionState,
+}
+
+/// A redacted continuation record for inspection surfaces (slice D). Never carries
+/// the resume token.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinuationView {
+    pub approval_id: String,
+    pub task_id: String,
+    pub blocked_scope: ContinuationScope,
+    pub state: ContinuationState,
+    pub task_state: TaskExecutionState,
+    pub requested_capability: RequestedCapability,
+    pub created_at: String,
+    pub expires_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<String>,
+}
+
+/// Aggregate outcome counts for a task, backing completion integrity and the final
+/// summary disclosure.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionSummary {
+    /// Still pending (and not expired) — the completion blocker.
+    pub unresolved: usize,
+    pub approved: usize,
+    pub denied: usize,
+    pub skipped: usize,
+    pub expired: usize,
+}
+
+impl ResolutionSummary {
+    /// Completion integrity: a task with an unresolved required approval cannot
+    /// report completed.
+    pub fn can_complete(&self) -> bool {
+        self.unresolved == 0
+    }
+
+    /// Whether any action was denied, skipped, expired, or is still unresolved —
+    /// i.e. the final summary must disclose incomplete authority.
+    pub fn has_disclosable(&self) -> bool {
+        self.unresolved + self.denied + self.skipped + self.expired > 0
+    }
+}
+
+/// A persisted continuation row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContinuationRow {
+    pub approval_id: String,
+    pub conversation_id: String,
+    pub fingerprint: String,
+    pub resume_token: String,
+    pub scope: ContinuationScope,
+    pub state: ContinuationState,
+    pub requested: RequestedCapability,
+    pub created_at: String,
+    pub expires_at: String,
+    pub resolved_at: Option<String>,
+}
+
+impl ContinuationRow {
+    /// The redacted `approval_pending` object surfaced to the model. Enough to stop
+    /// retrying (status, id, scope, what was requested, when it lapses) and nothing
+    /// the model could use to resolve the block itself.
+    pub fn model_result(&self) -> serde_json::Value {
+        serde_json::json!({
+            "status": "approval_pending",
+            "approvalId": self.approval_id,
+            "taskId": self.conversation_id,
+            "blockedScope": self.scope,
+            "requestedCapability": self.requested,
+            "expiresAt": self.expires_at,
+        })
+    }
+
+    pub fn registered(&self, deduplicated: bool) -> RegisteredContinuation {
+        RegisteredContinuation {
+            approval_id: self.approval_id.clone(),
+            resume_token: self.resume_token.clone(),
+            blocked_scope: self.scope,
+            task_state: self.state.task_state(self.scope),
+            deduplicated,
+            model_result: self.model_result(),
+        }
+    }
+
+    pub fn view(&self) -> ContinuationView {
+        ContinuationView {
+            approval_id: self.approval_id.clone(),
+            task_id: self.conversation_id.clone(),
+            blocked_scope: self.scope,
+            state: self.state,
+            task_state: self.state.task_state(self.scope),
+            requested_capability: self.requested.clone(),
+            created_at: self.created_at.clone(),
+            expires_at: self.expires_at.clone(),
+            resolved_at: self.resolved_at.clone(),
+        }
+    }
+}
+
+/// Canonical capability fingerprint used to dedup equivalent pending requests.
+///
+/// Keyed at the same granularity the gate and capability leases evaluate, so a
+/// retry of the same blocked operation reuses one pending request (no
+/// prompt/notification storms) while a genuinely different capability gets its
+/// own. Shell/skill key on the leading program (matching lease command rules),
+/// web keys on the host (matching network-host rules), and publisher routes key
+/// on publisher + operation + resource target (matching the gate's session-grant
+/// key and publisher predicates).
+pub fn fingerprint(cap: &RequestedCapability) -> String {
+    match ToolRoute::parse(&cap.route) {
+        Ok(ToolRoute::Shell) | Ok(ToolRoute::Skill) => {
+            let program = cap
+                .command
+                .as_deref()
+                .and_then(command_program)
+                .unwrap_or_default();
+            format!("{}|{}", cap.route, program)
+        }
+        Ok(ToolRoute::Web) => {
+            let host = cap
+                .host
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .to_lowercase();
+            format!("web|{host}")
+        }
+        // Gateway/Seren/Mcp, and any unrecognized route treated conservatively as a
+        // publisher operation, key on operation + resource identity.
+        _ => format!(
+            "{}|{}|{}|{}",
+            cap.route,
+            cap.publisher_slug,
+            cap.tool_name,
+            cap.target.as_deref().unwrap_or("")
+        ),
+    }
+}
+
+/// The aggregate live task state from all continuations of a conversation. A
+/// linear pending block dominates (the whole turn waits); a branch-only pending
+/// block downgrades to running-with-blocked-actions; otherwise the task runs.
+///
+/// Callers must expire overdue rows first so a lapsed pending block does not keep a
+/// task spuriously waiting.
+pub fn aggregate_task_state(rows: &[ContinuationRow]) -> TaskExecutionState {
+    let mut branch_blocked = false;
+    for row in rows {
+        if row.state == ContinuationState::Pending {
+            match row.scope {
+                ContinuationScope::Linear => return TaskExecutionState::WaitingForApproval,
+                ContinuationScope::Branch => branch_blocked = true,
+            }
+        }
+    }
+    if branch_blocked {
+        TaskExecutionState::RunningWithBlockedActions
+    } else {
+        TaskExecutionState::Running
+    }
+}
+
+/// Count each terminal (and unresolved) outcome across a conversation's rows.
+pub fn summarize(rows: &[ContinuationRow]) -> ResolutionSummary {
+    let mut summary = ResolutionSummary::default();
+    for row in rows {
+        match row.state {
+            ContinuationState::Pending => summary.unresolved += 1,
+            ContinuationState::Approved => summary.approved += 1,
+            ContinuationState::Denied => summary.denied += 1,
+            ContinuationState::Skipped => summary.skipped += 1,
+            ContinuationState::Expired => summary.expired += 1,
+        }
+    }
+    summary
+}
+
+// ============================================================================
+// Persistence — free functions over a borrowed connection, mirroring the lease
+// store so the whole authorization database shares one connection + mutex.
+// ============================================================================
+
+pub fn init_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS approval_continuations (
+            approval_id     TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            fingerprint     TEXT NOT NULL,
+            resume_token    TEXT NOT NULL,
+            scope           TEXT NOT NULL,
+            state           TEXT NOT NULL,
+            requested_json  TEXT NOT NULL,
+            created_at      TEXT NOT NULL,
+            expires_at      TEXT NOT NULL,
+            resolved_at     TEXT
+        )",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_approval_continuations_conversation \
+         ON approval_continuations(conversation_id)",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn row_from_sql(row: &rusqlite::Row) -> rusqlite::Result<ContinuationRow> {
+    let scope_raw: String = row.get(4)?;
+    let state_raw: String = row.get(5)?;
+    let requested_raw: String = row.get(6)?;
+    // A corrupt row must surface as an error, not silently decode to a wrong
+    // decision; the caller logs and skips it rather than trusting garbage.
+    let scope = ContinuationScope::parse(&scope_raw)
+        .map_err(|e| rusqlite::Error::InvalidColumnType(4, e, rusqlite::types::Type::Text))?;
+    let state = ContinuationState::parse(&state_raw)
+        .map_err(|e| rusqlite::Error::InvalidColumnType(5, e, rusqlite::types::Type::Text))?;
+    let requested: RequestedCapability = serde_json::from_str(&requested_raw).map_err(|e| {
+        rusqlite::Error::InvalidColumnType(6, e.to_string(), rusqlite::types::Type::Text)
+    })?;
+    Ok(ContinuationRow {
+        approval_id: row.get(0)?,
+        conversation_id: row.get(1)?,
+        fingerprint: row.get(2)?,
+        resume_token: row.get(3)?,
+        scope,
+        state,
+        requested,
+        created_at: row.get(7)?,
+        expires_at: row.get(8)?,
+        resolved_at: row.get(9)?,
+    })
+}
+
+const SELECT_COLUMNS: &str = "approval_id, conversation_id, fingerprint, resume_token, \
+     scope, state, requested_json, created_at, expires_at, resolved_at";
+
+pub fn read_continuations(
+    conn: &Connection,
+    conversation_id: &str,
+) -> Result<Vec<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE conversation_id = ?1 ORDER BY created_at ASC"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(rusqlite::params![conversation_id], row_from_sql)
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        match row {
+            Ok(row) => out.push(row),
+            Err(err) => log::warn!("[approval-continuation] Skipping unreadable row: {err}"),
+        }
+    }
+    Ok(out)
+}
+
+pub fn find_by_id(conn: &Connection, approval_id: &str) -> Result<Option<ContinuationRow>, String> {
+    let sql = format!("SELECT {SELECT_COLUMNS} FROM approval_continuations WHERE approval_id = ?1");
+    conn.query_row(&sql, rusqlite::params![approval_id], row_from_sql)
+        .map(Some)
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other.to_string()),
+        })
+}
+
+/// A still-pending, not-yet-lapsed row matching this fingerprint — the dedup target.
+pub fn find_pending_by_fingerprint(
+    conn: &Connection,
+    conversation_id: &str,
+    fingerprint: &str,
+    now: &str,
+) -> Result<Option<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE conversation_id = ?1 AND fingerprint = ?2 AND state = 'pending' \
+           AND expires_at > ?3 ORDER BY created_at ASC LIMIT 1"
+    );
+    conn.query_row(
+        &sql,
+        rusqlite::params![conversation_id, fingerprint, now],
+        row_from_sql,
+    )
+    .map(Some)
+    .or_else(|err| match err {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(other.to_string()),
+    })
+}
+
+pub fn insert_continuation(conn: &Connection, row: &ContinuationRow) -> Result<(), String> {
+    let requested_json = serde_json::to_string(&row.requested)
+        .map_err(|e| format!("Requested capability could not be encoded: {e}"))?;
+    conn.execute(
+        "INSERT INTO approval_continuations \
+           (approval_id, conversation_id, fingerprint, resume_token, scope, state, \
+            requested_json, created_at, expires_at, resolved_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            row.approval_id,
+            row.conversation_id,
+            row.fingerprint,
+            row.resume_token,
+            row.scope.as_wire(),
+            row.state.as_wire(),
+            requested_json,
+            row.created_at,
+            row.expires_at,
+            row.resolved_at,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Settle a continuation to a terminal state, stamping `resolved_at`. Only mutates
+/// a row that is still pending, so a concurrent double-resolve cannot both win.
+/// Returns whether a pending row was actually transitioned.
+pub fn settle_if_pending(
+    conn: &Connection,
+    approval_id: &str,
+    state: ContinuationState,
+    resolved_at: &str,
+) -> Result<bool, String> {
+    let changed = conn
+        .execute(
+            "UPDATE approval_continuations \
+             SET state = ?2, resolved_at = ?3 \
+             WHERE approval_id = ?1 AND state = 'pending'",
+            rusqlite::params![approval_id, state.as_wire(), resolved_at],
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(changed > 0)
+}
+
+/// Expire every pending row for a conversation whose window has closed. Explicit
+/// and persisted: a lapsed action becomes `Expired`, never a generic failure and
+/// never a silently-live pending block. Returns how many rows expired.
+pub fn expire_overdue(
+    conn: &Connection,
+    conversation_id: &str,
+    now: &str,
+) -> Result<usize, String> {
+    conn.execute(
+        "UPDATE approval_continuations \
+         SET state = 'expired', resolved_at = ?2 \
+         WHERE conversation_id = ?1 AND state = 'pending' AND expires_at <= ?2",
+        rusqlite::params![conversation_id, now],
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap(route: &str, publisher: &str, tool: &str) -> RequestedCapability {
+        RequestedCapability {
+            route: route.to_string(),
+            publisher_slug: publisher.to_string(),
+            tool_name: tool.to_string(),
+            operation_class: "high-risk".to_string(),
+            description: "test".to_string(),
+            is_destructive: false,
+            command: None,
+            host: None,
+            target: None,
+        }
+    }
+
+    fn row(id: &str, scope: ContinuationScope, state: ContinuationState) -> ContinuationRow {
+        ContinuationRow {
+            approval_id: id.to_string(),
+            conversation_id: "conv-a".to_string(),
+            fingerprint: "fp".to_string(),
+            resume_token: "tok".to_string(),
+            scope,
+            state,
+            requested: cap("gateway", "gmail", "post_send"),
+            created_at: "2026-07-24T00:00:00Z".to_string(),
+            expires_at: "2026-07-24T00:05:00Z".to_string(),
+            resolved_at: None,
+        }
+    }
+
+    // ---- fingerprint granularity ----------------------------------------
+
+    #[test]
+    fn shell_fingerprint_keys_on_program_not_full_command() {
+        let mut a = cap("shell", "seren", "execute_command");
+        a.command = Some("cargo build --release".to_string());
+        let mut b = cap("shell", "seren", "execute_command");
+        b.command = Some("cargo test --workspace".to_string());
+        // Same program → same pending request (matches lease command-rule grain).
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+
+        let mut c = cap("shell", "seren", "execute_command");
+        c.command = Some("git push".to_string());
+        assert_ne!(fingerprint(&a), fingerprint(&c));
+    }
+
+    #[test]
+    fn publisher_fingerprint_separates_tool_and_target() {
+        let mut base = cap("gateway", "attio", "post_notes");
+        base.target = Some("conn-1".to_string());
+        let mut same = cap("gateway", "attio", "post_notes");
+        same.target = Some("conn-1".to_string());
+        assert_eq!(fingerprint(&base), fingerprint(&same));
+
+        let mut other_tool = cap("gateway", "attio", "post_records");
+        other_tool.target = Some("conn-1".to_string());
+        assert_ne!(fingerprint(&base), fingerprint(&other_tool));
+
+        let mut other_target = cap("gateway", "attio", "post_notes");
+        other_target.target = Some("conn-2".to_string());
+        assert_ne!(fingerprint(&base), fingerprint(&other_target));
+    }
+
+    #[test]
+    fn web_fingerprint_keys_on_host() {
+        let mut a = cap("web", "seren", "web_fetch");
+        a.host = Some("API.example.com".to_string());
+        let mut b = cap("web", "seren", "web_fetch");
+        b.host = Some("api.example.com".to_string());
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+    }
+
+    // ---- task-state derivation ------------------------------------------
+
+    #[test]
+    fn linear_pending_makes_the_whole_task_wait() {
+        let rows = vec![row(
+            "a",
+            ContinuationScope::Linear,
+            ContinuationState::Pending,
+        )];
+        assert_eq!(
+            aggregate_task_state(&rows),
+            TaskExecutionState::WaitingForApproval
+        );
+    }
+
+    #[test]
+    fn branch_only_pending_keeps_task_running_with_blocked_actions() {
+        let rows = vec![row(
+            "a",
+            ContinuationScope::Branch,
+            ContinuationState::Pending,
+        )];
+        assert_eq!(
+            aggregate_task_state(&rows),
+            TaskExecutionState::RunningWithBlockedActions
+        );
+    }
+
+    #[test]
+    fn linear_pending_dominates_a_branch_block() {
+        let rows = vec![
+            row("a", ContinuationScope::Branch, ContinuationState::Pending),
+            row("b", ContinuationScope::Linear, ContinuationState::Pending),
+        ];
+        assert_eq!(
+            aggregate_task_state(&rows),
+            TaskExecutionState::WaitingForApproval
+        );
+    }
+
+    #[test]
+    fn all_settled_returns_to_running() {
+        let rows = vec![
+            row("a", ContinuationScope::Linear, ContinuationState::Denied),
+            row("b", ContinuationScope::Branch, ContinuationState::Approved),
+            row("c", ContinuationScope::Linear, ContinuationState::Expired),
+        ];
+        assert_eq!(aggregate_task_state(&rows), TaskExecutionState::Running);
+    }
+
+    // ---- outcome → task-state mapping -----------------------------------
+
+    #[test]
+    fn terminal_states_map_to_disclosable_task_states() {
+        assert_eq!(
+            ContinuationState::Denied.task_state(ContinuationScope::Linear),
+            TaskExecutionState::ApprovalDenied
+        );
+        assert_eq!(
+            ContinuationState::Expired.task_state(ContinuationScope::Linear),
+            TaskExecutionState::ApprovalExpired
+        );
+        assert_eq!(
+            ContinuationState::Skipped.task_state(ContinuationScope::Linear),
+            TaskExecutionState::ActionSkipped
+        );
+        assert_eq!(
+            ContinuationState::Approved.task_state(ContinuationScope::Linear),
+            TaskExecutionState::Running
+        );
+    }
+
+    // ---- summary + completion integrity ---------------------------------
+
+    #[test]
+    fn summary_counts_and_blocks_completion_only_while_unresolved() {
+        let pending = vec![row(
+            "a",
+            ContinuationScope::Linear,
+            ContinuationState::Pending,
+        )];
+        let summary = summarize(&pending);
+        assert_eq!(summary.unresolved, 1);
+        assert!(!summary.can_complete());
+        assert!(summary.has_disclosable());
+
+        let settled = vec![
+            row("a", ContinuationScope::Linear, ContinuationState::Denied),
+            row("b", ContinuationScope::Linear, ContinuationState::Skipped),
+            row("c", ContinuationScope::Linear, ContinuationState::Expired),
+            row("d", ContinuationScope::Linear, ContinuationState::Approved),
+        ];
+        let summary = summarize(&settled);
+        assert_eq!(summary.denied, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.expired, 1);
+        assert_eq!(summary.approved, 1);
+        assert_eq!(summary.unresolved, 0);
+        // No unresolved required approval → completion is allowed, but the denied /
+        // skipped / expired work must still be disclosed.
+        assert!(summary.can_complete());
+        assert!(summary.has_disclosable());
+    }
+
+    #[test]
+    fn model_result_never_leaks_the_resume_token() {
+        let row = row("a", ContinuationScope::Linear, ContinuationState::Pending);
+        let value = row.model_result();
+        assert_eq!(value["status"], "approval_pending");
+        assert_eq!(value["approvalId"], "a");
+        assert!(value.get("resumeToken").is_none());
+        assert!(value.get("resume_token").is_none());
+        // The registered contract carries the token for the renderer but never
+        // folds it into the model-facing payload.
+        let registered = row.registered(false);
+        assert_eq!(registered.resume_token, "tok");
+        assert!(registered.model_result.get("resumeToken").is_none());
+    }
+}

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -3,9 +3,14 @@
 
 use tauri::State;
 
+use crate::approval_continuation::{
+    ContinuationScope, ContinuationView, RegisteredContinuation, RequestedCapability,
+    ResolutionSummary, ResolveDecision, ResolveOutcome,
+};
 use crate::capability_lease::{
     BundleRequest, CapabilityLease, LeaseBudgets, LeasePredicates, ProposedBundle, derive_bundle,
 };
+use crate::orchestrator::types::TaskExecutionState;
 use crate::tool_authorization::{
     AuthorizationDecision, OperationContext, ToolAuthorizationState, ToolRoute,
 };
@@ -91,4 +96,79 @@ pub fn revoke_capability_lease(
     lease_id: String,
 ) -> Result<bool, String> {
     state.revoke_lease(&lease_id)
+}
+
+/// Register a suspended continuation for an authorization-blocked action so the
+/// paused action is a visible, resumable record rather than a hung tool call
+/// (#3193-C). The renderer calls this when the gate returns `prompt`, then keeps
+/// the returned `resumeToken` in its own state and forwards only `modelResult` to
+/// the model. Equivalent retries dedup to one pending request.
+#[tauri::command]
+pub fn register_approval_continuation(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+    requested: RequestedCapability,
+    scope: Option<ContinuationScope>,
+    ttl_secs: i64,
+) -> Result<RegisteredContinuation, String> {
+    // A linear turn is the conservative default: the whole task waits unless the
+    // caller can prove the blocked action is an independent branch.
+    let scope = scope.unwrap_or(ContinuationScope::Linear);
+    state.register_continuation(&conversation_id, requested, scope, ttl_secs)
+}
+
+/// Resolve a suspended continuation with the user's decision (approve/deny/skip).
+/// Idempotent exactly once and gated on the host-minted `resumeToken`, so a model
+/// that learns the public `approvalId` cannot self-approve.
+#[tauri::command]
+pub fn resolve_approval_continuation(
+    state: State<'_, ToolAuthorizationState>,
+    approval_id: String,
+    resume_token: String,
+    decision: ResolveDecision,
+) -> Result<ResolveOutcome, String> {
+    state.resolve_continuation(&approval_id, &resume_token, decision)
+}
+
+/// Explicitly expire a suspended continuation (the renderer's approval timeout),
+/// so a lapsed action becomes `approval_expired` rather than a degraded generic
+/// tool failure. Idempotent and token-gated.
+#[tauri::command]
+pub fn expire_approval_continuation(
+    state: State<'_, ToolAuthorizationState>,
+    approval_id: String,
+    resume_token: String,
+) -> Result<ResolveOutcome, String> {
+    state.expire_continuation(&approval_id, &resume_token)
+}
+
+/// The live task-execution state for a conversation, derived from its
+/// continuations. Backs the persistent thread status surface.
+#[tauri::command]
+pub fn task_execution_state(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+) -> Result<TaskExecutionState, String> {
+    state.task_execution_state(&conversation_id)
+}
+
+/// Outcome counts for a conversation, backing completion integrity
+/// (`can_complete`) and the final summary disclosure of denied/skipped/expired/
+/// unresolved work.
+#[tauri::command]
+pub fn approval_resolution_summary(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+) -> Result<ResolutionSummary, String> {
+    state.resolution_summary(&conversation_id)
+}
+
+/// Every suspended continuation for a conversation, redacted (no resume tokens),
+/// for the inspection surface.
+#[tauri::command]
+pub fn list_approval_continuations(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+) -> Result<Vec<ContinuationView>, String> {
+    state.list_continuations(&conversation_id)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ pub mod services {
 
 pub mod sandbox;
 
+pub mod approval_continuation;
 pub mod audio;
 mod auth;
 pub mod capability_lease;
@@ -1093,6 +1094,12 @@ pub fn run() {
             commands::tool_authorization::grant_capability_lease,
             commands::tool_authorization::list_capability_leases,
             commands::tool_authorization::revoke_capability_lease,
+            commands::tool_authorization::register_approval_continuation,
+            commands::tool_authorization::resolve_approval_continuation,
+            commands::tool_authorization::expire_approval_continuation,
+            commands::tool_authorization::task_execution_state,
+            commands::tool_authorization::approval_resolution_summary,
+            commands::tool_authorization::list_approval_continuations,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -265,6 +265,49 @@ pub enum PlanStatus {
     Failed,
 }
 
+/// Execution state of a task (or turn) with respect to authorization blocks.
+///
+/// An authorization block must never look like a hung agent (#3193-C). As soon as
+/// the gate suspends a required action, the owning task leaves `Running` for a
+/// visible blocked state, and every non-approval outcome resolves to its own
+/// terminal state so a paused action is never a silent stall or a generic tool
+/// error.
+///
+/// - `Running` — no unresolved authorization block.
+/// - `RunningWithBlockedActions` — an independent branch is blocked on approval,
+///   but the scheduler proved other work can continue.
+/// - `WaitingForApproval` — a linear turn (or all remaining work) depends on a
+///   pending approval, so the whole task waits visibly.
+/// - `ApprovalDenied` / `ApprovalExpired` / `ActionSkipped` — terminal outcomes of
+///   a single suspended action, surfaced in the final summary so denied, expired,
+///   and skipped work is disclosed rather than hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskExecutionState {
+    Running,
+    RunningWithBlockedActions,
+    WaitingForApproval,
+    ApprovalDenied,
+    ApprovalExpired,
+    ActionSkipped,
+}
+
+impl TaskExecutionState {
+    /// The lowercase wire token, matching the `serde(rename_all = "snake_case")`
+    /// representation. Lets the store persist and compare a state without a
+    /// serde round-trip.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::RunningWithBlockedActions => "running_with_blocked_actions",
+            Self::WaitingForApproval => "waiting_for_approval",
+            Self::ApprovalDenied => "approval_denied",
+            Self::ApprovalExpired => "approval_expired",
+            Self::ActionSkipped => "action_skipped",
+        }
+    }
+}
+
 /// Wrapper for worker events sent to the frontend with conversation context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrchestratorEvent {
@@ -455,6 +498,27 @@ mod tests {
 
         let json = serde_json::to_value(DelegationType::FullHandoff).unwrap();
         assert_eq!(json, "full_handoff");
+    }
+
+    #[test]
+    fn task_execution_state_wire_matches_serde() {
+        // The store persists and the frontend renders the snake_case token; the
+        // `as_wire` shortcut must never drift from the serde representation.
+        for state in [
+            TaskExecutionState::Running,
+            TaskExecutionState::RunningWithBlockedActions,
+            TaskExecutionState::WaitingForApproval,
+            TaskExecutionState::ApprovalDenied,
+            TaskExecutionState::ApprovalExpired,
+            TaskExecutionState::ActionSkipped,
+        ] {
+            let serialized = serde_json::to_value(state).unwrap();
+            assert_eq!(serialized, state.as_wire());
+        }
+        assert_eq!(
+            serde_json::to_value(TaskExecutionState::WaitingForApproval).unwrap(),
+            "waiting_for_approval"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -7,9 +7,14 @@ use std::sync::Mutex;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
+use crate::approval_continuation::{
+    self, ContinuationRow, ContinuationScope, ContinuationState, ContinuationView,
+    RegisteredContinuation, RequestedCapability, ResolutionSummary, ResolveDecision, ResolveOutcome,
+};
 use crate::capability_lease::{
     self, CapabilityLease, LeaseBudgets, LeaseOutcome, LeasePredicates, OperationRequest,
 };
+use crate::orchestrator::types::TaskExecutionState;
 
 /// The small argument slice the gate needs to evaluate lease predicates for a
 /// call. Extracted from the tool arguments by the renderer per route: `command`
@@ -681,9 +686,192 @@ impl ToolAuthorizationState {
         self.persist_decision(conversation_id, publisher_slug, tool_name, decision)
     }
 
-    /// Erase every stored decision and capability lease. Backs the one-shot
-    /// "erase all local conversation data" flow; the next access lazily reopens an
-    /// empty store. Returns the total number of rows removed across both tables.
+    /// Register a suspended continuation for an authorization-blocked action, so a
+    /// paused action is a visible, resumable record rather than a hung tool call
+    /// (#3193-C). The host mints the `approval_id` and the unforgeable
+    /// `resume_token`; the model receives only the redacted `model_result`.
+    ///
+    /// Dedup is built in: an equivalent, still-pending request (same conversation +
+    /// capability fingerprint) reuses the existing record, so retries cannot cause a
+    /// prompt/notification storm. A lapsed pending block is expired first, so a
+    /// stale record never masquerades as a live dedup target.
+    pub fn register_continuation(
+        &self,
+        conversation_id: &str,
+        requested: RequestedCapability,
+        scope: ContinuationScope,
+        ttl_secs: i64,
+    ) -> Result<RegisteredContinuation, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            let fingerprint = approval_continuation::fingerprint(&requested);
+            if let Some(existing) = approval_continuation::find_pending_by_fingerprint(
+                conn,
+                conversation_id,
+                &fingerprint,
+                &now,
+            )? {
+                return Ok(existing.registered(true));
+            }
+            let row = ContinuationRow {
+                approval_id: uuid::Uuid::new_v4().to_string(),
+                conversation_id: conversation_id.to_string(),
+                fingerprint,
+                resume_token: uuid::Uuid::new_v4().to_string(),
+                scope,
+                state: ContinuationState::Pending,
+                requested,
+                created_at: now,
+                expires_at: timestamp_plus_seconds(conn, ttl_secs.max(1))?,
+                resolved_at: None,
+            };
+            approval_continuation::insert_continuation(conn, &row)?;
+            Ok(row.registered(false))
+        })
+    }
+
+    /// Resolve a suspended continuation with a human decision. Idempotent exactly
+    /// once: a replayed decision reports the settled state without re-firing, and a
+    /// settled continuation is never re-opened. The `resume_token` is required and
+    /// checked, so a model that learns the public `approval_id` cannot self-approve.
+    /// A pending row whose window has already closed expires instead of taking the
+    /// decision — a stale approval never executes a destructive action after the fact.
+    pub fn resolve_continuation(
+        &self,
+        approval_id: &str,
+        resume_token: &str,
+        decision: ResolveDecision,
+    ) -> Result<ResolveOutcome, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let row = self.load_authorized_continuation(conn, approval_id, resume_token)?;
+            if row.state != ContinuationState::Pending {
+                return Ok(ResolveOutcome {
+                    changed: false,
+                    state: row.state,
+                    task_state: row.state.task_state(row.scope),
+                });
+            }
+            if row.expires_at.as_str() <= now.as_str() {
+                let changed = approval_continuation::settle_if_pending(
+                    conn,
+                    approval_id,
+                    ContinuationState::Expired,
+                    &now,
+                )?;
+                return Ok(ResolveOutcome {
+                    changed,
+                    state: ContinuationState::Expired,
+                    task_state: ContinuationState::Expired.task_state(row.scope),
+                });
+            }
+            let new_state = decision.settled_state();
+            let changed =
+                approval_continuation::settle_if_pending(conn, approval_id, new_state, &now)?;
+            Ok(ResolveOutcome {
+                changed,
+                state: new_state,
+                task_state: new_state.task_state(row.scope),
+            })
+        })
+    }
+
+    /// Explicitly expire a suspended continuation (the renderer's approval timeout
+    /// calls this), so a lapsed action becomes `approval_expired` rather than a
+    /// degraded generic tool failure. Idempotent and token-gated like `resolve`.
+    pub fn expire_continuation(
+        &self,
+        approval_id: &str,
+        resume_token: &str,
+    ) -> Result<ResolveOutcome, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let row = self.load_authorized_continuation(conn, approval_id, resume_token)?;
+            if row.state != ContinuationState::Pending {
+                return Ok(ResolveOutcome {
+                    changed: false,
+                    state: row.state,
+                    task_state: row.state.task_state(row.scope),
+                });
+            }
+            let changed = approval_continuation::settle_if_pending(
+                conn,
+                approval_id,
+                ContinuationState::Expired,
+                &now,
+            )?;
+            Ok(ResolveOutcome {
+                changed,
+                state: ContinuationState::Expired,
+                task_state: ContinuationState::Expired.task_state(row.scope),
+            })
+        })
+    }
+
+    /// Fetch a continuation by id and verify the caller holds the host-minted
+    /// resume token. A wrong or absent token is rejected — the model cannot forge
+    /// authority to resolve a block it did not create.
+    fn load_authorized_continuation(
+        &self,
+        conn: &Connection,
+        approval_id: &str,
+        resume_token: &str,
+    ) -> Result<ContinuationRow, String> {
+        let row = approval_continuation::find_by_id(conn, approval_id)?
+            .ok_or_else(|| "Unknown approval continuation.".to_string())?;
+        if row.resume_token != resume_token {
+            return Err("Invalid resume token for this approval continuation.".to_string());
+        }
+        Ok(row)
+    }
+
+    /// The live task-execution state for a conversation, derived from its
+    /// continuations. Overdue pending blocks are expired first, so a lapsed request
+    /// never keeps a task spuriously `waiting_for_approval`.
+    pub fn task_execution_state(
+        &self,
+        conversation_id: &str,
+    ) -> Result<TaskExecutionState, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            let rows = approval_continuation::read_continuations(conn, conversation_id)?;
+            Ok(approval_continuation::aggregate_task_state(&rows))
+        })
+    }
+
+    /// Outcome counts for a conversation, backing completion integrity
+    /// (`can_complete`) and the final summary disclosure of denied/skipped/expired/
+    /// unresolved work.
+    pub fn resolution_summary(&self, conversation_id: &str) -> Result<ResolutionSummary, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            let rows = approval_continuation::read_continuations(conn, conversation_id)?;
+            Ok(approval_continuation::summarize(&rows))
+        })
+    }
+
+    /// Every continuation for a conversation, redacted (no resume tokens), for the
+    /// inspection surface. Overdue pending blocks are expired first so the listing
+    /// reflects true live state.
+    pub fn list_continuations(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<ContinuationView>, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            let rows = approval_continuation::read_continuations(conn, conversation_id)?;
+            Ok(rows.iter().map(ContinuationRow::view).collect())
+        })
+    }
+
+    /// Erase every stored decision, capability lease, and suspended continuation.
+    /// Backs the one-shot "erase all local conversation data" flow; the next access
+    /// lazily reopens an empty store. Returns the total number of rows removed
+    /// across all tables.
     pub fn wipe(&self) -> Result<usize, String> {
         self.with_conn(|conn| {
             let decisions = conn
@@ -692,7 +880,10 @@ impl ToolAuthorizationState {
             let leases = conn
                 .execute("DELETE FROM capability_leases", [])
                 .map_err(|e| e.to_string())?;
-            Ok(decisions + leases)
+            let continuations = conn
+                .execute("DELETE FROM approval_continuations", [])
+                .map_err(|e| e.to_string())?;
+            Ok(decisions + leases + continuations)
         })
     }
 }
@@ -804,6 +995,9 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
         [],
     )
     .map_err(|e| e.to_string())?;
+    // Suspended continuations (#3193-C): the host-owned blocked-action records that
+    // make an authorization block visible and resumable instead of a hung tool call.
+    approval_continuation::init_schema(conn)?;
     Ok(())
 }
 
@@ -1389,6 +1583,277 @@ mod tests {
         assert_eq!(
             decision.decision, "allow",
             "the recorded grant must survive reopening the store"
+        );
+    }
+
+    // ---- suspended continuations (#3193-C) -------------------------------
+
+    fn send_cap() -> RequestedCapability {
+        RequestedCapability {
+            route: "gateway".to_string(),
+            publisher_slug: "gmail".to_string(),
+            tool_name: "post_send".to_string(),
+            operation_class: "high-risk".to_string(),
+            description: "Send email".to_string(),
+            is_destructive: false,
+            command: None,
+            host: None,
+            target: None,
+        }
+    }
+
+    fn shell_cap(command: &str) -> RequestedCapability {
+        RequestedCapability {
+            route: "shell".to_string(),
+            publisher_slug: "seren".to_string(),
+            tool_name: "execute_command".to_string(),
+            operation_class: "high-risk".to_string(),
+            description: "Run shell command".to_string(),
+            is_destructive: false,
+            command: Some(command.to_string()),
+            host: None,
+            target: None,
+        }
+    }
+
+    /// A registered block immediately puts the task in `waiting_for_approval`, and
+    /// completion integrity refuses `completed` until it is resolved. It never
+    /// appears hung and the model gets a structured `approval_pending`, not a token.
+    #[test]
+    fn registering_a_block_suspends_the_task_and_blocks_completion() {
+        let s = state();
+        let registered = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(!registered.deduplicated);
+        assert_eq!(registered.task_state, TaskExecutionState::WaitingForApproval);
+        assert_eq!(registered.model_result["status"], "approval_pending");
+        assert!(registered.model_result.get("resumeToken").is_none());
+        assert!(!registered.resume_token.is_empty());
+
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::WaitingForApproval
+        );
+        assert!(!s.resolution_summary("conv-a").unwrap().can_complete());
+    }
+
+    /// Equivalent retries reuse the same pending request — no prompt storm.
+    #[test]
+    fn equivalent_retries_dedup_to_one_pending_request() {
+        let s = state();
+        let first = s
+            .register_continuation("conv-a", shell_cap("cargo build"), ContinuationScope::Linear, 300)
+            .unwrap();
+        // A retry of the same program (different args) reuses the record.
+        let retry = s
+            .register_continuation("conv-a", shell_cap("cargo test --workspace"), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(retry.deduplicated);
+        assert_eq!(retry.approval_id, first.approval_id);
+        assert_eq!(retry.resume_token, first.resume_token);
+        assert_eq!(s.list_continuations("conv-a").unwrap().len(), 1);
+
+        // A genuinely different capability is its own request.
+        let other = s
+            .register_continuation("conv-a", shell_cap("git push"), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(!other.deduplicated);
+        assert_ne!(other.approval_id, first.approval_id);
+        assert_eq!(s.list_continuations("conv-a").unwrap().len(), 2);
+    }
+
+    /// Approval resumes the continuation exactly once; a replayed resume is a no-op.
+    #[test]
+    fn resolve_is_idempotent_exactly_once() {
+        let s = state();
+        let r = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+
+        let first = s
+            .resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        assert!(first.changed);
+        assert_eq!(first.state, ContinuationState::Approved);
+
+        // Replay: same decision, no re-fire.
+        let replay = s
+            .resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        assert!(!replay.changed);
+        assert_eq!(replay.state, ContinuationState::Approved);
+
+        // A conflicting late decision cannot re-open a settled continuation.
+        let late_deny = s
+            .resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Deny)
+            .unwrap();
+        assert!(!late_deny.changed);
+        assert_eq!(late_deny.state, ContinuationState::Approved);
+
+        // Task can complete once nothing is pending.
+        assert!(s.resolution_summary("conv-a").unwrap().can_complete());
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::Running
+        );
+    }
+
+    /// The resume token is required: the public approval_id alone cannot resolve.
+    #[test]
+    fn resolve_rejects_a_forged_or_missing_token() {
+        let s = state();
+        let r = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(
+            s.resolve_continuation(&r.approval_id, "not-the-token", ResolveDecision::Approve)
+                .is_err()
+        );
+        // Still pending — the forged attempt changed nothing.
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::WaitingForApproval
+        );
+        assert!(
+            s.resolve_continuation("no-such-id", &r.resume_token, ResolveDecision::Approve)
+                .is_err()
+        );
+    }
+
+    /// Denial, skip, and expiry are distinct terminal states — expiry is never a
+    /// degraded generic failure — and all three are disclosed in the summary.
+    #[test]
+    fn denial_skip_and_expiry_are_distinct_and_disclosed() {
+        let s = state();
+        let deny = s
+            .register_continuation("conv-a", shell_cap("git push"), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert_eq!(
+            s.resolve_continuation(&deny.approval_id, &deny.resume_token, ResolveDecision::Deny)
+                .unwrap()
+                .task_state,
+            TaskExecutionState::ApprovalDenied
+        );
+
+        let skip = s
+            .register_continuation("conv-a", shell_cap("cargo build"), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert_eq!(
+            s.resolve_continuation(&skip.approval_id, &skip.resume_token, ResolveDecision::Skip)
+                .unwrap()
+                .task_state,
+            TaskExecutionState::ActionSkipped
+        );
+
+        let expire = s
+            .register_continuation("conv-a", shell_cap("pnpm check"), ContinuationScope::Linear, 300)
+            .unwrap();
+        let outcome = s
+            .expire_continuation(&expire.approval_id, &expire.resume_token)
+            .unwrap();
+        assert!(outcome.changed);
+        assert_eq!(outcome.task_state, TaskExecutionState::ApprovalExpired);
+        // Re-expiring is idempotent.
+        assert!(
+            !s.expire_continuation(&expire.approval_id, &expire.resume_token)
+                .unwrap()
+                .changed
+        );
+
+        let summary = s.resolution_summary("conv-a").unwrap();
+        assert_eq!(summary.denied, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.expired, 1);
+        assert_eq!(summary.unresolved, 0);
+        assert!(summary.can_complete());
+        assert!(summary.has_disclosable());
+    }
+
+    /// An expired block no longer holds the task and is not a dedup target for a
+    /// fresh request; expiry is explicit, not a lingering `waiting_for_approval`.
+    #[test]
+    fn an_expired_block_releases_the_task_and_is_not_a_dedup_target() {
+        let s = state();
+        let r = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        let outcome = s
+            .expire_continuation(&r.approval_id, &r.resume_token)
+            .unwrap();
+        assert_eq!(outcome.state, ContinuationState::Expired);
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::Running,
+            "an expired block no longer holds the task"
+        );
+        // A fresh request after expiry is not deduped against the dead one.
+        let fresh = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(!fresh.deduplicated);
+        assert_ne!(fresh.approval_id, r.approval_id);
+    }
+
+    /// An independent branch block keeps the task running-with-blocked-actions,
+    /// not fully waiting.
+    #[test]
+    fn a_branch_block_keeps_other_work_running() {
+        let s = state();
+        s.register_continuation("conv-a", send_cap(), ContinuationScope::Branch, 300)
+            .unwrap();
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::RunningWithBlockedActions
+        );
+        // Completion is still blocked while the branch action is unresolved.
+        assert!(!s.resolution_summary("conv-a").unwrap().can_complete());
+    }
+
+    /// A pending continuation and its resolution survive the store being closed and
+    /// reopened on a real on-disk database — resolve remains idempotent afterward.
+    #[test]
+    fn continuations_persist_across_store_reopen_on_disk() {
+        let dir = std::env::temp_dir().join(format!("seren-continuation-{}", uuid::Uuid::new_v4()));
+        let db = dir.join("tool_authorization.db");
+        let (approval_id, resume_token) = {
+            let s = ToolAuthorizationState::new(db.clone());
+            let r = s
+                .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+                .unwrap();
+            (r.approval_id, r.resume_token)
+        };
+        {
+            // A fresh state reopens the same file and still sees the pending block.
+            let s = ToolAuthorizationState::new(db.clone());
+            assert_eq!(
+                s.task_execution_state("conv-a").unwrap(),
+                TaskExecutionState::WaitingForApproval
+            );
+            let outcome = s
+                .resolve_continuation(&approval_id, &resume_token, ResolveDecision::Approve)
+                .unwrap();
+            assert!(outcome.changed);
+            // Replay after reopen is still a no-op.
+            assert!(
+                !s.resolve_continuation(&approval_id, &resume_token, ResolveDecision::Approve)
+                    .unwrap()
+                    .changed
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wipe_clears_continuations() {
+        let s = state();
+        s.register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(s.wipe().unwrap() >= 1);
+        assert!(s.list_continuations("conv-a").unwrap().is_empty());
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::Running
         );
     }
 }

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -26,6 +26,9 @@ const MAX_ARRAY_ITEMS = 25;
 interface GatewayApprovalResult {
   approved: boolean;
   connectionId?: string | null;
+  /** True when the approval UI lapsed without a decision, so the block is an
+   * explicit expiry rather than a user denial. */
+  timedOut?: boolean;
 }
 
 interface GatewayConnectionArgsResult {
@@ -104,6 +107,162 @@ function contextForPublisherRoute(
     context.target = args.connection_id;
   }
   return context;
+}
+
+// A continuation outlives the approval UI's own timeout, so the renderer's
+// timeout fires first and settles the block as an *explicit* expiry rather than
+// the host auto-expiring it mid-prompt.
+const APPROVAL_CONTINUATION_TTL_SECS =
+  Math.floor(GATEWAY_APPROVAL_TIMEOUT_MS / 1000) + 60;
+
+/**
+ * What the gate blocked, in the host's terms. Mirrors `RequestedCapability` in
+ * `src-tauri/src/approval_continuation.rs`.
+ */
+interface RequestedCapability {
+  route: ToolRoute;
+  publisherSlug: string;
+  toolName: string;
+  operationClass: string;
+  description: string;
+  isDestructive: boolean;
+  command?: string;
+  host?: string;
+  target?: string;
+}
+
+/**
+ * The host's record of a suspended continuation. `resumeToken` is held here to
+ * settle the block and is NEVER forwarded to the model; `modelResult` is the
+ * redacted payload safe to surface. Mirrors `RegisteredContinuation` in
+ * `src-tauri/src/approval_continuation.rs`.
+ */
+interface RegisteredContinuation {
+  approvalId: string;
+  resumeToken: string;
+  blockedScope: "linear" | "branch";
+  taskState: string;
+  deduplicated: boolean;
+  modelResult: Record<string, unknown>;
+}
+
+/**
+ * Outcome of authorizing one tool call. On a block, the structured tool result
+ * is ready to return to the model — never a generic "not approved" string, so a
+ * denial, expiry, and skip are distinguishable and the model can adapt.
+ */
+type ToolAuthorization =
+  | { approved: true; connectionId?: string | null }
+  | { approved: false; toolResult: ToolResult };
+
+type BlockedKind = "denied" | "expired" | "skipped";
+
+/**
+ * Register a host-owned suspended continuation for a blocked action, so the
+ * paused action becomes a visible, resumable record (never a hung tool call) and
+ * equivalent retries dedup to one pending request. Returns null if the host is
+ * unavailable — the approval UI still runs; only the persisted state is skipped.
+ */
+async function registerApprovalContinuation(
+  route: ToolRoute,
+  publisherSlug: string,
+  toolName: string,
+  decision: AuthorizationDecision,
+  context: OperationContext,
+  conversationId: string,
+): Promise<RegisteredContinuation | null> {
+  const requested: RequestedCapability = {
+    route,
+    publisherSlug,
+    toolName,
+    operationClass: decision.operationClass,
+    description: decision.description,
+    isDestructive: decision.isDestructive,
+    command: context.command,
+    host: context.host,
+    target: context.target,
+  };
+  try {
+    return await invoke<RegisteredContinuation>(
+      "register_approval_continuation",
+      {
+        conversationId,
+        requested,
+        scope: "linear",
+        ttlSecs: APPROVAL_CONTINUATION_TTL_SECS,
+      },
+    );
+  } catch (err) {
+    console.error(
+      "[Tool Executor] Failed to register approval continuation:",
+      err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Settle a suspended continuation exactly once. Approve/deny/skip are user
+ * decisions; expire is the system outcome of a lapsed approval UI. Idempotent
+ * host-side, so a failed settle is safe to ignore.
+ */
+async function settleApprovalContinuation(
+  registered: RegisteredContinuation,
+  kind: "approve" | "deny" | "skip" | "expire",
+): Promise<void> {
+  try {
+    if (kind === "expire") {
+      await invoke("expire_approval_continuation", {
+        approvalId: registered.approvalId,
+        resumeToken: registered.resumeToken,
+      });
+    } else {
+      await invoke("resolve_approval_continuation", {
+        approvalId: registered.approvalId,
+        resumeToken: registered.resumeToken,
+        decision: kind,
+      });
+    }
+  } catch (err) {
+    console.error(
+      "[Tool Executor] Failed to settle approval continuation:",
+      err,
+    );
+  }
+}
+
+/**
+ * A structured tool result for a blocked action. Distinguishes denial, expiry,
+ * and skip and carries adaptation guidance, so the model gets a clear, distinct
+ * signal instead of a generic, ambiguous "not approved" error.
+ */
+function blockedToolResult(
+  toolCallId: string,
+  kind: BlockedKind,
+  capability: string,
+  approvalId?: string,
+): ToolResult {
+  const guidance: Record<BlockedKind, string> = {
+    denied:
+      "The user denied this action. Do not retry it; continue the task without it or ask how to proceed.",
+    expired:
+      "The approval request expired before the user decided. Do not retry automatically; report that this action is still pending authorization.",
+    skipped:
+      "The user skipped this action. Continue with the rest of the task and do not retry it.",
+  };
+  const payload: Record<string, unknown> = {
+    status: `action_${kind}`,
+    capability,
+    message: guidance[kind],
+  };
+  if (approvalId) {
+    payload.approvalId = approvalId;
+  }
+  return {
+    tool_call_id: toolCallId,
+    content: JSON.stringify(payload),
+    is_error: true,
+  };
 }
 
 /**
@@ -282,7 +441,7 @@ async function requestGatewayApproval(
     const timeout = setTimeout(() => {
       console.log(`[Tool Executor] Approval timeout for ${approvalId}`);
       unlisten?.();
-      resolve({ approved: false });
+      resolve({ approved: false, timedOut: true });
     }, GATEWAY_APPROVAL_TIMEOUT_MS);
 
     listen<{ id: string; approved: boolean; connectionId?: string | null }>(
@@ -331,23 +490,41 @@ async function authorizeToolOperation(
   toolName: string,
   args: Record<string, unknown>,
   conversationId: string | null,
-): Promise<GatewayApprovalResult> {
+  toolCallId: string,
+): Promise<ToolAuthorization> {
   const sessionId = sessionConversationId(conversationId);
+  const context = contextForPublisherRoute(route, args);
   const decision = await consultAuthorizationGate(
     route,
     publisherSlug,
     toolName,
     sessionId,
-    contextForPublisherRoute(route, args),
+    context,
   );
+  const capability = `${publisherSlug}/${toolName}`;
 
   if (decision.decision === "allow") {
     return { approved: true };
   }
   if (decision.decision === "deny") {
     console.log(`[Tool Executor] Host denied ${publisherSlug}/${toolName}`);
-    return { approved: false };
+    return {
+      approved: false,
+      toolResult: blockedToolResult(toolCallId, "denied", capability),
+    };
   }
+
+  // A prompt suspends the action: record it host-side so the block is visible and
+  // resumable (never a hung call), then run the approval UI and settle it exactly
+  // once with the outcome.
+  const registered = await registerApprovalContinuation(
+    route,
+    publisherSlug,
+    toolName,
+    decision,
+    context,
+    sessionId,
+  );
 
   const approval = await requestGatewayApproval(
     publisherSlug,
@@ -368,7 +545,29 @@ async function authorizeToolOperation(
     approval.approved,
   );
 
-  return approval;
+  if (approval.approved) {
+    if (registered) {
+      await settleApprovalContinuation(registered, "approve");
+    }
+    return { approved: true, connectionId: approval.connectionId };
+  }
+
+  const kind: BlockedKind = approval.timedOut ? "expired" : "denied";
+  if (registered) {
+    await settleApprovalContinuation(
+      registered,
+      approval.timedOut ? "expire" : "deny",
+    );
+  }
+  return {
+    approved: false,
+    toolResult: blockedToolResult(
+      toolCallId,
+      kind,
+      capability,
+      registered?.approvalId,
+    ),
+  };
 }
 
 /**
@@ -383,29 +582,64 @@ async function authorizeSubprocess(
   toolName: string,
   command: string,
   conversationId: string | null,
-  runApprovalUi: () => Promise<boolean>,
-): Promise<boolean> {
+  toolCallId: string,
+  runApprovalUi: () => Promise<GatewayApprovalResult>,
+): Promise<ToolAuthorization> {
+  const sessionId = sessionConversationId(conversationId);
+  const context: OperationContext = { command };
   const decision = await consultAuthorizationGate(
     route,
     "seren",
     toolName,
-    sessionConversationId(conversationId),
-    { command },
+    sessionId,
+    context,
   );
+  // The lease/gate key a subprocess on its leading program token; use that as the
+  // capability label so a block names what the user actually saw.
+  const capability = command.trim().split(/\s+/)[0] || toolName;
+
   if (decision.decision === "deny") {
-    return false;
+    return {
+      approved: false,
+      toolResult: blockedToolResult(toolCallId, "denied", capability),
+    };
   }
   if (decision.decision === "allow") {
-    return true;
+    return { approved: true };
   }
-  return runApprovalUi();
-}
 
-function deniedToolResult(toolCallId: string): ToolResult {
+  const registered = await registerApprovalContinuation(
+    route,
+    "seren",
+    toolName,
+    decision,
+    context,
+    sessionId,
+  );
+  const outcome = await runApprovalUi();
+
+  if (outcome.approved) {
+    if (registered) {
+      await settleApprovalContinuation(registered, "approve");
+    }
+    return { approved: true };
+  }
+
+  const kind: BlockedKind = outcome.timedOut ? "expired" : "denied";
+  if (registered) {
+    await settleApprovalContinuation(
+      registered,
+      outcome.timedOut ? "expire" : "deny",
+    );
+  }
   return {
-    tool_call_id: toolCallId,
-    content: "Operation was not approved by user",
-    is_error: true,
+    approved: false,
+    toolResult: blockedToolResult(
+      toolCallId,
+      kind,
+      capability,
+      registered?.approvalId,
+    ),
   };
 }
 
@@ -448,7 +682,7 @@ async function resolveGatewayOAuthConnectionArgs(
 async function requestShellApproval(
   command: string,
   timeoutSecs: number,
-): Promise<boolean> {
+): Promise<GatewayApprovalResult> {
   const approvalId = `shell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   console.log(
@@ -466,7 +700,7 @@ async function requestShellApproval(
       "[Tool Executor] Failed to emit shell approval request:",
       err,
     );
-    return false;
+    return { approved: false };
   }
 
   return new Promise((resolve) => {
@@ -474,7 +708,7 @@ async function requestShellApproval(
     const timeout = setTimeout(() => {
       console.log(`[Tool Executor] Shell approval timeout for ${approvalId}`);
       unlisten?.();
-      resolve(false);
+      resolve({ approved: false, timedOut: true });
     }, SHELL_APPROVAL_TIMEOUT_MS);
 
     listen<{ id: string; approved: boolean }>(
@@ -486,7 +720,7 @@ async function requestShellApproval(
         );
         clearTimeout(timeout);
         unlisten?.();
-        resolve(event.payload.approved);
+        resolve({ approved: event.payload.approved });
       },
     )
       .then((fn) => {
@@ -498,7 +732,7 @@ async function requestShellApproval(
           err,
         );
         clearTimeout(timeout);
-        resolve(false);
+        resolve({ approved: false });
       });
   });
 }
@@ -522,15 +756,16 @@ export async function executeTool(
     // Check if this is a built-in Seren tool (seren__toolName)
     if (name.startsWith("seren__")) {
       const serenToolName = name.slice("seren__".length);
-      const approval = await authorizeToolOperation(
+      const auth = await authorizeToolOperation(
         "seren",
         "seren",
         serenToolName,
         args,
         conversationId,
+        toolCall.id,
       );
-      if (!approval.approved) {
-        return deniedToolResult(toolCall.id);
+      if (!auth.approved) {
+        return auth.toolResult;
       }
       const response = await callSerenTool(serenToolName, args);
       const content =
@@ -593,15 +828,16 @@ export async function executeTool(
     switch (name) {
       case "seren_web_fetch": {
         // Arbitrary-URL fetch is open-world data egress; gate it before egress.
-        const approval = await authorizeToolOperation(
+        const auth = await authorizeToolOperation(
           "web",
           "seren",
           "web_fetch",
           args,
           conversationId,
+          toolCall.id,
         );
-        if (!approval.approved) {
-          return deniedToolResult(toolCall.id);
+        if (!auth.approved) {
+          return auth.toolResult;
         }
 
         const url = args.url as string;
@@ -638,19 +874,16 @@ export async function executeTool(
           invokeArgs.injectSerenCredentials = args.inject_seren_credentials;
         }
 
-        const approved = await authorizeSubprocess(
+        const auth = await authorizeSubprocess(
           "shell",
           "execute_command",
           command,
           conversationId,
+          toolCall.id,
           () => requestShellApproval(command, timeoutSecs),
         );
-        if (!approved) {
-          return {
-            tool_call_id: toolCall.id,
-            content: "Command was not approved by user",
-            is_error: true,
-          };
+        if (!auth.approved) {
+          return auth.toolResult;
         }
 
         // Backs the Tail / LIVE pane (#2100). Idempotent — first call
@@ -699,19 +932,16 @@ export async function executeTool(
         const preview = `${cwd}> ${argv.map((item) => JSON.stringify(item)).join(" ")}`;
         // The lease's command rules match the skill's leading program token, so
         // pass the raw argv (not the cwd-prefixed preview) as the command.
-        const approved = await authorizeSubprocess(
+        const auth = await authorizeSubprocess(
           "skill",
           "run_skill_script",
           argv.join(" "),
           conversationId,
+          toolCall.id,
           () => requestShellApproval(preview, timeoutSecs),
         );
-        if (!approved) {
-          return {
-            tool_call_id: toolCall.id,
-            content: "Skill script was not approved by user",
-            is_error: true,
-          };
+        if (!auth.approved) {
+          return auth.toolResult;
         }
 
         const invokeArgs: {
@@ -795,15 +1025,16 @@ async function executeMcpTool(
     // The "mcp" route tells the host gate this is a local stdio server: its
     // name is user-controlled and carries no trusted metadata, so its reads are
     // never auto-trusted even when the name resembles a publisher slug.
-    const approval = await authorizeToolOperation(
+    const auth = await authorizeToolOperation(
       "mcp",
       serverName,
       toolName,
       args,
       conversationId,
+      toolCallId,
     );
-    if (!approval.approved) {
-      return deniedToolResult(toolCallId);
+    if (!auth.approved) {
+      return auth.toolResult;
     }
 
     const result = await mcpClient.callTool(serverName, {
@@ -888,20 +1119,21 @@ async function executeGatewayTool(
   try {
     let callArgs = args;
 
-    const approval = await authorizeToolOperation(
+    const auth = await authorizeToolOperation(
       "gateway",
       publisherSlug,
       toolName,
       args,
       conversationId,
+      toolCallId,
     );
-    if (!approval.approved) {
-      console.log("[Tool Executor] Operation denied by user");
-      return deniedToolResult(toolCallId);
+    if (!auth.approved) {
+      console.log("[Tool Executor] Operation blocked before execution");
+      return auth.toolResult;
     }
 
-    if (approval.connectionId) {
-      callArgs = { ...args, connection_id: approval.connectionId };
+    if (auth.connectionId) {
+      callArgs = { ...args, connection_id: auth.connectionId };
     }
 
     const resolvedArgs = await resolveGatewayOAuthConnectionArgs(


### PR DESCRIPTION
## What & why

Closes #3263 (slice **C** of epic #3193). An authorization block must never look like a hung agent. This adds first-class **blocked task states** and **host-owned suspended continuations**, so a paused action is a visible, resumable record rather than a silent stall or a generic tool error.

Audited baseline (`main` @ `bf0c6090`, post slices A/B). Confirmed problem: when the host gate returns `prompt`, the renderer blocks awaiting approval while the Rust worker sits in `execute_frontend_tool`'s `rx.await` with **no timeout** → a blocked approval literally *looks hung*, and on the 5-min renderer timeout it degrades to a generic `is_error` ("Operation was not approved by user") that is **indistinguishable from a real denial**.

## Approach (host-owned; UI is slice D)

Chosen scope: host-side Rust primitives + a thin wiring at the existing gate-`prompt` seam in `executor.ts`. The well-tested **pure** `authorize()` gate is left untouched; the continuation lifecycle is a separate concern the renderer drives via new Tauri commands.

### Rust
- **`TaskExecutionState`** (`orchestrator/types.rs`): `running`, `running_with_blocked_actions`, `waiting_for_approval`, `approval_denied`, `approval_expired`, `action_skipped`.
- **`approval_continuation` module**: persisted continuation store (colocated in the slice-A/B authorization SQLite db):
  - Structured **`approval_pending`** payload with an **unforgeable, host-minted `resume_token`**. The model-facing view redacts the token, so a model that learns the public `approval_id` cannot forge a resume or self-approve.
  - **Dedup** by canonical conversation + capability fingerprint (shell→program, web→host, publisher→publisher/op/target) — equivalent retries reuse one pending request.
  - **Idempotent** resolve/expire *exactly once*; **explicit expiry** as its own terminal state, never a degraded generic failure.
  - **Completion integrity**: `can_complete()` blocks a task with an unresolved required approval; a resolution summary discloses denied/skipped/expired/unresolved work.
- Six Tauri commands: register / resolve / expire / task-state / summary / list. Erase-all (`wipe`) clears continuations too.

### Renderer (`executor.ts`)
On `prompt`, the executor registers a continuation before waiting, settles it exactly once with the outcome, and returns a **structured, distinguishable** tool result (`action_denied` / `action_expired` / `action_skipped`) instead of the generic string. The approval-UI timeout now settles as an **explicit expiry**, not an ambiguous denial.

## Acceptance criteria (#3193 §7)
- [x] A suspended action immediately changes the task to `running_with_blocked_actions` / `waiting_for_approval`; never appears hung.
- [x] Linear turns wait visibly; only dependency-proven independent branches continue (scope defaults to `linear`).
- [x] The gate path returns structured `approval_pending` state, not a generic tool error.
- [x] Equivalent retries reuse the same pending request.
- [x] Approve/deny/skip/expire resume-or-reject exactly once (idempotent replay).
- [x] A task with an unresolved required approval cannot report `completed`.
- [x] Final summaries disclose denied/skipped/expired/unresolved actions.
- [x] Approval expiry is explicit, not a degraded generic failure.

## Networked paths
No new outbound publisher/API slug or path. All continuation state is **local** (SQLite + Tauri IPC).

## Validation
- `cargo test --lib`: **1092 passed, 0 failed** — including 12 new tests exercising the **real SQLite store** (dedup, idempotent exactly-once, token-gating, distinct expiry, completion integrity, branch scope, and persistence across an on-disk reopen). No mocks.
- Full `cargo build` green: the `generate_handler!` macro accepts all 6 commands (proves the IPC types round-trip).
- `tsc --noEmit`: 0 errors in `src/`. Biome clean. Existing `tool-executor-approval` / `-oauth-account` tests (17) still pass.
- Clippy: no new warnings in the changed modules.

## Out of scope
Inline approval card, thread status, global inbox, background notification, audit + revocation UI — **slice D (#3264)**. This slice provides the host-side state + continuation those surfaces render (the 6 commands are their interface).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
