### PR TITLE
fix(agent): approval timeout is an expiry, not a durable denial (#3272)

### DIFF
--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -537,13 +537,18 @@ async function authorizeToolOperation(
     },
   );
 
-  await recordAuthorizationDecision(
-    route,
-    publisherSlug,
-    toolName,
-    sessionId,
-    approval.approved,
-  );
+  // Only an explicit choice is durable. An approval-UI timeout is an expiry, not
+  // a denial: persisting it would auto-deny the operation on the next attempt, so
+  // the decision store is left untouched and a later call re-prompts.
+  if (!approval.timedOut) {
+    await recordAuthorizationDecision(
+      route,
+      publisherSlug,
+      toolName,
+      sessionId,
+      approval.approved,
+    );
+  }
 
   if (approval.approved) {
     if (registered) {

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -6,6 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   approvalId: "",
   approvalResponse: true,
+  // When true, the approval-response listener never fires, so the approval UI's
+  // own timeout is what resolves the request (an expiry).
+  approvalNoResponse: false,
   shellApprovalId: "",
   shellApprovalResponse: true,
   // Default gate decision; individual tests override before calling executeTool.
@@ -171,6 +174,7 @@ describe("tool executor authorization gate", () => {
     vi.clearAllMocks();
     mocks.approvalId = "";
     mocks.approvalResponse = true;
+    mocks.approvalNoResponse = false;
     mocks.shellApprovalId = "";
     mocks.shellApprovalResponse = true;
     mocks.authorizeError = false;
@@ -234,9 +238,12 @@ describe("tool executor authorization gate", () => {
         }) => void,
       ) => {
         if (eventName === "gateway-tool-approval-response") {
-          handler({
-            payload: { id: mocks.approvalId, approved: mocks.approvalResponse },
-          });
+          // Simulate the user never answering: leave the request to time out.
+          if (!mocks.approvalNoResponse) {
+            handler({
+              payload: { id: mocks.approvalId, approved: mocks.approvalResponse },
+            });
+          }
         }
         if (eventName === "shell-command-approval-response") {
           handler({
@@ -340,6 +347,35 @@ describe("tool executor authorization gate", () => {
     expect(recordCalls()).toEqual([
       expect.objectContaining({ approved: false }),
     ]);
+  });
+
+  it("treats an approval-UI timeout as an expiry, not a durable denial", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision.decision = "prompt";
+    mocks.authorizeDecision.promptKind = "session";
+    mocks.authorizeDecision.operationClass = "unclassified";
+    // The user never answers; the request must resolve via its own timeout.
+    mocks.approvalNoResponse = true;
+
+    vi.useFakeTimers();
+    try {
+      const pending = executeTool(
+        gatewayCall("new-publisher", "inspect_records"),
+        "conv-a",
+      );
+      // Fire the 5-minute approval timeout (GATEWAY_APPROVAL_TIMEOUT_MS).
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      const result = await pending;
+
+      expect(result.is_error).toBe(true);
+      expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+      // Structured, distinct expiry — not a generic "not approved".
+      expect(JSON.parse(result.content).status).toBe("action_expired");
+      // The expiry must NOT be persisted; a later attempt has to re-prompt.
+      expect(recordCalls()).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("fails closed when the gate is unavailable", async () => {


### PR DESCRIPTION
Closes #3272. Found during the post-merge functional walkthrough of #3263 (#3271).

## Problem
`authorizeToolOperation` (`src/lib/tools/executor.ts`) called `recordAuthorizationDecision(..., approval.approved)` **unconditionally** after the approval UI resolved. On a 5-minute **timeout** (expiry), `approved === false`, so the expiry was persisted through `record_tool_operation_decision` as a **durable session denial**. The next identical call then auto-denied via the host gate's stored `Denied` decision — a user who simply did not respond permanently lost that new-publisher operation for the conversation.

This contradicts #3263's acceptance criterion: "Approval expiry is explicit, not a degraded generic tool failure" — expiry must be distinct from a deliberate denial *through the whole stack*, not just in the continuation record.

## Fix
Only persist a decision on an explicit user choice — skip `recordAuthorizationDecision` when `approval.timedOut`. The continuation is already settled as `approval_expired`, so a lapsed prompt leaves the decision store untouched and a later attempt re-prompts.

```ts
if (!approval.timedOut) {
  await recordAuthorizationDecision(route, publisherSlug, toolName, sessionId, approval.approved);
}
```

## Scope / safety
- **P2.** Reachable only for unclassified (new-publisher first-use) ops; high-risk ops are one-shot and never recorded, trusted reads never prompt.
- The change only **relaxes** a durable denial — it never grants new authority (fails safe).

## Validation
- New regression test `treats an approval-UI timeout as an expiry, not a durable denial`: drives the **real** 5-minute timeout with vitest fake timers (only the Tauri IPC boundary is faked, as this suite already does) and asserts (a) no `record_tool_operation_decision` invoke and (b) a structured `action_expired` result.
- **Proved non-vacuous**: mutating the guard back to the pre-fix behavior makes the test fail with `recordCalls()` = a durable `{approved:false}` denial.
- Full `tool-executor-approval` suite: **13 passed**. `tsc --noEmit`: 0 errors in `src/`. Biome clean on `executor.ts`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
