### PR TITLE
feat(security): approval inbox, audit trail + lease revocation UI (#3264)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -409,18 +409,7 @@ pub fn read_continuations(
         "SELECT {SELECT_COLUMNS} FROM approval_continuations \
          WHERE conversation_id = ?1 ORDER BY created_at ASC"
     );
-    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-    let rows = stmt
-        .query_map(rusqlite::params![conversation_id], row_from_sql)
-        .map_err(|e| e.to_string())?;
-    let mut out = Vec::new();
-    for row in rows {
-        match row {
-            Ok(row) => out.push(row),
-            Err(err) => log::warn!("[approval-continuation] Skipping unreadable row: {err}"),
-        }
-    }
-    Ok(out)
+    collect_rows(conn, &sql, rusqlite::params![conversation_id])
 }
 
 pub fn find_by_id(conn: &Connection, approval_id: &str) -> Result<Option<ContinuationRow>, String> {
@@ -504,19 +493,71 @@ pub fn settle_if_pending(
 
 /// Expire every pending row for a conversation whose window has closed. Explicit
 /// and persisted: a lapsed action becomes `Expired`, never a generic failure and
-/// never a silently-live pending block. Returns how many rows expired.
+/// never a silently-live pending block. Returns the rows this call expired so the
+/// caller can audit each lapse (#3193-D).
 pub fn expire_overdue(
     conn: &Connection,
     conversation_id: &str,
     now: &str,
-) -> Result<usize, String> {
+) -> Result<Vec<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE conversation_id = ?1 AND state = 'pending' AND expires_at <= ?2"
+    );
+    let overdue = collect_rows(conn, &sql, rusqlite::params![conversation_id, now])?;
     conn.execute(
         "UPDATE approval_continuations \
          SET state = 'expired', resolved_at = ?2 \
          WHERE conversation_id = ?1 AND state = 'pending' AND expires_at <= ?2",
         rusqlite::params![conversation_id, now],
     )
-    .map_err(|e| e.to_string())
+    .map_err(|e| e.to_string())?;
+    Ok(overdue)
+}
+
+/// `expire_overdue` across every conversation — backs the global approval inbox,
+/// which must reflect true live state without knowing conversation ids up front.
+pub fn expire_overdue_all(conn: &Connection, now: &str) -> Result<Vec<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE state = 'pending' AND expires_at <= ?1"
+    );
+    let overdue = collect_rows(conn, &sql, rusqlite::params![now])?;
+    conn.execute(
+        "UPDATE approval_continuations \
+         SET state = 'expired', resolved_at = ?1 \
+         WHERE state = 'pending' AND expires_at <= ?1",
+        rusqlite::params![now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(overdue)
+}
+
+/// Every live pending row across all conversations, oldest first — the global
+/// approval-inbox listing. Callers expire overdue rows first.
+pub fn read_pending_all(conn: &Connection) -> Result<Vec<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE state = 'pending' ORDER BY created_at ASC"
+    );
+    collect_rows(conn, &sql, [])
+}
+
+fn collect_rows(
+    conn: &Connection,
+    sql: &str,
+    params: impl rusqlite::Params,
+) -> Result<Vec<ContinuationRow>, String> {
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let rows = stmt.query_map(params, row_from_sql).map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        match row {
+            Ok(row) => out.push(row),
+            Err(err) => log::warn!("[approval-continuation] Skipping unreadable row: {err}"),
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/authorization_audit.rs
+++ b/src-tauri/src/authorization_audit.rs
@@ -1,0 +1,269 @@
+// ABOUTME: Append-only audit trail for the authorization gate: lease lifecycle, approval outcomes, and durable decisions (#3193-D).
+// ABOUTME: Rows carry identity + a credential-safe detail (program token/host/target) — never full command lines, arguments, or credentials.
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::capability_lease::{CapabilityLease, OperationRequest, command_program};
+use crate::tool_authorization::ToolRoute;
+
+/// Every event the gate audits. Lease "expand" from the epic has no dedicated
+/// operation today — widening authority is only possible via a fresh grant, which
+/// `LeaseGranted` records.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditEvent {
+    /// A user-approved capability lease was persisted.
+    LeaseGranted,
+    /// A covered call ran silently under a lease (its budget was charged).
+    LeaseUsed,
+    /// A lease exclusion denied a call outright.
+    LeaseDenied,
+    /// A lease's expiry window closed (recorded once, on first observation).
+    LeaseExpired,
+    /// A lease was revoked by the user.
+    LeaseRevoked,
+    /// The gate suspended an action pending approval (deduped requests log once).
+    ApprovalRequested,
+    /// A suspended action was settled by a user decision or lapse.
+    ApprovalApproved,
+    ApprovalDenied,
+    ApprovalSkipped,
+    ApprovalExpired,
+    /// A durable session decision was stored for an unclassified operation.
+    DecisionGranted,
+    DecisionDenied,
+}
+
+impl AuditEvent {
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::LeaseGranted => "lease_granted",
+            Self::LeaseUsed => "lease_used",
+            Self::LeaseDenied => "lease_denied",
+            Self::LeaseExpired => "lease_expired",
+            Self::LeaseRevoked => "lease_revoked",
+            Self::ApprovalRequested => "approval_requested",
+            Self::ApprovalApproved => "approval_approved",
+            Self::ApprovalDenied => "approval_denied",
+            Self::ApprovalSkipped => "approval_skipped",
+            Self::ApprovalExpired => "approval_expired",
+            Self::DecisionGranted => "decision_granted",
+            Self::DecisionDenied => "decision_denied",
+        }
+    }
+}
+
+/// One audit row, serialized camelCase for the inspection UI. `subject_id` links
+/// the row to its lease or approval continuation; `detail` is the credential-safe
+/// summary written at record time (never recomputed from stored arguments).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEntry {
+    pub id: i64,
+    pub conversation_id: String,
+    pub event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher_slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub created_at: String,
+}
+
+/// What one event needs to say about the operation involved, already reduced to
+/// the credential-safe slice. Built by the helpers below — call sites never pass
+/// raw arguments in.
+#[derive(Clone, Debug, Default)]
+pub struct AuditContext {
+    pub subject_id: Option<String>,
+    pub route: Option<String>,
+    pub publisher_slug: Option<String>,
+    pub tool_name: Option<String>,
+    pub detail: Option<String>,
+}
+
+impl AuditContext {
+    /// Context for a lease lifecycle event: the lease id and its human label.
+    /// The label was reviewed by the user at grant time, so it is display-safe.
+    pub fn for_lease(lease: &CapabilityLease) -> Self {
+        Self {
+            subject_id: Some(lease.id.clone()),
+            detail: Some(lease.label.clone()),
+            ..Default::default()
+        }
+    }
+
+    /// Context for a gate evaluation event. Reduces the operation to the same
+    /// granularity lease predicates match on: the leading program token for
+    /// subprocess routes (never the full command line), the host for web, and
+    /// the resource target for publisher routes.
+    pub fn for_request(request: &OperationRequest, lease_id: Option<&str>) -> Self {
+        let detail = match request.route {
+            ToolRoute::Shell | ToolRoute::Skill => {
+                request.command.as_deref().and_then(command_program)
+            }
+            ToolRoute::Web => request.host.clone(),
+            ToolRoute::Gateway | ToolRoute::Seren | ToolRoute::Mcp => request.target.clone(),
+        };
+        Self {
+            subject_id: lease_id.map(str::to_string),
+            route: Some(request.route.as_wire().to_string()),
+            publisher_slug: Some(request.publisher_slug.clone()),
+            tool_name: Some(request.tool_name.clone()),
+            detail,
+        }
+    }
+
+    /// Context for an approval-continuation event. The continuation's stored
+    /// capability already excludes credentials; the audit row keeps only its
+    /// identity — the continuation record remains the display source of truth.
+    pub fn for_approval(
+        approval_id: &str,
+        route: &str,
+        publisher_slug: &str,
+        tool_name: &str,
+    ) -> Self {
+        Self {
+            subject_id: Some(approval_id.to_string()),
+            route: Some(route.to_string()),
+            publisher_slug: Some(publisher_slug.to_string()),
+            tool_name: Some(tool_name.to_string()),
+            detail: None,
+        }
+    }
+
+    /// Context for a durable per-tool session decision.
+    pub fn for_decision(route: ToolRoute, publisher_slug: &str, tool_name: &str) -> Self {
+        Self {
+            subject_id: None,
+            route: Some(route.as_wire().to_string()),
+            publisher_slug: Some(publisher_slug.to_string()),
+            tool_name: Some(tool_name.to_string()),
+            detail: None,
+        }
+    }
+}
+
+pub fn init_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS authorization_audit (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id TEXT NOT NULL,
+            event           TEXT NOT NULL,
+            subject_id      TEXT,
+            route           TEXT,
+            publisher_slug  TEXT,
+            tool_name       TEXT,
+            detail          TEXT,
+            created_at      TEXT NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_authorization_audit_conversation \
+         ON authorization_audit(conversation_id)",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_authorization_audit_subject \
+         ON authorization_audit(subject_id)",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Append one audit row. Failures are returned, not panicked; callers on the hot
+/// gate path log-and-continue so a full disk never blocks an authorization
+/// decision that is otherwise sound.
+pub fn record(
+    conn: &Connection,
+    conversation_id: &str,
+    event: AuditEvent,
+    context: &AuditContext,
+    now: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO authorization_audit \
+           (conversation_id, event, subject_id, route, publisher_slug, tool_name, detail, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        rusqlite::params![
+            conversation_id,
+            event.as_wire(),
+            context.subject_id,
+            context.route,
+            context.publisher_slug,
+            context.tool_name,
+            context.detail,
+            now,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Record `lease_expired` exactly once per lease whose window has closed. Runs
+/// on the gate path, so it is a single set-based statement guarded by NOT EXISTS
+/// rather than a per-lease read-modify-write.
+pub fn record_lease_expiries(
+    conn: &Connection,
+    conversation_id: &str,
+    now: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO authorization_audit \
+           (conversation_id, event, subject_id, created_at) \
+         SELECT cl.conversation_id, 'lease_expired', cl.id, ?2 \
+         FROM capability_leases cl \
+         WHERE cl.conversation_id = ?1 AND cl.revoked = 0 AND cl.expires_at <= ?2 \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM authorization_audit a \
+             WHERE a.subject_id = cl.id AND a.event = 'lease_expired')",
+        rusqlite::params![conversation_id, now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// The newest `limit` audit rows for a conversation.
+pub fn read_entries(
+    conn: &Connection,
+    conversation_id: &str,
+    limit: u32,
+) -> Result<Vec<AuditEntry>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, conversation_id, event, subject_id, route, publisher_slug, \
+                    tool_name, detail, created_at \
+             FROM authorization_audit WHERE conversation_id = ?1 \
+             ORDER BY id DESC LIMIT ?2",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(rusqlite::params![conversation_id, limit], |row| {
+            Ok(AuditEntry {
+                id: row.get(0)?,
+                conversation_id: row.get(1)?,
+                event: row.get(2)?,
+                subject_id: row.get(3)?,
+                route: row.get(4)?,
+                publisher_slug: row.get(5)?,
+                tool_name: row.get(6)?,
+                detail: row.get(7)?,
+                created_at: row.get(8)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    let mut entries = Vec::new();
+    for row in rows {
+        entries.push(row.map_err(|e| e.to_string())?);
+    }
+    Ok(entries)
+}

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -7,6 +7,7 @@ use crate::approval_continuation::{
     ContinuationScope, ContinuationView, RegisteredContinuation, RequestedCapability,
     ResolutionSummary, ResolveDecision, ResolveOutcome,
 };
+use crate::authorization_audit::AuditEntry;
 use crate::capability_lease::{
     BundleRequest, CapabilityLease, LeaseBudgets, LeasePredicates, ProposedBundle, derive_bundle,
 };
@@ -171,4 +172,25 @@ pub fn list_approval_continuations(
     conversation_id: String,
 ) -> Result<Vec<ContinuationView>, String> {
     state.list_continuations(&conversation_id)
+}
+
+/// Every live pending approval across all conversations — the global approval
+/// inbox and its badge, which stay visible after navigating away from a thread.
+#[tauri::command]
+pub fn list_pending_approvals(
+    state: State<'_, ToolAuthorizationState>,
+) -> Result<Vec<ContinuationView>, String> {
+    state.list_pending_continuations_all()
+}
+
+/// The newest audit rows for a conversation: lease create/use/deny/expiry/revoke,
+/// approval request/decision outcomes, and durable session decisions. Rows never
+/// contain credentials or full command arguments.
+#[tauri::command]
+pub fn list_authorization_audit(
+    state: State<'_, ToolAuthorizationState>,
+    conversation_id: String,
+    limit: Option<u32>,
+) -> Result<Vec<AuditEntry>, String> {
+    state.list_audit(&conversation_id, limit.unwrap_or(200).min(1000))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ pub mod sandbox;
 pub mod approval_continuation;
 pub mod audio;
 mod auth;
+pub mod authorization_audit;
 pub mod capability_lease;
 pub mod credential_broker;
 pub mod credential_lease;
@@ -1100,6 +1101,8 @@ pub fn run() {
             commands::tool_authorization::task_execution_state,
             commands::tool_authorization::approval_resolution_summary,
             commands::tool_authorization::list_approval_continuations,
+            commands::tool_authorization::list_pending_approvals,
+            commands::tool_authorization::list_authorization_audit,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -11,6 +11,7 @@ use crate::approval_continuation::{
     self, ContinuationRow, ContinuationScope, ContinuationState, ContinuationView,
     RegisteredContinuation, RequestedCapability, ResolutionSummary, ResolveDecision, ResolveOutcome,
 };
+use crate::authorization_audit::{self, AuditContext, AuditEntry, AuditEvent};
 use crate::capability_lease::{
     self, CapabilityLease, LeaseBudgets, LeaseOutcome, LeasePredicates, OperationRequest,
 };
@@ -566,6 +567,7 @@ impl ToolAuthorizationState {
     ) -> Result<LeaseOutcome, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
+            record_lease_expiries_audited(conn, conversation_id, &now);
             let leases = read_leases(conn, conversation_id)?;
             let outcome = capability_lease::evaluate_for_conversation(
                 &leases,
@@ -573,17 +575,38 @@ impl ToolAuthorizationState {
                 conversation_id,
                 &now,
             );
-            if let LeaseOutcome::Allow(lease_id) = &outcome
-                && let Some(mut lease) = leases.into_iter().find(|lease| &lease.id == lease_id)
-            {
-                lease.budgets.calls_used = lease.budgets.calls_used.saturating_add(1);
-                if request.cost_micros > 0 {
-                    lease.budgets.spend_used_micros = lease
-                        .budgets
-                        .spend_used_micros
-                        .saturating_add(request.cost_micros);
+            match &outcome {
+                LeaseOutcome::Allow(lease_id) => {
+                    if let Some(mut lease) =
+                        leases.into_iter().find(|lease| &lease.id == lease_id)
+                    {
+                        lease.budgets.calls_used = lease.budgets.calls_used.saturating_add(1);
+                        if request.cost_micros > 0 {
+                            lease.budgets.spend_used_micros = lease
+                                .budgets
+                                .spend_used_micros
+                                .saturating_add(request.cost_micros);
+                        }
+                        write_lease(conn, &lease)?;
+                        audit(
+                            conn,
+                            conversation_id,
+                            AuditEvent::LeaseUsed,
+                            &AuditContext::for_request(request, Some(lease_id)),
+                            &now,
+                        );
+                    }
                 }
-                write_lease(conn, &lease)?;
+                LeaseOutcome::Deny => audit(
+                    conn,
+                    conversation_id,
+                    AuditEvent::LeaseDenied,
+                    &AuditContext::for_request(request, None),
+                    &now,
+                ),
+                // An escalation is audited when its continuation is registered,
+                // not here — the gate may escalate without a prompt ever showing.
+                LeaseOutcome::Escalate => {}
             }
             Ok(outcome)
         })
@@ -613,13 +636,20 @@ impl ToolAuthorizationState {
                 id: lease_id.clone(),
                 conversation_id: conversation_id.to_string(),
                 label: label.to_string(),
-                created_at: now,
+                created_at: now.clone(),
                 expires_at,
                 revoked: false,
                 predicates: predicates.clone(),
                 budgets: budgets.clone(),
             };
             write_lease(conn, &lease)?;
+            audit(
+                conn,
+                conversation_id,
+                AuditEvent::LeaseGranted,
+                &AuditContext::for_lease(&lease),
+                &now,
+            );
             Ok(lease)
         })
     }
@@ -627,7 +657,11 @@ impl ToolAuthorizationState {
     /// Every lease bound to a conversation, newest first. Backs inspection and the
     /// (slice-D) revocation UI.
     pub fn list_leases(&self, conversation_id: &str) -> Result<Vec<CapabilityLease>, String> {
-        self.with_conn(|conn| read_leases(conn, conversation_id))
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            record_lease_expiries_audited(conn, conversation_id, &now);
+            read_leases(conn, conversation_id)
+        })
     }
 
     /// Mark a lease revoked. Idempotent: revoking an unknown or already-revoked
@@ -659,6 +693,14 @@ impl ToolAuthorizationState {
             }
             lease.revoked = true;
             write_lease(conn, &lease)?;
+            let now = current_timestamp(conn)?;
+            audit(
+                conn,
+                &lease.conversation_id,
+                AuditEvent::LeaseRevoked,
+                &AuditContext::for_lease(&lease),
+                &now,
+            );
             Ok(true)
         })
     }
@@ -683,7 +725,23 @@ impl ToolAuthorizationState {
         } else {
             StoredDecision::Denied
         };
-        self.persist_decision(conversation_id, publisher_slug, tool_name, decision)
+        self.persist_decision(conversation_id, publisher_slug, tool_name, decision)?;
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let event = if approved {
+                AuditEvent::DecisionGranted
+            } else {
+                AuditEvent::DecisionDenied
+            };
+            audit(
+                conn,
+                conversation_id,
+                event,
+                &AuditContext::for_decision(route, publisher_slug, tool_name),
+                &now,
+            );
+            Ok(())
+        })
     }
 
     /// Register a suspended continuation for an authorization-blocked action, so a
@@ -704,7 +762,7 @@ impl ToolAuthorizationState {
     ) -> Result<RegisteredContinuation, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
-            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            expire_overdue_audited(conn, conversation_id, &now);
             let fingerprint = approval_continuation::fingerprint(&requested);
             if let Some(existing) = approval_continuation::find_pending_by_fingerprint(
                 conn,
@@ -722,11 +780,20 @@ impl ToolAuthorizationState {
                 scope,
                 state: ContinuationState::Pending,
                 requested,
-                created_at: now,
+                created_at: now.clone(),
                 expires_at: timestamp_plus_seconds(conn, ttl_secs.max(1))?,
                 resolved_at: None,
             };
             approval_continuation::insert_continuation(conn, &row)?;
+            // A deduped retry reuses the pending record above and is deliberately
+            // not re-audited — one suspended request, one audit row.
+            audit(
+                conn,
+                conversation_id,
+                AuditEvent::ApprovalRequested,
+                &audit_context_for_row(&row),
+                &now,
+            );
             Ok(row.registered(false))
         })
     }
@@ -760,6 +827,15 @@ impl ToolAuthorizationState {
                     ContinuationState::Expired,
                     &now,
                 )?;
+                if changed {
+                    audit(
+                        conn,
+                        &row.conversation_id,
+                        AuditEvent::ApprovalExpired,
+                        &audit_context_for_row(&row),
+                        &now,
+                    );
+                }
                 return Ok(ResolveOutcome {
                     changed,
                     state: ContinuationState::Expired,
@@ -769,6 +845,24 @@ impl ToolAuthorizationState {
             let new_state = decision.settled_state();
             let changed =
                 approval_continuation::settle_if_pending(conn, approval_id, new_state, &now)?;
+            if changed {
+                let event = match new_state {
+                    ContinuationState::Approved => AuditEvent::ApprovalApproved,
+                    ContinuationState::Denied => AuditEvent::ApprovalDenied,
+                    ContinuationState::Skipped => AuditEvent::ApprovalSkipped,
+                    // settled_state never yields these; keep the mapping total.
+                    ContinuationState::Pending | ContinuationState::Expired => {
+                        AuditEvent::ApprovalExpired
+                    }
+                };
+                audit(
+                    conn,
+                    &row.conversation_id,
+                    event,
+                    &audit_context_for_row(&row),
+                    &now,
+                );
+            }
             Ok(ResolveOutcome {
                 changed,
                 state: new_state,
@@ -801,6 +895,15 @@ impl ToolAuthorizationState {
                 ContinuationState::Expired,
                 &now,
             )?;
+            if changed {
+                audit(
+                    conn,
+                    &row.conversation_id,
+                    AuditEvent::ApprovalExpired,
+                    &audit_context_for_row(&row),
+                    &now,
+                );
+            }
             Ok(ResolveOutcome {
                 changed,
                 state: ContinuationState::Expired,
@@ -835,7 +938,7 @@ impl ToolAuthorizationState {
     ) -> Result<TaskExecutionState, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
-            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            expire_overdue_audited(conn, conversation_id, &now);
             let rows = approval_continuation::read_continuations(conn, conversation_id)?;
             Ok(approval_continuation::aggregate_task_state(&rows))
         })
@@ -847,7 +950,7 @@ impl ToolAuthorizationState {
     pub fn resolution_summary(&self, conversation_id: &str) -> Result<ResolutionSummary, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
-            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            expire_overdue_audited(conn, conversation_id, &now);
             let rows = approval_continuation::read_continuations(conn, conversation_id)?;
             Ok(approval_continuation::summarize(&rows))
         })
@@ -862,16 +965,55 @@ impl ToolAuthorizationState {
     ) -> Result<Vec<ContinuationView>, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
-            approval_continuation::expire_overdue(conn, conversation_id, &now)?;
+            expire_overdue_audited(conn, conversation_id, &now);
             let rows = approval_continuation::read_continuations(conn, conversation_id)?;
             Ok(rows.iter().map(ContinuationRow::view).collect())
         })
     }
 
-    /// Erase every stored decision, capability lease, and suspended continuation.
-    /// Backs the one-shot "erase all local conversation data" flow; the next access
-    /// lazily reopens an empty store. Returns the total number of rows removed
-    /// across all tables.
+    /// Every live pending continuation across all conversations, oldest first —
+    /// the global approval inbox. Overdue rows are expired (and audited) first so
+    /// the inbox never shows a lapsed request as actionable.
+    pub fn list_pending_continuations_all(&self) -> Result<Vec<ContinuationView>, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            match approval_continuation::expire_overdue_all(conn, &now) {
+                Ok(expired) => {
+                    for row in &expired {
+                        audit(
+                            conn,
+                            &row.conversation_id,
+                            AuditEvent::ApprovalExpired,
+                            &audit_context_for_row(row),
+                            &now,
+                        );
+                    }
+                }
+                Err(err) => {
+                    log::warn!("[tool-authorization] Failed to expire overdue approvals: {err}")
+                }
+            }
+            let rows = approval_continuation::read_pending_all(conn)?;
+            Ok(rows.iter().map(ContinuationRow::view).collect())
+        })
+    }
+
+    /// The newest audit rows for a conversation (lease lifecycle, approval
+    /// outcomes, durable decisions). Lease expiries are refreshed first so an
+    /// expired-but-unobserved lease still shows its expiry event.
+    pub fn list_audit(&self, conversation_id: &str, limit: u32) -> Result<Vec<AuditEntry>, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            record_lease_expiries_audited(conn, conversation_id, &now);
+            expire_overdue_audited(conn, conversation_id, &now);
+            authorization_audit::read_entries(conn, conversation_id, limit)
+        })
+    }
+
+    /// Erase every stored decision, capability lease, suspended continuation, and
+    /// audit row. Backs the one-shot "erase all local conversation data" flow; the
+    /// next access lazily reopens an empty store. Returns the total number of rows
+    /// removed across all tables.
     pub fn wipe(&self) -> Result<usize, String> {
         self.with_conn(|conn| {
             let decisions = conn
@@ -883,8 +1025,69 @@ impl ToolAuthorizationState {
             let continuations = conn
                 .execute("DELETE FROM approval_continuations", [])
                 .map_err(|e| e.to_string())?;
-            Ok(decisions + leases + continuations)
+            let audit_rows = conn
+                .execute("DELETE FROM authorization_audit", [])
+                .map_err(|e| e.to_string())?;
+            Ok(decisions + leases + continuations + audit_rows)
         })
+    }
+}
+
+/// Append one audit row, logging (never failing) on error: the audit trail lives
+/// in the same database as the state it describes, so the only failure modes are
+/// store-wide ones — and an authorization decision that was already persisted
+/// must not be un-done by a failed audit insert.
+fn audit(
+    conn: &Connection,
+    conversation_id: &str,
+    event: AuditEvent,
+    context: &AuditContext,
+    now: &str,
+) {
+    if let Err(err) = authorization_audit::record(conn, conversation_id, event, context, now) {
+        log::warn!(
+            "[tool-authorization] Failed to record audit event {}: {err}",
+            event.as_wire()
+        );
+    }
+}
+
+/// The audit identity of a continuation: ids and route/operation only. The full
+/// capability (including any command text) stays in the continuation record —
+/// the audit trail does not duplicate it.
+fn audit_context_for_row(row: &ContinuationRow) -> AuditContext {
+    AuditContext::for_approval(
+        &row.approval_id,
+        &row.requested.route,
+        &row.requested.publisher_slug,
+        &row.requested.tool_name,
+    )
+}
+
+/// Expire a conversation's overdue pending continuations and audit each lapse.
+/// Log-and-continue: a read path must not fail because expiry bookkeeping did.
+fn expire_overdue_audited(conn: &Connection, conversation_id: &str, now: &str) {
+    match approval_continuation::expire_overdue(conn, conversation_id, now) {
+        Ok(expired) => {
+            for row in &expired {
+                audit(
+                    conn,
+                    &row.conversation_id,
+                    AuditEvent::ApprovalExpired,
+                    &audit_context_for_row(row),
+                    now,
+                );
+            }
+        }
+        Err(err) => log::warn!("[tool-authorization] Failed to expire overdue approvals: {err}"),
+    }
+}
+
+/// Record `lease_expired` audit rows for newly lapsed leases. Log-and-continue on
+/// the same rationale as `audit`.
+fn record_lease_expiries_audited(conn: &Connection, conversation_id: &str, now: &str) {
+    if let Err(err) = authorization_audit::record_lease_expiries(conn, conversation_id, now) {
+        log::warn!("[tool-authorization] Failed to record lease expiries: {err}");
     }
 }
 
@@ -998,6 +1201,8 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
     // Suspended continuations (#3193-C): the host-owned blocked-action records that
     // make an authorization block visible and resumable instead of a hung tool call.
     approval_continuation::init_schema(conn)?;
+    // Audit trail (#3193-D): lease lifecycle, approval outcomes, durable decisions.
+    authorization_audit::init_schema(conn)?;
     Ok(())
 }
 
@@ -1269,7 +1474,8 @@ mod tests {
         let s = state();
         s.record_decision(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", true)
             .unwrap();
-        assert_eq!(s.wipe().unwrap(), 1);
+        // Two rows: the stored decision and its audit entry.
+        assert_eq!(s.wipe().unwrap(), 2);
         let decision = s
             .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
             .unwrap();
@@ -1855,5 +2061,182 @@ mod tests {
             s.task_execution_state("conv-a").unwrap(),
             TaskExecutionState::Running
         );
+    }
+
+    // ---- audit trail (#3193-D) -------------------------------------------
+
+    fn audit_events(s: &ToolAuthorizationState, conversation_id: &str) -> Vec<String> {
+        s.list_audit(conversation_id, 100)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.event)
+            .collect()
+    }
+
+    /// The lease lifecycle is fully auditable: grant, silent use, and revoke each
+    /// leave exactly one row, newest first.
+    #[test]
+    fn lease_grant_use_and_revoke_are_audited() {
+        let s = state();
+        let lease = s
+            .grant_lease("conv-a", "Coding lease", 3600, command_rules(&["cargo"]), call_budget(10))
+            .unwrap();
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            .unwrap();
+        assert_eq!(decision.decision, "allow");
+        assert!(s.revoke_lease(&lease.id).unwrap());
+
+        assert_eq!(
+            audit_events(&s, "conv-a"),
+            vec!["lease_revoked", "lease_used", "lease_granted"],
+        );
+
+        // Idempotent replay of the revoke adds nothing.
+        assert!(!s.revoke_lease(&lease.id).unwrap());
+        assert_eq!(audit_events(&s, "conv-a").len(), 3);
+
+        // Rows carry identity, not arguments.
+        let entries = s.list_audit("conv-a", 100).unwrap();
+        let used = entries.iter().find(|e| e.event == "lease_used").unwrap();
+        assert_eq!(used.subject_id.as_deref(), Some(lease.id.as_str()));
+        assert_eq!(used.route.as_deref(), Some("shell"));
+        assert_eq!(used.detail.as_deref(), Some("cargo"));
+    }
+
+    /// Credential safety: a shell command's arguments (which may contain secrets)
+    /// never reach the audit table — only the leading program token does.
+    #[test]
+    fn audit_rows_never_store_command_arguments() {
+        let s = state();
+        s.grant_lease("conv-a", "lease", 3600, command_rules(&["curl"]), call_budget(10))
+            .unwrap();
+        let secret_command = "curl -H 'Authorization: Bearer sk-live-SECRET' https://api.example.com";
+        s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx(secret_command))
+            .unwrap();
+
+        let entries = s.list_audit("conv-a", 100).unwrap();
+        assert!(entries.iter().any(|e| e.event == "lease_used"));
+        for entry in &entries {
+            let row = serde_json::to_string(entry).unwrap();
+            assert!(!row.contains("SECRET"), "audit row leaked command arguments: {row}");
+            assert!(!row.contains("Bearer"), "audit row leaked command arguments: {row}");
+        }
+    }
+
+    /// A lease-exclusion deny is audited as such.
+    #[test]
+    fn lease_exclusion_deny_is_audited() {
+        let s = state();
+        let mut predicates = command_rules(&["git"]);
+        predicates.exclusions = vec![capability_lease::Exclusion {
+            program: Some("git".to_string()),
+            ..Default::default()
+        }];
+        s.grant_lease("conv-a", "lease", 3600, predicates, call_budget(10))
+            .unwrap();
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("git push"))
+            .unwrap();
+        assert_eq!(decision.decision, "deny");
+        assert_eq!(audit_events(&s, "conv-a"), vec!["lease_denied", "lease_granted"]);
+    }
+
+    /// One suspended request logs once — a deduped retry does not re-audit — and
+    /// its resolution logs exactly once more, even on idempotent replay.
+    #[test]
+    fn approval_lifecycle_is_audited_exactly_once() {
+        let s = state();
+        let r = s
+            .register_continuation("conv-a", shell_cap("cargo build"), ContinuationScope::Linear, 300)
+            .unwrap();
+        // Dedup reuse must not add a second requested row.
+        s.register_continuation("conv-a", shell_cap("cargo test"), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert_eq!(audit_events(&s, "conv-a"), vec!["approval_requested"]);
+
+        s.resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Deny)
+            .unwrap();
+        // Idempotent replay adds nothing.
+        s.resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Deny)
+            .unwrap();
+        assert_eq!(
+            audit_events(&s, "conv-a"),
+            vec!["approval_denied", "approval_requested"],
+        );
+        let denied = &s.list_audit("conv-a", 100).unwrap()[0];
+        assert_eq!(denied.subject_id.as_deref(), Some(r.approval_id.as_str()));
+    }
+
+    /// A durable session decision is audited; a high-risk prompt outcome (which
+    /// never persists) is not.
+    #[test]
+    fn durable_decisions_are_audited_and_one_shots_are_not() {
+        let s = state();
+        s.record_decision(ToolRoute::Gateway, "attio", "post_notes", "conv-a", true)
+            .unwrap();
+        // High-risk outcomes are one-shot: no durable decision, no decision audit.
+        s.record_decision(ToolRoute::Gateway, "gmail", "post_send", "conv-a", true)
+            .unwrap();
+        assert_eq!(audit_events(&s, "conv-a"), vec!["decision_granted"]);
+    }
+
+    /// A lapsed lease gets exactly one `lease_expired` row, on first observation.
+    #[test]
+    fn lease_expiry_is_audited_once() {
+        let s = state();
+        let lease = s
+            .grant_lease("conv-a", "lease", 3600, command_rules(&["cargo"]), call_budget(10))
+            .unwrap();
+        // Force the window closed by rewriting the stored expiry into the past.
+        s.with_conn(|conn| {
+            let mut expired = lease.clone();
+            expired.expires_at = "2000-01-01T00:00:00.000Z".to_string();
+            write_lease(conn, &expired)
+        })
+        .unwrap();
+
+        s.list_leases("conv-a").unwrap();
+        s.list_leases("conv-a").unwrap();
+        let events = audit_events(&s, "conv-a");
+        assert_eq!(
+            events.iter().filter(|e| e.as_str() == "lease_expired").count(),
+            1,
+            "expiry must be recorded exactly once: {events:?}"
+        );
+    }
+
+    /// The global pending listing spans conversations and drops settled rows —
+    /// the badge that stays visible after navigating away.
+    #[test]
+    fn pending_approvals_span_conversations() {
+        let s = state();
+        let a = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        s.register_continuation("conv-b", shell_cap("git push"), ContinuationScope::Linear, 300)
+            .unwrap();
+
+        let pending = s.list_pending_continuations_all().unwrap();
+        assert_eq!(pending.len(), 2);
+        let tasks: Vec<&str> = pending.iter().map(|view| view.task_id.as_str()).collect();
+        assert!(tasks.contains(&"conv-a") && tasks.contains(&"conv-b"));
+
+        s.resolve_continuation(&a.approval_id, &a.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        let pending = s.list_pending_continuations_all().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].task_id, "conv-b");
+    }
+
+    /// The erase-all flow removes the audit trail with everything else.
+    #[test]
+    fn wipe_clears_audit_rows() {
+        let s = state();
+        s.grant_lease("conv-a", "lease", 3600, command_rules(&["cargo"]), call_budget(10))
+            .unwrap();
+        assert!(!s.list_audit("conv-a", 10).unwrap().is_empty());
+        s.wipe().unwrap();
+        assert!(s.list_audit("conv-a", 10).unwrap().is_empty());
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,15 @@ function App() {
       void updaterStore.initUpdater();
     }
 
+    // Global approval-inbox state: live prompt events + the host gate's pending
+    // continuations (badge, inline cards, background notification).
+    if (runtime.capabilities.localMcp) {
+      const { initializeApprovalsStore } = await import(
+        "@/stores/approvals.store"
+      );
+      void initializeApprovalsStore();
+    }
+
     // Load all settings including app settings (chatDefaultModel, etc.) and MCP settings
     await loadAllSettings();
     await loadPrivacySettings();

--- a/src/components/approvals/ApprovalActions.tsx
+++ b/src/components/approvals/ApprovalActions.tsx
@@ -1,0 +1,151 @@
+// ABOUTME: Shared five-action footer for approval surfaces: approve once, approve for
+// ABOUTME: this task with editable limits, deny, skip action, and stop task.
+
+import { type Component, createSignal, Show } from "solid-js";
+
+/** Requested lease lifetimes the editor offers, in hours. */
+const DURATION_CHOICES_HOURS = [1, 4, 8, 24];
+
+const DEFAULT_DURATION_HOURS = 4;
+const DEFAULT_MAX_CALLS = 100;
+
+interface ApprovalActionsProps {
+  isProcessing: boolean;
+  /** Label for the one-shot approve button (may name the sending account). */
+  approveOnceLabel: string;
+  approveDisabled?: boolean;
+  /** Human summary of what an approve-for-this-task lease will cover. */
+  leaseSummary: string;
+  onApproveOnce: () => void;
+  onApproveForTask: (durationSecs: number, maxCalls: number) => void;
+  onDeny: () => void;
+  onSkip: () => void;
+  onStopTask: () => void;
+}
+
+/**
+ * The five decisions every approval surface offers (#3193 §7). "Approve for
+ * this task" expands an inline editor for the lease's requested duration and
+ * call budget before granting, so the user reviews the limits they hand out.
+ */
+export const ApprovalActions: Component<ApprovalActionsProps> = (props) => {
+  const [showLeaseEditor, setShowLeaseEditor] = createSignal(false);
+  const [durationHours, setDurationHours] = createSignal(
+    DEFAULT_DURATION_HOURS,
+  );
+  const [maxCalls, setMaxCalls] = createSignal(DEFAULT_MAX_CALLS);
+
+  const secondaryButton =
+    "px-4 py-2.5 text-[0.9rem] font-medium rounded-md cursor-pointer transition-all duration-150 bg-transparent text-foreground border border-border hover:bg-surface-1 hover:border-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed";
+
+  const grantLease = () => {
+    const calls = Math.max(1, Math.floor(maxCalls()));
+    props.onApproveForTask(durationHours() * 3600, calls);
+  };
+
+  return (
+    <div class="border-t border-border">
+      <Show when={showLeaseEditor()}>
+        <div class="px-6 py-4 border-b border-border bg-surface-1/50 flex flex-col gap-3">
+          <span class="text-[0.9rem] text-foreground">
+            Allow <strong>{props.leaseSummary}</strong> to run without further
+            prompts for this task, within these limits:
+          </span>
+          <div class="flex items-center gap-4 flex-wrap">
+            <label class="flex items-center gap-2 text-[0.85rem] text-muted-foreground">
+              Duration
+              <select
+                class="bg-surface-1 border border-border rounded-md px-2 py-1.5 text-foreground"
+                value={durationHours()}
+                onChange={(event) =>
+                  setDurationHours(Number(event.currentTarget.value))
+                }
+                disabled={props.isProcessing}
+              >
+                {DURATION_CHOICES_HOURS.map((hours) => (
+                  <option value={hours}>{hours}h</option>
+                ))}
+              </select>
+            </label>
+            <label class="flex items-center gap-2 text-[0.85rem] text-muted-foreground">
+              Max calls
+              <input
+                type="number"
+                min="1"
+                class="bg-surface-1 border border-border rounded-md px-2 py-1.5 text-foreground w-24"
+                value={maxCalls()}
+                onInput={(event) =>
+                  setMaxCalls(Number(event.currentTarget.value))
+                }
+                disabled={props.isProcessing}
+              />
+            </label>
+            <button
+              type="button"
+              class="px-4 py-2 text-[0.9rem] font-medium rounded-md cursor-pointer transition-all duration-150 bg-accent text-primary-foreground hover:bg-primary/85 disabled:opacity-50"
+              onClick={grantLease}
+              disabled={props.isProcessing || props.approveDisabled}
+            >
+              Grant &amp; approve
+            </button>
+          </div>
+          <span class="text-[0.8rem] text-muted-foreground">
+            You can inspect or revoke this lease at any time from the thread's
+            capability panel.
+          </span>
+        </div>
+      </Show>
+
+      <div class="px-6 py-4 flex gap-2 items-center flex-wrap">
+        <button
+          type="button"
+          class="px-4 py-2.5 text-[0.9rem] font-medium rounded-md cursor-pointer transition-all duration-150 bg-transparent text-destructive border border-destructive/40 hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={() => props.onStopTask()}
+          disabled={props.isProcessing}
+          title="Deny this action and stop the whole task"
+        >
+          Stop task
+        </button>
+        <div class="flex gap-2 ml-auto flex-wrap justify-end">
+          <button
+            type="button"
+            class={secondaryButton}
+            onClick={() => props.onSkip()}
+            disabled={props.isProcessing}
+            title="Continue the task without this action"
+          >
+            Skip action
+          </button>
+          <button
+            type="button"
+            class={secondaryButton}
+            onClick={() => props.onDeny()}
+            disabled={props.isProcessing}
+            title="Deny this action; the agent adapts and continues"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            class={secondaryButton}
+            onClick={() => setShowLeaseEditor((open) => !open)}
+            disabled={props.isProcessing || props.approveDisabled}
+            title="Pre-approve matching actions for this task, with limits you set"
+          >
+            Approve for this task…
+          </button>
+          <button
+            type="button"
+            class="px-5 py-2.5 text-[0.9rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-accent text-primary-foreground hover:bg-primary/85 hover:shadow-[var(--glow-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => props.onApproveOnce()}
+            disabled={props.isProcessing || props.approveDisabled}
+          >
+            {props.approveOnceLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApprovalActions;

--- a/src/components/approvals/ApprovalRequestCard.tsx
+++ b/src/components/approvals/ApprovalRequestCard.tsx
@@ -26,25 +26,6 @@ interface ApprovalRequestCardProps {
   view: ContinuationView;
 }
 
-const STATE_BANNERS: Record<string, { label: string; classes: string }> = {
-  approved: {
-    label: "Approved — the action ran.",
-    classes: "text-success border-success/30 bg-success/10",
-  },
-  denied: {
-    label: "Denied — the agent was told to adapt without it.",
-    classes: "text-destructive border-destructive/30 bg-destructive/10",
-  },
-  skipped: {
-    label: "Skipped — the task continued without this action.",
-    classes: "text-muted-foreground border-border bg-surface-1",
-  },
-  expired: {
-    label: "Expired — no decision arrived before the request lapsed.",
-    classes: "text-warning border-warning/30 bg-warning/10",
-  },
-};
-
 function formatElapsed(sinceIso: string, nowMs: number): string {
   const started = Date.parse(sinceIso);
   if (Number.isNaN(started)) return "";
@@ -99,10 +80,12 @@ function leaseSummaryFor(view: ContinuationView): string {
 }
 
 /**
- * One authorization-blocked action, rendered at the timeline's suspension
- * point. While the request is live in this renderer, all five decisions are
- * available inline; afterwards the card stays as the visible, auditable
- * outcome (never a hung agent, never a vanished prompt).
+ * One pending authorization-blocked action, rendered at the timeline's
+ * suspension point so a block is never a hung agent. All five decisions are
+ * available inline while the request is live in this renderer; a request from
+ * an earlier app session is shown read-only with its auto-expiry time. Once
+ * decided, the store drops the request and the settled outcome is carried by
+ * the tool-result message, the thread status, and the audit history.
  */
 export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
   props,
@@ -116,9 +99,7 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
   });
 
   const live = createMemo<LiveApprovalRequest | undefined>(() =>
-    props.view.state === "pending"
-      ? liveRequestForContinuation(props.view.approvalId)
-      : undefined,
+    liveRequestForContinuation(props.view.approvalId),
   );
 
   const cap = () => props.view.requestedCapability;
@@ -169,16 +150,11 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
     }
   };
 
-  const banner = () =>
-    props.view.state === "pending" ? null : STATE_BANNERS[props.view.state];
-
   return (
     <div class="mx-5 my-3 border border-warning/40 rounded-xl overflow-hidden bg-surface-1/60">
       <div class="px-4 py-3 flex items-center gap-2 border-b border-border bg-warning/10">
         <span class="text-[0.95rem] font-semibold text-foreground">
-          {props.view.state === "pending"
-            ? "Approval needed"
-            : "Approval request"}
+          Approval needed
         </span>
         <Show when={cap().isDestructive}>
           <span class="text-[0.75rem] font-medium text-destructive border border-destructive/40 rounded px-1.5 py-0.5">
@@ -188,11 +164,9 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
         <span class="text-[0.75rem] font-medium text-muted-foreground border border-border rounded px-1.5 py-0.5">
           {cap().operationClass}
         </span>
-        <Show when={props.view.state === "pending"}>
-          <span class="ml-auto text-[0.8rem] text-muted-foreground">
-            pending for {formatElapsed(props.view.createdAt, nowMs())}
-          </span>
-        </Show>
+        <span class="ml-auto text-[0.8rem] text-muted-foreground">
+          pending for {formatElapsed(props.view.createdAt, nowMs())}
+        </span>
       </div>
 
       <div class="px-4 py-3 flex flex-col gap-2 text-[0.9rem]">
@@ -215,7 +189,7 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
             ? "The task is paused until you decide."
             : "Unrelated work in this task is continuing while this action waits."}
         </div>
-        <Show when={props.view.state === "pending" && !live()}>
+        <Show when={!live()}>
           <div class="text-[0.85rem] text-warning">
             This request is no longer resolvable from here (it belongs to an
             earlier app session). It expires automatically at{" "}
@@ -223,16 +197,6 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
           </div>
         </Show>
       </div>
-
-      <Show when={banner()}>
-        {(state) => (
-          <div
-            class={`mx-4 mb-3 px-3 py-2 border rounded-lg text-[0.85rem] ${state().classes}`}
-          >
-            {state().label}
-          </div>
-        )}
-      </Show>
 
       <Show when={live()}>
         <ApprovalActions

--- a/src/components/approvals/ApprovalRequestCard.tsx
+++ b/src/components/approvals/ApprovalRequestCard.tsx
@@ -1,0 +1,255 @@
+// ABOUTME: Inline timeline card for one authorization-blocked action: what was attempted,
+// ABOUTME: why it needs a decision, what is blocked, and the five decision actions.
+
+import {
+  type Component,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { ApprovalActions } from "@/components/approvals/ApprovalActions";
+import { cancelOrchestration } from "@/services/orchestrator";
+import {
+  type ContinuationView,
+  grantCapabilityLease,
+  type LeasePredicates,
+} from "@/services/tool-authorization";
+import {
+  type LiveApprovalRequest,
+  liveRequestForContinuation,
+  respondToApproval,
+} from "@/stores/approvals.store";
+
+interface ApprovalRequestCardProps {
+  view: ContinuationView;
+}
+
+const STATE_BANNERS: Record<string, { label: string; classes: string }> = {
+  approved: {
+    label: "Approved — the action ran.",
+    classes: "text-success border-success/30 bg-success/10",
+  },
+  denied: {
+    label: "Denied — the agent was told to adapt without it.",
+    classes: "text-destructive border-destructive/30 bg-destructive/10",
+  },
+  skipped: {
+    label: "Skipped — the task continued without this action.",
+    classes: "text-muted-foreground border-border bg-surface-1",
+  },
+  expired: {
+    label: "Expired — no decision arrived before the request lapsed.",
+    classes: "text-warning border-warning/30 bg-warning/10",
+  },
+};
+
+function formatElapsed(sinceIso: string, nowMs: number): string {
+  const started = Date.parse(sinceIso);
+  if (Number.isNaN(started)) return "";
+  const totalSecs = Math.max(0, Math.floor((nowMs - started) / 1000));
+  if (totalSecs < 60) return `${totalSecs}s`;
+  const mins = Math.floor(totalSecs / 60);
+  if (mins < 60) return `${mins}m ${totalSecs % 60}s`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+/** Why the gate could not run this silently, in the host's terms. */
+function uncoveredReason(view: ContinuationView): string {
+  if (view.requestedCapability.operationClass === "high-risk") {
+    return "High-risk operations require an explicit decision — no lease covers them unless you opt in.";
+  }
+  return "No active capability lease for this task covers this operation.";
+}
+
+/** The lease predicate that would cover this call, mirroring the gate's keys. */
+function leasePredicatesFor(view: ContinuationView): LeasePredicates | null {
+  const cap = view.requestedCapability;
+  if (cap.route === "shell" || cap.route === "skill") {
+    const first = cap.command?.trim().split(/\s+/)[0];
+    const program = first?.split(/[/\\]/).pop()?.toLowerCase();
+    return program ? { commandRules: [{ program }] } : null;
+  }
+  if (cap.route === "web") {
+    return cap.host ? { networkHosts: [cap.host] } : null;
+  }
+  return {
+    publisherOps: [
+      {
+        publisherSlug: cap.publisherSlug,
+        allowHighRisk: cap.operationClass === "high-risk",
+        target: cap.target,
+      },
+    ],
+  };
+}
+
+function leaseSummaryFor(view: ContinuationView): string {
+  const cap = view.requestedCapability;
+  if (cap.route === "shell" || cap.route === "skill") {
+    const first = cap.command?.trim().split(/\s+/)[0];
+    const program = first?.split(/[/\\]/).pop()?.toLowerCase();
+    return program ? `"${program}" commands` : "this command";
+  }
+  if (cap.route === "web") {
+    return cap.host ? `web access to ${cap.host}` : "this web fetch";
+  }
+  return `${cap.publisherSlug} operations`;
+}
+
+/**
+ * One authorization-blocked action, rendered at the timeline's suspension
+ * point. While the request is live in this renderer, all five decisions are
+ * available inline; afterwards the card stays as the visible, auditable
+ * outcome (never a hung agent, never a vanished prompt).
+ */
+export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
+  props,
+) => {
+  const [nowMs, setNowMs] = createSignal(Date.now());
+  const [isProcessing, setIsProcessing] = createSignal(false);
+
+  onMount(() => {
+    const timer = setInterval(() => setNowMs(Date.now()), 1000);
+    onCleanup(() => clearInterval(timer));
+  });
+
+  const live = createMemo<LiveApprovalRequest | undefined>(() =>
+    props.view.state === "pending"
+      ? liveRequestForContinuation(props.view.approvalId)
+      : undefined,
+  );
+
+  const cap = () => props.view.requestedCapability;
+
+  const respond = async (outcome: { approved: boolean; skipped?: boolean }) => {
+    const request = live();
+    if (!request || isProcessing()) return;
+    setIsProcessing(true);
+    try {
+      await respondToApproval(request, outcome);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleApproveForTask = async (
+    durationSecs: number,
+    maxCalls: number,
+  ) => {
+    const request = live();
+    if (!request || isProcessing()) return;
+    const predicates = leasePredicatesFor(props.view);
+    if (predicates) {
+      try {
+        await grantCapabilityLease(
+          props.view.taskId,
+          `Task lease: ${leaseSummaryFor(props.view)}`,
+          durationSecs,
+          predicates,
+          { maxCalls },
+        );
+      } catch (err) {
+        console.error(
+          "[ApprovalRequestCard] Failed to grant task lease; approving once:",
+          err,
+        );
+      }
+    }
+    await respond({ approved: true });
+  };
+
+  const handleStopTask = async () => {
+    await respond({ approved: false });
+    try {
+      await cancelOrchestration(props.view.taskId);
+    } catch (err) {
+      console.error("[ApprovalRequestCard] Failed to stop task:", err);
+    }
+  };
+
+  const banner = () =>
+    props.view.state === "pending" ? null : STATE_BANNERS[props.view.state];
+
+  return (
+    <div class="mx-5 my-3 border border-warning/40 rounded-xl overflow-hidden bg-surface-1/60">
+      <div class="px-4 py-3 flex items-center gap-2 border-b border-border bg-warning/10">
+        <span class="text-[0.95rem] font-semibold text-foreground">
+          {props.view.state === "pending"
+            ? "Approval needed"
+            : "Approval request"}
+        </span>
+        <Show when={cap().isDestructive}>
+          <span class="text-[0.75rem] font-medium text-destructive border border-destructive/40 rounded px-1.5 py-0.5">
+            destructive
+          </span>
+        </Show>
+        <span class="text-[0.75rem] font-medium text-muted-foreground border border-border rounded px-1.5 py-0.5">
+          {cap().operationClass}
+        </span>
+        <Show when={props.view.state === "pending"}>
+          <span class="ml-auto text-[0.8rem] text-muted-foreground">
+            pending for {formatElapsed(props.view.createdAt, nowMs())}
+          </span>
+        </Show>
+      </div>
+
+      <div class="px-4 py-3 flex flex-col gap-2 text-[0.9rem]">
+        <div class="text-foreground">
+          {cap().description || `${cap().publisherSlug}/${cap().toolName}`}
+        </div>
+        <div class="text-muted-foreground font-[var(--font-mono)] text-[0.8rem]">
+          {cap().route} · {cap().publisherSlug}/{cap().toolName}
+          <Show when={cap().command}>{(command) => <> · {command()}</>}</Show>
+          <Show when={cap().host}>{(host) => <> · {host()}</>}</Show>
+          <Show when={cap().target}>
+            {(target) => <> · account/resource: {target()}</>}
+          </Show>
+        </div>
+        <div class="text-[0.85rem] text-muted-foreground">
+          {uncoveredReason(props.view)}
+        </div>
+        <div class="text-[0.85rem] text-muted-foreground">
+          {props.view.blockedScope === "linear"
+            ? "The task is paused until you decide."
+            : "Unrelated work in this task is continuing while this action waits."}
+        </div>
+        <Show when={props.view.state === "pending" && !live()}>
+          <div class="text-[0.85rem] text-warning">
+            This request is no longer resolvable from here (it belongs to an
+            earlier app session). It expires automatically at{" "}
+            {new Date(props.view.expiresAt).toLocaleTimeString()}.
+          </div>
+        </Show>
+      </div>
+
+      <Show when={banner()}>
+        {(state) => (
+          <div
+            class={`mx-4 mb-3 px-3 py-2 border rounded-lg text-[0.85rem] ${state().classes}`}
+          >
+            {state().label}
+          </div>
+        )}
+      </Show>
+
+      <Show when={live()}>
+        <ApprovalActions
+          isProcessing={isProcessing()}
+          approveOnceLabel="Approve once"
+          leaseSummary={leaseSummaryFor(props.view)}
+          onApproveOnce={() => void respond({ approved: true })}
+          onApproveForTask={(durationSecs, maxCalls) =>
+            void handleApproveForTask(durationSecs, maxCalls)
+          }
+          onDeny={() => void respond({ approved: false })}
+          onSkip={() => void respond({ approved: false, skipped: true })}
+          onStopTask={() => void handleStopTask()}
+        />
+      </Show>
+    </div>
+  );
+};
+
+export default ApprovalRequestCard;

--- a/src/components/approvals/CapabilityLeasePanel.tsx
+++ b/src/components/approvals/CapabilityLeasePanel.tsx
@@ -1,0 +1,220 @@
+// ABOUTME: Inspect-and-revoke panel for a conversation's capability leases, with the
+// ABOUTME: authorization audit history (lease lifecycle, approval outcomes, decisions).
+
+import {
+  type Component,
+  createResource,
+  createSignal,
+  For,
+  Show,
+} from "solid-js";
+import {
+  type AuthorizationAuditEntry,
+  type CapabilityLease,
+  listAuthorizationAudit,
+  listCapabilityLeases,
+  revokeCapabilityLease,
+} from "@/services/tool-authorization";
+
+interface CapabilityLeasePanelProps {
+  conversationId: string;
+}
+
+const AUDIT_EVENT_LABELS: Record<string, string> = {
+  lease_granted: "Lease granted",
+  lease_used: "Ran under lease",
+  lease_denied: "Denied by lease exclusion",
+  lease_expired: "Lease expired",
+  lease_revoked: "Lease revoked",
+  approval_requested: "Approval requested",
+  approval_approved: "Approved",
+  approval_denied: "Denied",
+  approval_skipped: "Skipped",
+  approval_expired: "Approval expired",
+  decision_granted: "Session grant stored",
+  decision_denied: "Session denial stored",
+};
+
+function leaseIsActive(lease: CapabilityLease): boolean {
+  return !lease.revoked && Date.parse(lease.expiresAt) > Date.now();
+}
+
+function leaseStatus(lease: CapabilityLease): string {
+  if (lease.revoked) return "revoked";
+  if (Date.parse(lease.expiresAt) <= Date.now()) return "expired";
+  return "active";
+}
+
+function describePredicates(lease: CapabilityLease): string {
+  const parts: string[] = [];
+  const commands = lease.predicates.commandRules ?? [];
+  if (commands.length > 0) {
+    parts.push(`commands: ${commands.map((rule) => rule.program).join(", ")}`);
+  }
+  const hosts = lease.predicates.networkHosts ?? [];
+  if (hosts.length > 0) {
+    parts.push(`hosts: ${hosts.join(", ")}`);
+  }
+  const ops = lease.predicates.publisherOps ?? [];
+  if (ops.length > 0) {
+    parts.push(
+      `publishers: ${ops
+        .map(
+          (rule) =>
+            rule.publisherSlug +
+            (rule.target ? ` (${rule.target})` : "") +
+            (rule.allowHighRisk ? " incl. high-risk" : ""),
+        )
+        .join(", ")}`,
+    );
+  }
+  const exclusions = lease.predicates.exclusions ?? [];
+  if (exclusions.length > 0) {
+    parts.push(`${exclusions.length} exclusion(s)`);
+  }
+  return parts.join(" · ") || "no predicates";
+}
+
+function describeBudgets(lease: CapabilityLease): string {
+  const used = lease.budgets.callsUsed ?? 0;
+  const max = lease.budgets.maxCalls;
+  const calls =
+    max != null ? `${used}/${max} calls used` : `${used} calls used`;
+  if (lease.budgets.maxSpendMicros != null) {
+    const spent = (lease.budgets.spendUsedMicros ?? 0) / 1_000_000;
+    const cap = lease.budgets.maxSpendMicros / 1_000_000;
+    return `${calls} · ${spent}/${cap} ${lease.budgets.asset ?? ""} spent`;
+  }
+  return calls;
+}
+
+/**
+ * The user-facing half of lease lifecycle (#3193 §8): every lease bound to this
+ * conversation with its scope, budget usage, and expiry — revocable in one
+ * click, effective on the gate's next evaluation — plus the audit history.
+ */
+export const CapabilityLeasePanel: Component<CapabilityLeasePanelProps> = (
+  props,
+) => {
+  const [revision, setRevision] = createSignal(0);
+  const [revokingId, setRevokingId] = createSignal<string | null>(null);
+
+  const [leases] = createResource(
+    () => [props.conversationId, revision()] as const,
+    async ([conversationId]) => listCapabilityLeases(conversationId),
+  );
+
+  const [audit] = createResource(
+    () => [props.conversationId, revision()] as const,
+    async ([conversationId]) => listAuthorizationAudit(conversationId, 50),
+  );
+
+  const handleRevoke = async (lease: CapabilityLease) => {
+    if (revokingId()) return;
+    setRevokingId(lease.id);
+    try {
+      await revokeCapabilityLease(lease.id);
+      setRevision((n) => n + 1);
+    } catch (err) {
+      console.error("[CapabilityLeasePanel] Failed to revoke lease:", err);
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  const auditLine = (entry: AuthorizationAuditEntry): string => {
+    const label = AUDIT_EVENT_LABELS[entry.event] ?? entry.event;
+    const operation =
+      entry.publisherSlug && entry.toolName
+        ? ` — ${entry.publisherSlug}/${entry.toolName}`
+        : "";
+    const detail = entry.detail ? ` (${entry.detail})` : "";
+    return `${label}${operation}${detail}`;
+  };
+
+  return (
+    <div class="border border-border rounded-lg bg-surface-1/60 overflow-hidden">
+      <div class="px-4 py-2.5 border-b border-border text-[0.85rem] font-semibold text-foreground">
+        Capability leases
+      </div>
+      <div class="px-4 py-3 flex flex-col gap-2">
+        <Show
+          when={(leases() ?? []).length > 0}
+          fallback={
+            <span class="text-[0.85rem] text-muted-foreground">
+              No capability leases for this task. Approve an action "for this
+              task" to create one.
+            </span>
+          }
+        >
+          <For each={leases()}>
+            {(lease) => (
+              <div class="border border-border rounded-lg px-3 py-2.5 flex flex-col gap-1.5">
+                <div class="flex items-center gap-2">
+                  <span class="text-[0.88rem] text-foreground font-medium">
+                    {lease.label}
+                  </span>
+                  <span
+                    class={`text-[0.72rem] font-medium rounded px-1.5 py-0.5 border ${
+                      leaseStatus(lease) === "active"
+                        ? "text-success border-success/40"
+                        : "text-muted-foreground border-border"
+                    }`}
+                  >
+                    {leaseStatus(lease)}
+                  </span>
+                  <Show when={leaseIsActive(lease)}>
+                    <button
+                      type="button"
+                      class="ml-auto px-2.5 py-1 text-[0.78rem] font-medium rounded-md cursor-pointer bg-transparent text-destructive border border-destructive/40 hover:bg-destructive/10 disabled:opacity-50"
+                      onClick={() => void handleRevoke(lease)}
+                      disabled={revokingId() !== null}
+                    >
+                      {revokingId() === lease.id ? "Revoking…" : "Revoke now"}
+                    </button>
+                  </Show>
+                </div>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {describePredicates(lease)}
+                </span>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {describeBudgets(lease)} · expires{" "}
+                  {new Date(lease.expiresAt).toLocaleString()}
+                </span>
+              </div>
+            )}
+          </For>
+        </Show>
+      </div>
+
+      <div class="px-4 py-2.5 border-t border-b border-border text-[0.85rem] font-semibold text-foreground">
+        Authorization history
+      </div>
+      <div class="px-4 py-3 max-h-64 overflow-y-auto">
+        <Show
+          when={(audit() ?? []).length > 0}
+          fallback={
+            <span class="text-[0.85rem] text-muted-foreground">
+              No authorization events recorded for this task yet.
+            </span>
+          }
+        >
+          <ul class="m-0 p-0 list-none flex flex-col gap-1.5">
+            <For each={audit()}>
+              {(entry) => (
+                <li class="text-[0.78rem] text-muted-foreground flex gap-2">
+                  <span class="shrink-0 font-[var(--font-mono)]">
+                    {new Date(entry.createdAt).toLocaleTimeString()}
+                  </span>
+                  <span class="min-w-0">{auditLine(entry)}</span>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default CapabilityLeasePanel;

--- a/src/components/approvals/LocalApprovalsSection.tsx
+++ b/src/components/approvals/LocalApprovalsSection.tsx
@@ -1,0 +1,91 @@
+// ABOUTME: Local-gate section of the approval inbox: pending authorization blocks from this
+// ABOUTME: device's tool-authorization gate, with jump-to-thread. Separate from cloud approvals.
+
+import { type Component, For, onMount, Show } from "solid-js";
+import {
+  pendingApprovals,
+  refreshPendingApprovals,
+} from "@/stores/approvals.store";
+import { threadStore } from "@/stores/thread.store";
+
+/** Matches the executor's fallback session id for gate calls without a thread. */
+const NO_CONVERSATION_ID = "session-without-conversation";
+
+function relativeAge(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "-";
+  const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  return `${Math.round(diffMin / 60)}h`;
+}
+
+/**
+ * Pending decisions from the host authorization gate (#3193-D). These are
+ * device-local and deliberately not merged with the cloud operator inbox —
+ * different backend, different decide flow. Decisions happen on the thread's
+ * inline card or modal; this section is the global, navigation-safe view.
+ */
+export const LocalApprovalsSection: Component = () => {
+  onMount(() => {
+    void refreshPendingApprovals();
+  });
+
+  const openThread = (conversationId: string) => {
+    threadStore.selectThread(conversationId, "chat");
+    window.dispatchEvent(new CustomEvent("seren:close-inbox"));
+  };
+
+  return (
+    <Show when={pendingApprovals().length > 0}>
+      <div class="mb-5">
+        <h2 class="m-0 mb-1 text-[13px] font-semibold text-foreground">
+          This device
+        </h2>
+        <p class="m-0 mb-2 text-[12px] text-muted-foreground">
+          Agent actions paused by the local authorization gate. Decide them from
+          the thread.
+        </p>
+        <ul class="m-0 p-0 list-none flex flex-col gap-1.5">
+          <For each={pendingApprovals()}>
+            {(view) => (
+              <li class="border border-warning/40 bg-warning/5 rounded-lg px-3 py-2.5 flex items-center gap-3">
+                <div class="min-w-0 flex-1">
+                  <div class="text-[13px] text-foreground truncate">
+                    {view.requestedCapability.description ||
+                      `${view.requestedCapability.publisherSlug}/${view.requestedCapability.toolName}`}
+                  </div>
+                  <div class="text-[11.5px] text-muted-foreground truncate font-[var(--font-mono)]">
+                    {view.requestedCapability.route} ·{" "}
+                    {view.requestedCapability.publisherSlug}/
+                    {view.requestedCapability.toolName} · waiting{" "}
+                    {relativeAge(view.createdAt)}
+                  </div>
+                </div>
+                <Show
+                  when={view.taskId !== NO_CONVERSATION_ID}
+                  fallback={
+                    <span class="text-[11.5px] text-muted-foreground shrink-0">
+                      no thread
+                    </span>
+                  }
+                >
+                  <button
+                    type="button"
+                    class="shrink-0 py-1.5 px-3 rounded text-[12px] font-medium cursor-pointer transition-all duration-150 bg-transparent text-foreground border border-border hover:bg-muted"
+                    onClick={() => openThread(view.taskId)}
+                  >
+                    Open thread
+                  </button>
+                </Show>
+              </li>
+            )}
+          </For>
+        </ul>
+      </div>
+    </Show>
+  );
+};
+
+export default LocalApprovalsSection;

--- a/src/components/approvals/ThreadApprovalStatus.tsx
+++ b/src/components/approvals/ThreadApprovalStatus.tsx
@@ -1,0 +1,95 @@
+// ABOUTME: Persistent thread status strip: "Waiting for approval" / "N actions blocked",
+// ABOUTME: with a toggle for the capability-lease inspect/revoke panel.
+
+import {
+  type Component,
+  createMemo,
+  createResource,
+  createSignal,
+  Show,
+} from "solid-js";
+import { CapabilityLeasePanel } from "@/components/approvals/CapabilityLeasePanel";
+import { listCapabilityLeases } from "@/services/tool-authorization";
+import {
+  pendingForConversation,
+  threadApprovalStatus,
+} from "@/stores/approvals.store";
+
+interface ThreadApprovalStatusProps {
+  conversationId: string;
+}
+
+/**
+ * The always-visible blocked-state surface for a thread (#3193 §7). Renders
+ * whenever the thread has pending approvals or any capability lease exists, so
+ * an authorization block never looks like a hung agent and active authority is
+ * always one click from inspection or revocation.
+ */
+export const ThreadApprovalStatus: Component<ThreadApprovalStatusProps> = (
+  props,
+) => {
+  const [panelOpen, setPanelOpen] = createSignal(false);
+
+  // Re-check lease existence when pending-state changes too: a fresh
+  // approve-for-task grant should surface the capabilities button immediately.
+  const [leaseCount] = createResource(
+    () =>
+      [
+        props.conversationId,
+        pendingForConversation(props.conversationId).length,
+      ] as const,
+    async ([conversationId]) => {
+      try {
+        return (await listCapabilityLeases(conversationId)).length;
+      } catch {
+        return 0;
+      }
+    },
+  );
+
+  const status = createMemo(() => threadApprovalStatus(props.conversationId));
+  const visible = createMemo(
+    () => status() !== null || (leaseCount() ?? 0) > 0 || panelOpen(),
+  );
+
+  return (
+    <Show when={visible()}>
+      <div class="border-t border-surface-2 bg-surface-1/70">
+        <div class="flex items-center gap-2 px-4 py-1.5">
+          <Show
+            when={status()}
+            fallback={
+              <span class="text-[0.8rem] text-muted-foreground">
+                Task capabilities
+              </span>
+            }
+          >
+            {(label) => (
+              <span class="inline-flex items-center gap-2 text-[0.8rem] font-medium text-warning">
+                <span
+                  class="inline-block w-[7px] h-[7px] rounded-full bg-warning animate-pulse"
+                  aria-hidden="true"
+                />
+                {label()}
+              </span>
+            )}
+          </Show>
+          <button
+            type="button"
+            class="ml-auto text-[0.78rem] text-muted-foreground bg-transparent border border-border rounded px-2 py-0.5 cursor-pointer hover:bg-surface-2 hover:text-foreground"
+            onClick={() => setPanelOpen((open) => !open)}
+          >
+            {panelOpen() ? "Hide capabilities" : "Capabilities"}
+          </button>
+        </div>
+        <Show when={panelOpen()}>
+          <div class="px-4 pb-3">
+            <CapabilityLeasePanel conversationId={props.conversationId} />
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default ThreadApprovalStatus;

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -19,6 +19,8 @@ import {
   untrack,
 } from "solid-js";
 import { createStore } from "solid-js/store";
+import { ApprovalRequestCard } from "@/components/approvals/ApprovalRequestCard";
+import { ThreadApprovalStatus } from "@/components/approvals/ThreadApprovalStatus";
 import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
@@ -104,6 +106,7 @@ import {
 } from "@/services/organization-policy";
 import { assertPrivilegedConversationProvider } from "@/services/providers";
 import { skills } from "@/services/skills";
+import { pendingForConversation } from "@/stores/approvals.store";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -1995,6 +1998,16 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
               </Show>
             </article>
           </Show>
+
+          {/* Authorization-blocked actions surface at the suspension point —
+              the tail of the timeline, where execution is actually paused. */}
+          <Show when={conversationId()}>
+            {(id) => (
+              <For each={pendingForConversation(id())}>
+                {(view) => <ApprovalRequestCard view={view} />}
+              </For>
+            )}
+          </Show>
         </div>
 
         <Show when={contextPreview()}>
@@ -2019,6 +2032,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
               </pre>
             </div>
           )}
+        </Show>
+
+        <Show when={conversationId()}>
+          {(id) => <ThreadApprovalStatus conversationId={id()} />}
         </Show>
 
         <div class="shrink-0 border-t border-surface-2 bg-surface-1">

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -13,10 +13,16 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { ApprovalActions } from "@/components/approvals/ApprovalActions";
+import { cancelOrchestration } from "@/services/orchestrator";
 import {
   listConnectedPublishers,
   resolveOAuthProviderForPublisher,
 } from "@/services/publisher-oauth";
+import {
+  grantCapabilityLease,
+  type LeasePredicates,
+} from "@/services/tool-authorization";
 import { conversationStore } from "@/stores/conversation.store";
 import {
   formatOAuthConnectionLabel,
@@ -37,6 +43,9 @@ interface ApprovalRequest {
   threadId?: string | null;
   description: string;
   isDestructive: boolean;
+  /** Host classification wire token; decides whether a task lease must opt in
+   * to high-risk coverage for matching calls to run silently. */
+  operationClass?: string;
 }
 
 interface Provenance {
@@ -200,51 +209,153 @@ export const GatewayToolApproval: Component = () => {
     if (shouldRenderAccountChoices() && connection) {
       return `Approve & send from ${formatOAuthConnectionLabel(connection)}`;
     }
-    return "Approve";
+    return "Approve once";
   });
 
-  const handleApprove = async () => {
+  /** Emit the decision and dismiss; idempotent against double clicks. */
+  const settle = async (outcome: {
+    approved: boolean;
+    skipped?: boolean;
+  }): Promise<boolean> => {
     const req = request();
-    if (!req || isProcessing()) return;
-    if (needsConnectionChoice()) return;
+    if (!req || isProcessing()) return false;
 
     setIsProcessing(true);
-    console.log("[GatewayToolApproval] Approving operation:", req.approvalId);
-
     try {
       await emit("gateway-tool-approval-response", {
         id: req.approvalId,
-        approved: true,
-        connectionId: selectedConnection()?.id ?? null,
+        approved: outcome.approved,
+        skipped: outcome.skipped ?? false,
+        connectionId: outcome.approved
+          ? (selectedConnection()?.id ?? null)
+          : null,
       });
       setRequest(null);
       setProvenance(null);
       setSelectedConnectionId(null);
+      return true;
     } catch (err) {
-      console.error("[GatewayToolApproval] Failed to emit approval:", err);
+      console.error("[GatewayToolApproval] Failed to emit decision:", err);
       setIsProcessing(false);
+      return false;
     }
   };
 
+  const handleApprove = async () => {
+    if (needsConnectionChoice()) return;
+    console.log(
+      "[GatewayToolApproval] Approving operation:",
+      request()?.approvalId,
+    );
+    await settle({ approved: true });
+  };
+
   const handleDeny = async () => {
-    const req = request();
-    if (!req || isProcessing()) return;
+    console.log(
+      "[GatewayToolApproval] Denying operation:",
+      request()?.approvalId,
+    );
+    await settle({ approved: false });
+  };
 
-    setIsProcessing(true);
-    console.log("[GatewayToolApproval] Denying operation:", req.approvalId);
+  const handleSkip = async () => {
+    console.log(
+      "[GatewayToolApproval] Skipping operation:",
+      request()?.approvalId,
+    );
+    await settle({ approved: false, skipped: true });
+  };
 
-    try {
-      await emit("gateway-tool-approval-response", {
-        id: req.approvalId,
-        approved: false,
-      });
-      setRequest(null);
-      setProvenance(null);
-      setSelectedConnectionId(null);
-    } catch (err) {
-      console.error("[GatewayToolApproval] Failed to emit denial:", err);
-      setIsProcessing(false);
+  const handleStopTask = async () => {
+    const threadId = approvalThreadId();
+    console.log(
+      "[GatewayToolApproval] Stopping task for operation:",
+      request()?.approvalId,
+    );
+    const settled = await settle({ approved: false });
+    if (settled && threadId) {
+      try {
+        await cancelOrchestration(threadId);
+      } catch (err) {
+        console.error("[GatewayToolApproval] Failed to stop task:", err);
+      }
     }
+  };
+
+  /** The gate/lease key for this prompt — must match the executor's session id. */
+  const leaseConversationId = () =>
+    request()?.threadId ??
+    conversationStore.activeConversationId ??
+    "session-without-conversation";
+
+  /** What an approve-for-this-task lease will cover, in the user's terms. */
+  const leaseSummary = () => {
+    const req = request();
+    if (!req) return "";
+    const host = webFetchHost();
+    if (host) return `web access to ${host}`;
+    return `${req.publisherSlug} operations`;
+  };
+
+  /** For a web fetch, the lease predicate is the target host, not a publisher. */
+  const webFetchHost = (): string | null => {
+    const req = request();
+    if (!req || req.toolName !== "seren_web_fetch") return null;
+    const url = req.args.url;
+    if (typeof url !== "string") return null;
+    try {
+      return new URL(url).hostname || null;
+    } catch {
+      return null;
+    }
+  };
+
+  /**
+   * Grant a reviewed, bounded lease for this task, then approve this call. The
+   * lease mirrors what the gate evaluates: the target host for a web fetch,
+   * otherwise this publisher (scoped to the call's account/connection when it
+   * names one, and opting into high-risk coverage only when this operation
+   * already is high-risk). If the grant fails the call still proceeds as a
+   * one-shot approval — the conservative subset of the user's intent.
+   */
+  const handleApproveForTask = async (
+    durationSecs: number,
+    maxCalls: number,
+  ) => {
+    const req = request();
+    if (!req || isProcessing() || needsConnectionChoice()) return;
+
+    const host = webFetchHost();
+    const target =
+      typeof req.args.connection_id === "string"
+        ? req.args.connection_id
+        : (selectedConnection()?.id ?? undefined);
+    const predicates: LeasePredicates = host
+      ? { networkHosts: [host] }
+      : {
+          publisherOps: [
+            {
+              publisherSlug: req.publisherSlug,
+              allowHighRisk: req.operationClass === "high-risk",
+              target,
+            },
+          ],
+        };
+    try {
+      await grantCapabilityLease(
+        leaseConversationId(),
+        `Task lease: ${leaseSummary()}`,
+        durationSecs,
+        predicates,
+        { maxCalls },
+      );
+    } catch (err) {
+      console.error(
+        "[GatewayToolApproval] Failed to grant task lease; approving once:",
+        err,
+      );
+    }
+    await handleApprove();
   };
 
   const formatArgs = (args: Record<string, unknown>): string => {
@@ -496,24 +607,17 @@ export const GatewayToolApproval: Component = () => {
               </Show>
             </div>
 
-            <div class="px-6 py-4 border-t border-border flex gap-3 justify-end">
-              <button
-                type="button"
-                class="px-6 py-2.5 text-[0.95rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-transparent text-foreground border border-border hover:bg-surface-1 hover:border-muted-foreground"
-                onClick={handleDeny}
-                disabled={isProcessing()}
-              >
-                Deny
-              </button>
-              <button
-                type="button"
-                class="px-6 py-2.5 text-[0.95rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-accent text-primary-foreground hover:bg-primary/85 hover:shadow-[var(--glow-primary)]"
-                onClick={handleApprove}
-                disabled={isProcessing() || needsConnectionChoice()}
-              >
-                {approveLabel()}
-              </button>
-            </div>
+            <ApprovalActions
+              isProcessing={isProcessing()}
+              approveOnceLabel={approveLabel()}
+              approveDisabled={needsConnectionChoice()}
+              leaseSummary={leaseSummary()}
+              onApproveOnce={handleApprove}
+              onApproveForTask={handleApproveForTask}
+              onDeny={handleDeny}
+              onSkip={handleSkip}
+              onStopTask={handleStopTask}
+            />
           </div>
         </div>
       )}

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -128,8 +128,25 @@ export const GatewayToolApproval: Component = () => {
       },
     );
 
+    // The same request can be decided from another surface (the inline
+    // timeline card or the inbox). Dismiss this dialog when its request is
+    // settled elsewhere, so a stale prompt never lingers over a decided action.
+    const unlistenResolved = await listen<{ id: string }>(
+      "gateway-tool-approval-response",
+      (event) => {
+        const req = request();
+        if (req && event.payload.id === req.approvalId) {
+          setRequest(null);
+          setProvenance(null);
+          setSelectedConnectionId(null);
+          setIsProcessing(false);
+        }
+      },
+    );
+
     onCleanup(() => {
       unlisten();
+      unlistenResolved();
     });
   });
 

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -300,7 +300,7 @@ export const GatewayToolApproval: Component = () => {
   /** For a web fetch, the lease predicate is the target host, not a publisher. */
   const webFetchHost = (): string | null => {
     const req = request();
-    if (!req || req.toolName !== "seren_web_fetch") return null;
+    if (req?.toolName !== "seren_web_fetch") return null;
     const url = req.args.url;
     if (typeof url !== "string") return null;
     try {

--- a/src/components/inbox/InboxList.tsx
+++ b/src/components/inbox/InboxList.tsx
@@ -11,6 +11,7 @@ import {
   Show,
   Switch,
 } from "solid-js";
+import { LocalApprovalsSection } from "@/components/approvals/LocalApprovalsSection";
 import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
 import { groupInboxEntries } from "@/components/inbox/grouping";
 import { getDefaultOrganizationId } from "@/lib/tauri-bridge";
@@ -393,6 +394,8 @@ export const InboxList: Component = () => {
           {actionError()}
         </div>
       </Show>
+
+      <LocalApprovalsSection />
 
       <Switch>
         <Match when={initialPage.loading}>

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -47,8 +47,23 @@ export const ShellApproval: Component = () => {
       },
     );
 
+    // The same request can be decided from another surface (the inline
+    // timeline card or the inbox). Dismiss this dialog when its request is
+    // settled elsewhere, so a stale prompt never lingers over a decided action.
+    const unlistenResolved = await listen<{ id: string }>(
+      "shell-command-approval-response",
+      (event) => {
+        const req = request();
+        if (req && event.payload.id === req.approvalId) {
+          setRequest(null);
+          setIsProcessing(false);
+        }
+      },
+    );
+
     onCleanup(() => {
       unlisten();
+      unlistenResolved();
     });
   });
 

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -9,11 +9,25 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { ApprovalActions } from "@/components/approvals/ApprovalActions";
+import { cancelOrchestration } from "@/services/orchestrator";
+import { grantCapabilityLease } from "@/services/tool-authorization";
+import { conversationStore } from "@/stores/conversation.store";
 
 interface ShellApprovalRequest {
   approvalId: string;
   command: string;
   timeoutSecs: number;
+  threadId?: string | null;
+}
+
+/** Leading executable token, path-stripped and lowercased — the same key the
+ * gate's command-rule predicates match on (`command_program` in Rust). */
+function commandProgram(command: string): string | null {
+  const first = command.trim().split(/\s+/)[0];
+  if (!first) return null;
+  const program = first.split(/[/\\]/).pop()?.toLowerCase() ?? "";
+  return program.length > 0 ? program : null;
 }
 
 export const ShellApproval: Component = () => {
@@ -38,42 +52,103 @@ export const ShellApproval: Component = () => {
     });
   });
 
-  const handleApprove = async () => {
+  /** Emit the decision and dismiss; idempotent against double clicks. */
+  const settle = async (outcome: {
+    approved: boolean;
+    skipped?: boolean;
+  }): Promise<boolean> => {
     const req = request();
-    if (!req || isProcessing()) return;
+    if (!req || isProcessing()) return false;
 
     setIsProcessing(true);
-    console.log("[ShellApproval] Approving command:", req.approvalId);
-
     try {
       await emit("shell-command-approval-response", {
         id: req.approvalId,
-        approved: true,
+        approved: outcome.approved,
+        skipped: outcome.skipped ?? false,
       });
       setRequest(null);
+      return true;
     } catch (err) {
-      console.error("[ShellApproval] Failed to emit approval:", err);
+      console.error("[ShellApproval] Failed to emit decision:", err);
       setIsProcessing(false);
+      return false;
     }
   };
 
+  const handleApprove = async () => {
+    console.log("[ShellApproval] Approving command:", request()?.approvalId);
+    await settle({ approved: true });
+  };
+
   const handleDeny = async () => {
+    console.log("[ShellApproval] Denying command:", request()?.approvalId);
+    await settle({ approved: false });
+  };
+
+  const handleSkip = async () => {
+    console.log("[ShellApproval] Skipping command:", request()?.approvalId);
+    await settle({ approved: false, skipped: true });
+  };
+
+  const handleStopTask = async () => {
     const req = request();
+    const threadId = req?.threadId ?? conversationStore.activeConversationId;
+    console.log("[ShellApproval] Stopping task for:", req?.approvalId);
+    const settled = await settle({ approved: false });
+    if (settled && threadId) {
+      try {
+        await cancelOrchestration(threadId);
+      } catch (err) {
+        console.error("[ShellApproval] Failed to stop task:", err);
+      }
+    }
+  };
+
+  const leaseProgram = () => {
+    const req = request();
+    return req ? commandProgram(req.command) : null;
+  };
+
+  const leaseSummary = () => {
+    const program = leaseProgram();
+    return program ? `"${program}" commands` : "this command";
+  };
+
+  /**
+   * Grant a reviewed command-rule lease for this task (keyed on the leading
+   * program, matching the gate), then approve this call. A failed grant still
+   * approves once — the conservative subset of the user's intent.
+   */
+  const handleApproveForTask = async (
+    durationSecs: number,
+    maxCalls: number,
+  ) => {
+    const req = request();
+    const program = leaseProgram();
     if (!req || isProcessing()) return;
 
-    setIsProcessing(true);
-    console.log("[ShellApproval] Denying command:", req.approvalId);
-
-    try {
-      await emit("shell-command-approval-response", {
-        id: req.approvalId,
-        approved: false,
-      });
-      setRequest(null);
-    } catch (err) {
-      console.error("[ShellApproval] Failed to emit denial:", err);
-      setIsProcessing(false);
+    if (program) {
+      const conversationId =
+        req.threadId ??
+        conversationStore.activeConversationId ??
+        "session-without-conversation";
+      try {
+        await grantCapabilityLease(
+          conversationId,
+          `Task lease: "${program}" commands`,
+          durationSecs,
+          { commandRules: [{ program }] },
+          { maxCalls },
+        );
+      } catch (err) {
+        console.error(
+          "[ShellApproval] Failed to grant task lease; approving once:",
+          err,
+        );
+      }
     }
+    await handleApprove();
   };
 
   return (
@@ -112,24 +187,18 @@ export const ShellApproval: Component = () => {
               </div>
             </div>
 
-            <div class="px-6 py-4 border-t border-border flex gap-3 justify-end">
-              <button
-                type="button"
-                class="px-6 py-2.5 text-[0.95rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-transparent text-foreground border border-border hover:bg-surface-1 hover:border-muted-foreground"
-                onClick={handleDeny}
-                disabled={isProcessing()}
-              >
-                Deny
-              </button>
-              <button
-                type="button"
-                class="px-6 py-2.5 text-[0.95rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-accent text-white hover:bg-primary-hover hover:shadow-[0_2px_8px_var(--primary-muted)]"
-                onClick={handleApprove}
-                disabled={isProcessing()}
-              >
-                {isProcessing() ? "Processing..." : "Approve"}
-              </button>
-            </div>
+            <ApprovalActions
+              isProcessing={isProcessing()}
+              approveOnceLabel={
+                isProcessing() ? "Processing..." : "Approve once"
+              }
+              leaseSummary={leaseSummary()}
+              onApproveOnce={handleApprove}
+              onApproveForTask={handleApproveForTask}
+              onDeny={handleDeny}
+              onSkip={handleSkip}
+              onStopTask={handleStopTask}
+            />
           </div>
         </div>
       )}

--- a/src/components/sidebar/EmployeesSection.tsx
+++ b/src/components/sidebar/EmployeesSection.tsx
@@ -27,6 +27,7 @@ import {
   employeeApprovals,
   type OrgPendingApprovalRun,
 } from "@/services/employee-approvals";
+import { pendingApprovalCount } from "@/stores/approvals.store";
 import { authStore } from "@/stores/auth.store";
 import { employeeStore } from "@/stores/employees.store";
 import { type Thread, threadStore } from "@/stores/thread.store";
@@ -238,6 +239,17 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
 
   const pendingCountFor = (deploymentId: string): number =>
     pendingByDeployment().get(deploymentId)?.length ?? 0;
+
+  // The global inbox badge: local-gate blocks (this device) + cloud operator
+  // approvals. Stays visible wherever the sidebar is, i.e. after navigating
+  // away from the blocked thread.
+  const inboxPendingTotal = createMemo(() => {
+    let cloud = 0;
+    for (const rows of pendingByDeployment().values()) {
+      cloud += rows.length;
+    }
+    return cloud + pendingApprovalCount();
+  });
 
   const handleSelect = (id: string) => {
     threadStore.setActiveThread(null);
@@ -506,6 +518,51 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
                   Persistent cloud worker
                 </div>
               </div>
+            </button>
+            <button
+              type="button"
+              class="thread-list-row group flex items-center gap-2.5 w-full px-2 py-1.5 rounded-md bg-transparent border-none text-left cursor-pointer transition-colors duration-100 hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2 focus-visible:ring-1 focus-visible:ring-primary/40"
+              onClick={() => props.onOpenInbox?.()}
+              aria-label={`Open approval inbox${inboxPendingTotal() > 0 ? `, ${inboxPendingTotal()} pending` : ""}`}
+              data-testid="sidebar-approval-inbox"
+            >
+              <span
+                class="flex items-center justify-center w-[22px] h-[22px] rounded-md border border-border/80 text-muted-foreground/80 transition-colors duration-100 group-hover:border-primary/50 group-hover:text-primary"
+                aria-hidden="true"
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M2 9.5V12a1.5 1.5 0 0 0 1.5 1.5h9A1.5 1.5 0 0 0 14 12V9.5M2 9.5h3l1 1.5h4l1-1.5h3M2 9.5l1.6-6A1.5 1.5 0 0 1 5.05 2.5h5.9a1.5 1.5 0 0 1 1.45 1l1.6 6"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <div class="flex-1 min-w-0">
+                <div class="thread-list-title text-muted-foreground truncate transition-colors duration-100 group-hover:text-foreground">
+                  Approval inbox
+                </div>
+                <div class="thread-list-meta text-muted-foreground/70 truncate">
+                  Blocked actions awaiting you
+                </div>
+              </div>
+              <Show when={inboxPendingTotal() > 0}>
+                <span
+                  class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500/20 border border-amber-500/40 text-amber-800 dark:text-amber-200 text-[10.5px] font-semibold leading-none"
+                  title={`${inboxPendingTotal()} pending approval${inboxPendingTotal() === 1 ? "" : "s"}`}
+                  aria-hidden="true"
+                >
+                  {inboxPendingTotal()}
+                </span>
+              </Show>
             </button>
           </Show>
         </div>

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -49,6 +49,8 @@ interface GatewayConnectionArgsResult {
 interface GatewayApprovalPrompt {
   description?: string;
   isDestructive?: boolean;
+  /** Host classification wire token (trusted-read/high-risk/unclassified). */
+  operationClass?: string;
 }
 
 /**
@@ -443,6 +445,7 @@ async function requestGatewayApproval(
         conversationStore.activeConversationId,
       description: prompt?.description ?? "Execute operation",
       isDestructive: prompt?.isDestructive ?? false,
+      operationClass: prompt?.operationClass,
       continuationId: link?.continuationId,
     });
   } catch (err) {
@@ -552,6 +555,7 @@ async function authorizeToolOperation(
     {
       description: decision.description,
       isDestructive: decision.isDestructive,
+      operationClass: decision.operationClass,
     },
     { threadId: sessionId, continuationId: registered?.approvalId },
   );

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -29,6 +29,16 @@ interface GatewayApprovalResult {
   /** True when the approval UI lapsed without a decision, so the block is an
    * explicit expiry rather than a user denial. */
   timedOut?: boolean;
+  /** True when the user chose "skip this action": the task continues without
+   * it, distinct from a denial and never persisted as one. */
+  skipped?: boolean;
+}
+
+/** Links an approval prompt to its host continuation and thread so the inline
+ * card and global inbox can identify (and settle) the exact suspended action. */
+interface ApprovalLink {
+  threadId: string | null;
+  continuationId?: string;
 }
 
 interface GatewayConnectionArgsResult {
@@ -411,6 +421,7 @@ async function requestGatewayApproval(
   args: Record<string, unknown>,
   conversationId: string | null,
   prompt?: GatewayApprovalPrompt,
+  link?: ApprovalLink,
 ): Promise<GatewayApprovalResult> {
   const approvalId = `gateway-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
@@ -426,9 +437,13 @@ async function requestGatewayApproval(
       publisherSlug,
       toolName,
       args,
-      threadId: conversationId ?? conversationStore.activeConversationId,
+      threadId:
+        link?.threadId ??
+        conversationId ??
+        conversationStore.activeConversationId,
       description: prompt?.description ?? "Execute operation",
       isDestructive: prompt?.isDestructive ?? false,
+      continuationId: link?.continuationId,
     });
   } catch (err) {
     console.error("[Tool Executor] Failed to emit approval request:", err);
@@ -444,21 +459,24 @@ async function requestGatewayApproval(
       resolve({ approved: false, timedOut: true });
     }, GATEWAY_APPROVAL_TIMEOUT_MS);
 
-    listen<{ id: string; approved: boolean; connectionId?: string | null }>(
-      "gateway-tool-approval-response",
-      (event) => {
-        if (event.payload.id !== approvalId) return;
-        console.log(
-          `[Tool Executor] Received approval response: ${event.payload.approved}`,
-        );
-        clearTimeout(timeout);
-        unlisten?.();
-        resolve({
-          approved: event.payload.approved,
-          connectionId: event.payload.connectionId ?? null,
-        });
-      },
-    )
+    listen<{
+      id: string;
+      approved: boolean;
+      connectionId?: string | null;
+      skipped?: boolean;
+    }>("gateway-tool-approval-response", (event) => {
+      if (event.payload.id !== approvalId) return;
+      console.log(
+        `[Tool Executor] Received approval response: ${event.payload.approved}`,
+      );
+      clearTimeout(timeout);
+      unlisten?.();
+      resolve({
+        approved: event.payload.approved,
+        connectionId: event.payload.connectionId ?? null,
+        skipped: event.payload.skipped ?? false,
+      });
+    })
       .then((fn) => {
         unlisten = fn;
       })
@@ -535,12 +553,14 @@ async function authorizeToolOperation(
       description: decision.description,
       isDestructive: decision.isDestructive,
     },
+    { threadId: sessionId, continuationId: registered?.approvalId },
   );
 
-  // Only an explicit choice is durable. An approval-UI timeout is an expiry, not
-  // a denial: persisting it would auto-deny the operation on the next attempt, so
-  // the decision store is left untouched and a later call re-prompts.
-  if (!approval.timedOut) {
+  // Only an explicit approve/deny is durable. A timeout is an expiry and a skip
+  // is a one-time "continue without this action" — persisting either would
+  // auto-deny the operation on the next attempt, so the decision store is left
+  // untouched and a later call re-prompts.
+  if (!approval.timedOut && !approval.skipped) {
     await recordAuthorizationDecision(
       route,
       publisherSlug,
@@ -557,11 +577,15 @@ async function authorizeToolOperation(
     return { approved: true, connectionId: approval.connectionId };
   }
 
-  const kind: BlockedKind = approval.timedOut ? "expired" : "denied";
+  const kind: BlockedKind = approval.timedOut
+    ? "expired"
+    : approval.skipped
+      ? "skipped"
+      : "denied";
   if (registered) {
     await settleApprovalContinuation(
       registered,
-      approval.timedOut ? "expire" : "deny",
+      approval.timedOut ? "expire" : approval.skipped ? "skip" : "deny",
     );
   }
   return {
@@ -588,7 +612,7 @@ async function authorizeSubprocess(
   command: string,
   conversationId: string | null,
   toolCallId: string,
-  runApprovalUi: () => Promise<GatewayApprovalResult>,
+  runApprovalUi: (link: ApprovalLink) => Promise<GatewayApprovalResult>,
 ): Promise<ToolAuthorization> {
   const sessionId = sessionConversationId(conversationId);
   const context: OperationContext = { command };
@@ -621,7 +645,10 @@ async function authorizeSubprocess(
     context,
     sessionId,
   );
-  const outcome = await runApprovalUi();
+  const outcome = await runApprovalUi({
+    threadId: sessionId,
+    continuationId: registered?.approvalId,
+  });
 
   if (outcome.approved) {
     if (registered) {
@@ -630,11 +657,15 @@ async function authorizeSubprocess(
     return { approved: true };
   }
 
-  const kind: BlockedKind = outcome.timedOut ? "expired" : "denied";
+  const kind: BlockedKind = outcome.timedOut
+    ? "expired"
+    : outcome.skipped
+      ? "skipped"
+      : "denied";
   if (registered) {
     await settleApprovalContinuation(
       registered,
-      outcome.timedOut ? "expire" : "deny",
+      outcome.timedOut ? "expire" : outcome.skipped ? "skip" : "deny",
     );
   }
   return {
@@ -687,6 +718,7 @@ async function resolveGatewayOAuthConnectionArgs(
 async function requestShellApproval(
   command: string,
   timeoutSecs: number,
+  link?: ApprovalLink,
 ): Promise<GatewayApprovalResult> {
   const approvalId = `shell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
@@ -699,6 +731,8 @@ async function requestShellApproval(
       approvalId,
       command,
       timeoutSecs,
+      threadId: link?.threadId ?? conversationStore.activeConversationId,
+      continuationId: link?.continuationId,
     });
   } catch (err) {
     console.error(
@@ -716,7 +750,7 @@ async function requestShellApproval(
       resolve({ approved: false, timedOut: true });
     }, SHELL_APPROVAL_TIMEOUT_MS);
 
-    listen<{ id: string; approved: boolean }>(
+    listen<{ id: string; approved: boolean; skipped?: boolean }>(
       "shell-command-approval-response",
       (event) => {
         if (event.payload.id !== approvalId) return;
@@ -725,7 +759,10 @@ async function requestShellApproval(
         );
         clearTimeout(timeout);
         unlisten?.();
-        resolve({ approved: event.payload.approved });
+        resolve({
+          approved: event.payload.approved,
+          skipped: event.payload.skipped ?? false,
+        });
       },
     )
       .then((fn) => {
@@ -885,7 +922,7 @@ export async function executeTool(
           command,
           conversationId,
           toolCall.id,
-          () => requestShellApproval(command, timeoutSecs),
+          (link) => requestShellApproval(command, timeoutSecs, link),
         );
         if (!auth.approved) {
           return auth.toolResult;
@@ -943,7 +980,7 @@ export async function executeTool(
           argv.join(" "),
           conversationId,
           toolCall.id,
-          () => requestShellApproval(preview, timeoutSecs),
+          (link) => requestShellApproval(preview, timeoutSecs, link),
         );
         if (!auth.approved) {
           return auth.toolResult;

--- a/src/services/tool-authorization.ts
+++ b/src/services/tool-authorization.ts
@@ -1,0 +1,206 @@
+// ABOUTME: Renderer bridge for the host-owned tool-authorization gate: capability leases,
+// ABOUTME: suspended approval continuations, task execution state, and the audit trail.
+
+import { invoke } from "@tauri-apps/api/core";
+
+/** Mirrors `CommandRule` in `src-tauri/src/capability_lease.rs`. */
+export interface CommandRule {
+  program: string;
+}
+
+/** Mirrors `PublisherRule` in `src-tauri/src/capability_lease.rs`. */
+export interface PublisherRule {
+  publisherSlug: string;
+  allowHighRisk?: boolean;
+  target?: string | null;
+}
+
+/** Mirrors `Exclusion` in `src-tauri/src/capability_lease.rs`. */
+export interface LeaseExclusion {
+  route?: string;
+  publisherSlug?: string;
+  toolName?: string;
+  host?: string;
+  program?: string;
+}
+
+/** Mirrors `LeasePredicates` in `src-tauri/src/capability_lease.rs`. */
+export interface LeasePredicates {
+  commandRules?: CommandRule[];
+  networkHosts?: string[];
+  publisherOps?: PublisherRule[];
+  exclusions?: LeaseExclusion[];
+}
+
+/** Mirrors `LeaseBudgets` in `src-tauri/src/capability_lease.rs`. */
+export interface LeaseBudgets {
+  maxCalls?: number | null;
+  callsUsed?: number;
+  maxSpendMicros?: number | null;
+  spendUsedMicros?: number;
+  asset?: string | null;
+}
+
+/** Mirrors `CapabilityLease` in `src-tauri/src/capability_lease.rs`. */
+export interface CapabilityLease {
+  id: string;
+  conversationId: string;
+  label: string;
+  createdAt: string;
+  expiresAt: string;
+  revoked: boolean;
+  predicates: LeasePredicates;
+  budgets: LeaseBudgets;
+}
+
+/** Task states from `src-tauri/src/orchestrator/types.rs` (`TaskExecutionState`). */
+export type TaskExecutionState =
+  | "running"
+  | "running_with_blocked_actions"
+  | "waiting_for_approval"
+  | "approval_denied"
+  | "approval_expired"
+  | "action_skipped";
+
+export type ContinuationState =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "skipped"
+  | "expired";
+
+/** Mirrors `RequestedCapability` in `src-tauri/src/approval_continuation.rs`. */
+export interface RequestedCapability {
+  route: string;
+  publisherSlug: string;
+  toolName: string;
+  operationClass: string;
+  description: string;
+  isDestructive: boolean;
+  command?: string;
+  host?: string;
+  target?: string;
+}
+
+/** Mirrors `ContinuationView` — a redacted continuation (never a resume token). */
+export interface ContinuationView {
+  approvalId: string;
+  taskId: string;
+  blockedScope: "linear" | "branch";
+  state: ContinuationState;
+  taskState: TaskExecutionState;
+  requestedCapability: RequestedCapability;
+  createdAt: string;
+  expiresAt: string;
+  resolvedAt?: string;
+}
+
+/** Mirrors `ResolutionSummary` in `src-tauri/src/approval_continuation.rs`. */
+export interface ResolutionSummary {
+  unresolved: number;
+  approved: number;
+  denied: number;
+  skipped: number;
+  expired: number;
+}
+
+/** Mirrors `AuditEntry` in `src-tauri/src/authorization_audit.rs`. */
+export interface AuthorizationAuditEntry {
+  id: number;
+  conversationId: string;
+  event: string;
+  subjectId?: string;
+  route?: string;
+  publisherSlug?: string;
+  toolName?: string;
+  detail?: string;
+  createdAt: string;
+}
+
+/** Mirrors `ProposedBundle` in `src-tauri/src/capability_lease.rs`. */
+export interface ProposedBundle {
+  label: string;
+  durationSecs: number;
+  predicates: LeasePredicates;
+  budgets: LeaseBudgets;
+}
+
+/** Every capability lease bound to a conversation, newest first. */
+export async function listCapabilityLeases(
+  conversationId: string,
+): Promise<CapabilityLease[]> {
+  return invoke<CapabilityLease[]>("list_capability_leases", {
+    conversationId,
+  });
+}
+
+/**
+ * Revoke a lease immediately; the gate stops honoring it on the next
+ * evaluation. Idempotent — resolves to whether this call changed anything.
+ */
+export async function revokeCapabilityLease(leaseId: string): Promise<boolean> {
+  return invoke<boolean>("revoke_capability_lease", { leaseId });
+}
+
+/**
+ * Persist a user-approved lease. Only ever invoked from approval UI a human
+ * drives — model output cannot mint or widen authority.
+ */
+export async function grantCapabilityLease(
+  conversationId: string,
+  label: string,
+  durationSecs: number,
+  predicates: LeasePredicates,
+  budgets: LeaseBudgets,
+): Promise<CapabilityLease> {
+  return invoke<CapabilityLease>("grant_capability_lease", {
+    conversationId,
+    label,
+    durationSecs,
+    predicates,
+    budgets,
+  });
+}
+
+/** Every continuation for a conversation (pending and settled), for inspection. */
+export async function listApprovalContinuations(
+  conversationId: string,
+): Promise<ContinuationView[]> {
+  return invoke<ContinuationView[]>("list_approval_continuations", {
+    conversationId,
+  });
+}
+
+/** Every live pending approval across all conversations — the global inbox. */
+export async function listPendingApprovals(): Promise<ContinuationView[]> {
+  return invoke<ContinuationView[]>("list_pending_approvals");
+}
+
+/** The live task-execution state for a conversation. */
+export async function taskExecutionState(
+  conversationId: string,
+): Promise<TaskExecutionState> {
+  return invoke<TaskExecutionState>("task_execution_state", {
+    conversationId,
+  });
+}
+
+/** Outcome counts backing completion integrity and the final disclosure. */
+export async function approvalResolutionSummary(
+  conversationId: string,
+): Promise<ResolutionSummary> {
+  return invoke<ResolutionSummary>("approval_resolution_summary", {
+    conversationId,
+  });
+}
+
+/** The newest audit rows for a conversation (credential-safe by construction). */
+export async function listAuthorizationAudit(
+  conversationId: string,
+  limit?: number,
+): Promise<AuthorizationAuditEntry[]> {
+  return invoke<AuthorizationAuditEntry[]>("list_authorization_audit", {
+    conversationId,
+    limit,
+  });
+}

--- a/src/stores/approvals.store.ts
+++ b/src/stores/approvals.store.ts
@@ -1,0 +1,287 @@
+// ABOUTME: Global approval-inbox state: live in-renderer approval requests, host-persisted
+// ABOUTME: pending continuations, per-thread blocked status, and the deduplicated background notification.
+
+import { emit, listen } from "@tauri-apps/api/event";
+import { createStore, reconcile } from "solid-js/store";
+import {
+  type ContinuationView,
+  listPendingApprovals,
+} from "@/services/tool-authorization";
+
+/**
+ * A live approval request whose executor promise is still waiting in this
+ * renderer. Holds only display-safe fields — never the raw tool arguments.
+ * `continuationId` links it to the host's suspended continuation when the host
+ * was reachable at registration time.
+ */
+export interface LiveApprovalRequest {
+  requestId: string;
+  kind: "gateway" | "shell";
+  publisherSlug?: string;
+  toolName?: string;
+  command?: string;
+  threadId: string | null;
+  description: string;
+  isDestructive: boolean;
+  continuationId?: string;
+  receivedAt: number;
+}
+
+interface GatewayApprovalRequestPayload {
+  approvalId: string;
+  publisherSlug: string;
+  toolName: string;
+  threadId: string | null;
+  description: string;
+  isDestructive: boolean;
+  continuationId?: string;
+}
+
+interface ShellApprovalRequestPayload {
+  approvalId: string;
+  command: string;
+  timeoutSecs: number;
+  threadId?: string | null;
+  continuationId?: string;
+}
+
+interface StoreShape {
+  live: LiveApprovalRequest[];
+  pending: ContinuationView[];
+}
+
+/** Live requests outlive the executor's 5-minute window only by this margin. */
+const LIVE_REQUEST_MAX_AGE_MS = 6 * 60 * 1000;
+
+/** How often to re-read host state while anything is pending (observes TTL expiry). */
+const PENDING_REFRESH_INTERVAL_MS = 60 * 1000;
+
+const [state, setState] = createStore<StoreShape>({ live: [], pending: [] });
+
+/**
+ * Pending capability requests already notified this session. The host dedups
+ * equivalent retries to one continuation, so keying on its id yields at most
+ * one desktop notification per pending capability request.
+ */
+const notifiedApprovalIds = new Set<string>();
+
+let initialized = false;
+
+/** Every live pending approval across all conversations, oldest first. */
+export function pendingApprovals(): ContinuationView[] {
+  return state.pending;
+}
+
+/** The global badge count. */
+export function pendingApprovalCount(): number {
+  return state.pending.length;
+}
+
+/** Live (resolvable-in-this-renderer) requests, oldest first. */
+export function liveApprovalRequests(): LiveApprovalRequest[] {
+  return state.live;
+}
+
+/** Host-pending approvals bound to one conversation. */
+export function pendingForConversation(
+  conversationId: string,
+): ContinuationView[] {
+  return state.pending.filter((view) => view.taskId === conversationId);
+}
+
+/** The live request that can settle a given continuation, if this renderer holds it. */
+export function liveRequestForContinuation(
+  approvalId: string,
+): LiveApprovalRequest | undefined {
+  return state.live.find((request) => request.continuationId === approvalId);
+}
+
+/**
+ * The persistent thread status label for a conversation, or null when nothing
+ * is blocked. Linear blocks suspend the whole turn ("Waiting for approval");
+ * branch-only blocks keep unrelated work running ("N actions blocked").
+ */
+export function threadApprovalStatus(conversationId: string): string | null {
+  const pending = pendingForConversation(conversationId);
+  if (pending.length === 0) return null;
+  if (pending.some((view) => view.blockedScope === "linear")) {
+    return "Waiting for approval";
+  }
+  return pending.length === 1
+    ? "1 action blocked"
+    : `${pending.length} actions blocked`;
+}
+
+/** Re-read host-pending approvals; prune lapsed live requests as a side effect. */
+export async function refreshPendingApprovals(): Promise<void> {
+  try {
+    const pending = await listPendingApprovals();
+    setState("pending", reconcile(pending));
+    const cutoff = Date.now() - LIVE_REQUEST_MAX_AGE_MS;
+    setState("live", (live) =>
+      live.filter((request) => request.receivedAt >= cutoff),
+    );
+    maybeNotifyBackgrounded(pending);
+  } catch (err) {
+    console.error(
+      "[Approvals Store] Failed to refresh pending approvals:",
+      err,
+    );
+  }
+}
+
+/**
+ * Settle a live approval request. `skipped` distinguishes "skip this action"
+ * from a denial so the model receives a distinct, adaptable outcome.
+ */
+export async function respondToApproval(
+  request: LiveApprovalRequest,
+  outcome: {
+    approved: boolean;
+    skipped?: boolean;
+    connectionId?: string | null;
+  },
+): Promise<void> {
+  const channel =
+    request.kind === "gateway"
+      ? "gateway-tool-approval-response"
+      : "shell-command-approval-response";
+  try {
+    await emit(channel, {
+      id: request.requestId,
+      approved: outcome.approved,
+      skipped: outcome.skipped ?? false,
+      connectionId: outcome.connectionId ?? null,
+    });
+  } catch (err) {
+    console.error("[Approvals Store] Failed to emit approval response:", err);
+    return;
+  }
+  setState("live", (live) =>
+    live.filter((entry) => entry.requestId !== request.requestId),
+  );
+  // The executor settles the host continuation after the response round-trip;
+  // refresh twice so the badge and thread status converge without a reload.
+  setTimeout(() => void refreshPendingApprovals(), 300);
+  setTimeout(() => void refreshPendingApprovals(), 1500);
+}
+
+function addLiveRequest(request: LiveApprovalRequest): void {
+  setState("live", (live) => [
+    ...live.filter((entry) => entry.requestId !== request.requestId),
+    request,
+  ]);
+}
+
+function removeLiveRequest(requestId: string): void {
+  setState("live", (live) =>
+    live.filter((entry) => entry.requestId !== requestId),
+  );
+}
+
+function isBackgrounded(): boolean {
+  return document.hidden || !document.hasFocus();
+}
+
+/**
+ * One privacy-safe desktop notification per pending capability request, only
+ * while the app is backgrounded. The body deliberately names nothing about the
+ * operation — details stay in the app.
+ */
+function maybeNotifyBackgrounded(pending: ContinuationView[]): void {
+  if (!isBackgrounded()) return;
+  const unnotified = pending.filter(
+    (view) => !notifiedApprovalIds.has(view.approvalId),
+  );
+  if (unnotified.length === 0) return;
+  for (const view of unnotified) {
+    notifiedApprovalIds.add(view.approvalId);
+  }
+  void showApprovalNotification();
+}
+
+async function showApprovalNotification(): Promise<void> {
+  try {
+    if (typeof Notification === "undefined") return;
+    const title = "Approval needed";
+    const body = "Seren is waiting for your approval to continue a task.";
+    if (Notification.permission === "granted") {
+      new Notification(title, { body });
+      return;
+    }
+    if (Notification.permission !== "denied") {
+      const permission = await Notification.requestPermission();
+      if (permission === "granted") {
+        new Notification(title, { body });
+      }
+    }
+  } catch (err) {
+    console.warn("[Approvals Store] Failed to show notification:", err);
+  }
+}
+
+/**
+ * Wire the store to the executor's approval events and the host store. Safe to
+ * call more than once; only the first call registers listeners.
+ */
+export async function initializeApprovalsStore(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  await listen<GatewayApprovalRequestPayload>(
+    "gateway-tool-approval-request",
+    (event) => {
+      addLiveRequest({
+        requestId: event.payload.approvalId,
+        kind: "gateway",
+        publisherSlug: event.payload.publisherSlug,
+        toolName: event.payload.toolName,
+        threadId: event.payload.threadId,
+        description: event.payload.description,
+        isDestructive: event.payload.isDestructive,
+        continuationId: event.payload.continuationId,
+        receivedAt: Date.now(),
+      });
+      void refreshPendingApprovals();
+    },
+  );
+
+  await listen<ShellApprovalRequestPayload>(
+    "shell-command-approval-request",
+    (event) => {
+      addLiveRequest({
+        requestId: event.payload.approvalId,
+        kind: "shell",
+        command: event.payload.command,
+        threadId: event.payload.threadId ?? null,
+        description: "Run shell command",
+        isDestructive: true,
+        continuationId: event.payload.continuationId,
+        receivedAt: Date.now(),
+      });
+      void refreshPendingApprovals();
+    },
+  );
+
+  for (const channel of [
+    "gateway-tool-approval-response",
+    "shell-command-approval-response",
+  ]) {
+    await listen<{ id: string }>(channel, (event) => {
+      removeLiveRequest(event.payload.id);
+      setTimeout(() => void refreshPendingApprovals(), 300);
+    });
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) void refreshPendingApprovals();
+  });
+
+  setInterval(() => {
+    if (state.pending.length > 0 || state.live.length > 0) {
+      void refreshPendingApprovals();
+    }
+  }, PENDING_REFRESH_INTERVAL_MS);
+
+  await refreshPendingApprovals();
+}


### PR DESCRIPTION
Closes #3264 (slice **D** of epic #3193).

## What this delivers

The user-facing half of #3193 §7 (visible blocked state + inline/inbox surfaces) and all of §8 (auditable decisions + lease inspect/revoke), built **additively** on the slice-A/B/C host gate so the proven `authorize()` decision core and the security-critical approval modals are left intact.

### Rust — authorization audit trail (`authorization_audit.rs`)
- Append-only `authorization_audit` table recording lease **grant / use / deny / expiry / revoke**, approval **request / approve / deny / skip / expire**, and durable session **decisions**.
- Rows carry identity only (route, publisher/tool, lease id, a credential-safe `detail`) — the `detail` is the leading **program token** (`echo`, `cargo`), the **host**, the **resource target**, or the reviewed **lease label**. Never a full command line, arguments, or credentials.
- New commands: `list_authorization_audit` (per-conversation) and `list_pending_approvals` (cross-conversation — backs the global inbox + badge that stay visible after navigating away). `wipe()` clears the audit table too.

### Frontend
- `services/tool-authorization.ts` — the missing renderer bridge for the gate commands (leases, continuations, task state, audit).
- `stores/approvals.store.ts` — live in-renderer requests + host-pending continuations, per-thread blocked status, and a **deduplicated, privacy-safe** background notification (Web `Notification` API — no new dependency).
- **Five-action** approval surfaces via a shared `ApprovalActions` footer on both the Gateway and Shell modals **and** a new inline `ApprovalRequestCard`: **Approve once / Approve for this task** (reviewed duration + call-budget → `grant_capability_lease`) **/ Deny / Skip action / Stop task**. A skip settles as `skipped` (distinct from a denial, never persisted as one).
- Inline card at the timeline suspension point; persistent **thread status** strip ("Waiting for approval" / "N actions blocked") with a capability inspect/**revoke** panel + audit history; a **Local approvals** section in the inbox with jump-to-thread; and a sidebar **inbox entry with a combined local+cloud pending badge** (the inbox previously had no visible trigger).

## Networked path trace

Every surface talks only to the **host gate over Tauri IPC** (`invoke`) — no new outbound publisher/API slugs. Verified the commands are registered in `src-tauri/src/lib.rs`: `list_capability_leases`, `revoke_capability_lease`, `grant_capability_lease`, `list_approval_continuations`, `list_pending_approvals`, `list_authorization_audit`, `task_execution_state`. **There is no new networked/publisher path in this slice** — leases and audit are entirely local SQLite in `tool_authorization.db`.

## Validation — real system, no mocks

**Static:** `cargo test --lib` **1100 pass** (8 new audit tests over the real SQLite store, incl. a credential-safety assertion that a secret-bearing command never reaches the audit row). `pnpm test` **2708 pass**. `tsc` + Biome at parity with `main`.

**Live in-app walkthrough** — real signed-in build (isolated validation instance), real Opus tool calls, driven end to end:
- Real `execute_command` block surfaced the modal (five actions), the inline card, the "Waiting for approval" status, the sidebar badge (count 1), and the inbox "This device" section — simultaneously.
- **Approve for this task** granted a lease; a **second** matching command then ran with **no prompt** — silent reuse confirmed at the gate (`callsUsed=2`, two `lease_used` rows, zero intervening `approval_requested`).
- **Revoke now** → the next matching command **re-prompted immediately** (revocation effective on the next gate evaluation).
- **Skip** and **Deny** each returned a distinct, correct outcome to the agent ("The user skipped this action…" vs "The command was denied…").
- Deciding from the inline card **auto-dismisses** the modal (regression found + fixed in the walkthrough).
- Cross-session pending request renders **read-only** with its auto-expiry time.

**Audit DB proof** (real `tool_authorization.db`, credential-safe by construction):
```
id  event               detail
20  lease_used          echo
19  lease_used          echo
18  approval_approved
17  lease_granted       Task lease: "echo" commands
16  approval_requested
 5  lease_revoked       Task lease: "echo" commands
 4  lease_used          echo
 3  approval_approved
 2  lease_granted       Task lease: "echo" commands
 1  approval_requested
```
The only `detail` values ever written across the whole run were `echo` (program token) and `Task lease: "echo" commands` (reviewed label). Hard leak scan for command text/flags/args: **0**.

## Known environmental limit (disclosed, not mocked)

The background desktop **notification code path executes and dedups**, but the OS banner could not be visually observed in the validation sandbox: `Notification.permission === "denied"` for that bundle id, so `new Notification()` cannot display there. The "at most one per pending request" guarantee rests on the host deduping equivalent retries to one continuation (unit-tested, no mocks) plus a per-`approvalId` notified-set in the renderer. In a real install permission is `default` → prompted. Not validated further here; flagged rather than signed off on a mock.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
