### PR TITLE
refactor(agent): extract bootstrap-context helpers (#3250)

### DIFF
--- a/src/lib/agent/bootstrap-context.ts
+++ b/src/lib/agent/bootstrap-context.ts
@@ -1,0 +1,201 @@
+// ABOUTME: Pure prompt-text builders for fork and dropped-prompt-recovery bootstraps.
+// ABOUTME: Behavior-preserving extraction from agent.store; no store state closure.
+
+import type { ActiveSession, AgentMessage } from "@/stores/agent.store";
+
+const FORK_BOOTSTRAP_MAX_MSG_CHARS = 2_000;
+
+export function agentDisplayName(agentType?: string): string {
+  switch (agentType) {
+    case "codex":
+      return "Codex";
+    case "claude-code":
+      return "Claude Code";
+    case "gemini":
+      return "Gemini";
+    case "grok":
+      return "Grok";
+    case "claude-codex":
+      return "Claude + Codex";
+    case "lmstudio":
+      return "LM Studio";
+    default:
+      return agentType ?? "Agent";
+  }
+}
+
+export function agentInitializationFailureMessage(agentType?: string): string {
+  const agentName = agentDisplayName(agentType);
+  const remediation =
+    agentType === "codex"
+      ? "Codex is installed and signed in"
+      : agentType === "gemini"
+        ? "Gemini is installed and signed in"
+        : agentType === "grok"
+          ? "Grok is installed and signed in"
+          : agentType === "lmstudio"
+            ? "LM Studio is running and reachable"
+            : agentType === "claude-codex"
+              ? "Claude Code and Codex are installed and signed in"
+              : `${agentName} is installed and authenticated`;
+
+  return `Agent session terminated before initialization completed. Check that ${remediation}.`;
+}
+
+function truncateBootstrapText(content: string): string {
+  return content.length > FORK_BOOTSTRAP_MAX_MSG_CHARS
+    ? `${content.slice(0, FORK_BOOTSTRAP_MAX_MSG_CHARS)}... [truncated]`
+    : content;
+}
+
+function formatForkBootstrapMessage(message: AgentMessage): string | null {
+  const content = message.content.trim();
+
+  switch (message.type) {
+    case "user":
+      return content ? `USER: ${truncateBootstrapText(content)}` : null;
+    case "assistant":
+      return content ? `ASSISTANT: ${truncateBootstrapText(content)}` : null;
+    case "error":
+      return content ? `SYSTEM: ${truncateBootstrapText(content)}` : null;
+    case "tool": {
+      const label = message.toolCall?.status
+        ? `TOOL (${message.toolCall.status})`
+        : "TOOL";
+      return content ? `${label}: ${truncateBootstrapText(content)}` : null;
+    }
+    case "diff": {
+      const path = message.diff?.path;
+      const summary = path ? `Modified ${path}` : content;
+      return summary ? `DIFF: ${truncateBootstrapText(summary)}` : null;
+    }
+    case "handoff":
+      return content ? `SYSTEM: ${truncateBootstrapText(content)}` : null;
+    case "thought":
+      return null;
+  }
+}
+
+export function buildForkBootstrapContext(
+  session: ActiveSession,
+  messages: AgentMessage[],
+): string | null {
+  const summary = session.compactedSummary?.content.trim();
+  const transcript = messages
+    .map(formatForkBootstrapMessage)
+    .filter((line): line is string => Boolean(line))
+    .join("\n\n");
+
+  if (!summary && !transcript) {
+    return null;
+  }
+
+  const sections = [
+    "This prompt continues a forked branch of an earlier coding-agent conversation.",
+    "Treat the summary and transcript below as the authoritative history for this branch.",
+    "Anything that happened after the branch point is not part of this branch.",
+  ];
+
+  if (summary) {
+    sections.push(`Earlier summary:\n${summary}`);
+  }
+
+  if (transcript) {
+    sections.push(`Branch transcript:\n${transcript}`);
+  }
+
+  sections.push(
+    "Continue from the branch transcript's final message. Do not mention this bootstrap unless it helps answer the user.",
+  );
+
+  return sections.join("\n\n");
+}
+
+export function isSessionDeathMessage(message: string): boolean {
+  return (
+    message.includes("Session terminated") ||
+    message.includes("stopped before request completed") ||
+    message.includes("stopped while prompt was active") ||
+    message.includes("Worker thread dropped")
+  );
+}
+
+export function isRecoverableDeadSessionSendFailure(message: string): boolean {
+  if (message.includes("Task cancelled")) {
+    return false;
+  }
+  return (
+    message.includes("unresponsive") ||
+    message.includes("Worker thread dropped") ||
+    message.includes("not found") ||
+    message.includes("Session not initialized")
+  );
+}
+
+export function filterDroppedPromptRecoveryMessages(
+  messages: AgentMessage[],
+): AgentMessage[] {
+  return messages.filter((message) => {
+    if (message.type !== "error") {
+      return true;
+    }
+    return (
+      !message.content.includes("unresponsive") &&
+      !isSessionDeathMessage(message.content)
+    );
+  });
+}
+
+export function mergeRecoveryMessages(
+  liveMessages: AgentMessage[],
+  persistedMessages: AgentMessage[],
+): AgentMessage[] {
+  const byId = new Map<string, AgentMessage>();
+  for (const message of persistedMessages) {
+    byId.set(message.id, message);
+  }
+  for (const message of liveMessages) {
+    byId.set(message.id, message);
+  }
+  return [...byId.values()].sort((a, b) => a.timestamp - b.timestamp);
+}
+
+export function buildDroppedPromptRecoveryBootstrapContext(
+  session: ActiveSession,
+  messages: AgentMessage[],
+  reason: string,
+  persistedContext: string,
+): string | null {
+  const summary = session.compactedSummary?.content.trim();
+  const transcript = messages
+    .map(formatForkBootstrapMessage)
+    .filter((line): line is string => Boolean(line))
+    .join("\n\n");
+
+  if (!summary && !transcript && !persistedContext.trim()) {
+    return null;
+  }
+
+  const sections = [
+    "Seren Desktop restarted the coding-agent worker while a prompt was active.",
+    `Recovery reason: ${truncateBootstrapText(reason)}`,
+    "Use the recovered history below as authoritative context for the restarted worker.",
+    "The user's original prompt will be replayed automatically after this context; do not ask the user to type continue.",
+  ];
+
+  if (summary) {
+    sections.push(`Earlier summary:\n${summary}`);
+  }
+
+  if (transcript) {
+    sections.push(`Recovered transcript:\n${transcript}`);
+  } else if (persistedContext.trim()) {
+    sections.push(`Persisted transcript fallback:\n${persistedContext}`);
+  }
+
+  sections.push(
+    "Continue the interrupted task from the recovered context and the replayed prompt.",
+  );
+
+  return sections.join("\n\n");
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5,6 +5,16 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createEffect, createRoot } from "solid-js";
 import { produce } from "solid-js/store";
 import {
+  agentDisplayName,
+  agentInitializationFailureMessage,
+  buildDroppedPromptRecoveryBootstrapContext,
+  buildForkBootstrapContext,
+  filterDroppedPromptRecoveryMessages,
+  isRecoverableDeadSessionSendFailure,
+  isSessionDeathMessage,
+  mergeRecoveryMessages,
+} from "@/lib/agent/bootstrap-context";
+import {
   applyPrunedAgentMessages,
   buildAgentCompactionPrepend,
   type CompactAgentResult,
@@ -89,6 +99,9 @@ import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 
+// Bootstrap-context helpers live in @/lib/agent/bootstrap-context.
+// Re-exported so existing importers keep the unchanged public surface.
+export { agentDisplayName } from "@/lib/agent/bootstrap-context";
 // Compaction helpers live in @/lib/agent/compaction.
 // Re-exported so existing importers keep the unchanged public surface.
 export {
@@ -1302,149 +1315,6 @@ export interface ActiveSession {
 // Agent message persistence helpers
 // ============================================================================
 
-const FORK_BOOTSTRAP_MAX_MSG_CHARS = 2_000;
-
-export function agentDisplayName(agentType?: string): string {
-  switch (agentType) {
-    case "codex":
-      return "Codex";
-    case "claude-code":
-      return "Claude Code";
-    case "gemini":
-      return "Gemini";
-    case "grok":
-      return "Grok";
-    case "claude-codex":
-      return "Claude + Codex";
-    case "lmstudio":
-      return "LM Studio";
-    default:
-      return agentType ?? "Agent";
-  }
-}
-
-function agentInitializationFailureMessage(agentType?: string): string {
-  const agentName = agentDisplayName(agentType);
-  const remediation =
-    agentType === "codex"
-      ? "Codex is installed and signed in"
-      : agentType === "gemini"
-        ? "Gemini is installed and signed in"
-        : agentType === "grok"
-          ? "Grok is installed and signed in"
-          : agentType === "lmstudio"
-            ? "LM Studio is running and reachable"
-            : agentType === "claude-codex"
-              ? "Claude Code and Codex are installed and signed in"
-              : `${agentName} is installed and authenticated`;
-
-  return `Agent session terminated before initialization completed. Check that ${remediation}.`;
-}
-
-function truncateBootstrapText(content: string): string {
-  return content.length > FORK_BOOTSTRAP_MAX_MSG_CHARS
-    ? `${content.slice(0, FORK_BOOTSTRAP_MAX_MSG_CHARS)}... [truncated]`
-    : content;
-}
-
-function formatForkBootstrapMessage(message: AgentMessage): string | null {
-  const content = message.content.trim();
-
-  switch (message.type) {
-    case "user":
-      return content ? `USER: ${truncateBootstrapText(content)}` : null;
-    case "assistant":
-      return content ? `ASSISTANT: ${truncateBootstrapText(content)}` : null;
-    case "error":
-      return content ? `SYSTEM: ${truncateBootstrapText(content)}` : null;
-    case "tool": {
-      const label = message.toolCall?.status
-        ? `TOOL (${message.toolCall.status})`
-        : "TOOL";
-      return content ? `${label}: ${truncateBootstrapText(content)}` : null;
-    }
-    case "diff": {
-      const path = message.diff?.path;
-      const summary = path ? `Modified ${path}` : content;
-      return summary ? `DIFF: ${truncateBootstrapText(summary)}` : null;
-    }
-    case "handoff":
-      return content ? `SYSTEM: ${truncateBootstrapText(content)}` : null;
-    case "thought":
-      return null;
-  }
-}
-
-function buildForkBootstrapContext(
-  session: ActiveSession,
-  messages: AgentMessage[],
-): string | null {
-  const summary = session.compactedSummary?.content.trim();
-  const transcript = messages
-    .map(formatForkBootstrapMessage)
-    .filter((line): line is string => Boolean(line))
-    .join("\n\n");
-
-  if (!summary && !transcript) {
-    return null;
-  }
-
-  const sections = [
-    "This prompt continues a forked branch of an earlier coding-agent conversation.",
-    "Treat the summary and transcript below as the authoritative history for this branch.",
-    "Anything that happened after the branch point is not part of this branch.",
-  ];
-
-  if (summary) {
-    sections.push(`Earlier summary:\n${summary}`);
-  }
-
-  if (transcript) {
-    sections.push(`Branch transcript:\n${transcript}`);
-  }
-
-  sections.push(
-    "Continue from the branch transcript's final message. Do not mention this bootstrap unless it helps answer the user.",
-  );
-
-  return sections.join("\n\n");
-}
-
-function isSessionDeathMessage(message: string): boolean {
-  return (
-    message.includes("Session terminated") ||
-    message.includes("stopped before request completed") ||
-    message.includes("stopped while prompt was active") ||
-    message.includes("Worker thread dropped")
-  );
-}
-
-function isRecoverableDeadSessionSendFailure(message: string): boolean {
-  if (message.includes("Task cancelled")) {
-    return false;
-  }
-  return (
-    message.includes("unresponsive") ||
-    message.includes("Worker thread dropped") ||
-    message.includes("not found") ||
-    message.includes("Session not initialized")
-  );
-}
-
-function filterDroppedPromptRecoveryMessages(
-  messages: AgentMessage[],
-): AgentMessage[] {
-  return messages.filter((message) => {
-    if (message.type !== "error") {
-      return true;
-    }
-    return (
-      !message.content.includes("unresponsive") &&
-      !isSessionDeathMessage(message.content)
-    );
-  });
-}
-
 function usesClaudeMemory(agentType: AgentType): boolean {
   return agentType === "claude-code" || agentType === "claude-codex";
 }
@@ -1530,60 +1400,6 @@ async function refreshClaudeMemoryMdBeforeSpawn(
       clearTimeout(timeoutId);
     }
   }
-}
-
-function mergeRecoveryMessages(
-  liveMessages: AgentMessage[],
-  persistedMessages: AgentMessage[],
-): AgentMessage[] {
-  const byId = new Map<string, AgentMessage>();
-  for (const message of persistedMessages) {
-    byId.set(message.id, message);
-  }
-  for (const message of liveMessages) {
-    byId.set(message.id, message);
-  }
-  return [...byId.values()].sort((a, b) => a.timestamp - b.timestamp);
-}
-
-function buildDroppedPromptRecoveryBootstrapContext(
-  session: ActiveSession,
-  messages: AgentMessage[],
-  reason: string,
-  persistedContext: string,
-): string | null {
-  const summary = session.compactedSummary?.content.trim();
-  const transcript = messages
-    .map(formatForkBootstrapMessage)
-    .filter((line): line is string => Boolean(line))
-    .join("\n\n");
-
-  if (!summary && !transcript && !persistedContext.trim()) {
-    return null;
-  }
-
-  const sections = [
-    "Seren Desktop restarted the coding-agent worker while a prompt was active.",
-    `Recovery reason: ${truncateBootstrapText(reason)}`,
-    "Use the recovered history below as authoritative context for the restarted worker.",
-    "The user's original prompt will be replayed automatically after this context; do not ask the user to type continue.",
-  ];
-
-  if (summary) {
-    sections.push(`Earlier summary:\n${summary}`);
-  }
-
-  if (transcript) {
-    sections.push(`Recovered transcript:\n${transcript}`);
-  } else if (persistedContext.trim()) {
-    sections.push(`Persisted transcript fallback:\n${persistedContext}`);
-  }
-
-  sections.push(
-    "Continue the interrupted task from the recovered context and the replayed prompt.",
-  );
-
-  return sections.join("\n\n");
 }
 
 async function buildDroppedPromptRecoverySnapshot(

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -5,6 +5,7 @@ import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
 const agentStoreSource = readSource("src/stores/agent.store.ts");
+const bootstrapContextSource = readSource("src/lib/agent/bootstrap-context.ts");
 const agentChatSource = readSource("src/components/chat/AgentChat.tsx");
 
 const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
@@ -54,9 +55,9 @@ describe("#1805 — death-string catalog matches what runtimes emit", () => {
 
 describe("#1805 — error event handler detects mid-prompt session death", () => {
   it("matches the four substring patterns covering all three providers", () => {
-    const idx = agentStoreSource.indexOf("function isSessionDeathMessage");
+    const idx = bootstrapContextSource.indexOf("function isSessionDeathMessage");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 500);
+    const body = bootstrapContextSource.slice(idx, idx + 500);
     expect(body).toContain('message.includes("Session terminated")');
     expect(body).toContain(
       'message.includes("stopped before request completed")',
@@ -128,11 +129,11 @@ describe("#1952 — dropped-prompt recovery keeps context and replay invisible",
   });
 
   it("explicitly tells the restarted worker not to rely on a manual continue", () => {
-    const idx = agentStoreSource.indexOf(
+    const idx = bootstrapContextSource.indexOf(
       "function buildDroppedPromptRecoveryBootstrapContext",
     );
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 1800);
+    const body = bootstrapContextSource.slice(idx, idx + 1800);
     expect(body).toContain(
       "do not ask the user to type continue",
     );

--- a/tests/unit/agent-spawn-guard.test.ts
+++ b/tests/unit/agent-spawn-guard.test.ts
@@ -59,11 +59,15 @@ describe("agent initialization failure copy", () => {
     resolve("src/stores/agent.store.ts"),
     "utf-8",
   );
+  const bootstrapContextSource = readFileSync(
+    resolve("src/lib/agent/bootstrap-context.ts"),
+    "utf-8",
+  );
 
   it("uses provider-specific fallback remediation instead of a Claude-only message", () => {
     expect(agentStoreSource).toContain("agentInitializationFailureMessage");
-    expect(agentStoreSource).toContain("Codex is installed and signed in");
-    expect(agentStoreSource).not.toContain(
+    expect(bootstrapContextSource).toContain("Codex is installed and signed in");
+    expect(bootstrapContextSource).not.toContain(
       "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.",
     );
   });

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -29,6 +29,10 @@ const compactionTs = readFileSync(
   resolve("src/lib/agent/compaction.ts"),
   "utf-8",
 );
+const bootstrapContextTs = readFileSync(
+  resolve("src/lib/agent/bootstrap-context.ts"),
+  "utf-8",
+);
 const threadStoreTs = readFileSync(
   resolve("src/stores/thread.store.ts"),
   "utf-8",
@@ -140,7 +144,7 @@ describe("Gemini Agent — shared ACP client (#1471, #3084)", () => {
 describe("Gemini Agent — agent.store.ts wiring (#1471)", () => {
   it("agentDisplayName has a 'gemini' case", () => {
     // Whitespace-tolerant: case "gemini": ... return "Gemini";
-    expect(agentStoreTs).toMatch(/case\s+"gemini":\s*\n\s*return\s+"Gemini"/);
+    expect(bootstrapContextTs).toMatch(/case\s+"gemini":\s*\n\s*return\s+"Gemini"/);
   });
 
   it("CLI ensure dispatcher routes gemini to providerService.ensureGeminiCli", () => {


### PR DESCRIPTION
## What

Fifth behavior-preserving extraction from `agent.store.ts` (#3250) — the **fork & dropped-prompt-recovery bootstrap-context cluster** → co-located `src/lib/agent/bootstrap-context.ts`. Same safe profile as #3258 / #3260 / #3269: module-level code, **zero `this.`**, **zero `state`/`setState` closure**, relocation + re-export.

Moved (all verified pure — the purity check found 0 store/service references in every function):
- `agentDisplayName`, `agentInitializationFailureMessage`
- `truncateBootstrapText`, `formatForkBootstrapMessage`, `FORK_BOOTSTRAP_MAX_MSG_CHARS` — now **module-private** (no store callers remain outside the moved functions)
- `buildForkBootstrapContext`
- `isSessionDeathMessage`, `isRecoverableDeadSessionSendFailure`, `filterDroppedPromptRecoveryMessages`
- `mergeRecoveryMessages`, `buildDroppedPromptRecoveryBootstrapContext`

## Deliberately NOT moved (impure)

- `refreshClaudeMemoryMdBeforeSpawn` — calls the claude-memory render service.
- `buildDroppedPromptRecoverySnapshot` — reads SQLite via `loadPersistedAgentHistory`.

Both stay in the store.

## Public surface + call sites unchanged

- `ActiveSession` / `AgentMessage` are **type-only** imports (erased at runtime → no cycle).
- The store **re-exports** `agentDisplayName`, so its two component importers (`ModelSelector.tsx`, `ThreadProviderSwitcher.tsx`) and the `@/stores/agent.store` public surface are identical.
- Every call site unchanged (verified per symbol before the move).
- `agent.store.ts`: **9101 → 8918 lines**.

## Test changes (transparency)

Three tests pin the moved declarations **by source text**; those assertions are **repointed to `bootstrap-context.ts`** where the code now lives — same fact, same body asserted, zero weakening. Assertions about the *store's own wiring* (e.g. that it still references `agentInitializationFailureMessage`) stay pointed at `agent.store.ts`. No test deleted or loosened.

- `gemini-agent` — `agentDisplayName` "gemini" case
- `agent-session-died-mid-prompt` — `isSessionDeathMessage` body, `buildDroppedPromptRecoveryBootstrapContext` copy
- `agent-spawn-guard` — provider-specific initialization-failure copy

## Validation

- Full unit suite green: **379 files / 2708 tests passed**, 0 failures — **identical counts to clean `main` at the same base commit** (verified side-by-side).
- `biome check`: both source files clean.
- `tsc --noEmit`: all changed files type-clean.

No new test added: the moved functions are already source-pinned by the existing fork/recovery/spawn-guard tests.

## Non-goals

No behavior, IPC-contract, or persistence-schema change. No new features. No dependency additions. No outbound network path touched (pure in-process text/predicate helpers).

Refs #3250

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
