### PR TITLE
fix(agent): enforce completion integrity for pending approvals (#3282)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -204,6 +204,29 @@ impl ResolutionSummary {
     pub fn has_disclosable(&self) -> bool {
         self.unresolved + self.denied + self.skipped + self.expired > 0
     }
+
+    /// Plain-language completion-integrity notice for a task's final summary, or
+    /// `None` when nothing is pending (a clean completion is left untouched).
+    ///
+    /// Scoped to still-`unresolved` (pending) approvals: a task cannot honestly
+    /// report finished while an approval is still open. Settled denials, skips,
+    /// and expiries belong to the turn that produced them and are surfaced as each
+    /// action's own tool result, so they are deliberately not re-disclosed on
+    /// every later completion in the same conversation.
+    pub fn completion_notice(&self) -> Option<String> {
+        if self.unresolved == 0 {
+            return None;
+        }
+        let actions = if self.unresolved == 1 {
+            "action"
+        } else {
+            "actions"
+        };
+        Some(format!(
+            "\n\n_This task is still awaiting approval for {} {} and is not fully complete._",
+            self.unresolved, actions
+        ))
+    }
 }
 
 /// A persisted continuation row.
@@ -737,6 +760,39 @@ mod tests {
         // skipped / expired work must still be disclosed.
         assert!(summary.can_complete());
         assert!(summary.has_disclosable());
+    }
+
+    #[test]
+    fn completion_notice_fires_only_for_pending_approvals() {
+        // A clean completion (nothing pending) is left untouched.
+        let clean = summarize(&[
+            row("a", ContinuationScope::Linear, ContinuationState::Approved),
+            row("b", ContinuationScope::Linear, ContinuationState::Denied),
+        ]);
+        assert_eq!(clean.completion_notice(), None);
+
+        // A pending approval yields a notice that the task is not fully complete.
+        let one_pending = summarize(&[row(
+            "a",
+            ContinuationScope::Linear,
+            ContinuationState::Pending,
+        )]);
+        let notice = one_pending.completion_notice().expect("pending → notice");
+        assert!(notice.contains("still awaiting approval"));
+        assert!(notice.contains("1 action"));
+        assert!(!notice.contains("actions")); // singular for one
+
+        // Plural for several pending.
+        let two_pending = summarize(&[
+            row("a", ContinuationScope::Linear, ContinuationState::Pending),
+            row("b", ContinuationScope::Branch, ContinuationState::Pending),
+        ]);
+        assert!(
+            two_pending
+                .completion_notice()
+                .unwrap()
+                .contains("2 actions")
+        );
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -166,6 +166,57 @@ async fn persist_completion_message(app: AppHandle, mut message: PersistedMessag
     }
 }
 
+/// Completion integrity (#3193-C): consult the host continuation store and, when a
+/// task still has an approval pending, append a notice to its final summary so it
+/// cannot silently report a clean finish. Applied to the `Complete` event before
+/// it is persisted or forwarded, so both the stored message and the frontend see
+/// the same disclosed text.
+///
+/// The guard never blocks a legitimate completion: a store error, a missing state,
+/// or nothing pending leaves the event untouched. It fires when a completion
+/// coexists with a pending approval — a settle failure that leaves a stuck pending
+/// record, or a future parallel/branch flow — rather than the common linear path,
+/// where the renderer holds the tool call open until the approval resolves.
+fn guard_completion(app: &AppHandle, conversation_id: &str, event: WorkerEvent) -> WorkerEvent {
+    let WorkerEvent::Complete {
+        final_content,
+        thinking,
+        cost,
+        rlm_steps,
+    } = event
+    else {
+        return event;
+    };
+    let notice = app
+        .try_state::<crate::tool_authorization::ToolAuthorizationState>()
+        .and_then(
+            |state| match state.resolution_summary(conversation_id) {
+                Ok(summary) => summary.completion_notice(),
+                Err(err) => {
+                    log::warn!(
+                        "[Orchestrator] Completion-integrity check failed for {conversation_id}: {err}"
+                    );
+                    None
+                }
+            },
+        );
+    let final_content = match notice {
+        Some(note) => {
+            log::warn!(
+                "[Orchestrator] Task {conversation_id} completed with an approval still pending"
+            );
+            format!("{final_content}{note}")
+        }
+        None => final_content,
+    };
+    WorkerEvent::Complete {
+        final_content,
+        thinking,
+        cost,
+        rlm_steps,
+    }
+}
+
 /// Sleep for `duration`, returning early if the cancel flag flips to true.
 ///
 /// Returns `true` if the sleep completed normally, `false` if cancelled.
@@ -386,6 +437,7 @@ pub async fn orchestrate(
             if let WorkerEvent::Content { text } = &event {
                 streamed_content.push_str(text);
             }
+            let event = guard_completion(&app_clone, &conversation_id, event);
             if matches!(event, WorkerEvent::Complete { .. }) {
                 if let Some(record) = completion_message_record(
                     &conversation_id,
@@ -626,6 +678,8 @@ async fn execute_single_task(
                                 if let WorkerEvent::Error { ref message } = worker_event {
                                     captured_error = Some(message.clone());
                                 }
+                                let worker_event =
+                                    guard_completion(&app_for_events, &conv_id, worker_event);
                                 if matches!(worker_event, WorkerEvent::Complete { .. }) {
                                     if let Some(record) = completion_message_record(
                                         &conv_id,


### PR DESCRIPTION
Closes #3282. Follow-up to #3263 (slice C), wiring the completion-integrity guard that slice C shipped as a queryable primitive into the Rust completion path.

## Problem
Slice C added `ResolutionSummary::can_complete()` (and the `resolution_summary` command), but nothing in `orchestrator/service.rs` consulted it. A task could emit `WorkerEvent::Complete` while an approval was still pending in the host continuation store, so #3263's "a task with an unresolved required approval cannot report completed" held only as a primitive, never enforced at the moment a task reports finished.

## Change
`service.rs` now runs every `Complete` event through `guard_completion(app, conversation_id, event)` before it is persisted or forwarded. When the continuation store reports a still-**pending** approval for the conversation, a plain-language notice — *"This task is still awaiting approval for N action(s) and is not fully complete."* — is appended to the final summary, so the task cannot silently claim a clean finish. Both single-worker completion paths (the RLM fast path and the main forward loop) are wired.

The guard never blocks a legitimate completion: a store error, a missing state, or nothing pending leaves the event untouched.

## Honest scope / reachability
This is a **correctness backstop**, not a change to the common path. In today's linear, blocking approval flow the renderer holds the tool call open until the approval is approved/denied/expired, so a completion rarely coexists with a *pending* approval. It fires when:
- a settle call fails (the renderer catches and continues, leaving a stuck `pending` record — a real, if rare, edge the guard now surfaces instead of silently completing), or
- future parallel/branch/async approval flows let independent work finish while a branch is still blocked.

Deliberately **not** in scope: re-disclosing settled denied/skipped/expired outcomes on completion. Those belong to the turn that produced them (already surfaced as each action's own tool result) and would otherwise repeat on every later completion in the same conversation; per-turn scoping for that disclosure is slice D UI (#3264).

The decomposed multi-subtask completion path is left alone — its `Complete` events are per-subtask and share one conversation id, so a conversation-scoped notice would repeat on every subtask; that path ties to the not-yet-active branch-scope flow.

## Validation
- New unit test `completion_notice_fires_only_for_pending_approvals` (real `ResolutionSummary`): no notice for a clean/settled summary, singular/plural notice for 1 vs 2 pending.
- `resolution_summary` (the store layer the guard consults) is already covered by slice C's real-SQLite tests.
- Full `cargo test --lib` green; full `cargo build` green (compiles the wired `service.rs`).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
