### PR TITLE
feat(security): non-bypassable dispatch enforcement — host-issued authorization handles (#3276)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -128,6 +128,12 @@ pub struct RequestedCapability {
     pub host: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
+    /// Opaque host-computed operation binding (#3193-F), echoed by the renderer
+    /// from the gate's prompt decision. The post-approval dispatch handle is
+    /// minted against it, so an approval can only ever release the exact
+    /// operation the gate blocked. Tampering fails closed at the transport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding: Option<String>,
 }
 
 /// The renderer's contract for a freshly registered (or deduped) continuation.
@@ -160,6 +166,11 @@ pub struct ResolveOutcome {
     pub changed: bool,
     pub state: ContinuationState,
     pub task_state: TaskExecutionState,
+    /// Host-minted dispatch handle (#3193-F), present only on the single
+    /// pending→approved settle and bound to the registered capability. Replays
+    /// and non-approve outcomes never carry one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch_handle: Option<String>,
 }
 
 /// A redacted continuation record for inspection surfaces (slice D). Never carries
@@ -295,6 +306,11 @@ impl ContinuationRow {
 /// on publisher + operation + resource target (matching the gate's session-grant
 /// key and publisher predicates).
 pub fn fingerprint(cap: &RequestedCapability) -> String {
+    // The exact-operation binding participates so a pending request only dedups
+    // a retry of the same operation with the same arguments (#3193-F). Without
+    // it, a coarser match could hand a differently-argued retry a continuation
+    // whose post-approval handle it can never redeem.
+    let binding = cap.binding.as_deref().unwrap_or("");
     match ToolRoute::parse(&cap.route) {
         Ok(ToolRoute::Shell) | Ok(ToolRoute::Skill) => {
             let program = cap
@@ -302,7 +318,7 @@ pub fn fingerprint(cap: &RequestedCapability) -> String {
                 .as_deref()
                 .and_then(command_program)
                 .unwrap_or_default();
-            format!("{}|{}", cap.route, program)
+            format!("{}|{}|{}", cap.route, program, binding)
         }
         Ok(ToolRoute::Web) => {
             let host = cap
@@ -311,16 +327,17 @@ pub fn fingerprint(cap: &RequestedCapability) -> String {
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
-            format!("web|{host}")
+            format!("web|{host}|{binding}")
         }
         // Gateway/Seren/Mcp, and any unrecognized route treated conservatively as a
         // publisher operation, key on operation + resource identity.
         _ => format!(
-            "{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}",
             cap.route,
             cap.publisher_slug,
             cap.tool_name,
-            cap.target.as_deref().unwrap_or("")
+            cap.target.as_deref().unwrap_or(""),
+            binding
         ),
     }
 }
@@ -598,6 +615,7 @@ mod tests {
             command: None,
             host: None,
             target: None,
+            binding: None,
         }
     }
 

--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -403,6 +403,18 @@ mod tests {
         assert!(!should_use_stored_auth(&refresh, &no_auth_headers));
     }
 
+    /// The dispatch handle is app-internal proof — it must be stripped before
+    /// the request goes on the wire, whatever its casing.
+    #[test]
+    fn auth_handle_header_never_reaches_the_wire() {
+        let mut raw = HashMap::new();
+        raw.insert("X-Seren-Auth-Handle".to_string(), "handle-1".to_string());
+        raw.insert("accept".to_string(), "application/json".to_string());
+        let headers = build_header_map(&raw).unwrap();
+        assert!(!headers.contains_key(AUTH_HANDLE_HEADER));
+        assert!(headers.contains_key("accept"));
+    }
+
     /// #3193-F: only the publisher tool-dispatch surface demands a dispatch
     /// handle; every other Gateway path is app-level API traffic.
     #[test]

--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -89,6 +89,53 @@ fn normalize_path(path: &str) -> String {
     }
 }
 
+/// Renderer-supplied dispatch-handle header (#3193-F). Always stripped before
+/// the request leaves the app; consumed only for publisher tool dispatch.
+const AUTH_HANDLE_HEADER: &str = "x-seren-auth-handle";
+
+/// Detect the publisher tool-dispatch surface:
+/// `/publishers/{slug}/_mcp/tools/{tool}`. Returns the decoded publisher slug
+/// and tool name. Every other Gateway path (auth, billing, chat, catalog) is
+/// app-level API traffic, not model tool dispatch, and passes through.
+fn publisher_dispatch_target(url: &Url) -> Option<(String, String)> {
+    let segments: Vec<&str> = url.path_segments()?.filter(|s| !s.is_empty()).collect();
+    match segments.as_slice() {
+        ["publishers", slug, "_mcp", "tools", tool] => Some((
+            urlencoding::decode(slug).ok()?.into_owned(),
+            urlencoding::decode(tool).ok()?.into_owned(),
+        )),
+        _ => None,
+    }
+}
+
+/// #3193-F: a publisher tool dispatch through the HTTP bridge must redeem a
+/// live host-minted handle for the exact publisher, tool, and body payload —
+/// the same rule the MCP transport enforces, so neither wire shape can be used
+/// to skip the authorization gate.
+fn enforce_publisher_dispatch(
+    app: &AppHandle,
+    url: &Url,
+    body: Option<&str>,
+    auth_handle: Option<&str>,
+) -> Result<(), String> {
+    let Some((publisher, tool)) = publisher_dispatch_target(url) else {
+        return Ok(());
+    };
+    let body_args: serde_json::Value = match body {
+        Some(raw) if !raw.trim().is_empty() => serde_json::from_str(raw)
+            .map_err(|_| "Dispatch refused: publisher tool body was not valid JSON.".to_string())?,
+        _ => serde_json::json!({}),
+    };
+    app.state::<crate::tool_authorization::ToolAuthorizationState>()
+        .consume_dispatch_handle(
+            auth_handle.unwrap_or_default(),
+            crate::tool_authorization::ToolRoute::Gateway,
+            &publisher,
+            &tool,
+            &crate::tool_authorization::binding_for_publisher_args(&body_args),
+        )
+}
+
 fn should_skip_stored_auth(path: &str) -> bool {
     matches!(
         normalize_path(path).as_str(),
@@ -120,9 +167,11 @@ fn build_header_map(raw_headers: &HashMap<String, String>) -> Result<HeaderMap, 
 
     for (name, value) in raw_headers {
         let lower = name.to_ascii_lowercase();
+        // The dispatch handle is app-internal proof for the Rust gate — it must
+        // never leave the process on the wire.
         if matches!(
             lower.as_str(),
-            "host" | "origin" | "content-length" | "connection"
+            "host" | "origin" | "content-length" | "connection" | AUTH_HANDLE_HEADER
         ) {
             continue;
         }
@@ -202,6 +251,12 @@ pub async fn gateway_http_start(
         .method
         .parse::<Method>()
         .map_err(|e| format!("Invalid HTTP method '{}': {}", request.method, e))?;
+    let auth_handle = request
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(AUTH_HANDLE_HEADER))
+        .map(|(_, value)| value.clone());
+    enforce_publisher_dispatch(&app, &url, request.body.as_deref(), auth_handle.as_deref())?;
     let headers = build_header_map(&request.headers)?;
     let body = request.body.clone();
 
@@ -346,6 +401,37 @@ mod tests {
 
         let refresh = Url::parse("https://api.serendb.com/auth/refresh").unwrap();
         assert!(!should_use_stored_auth(&refresh, &no_auth_headers));
+    }
+
+    /// #3193-F: only the publisher tool-dispatch surface demands a dispatch
+    /// handle; every other Gateway path is app-level API traffic.
+    #[test]
+    fn publisher_dispatch_target_matches_only_the_tool_dispatch_surface() {
+        let dispatch =
+            Url::parse("https://api.serendb.com/publishers/gmail/_mcp/tools/post_send").unwrap();
+        assert_eq!(
+            publisher_dispatch_target(&dispatch),
+            Some(("gmail".to_string(), "post_send".to_string()))
+        );
+
+        let encoded = Url::parse(
+            "https://api.serendb.com/publishers/my%2Dpub/_mcp/tools/get%5Fmessages",
+        )
+        .unwrap();
+        assert_eq!(
+            publisher_dispatch_target(&encoded),
+            Some(("my-pub".to_string(), "get_messages".to_string()))
+        );
+
+        for other in [
+            "https://api.serendb.com/auth/login",
+            "https://api.serendb.com/publishers/gmail",
+            "https://api.serendb.com/publishers/seren-skills/skills",
+            "https://api.serendb.com/publishers/gmail/_mcp/tools",
+            "https://api.serendb.com/publishers/gmail/_mcp/tools/post_send/extra",
+        ] {
+            assert_eq!(publisher_dispatch_target(&Url::parse(other).unwrap()), None, "{other}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -24,6 +24,10 @@ use crate::tool_authorization::{
 /// (command, host, resource target, monetary cost). It is optional so callers
 /// that have nothing to contribute pass nothing; a predicate that needs a field
 /// simply will not match a call that omits it.
+///
+/// `call_args` is the full tool-argument payload for the operation. The host
+/// derives the exact-operation binding from it (#3193-F); an `allow` without it
+/// carries no dispatch handle, and the transports then refuse to execute.
 #[tauri::command]
 pub fn authorize_tool_operation(
     state: State<'_, ToolAuthorizationState>,
@@ -32,10 +36,18 @@ pub fn authorize_tool_operation(
     tool_name: String,
     conversation_id: String,
     context: Option<OperationContext>,
+    call_args: Option<serde_json::Value>,
 ) -> Result<AuthorizationDecision, String> {
     let route = ToolRoute::parse(&route)?;
     let context = context.unwrap_or_default();
-    state.authorize(route, &publisher_slug, &tool_name, &conversation_id, &context)
+    state.authorize(
+        route,
+        &publisher_slug,
+        &tool_name,
+        &conversation_id,
+        &context,
+        call_args.as_ref(),
+    )
 }
 
 /// Persist a prompt outcome host-side. Classification is re-derived here, so a

--- a/src-tauri/src/commands/web.rs
+++ b/src-tauri/src/commands/web.rs
@@ -18,14 +18,40 @@ pub struct WebFetchResult {
 
 /// Fetch content from a public URL and convert HTML to markdown.
 ///
+/// #3193-F: web fetch is open-world data egress, so the renderer-invokable
+/// command refuses to run without a live host-minted dispatch handle for this
+/// exact URL. Host-side callers (the orchestrator's own gated tool loop) use
+/// [`fetch_web_content`] directly.
+#[tauri::command]
+pub async fn web_fetch(
+    authorization: tauri::State<'_, crate::tool_authorization::ToolAuthorizationState>,
+    url: String,
+    timeout_ms: Option<u64>,
+    auth_handle: Option<String>,
+) -> Result<WebFetchResult, String> {
+    authorization.consume_dispatch_handle(
+        auth_handle.as_deref().unwrap_or_default(),
+        crate::tool_authorization::ToolRoute::Web,
+        "seren",
+        "web_fetch",
+        &crate::tool_authorization::binding_for_url(&url),
+    )?;
+    fetch_web_content(url, timeout_ms).await
+}
+
+/// Transport-free fetch used by the command above (after handle redemption)
+/// and by host-side tool loops that gate their own calls.
+///
 /// # Arguments
 /// * `url` - The URL to fetch (must be http or https)
 /// * `timeout_ms` - Request timeout in milliseconds (default: 30000)
 ///
 /// # Returns
 /// * `WebFetchResult` with content, content_type, final url, and status code
-#[tauri::command]
-pub async fn web_fetch(url: String, timeout_ms: Option<u64>) -> Result<WebFetchResult, String> {
+pub async fn fetch_web_content(
+    url: String,
+    timeout_ms: Option<u64>,
+) -> Result<WebFetchResult, String> {
     // Validate URL
     let parsed_url = url::Url::parse(&url).map_err(|e| format!("Invalid URL: {}", e))?;
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -725,14 +725,28 @@ struct ResourcesListResponse {
     resources: Vec<McpResource>,
 }
 
-/// Call a tool on an MCP server
+/// Call a tool on an MCP server.
+///
+/// #3193-F: executing a tool is a side effect, so this transport refuses to run
+/// without a live host-minted dispatch handle for this exact server, tool, and
+/// argument payload. The handle is redeemed before the child process sees the
+/// call — a renderer path that skipped the authorization gate cannot get here.
 #[tauri::command]
 pub async fn mcp_call_tool(
     state: State<'_, McpState>,
+    authorization: State<'_, crate::tool_authorization::ToolAuthorizationState>,
     server_name: String,
     tool_name: String,
     arguments: serde_json::Value,
+    auth_handle: Option<String>,
 ) -> Result<McpToolResult, String> {
+    authorization.consume_dispatch_handle(
+        auth_handle.as_deref().unwrap_or_default(),
+        crate::tool_authorization::ToolRoute::Mcp,
+        &server_name,
+        &tool_name,
+        &crate::tool_authorization::binding_for_publisher_args(&arguments),
+    )?;
     let slot = lookup_slot(&state, &server_name)?;
     let params = serde_json::json!({
         "name": tool_name,
@@ -915,14 +929,79 @@ pub async fn mcp_list_tools_http(
     Ok(tools)
 }
 
-/// Call a tool on an HTTP MCP server
+/// The gate-facing identity of one HTTP MCP dispatch: which route/publisher/
+/// tool the renderer must have authorized, and the argument payload the
+/// operation binding covers. Mirrors how the renderer consults the gate:
+/// `call_publisher` and native `mcp__{publisher}__{tool}` names authorize as
+/// the wrapped gateway operation, everything else as a built-in seren tool.
+pub(crate) fn http_dispatch_identity(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+) -> (
+    crate::tool_authorization::ToolRoute,
+    String,
+    String,
+    serde_json::Value,
+) {
+    use crate::tool_authorization::ToolRoute;
+    if tool_name == "call_publisher" {
+        let publisher = arguments
+            .get("publisher")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let tool = arguments
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let tool_args = arguments
+            .get("tool_args")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        return (ToolRoute::Gateway, publisher, tool, tool_args);
+    }
+    if let Some(rest) = tool_name.strip_prefix("mcp__") {
+        if let Some((publisher, tool)) = rest.split_once("__") {
+            return (
+                ToolRoute::Gateway,
+                publisher.to_string(),
+                tool.to_string(),
+                arguments.clone(),
+            );
+        }
+    }
+    (
+        ToolRoute::Seren,
+        "seren".to_string(),
+        tool_name.to_string(),
+        arguments.clone(),
+    )
+}
+
+/// Call a tool on an HTTP MCP server.
+///
+/// #3193-F: like the stdio transport, this refuses to execute without a live
+/// dispatch handle. The handle is verified against the *effective* operation —
+/// a `call_publisher` envelope is unwrapped to the publisher tool it carries,
+/// so wrapping a call cannot dodge the binding.
 #[tauri::command]
 pub async fn mcp_call_tool_http(
     state: State<'_, HttpMcpState>,
+    authorization: State<'_, crate::tool_authorization::ToolAuthorizationState>,
     server_name: String,
     tool_name: String,
     arguments: serde_json::Value,
+    auth_handle: Option<String>,
 ) -> Result<McpToolResult, String> {
+    let (route, publisher, tool, bound_args) = http_dispatch_identity(&tool_name, &arguments);
+    authorization.consume_dispatch_handle(
+        auth_handle.as_deref().unwrap_or_default(),
+        route,
+        &publisher,
+        &tool,
+        &crate::tool_authorization::binding_for_publisher_args(&bound_args),
+    )?;
     let clients = state.clients.read().await;
     let client = clients
         .get(&server_name)
@@ -976,6 +1055,51 @@ pub async fn mcp_list_connected_http(
 // rather than hanging. A regression on either `spawn_blocking` or
 // `tokio::time::timeout` would fail this test.
 // ============================================================================
+
+#[cfg(test)]
+mod dispatch_identity_tests {
+    use super::http_dispatch_identity;
+    use crate::tool_authorization::ToolRoute;
+
+    /// The transport verifies handles against the *effective* operation, so
+    /// the identity parser must mirror how the renderer consults the gate for
+    /// each wire shape (#3193-F).
+    #[test]
+    fn call_publisher_envelopes_unwrap_to_the_carried_operation() {
+        let args = serde_json::json!({
+            "publisher": "gmail",
+            "tool": "post_send",
+            "tool_args": { "to": "a@example.com" },
+            "_x402_payment": "header",
+        });
+        let (route, publisher, tool, bound) = http_dispatch_identity("call_publisher", &args);
+        assert_eq!(route, ToolRoute::Gateway);
+        assert_eq!(publisher, "gmail");
+        assert_eq!(tool, "post_send");
+        assert_eq!(bound, serde_json::json!({ "to": "a@example.com" }));
+    }
+
+    #[test]
+    fn native_mcp_names_parse_to_their_publisher_operation() {
+        let args = serde_json::json!({ "tz": "UTC" });
+        let (route, publisher, tool, bound) =
+            http_dispatch_identity("mcp__mcp-time__get_current_time", &args);
+        assert_eq!(route, ToolRoute::Gateway);
+        assert_eq!(publisher, "mcp-time");
+        assert_eq!(tool, "get_current_time");
+        assert_eq!(bound, args);
+    }
+
+    #[test]
+    fn builtin_tools_identify_as_seren_route() {
+        let args = serde_json::json!({ "publisher": "gmail" });
+        let (route, publisher, tool, bound) = http_dispatch_identity("list_mcp_tools", &args);
+        assert_eq!(route, ToolRoute::Seren);
+        assert_eq!(publisher, "seren");
+        assert_eq!(tool, "list_mcp_tools");
+        assert_eq!(bound, args);
+    }
+}
 
 #[cfg(test)]
 #[cfg(unix)]

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1614,7 +1614,7 @@ created if missing.",
                     return ("Missing required parameter: url".to_string(), true);
                 }
                 let timeout_ms = args["timeout_ms"].as_u64();
-                match crate::commands::web::web_fetch(url, timeout_ms).await {
+                match crate::commands::web::fetch_web_content(url, timeout_ms).await {
                     Ok(fetch_result) => (fetch_result.content, false),
                     Err(e) => (e, true),
                 }

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -5,11 +5,35 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_store::StoreExt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
+
+use crate::tool_authorization::{
+    ToolAuthorizationState, ToolRoute, binding_for_command, binding_for_skill,
+};
+
+/// Redeem the dispatch handle for a subprocess execution (#3193-F). Every
+/// renderer-invokable subprocess command runs this before spawning anything:
+/// no live host-minted handle for this exact command line (or skill argv)
+/// means no execution, regardless of caller.
+fn consume_subprocess_handle<R: Runtime>(
+    app: &AppHandle<R>,
+    route: ToolRoute,
+    tool_name: &str,
+    binding: &str,
+    auth_handle: Option<&str>,
+) -> Result<(), String> {
+    app.state::<ToolAuthorizationState>().consume_dispatch_handle(
+        auth_handle.unwrap_or_default(),
+        route,
+        "seren",
+        tool_name,
+        binding,
+    )
+}
 
 /// Tauri event channel for streaming Bash stdout/stderr while the command
 /// is still running (#2100). Payload: [`ShellProgressEvent`]. Subscribed
@@ -129,7 +153,15 @@ pub async fn execute_shell_command<R: Runtime>(
     command: String,
     timeout_secs: Option<u64>,
     inject_seren_credentials: Option<bool>,
+    auth_handle: Option<String>,
 ) -> Result<CommandResult, String> {
+    consume_subprocess_handle(
+        &app,
+        ToolRoute::Shell,
+        "execute_command",
+        &binding_for_command(&command),
+        auth_handle.as_deref(),
+    )?;
     let api_key = if should_inject_seren_credentials(&command, inject_seren_credentials) {
         read_stored_seren_api_key(&app)?
     } else {
@@ -152,7 +184,15 @@ pub async fn execute_shell_command_streaming<R: Runtime>(
     timeout_secs: Option<u64>,
     inject_seren_credentials: Option<bool>,
     tool_call_id: String,
+    auth_handle: Option<String>,
 ) -> Result<CommandResult, String> {
+    consume_subprocess_handle(
+        &app,
+        ToolRoute::Shell,
+        "execute_command",
+        &binding_for_command(&command),
+        auth_handle.as_deref(),
+    )?;
     if tool_call_id.trim().is_empty() {
         return Err("tool_call_id must not be empty".to_string());
     }
@@ -230,7 +270,15 @@ pub async fn run_skill_script<R: Runtime>(
     env: Option<HashMap<String, String>>,
     timeout_secs: Option<u64>,
     inject_seren_credentials: Option<bool>,
+    auth_handle: Option<String>,
 ) -> Result<CommandResult, String> {
+    consume_subprocess_handle(
+        &app,
+        ToolRoute::Skill,
+        "run_skill_script",
+        &binding_for_skill(&skill_slug, &argv),
+        auth_handle.as_deref(),
+    )?;
     let cwd = validate_skill_script_cwd(&skill_slug, &cwd)?;
     let (program, args) = validate_skill_script_argv(&argv)?;
     let api_key = if inject_seren_credentials.unwrap_or(true) {
@@ -797,7 +845,27 @@ mod tests {
             store.set(SEREN_API_KEY_KEY, json!(api_key));
         }
 
+        // The subprocess commands redeem a dispatch handle before spawning
+        // (#3193-F), so the mock app manages a real in-memory authorization
+        // store the tests mint handles from.
+        app.manage(ToolAuthorizationState::new(PathBuf::from(":memory:")));
+
         app
+    }
+
+    /// A real host-minted handle for one exact command, so command-level tests
+    /// exercise the same verify/consume path production dispatches take.
+    fn handle_for_command<R: Runtime>(app: &tauri::App<R>, command: &str) -> Option<String> {
+        Some(
+            app.state::<ToolAuthorizationState>()
+                .mint_dispatch_handle_for_test(
+                    ToolRoute::Shell,
+                    "seren",
+                    "execute_command",
+                    &binding_for_command(command),
+                )
+                .expect("test handle mints"),
+        )
     }
 
     #[test]
@@ -826,6 +894,7 @@ mod tests {
             print_seren_key_env_command().to_string(),
             Some(5),
             Some(true),
+            handle_for_command(&app, print_seren_key_env_command()),
         )
         .await
         .expect("command succeeds");
@@ -847,15 +916,99 @@ mod tests {
             print_seren_key_env_command()
         );
 
-        let result = execute_shell_command(app.handle().clone(), command, Some(5), Some(true))
-            .await
-            .expect("command succeeds");
+        let auth_handle = handle_for_command(&app, &command);
+        let result =
+            execute_shell_command(app.handle().clone(), command, Some(5), Some(true), auth_handle)
+                .await
+                .expect("command succeeds");
 
         assert_eq!(result.exit_code, Some(0));
         assert!(
             result.stdout.contains("seren_test_shell_key"),
             "skill-path commands must keep receiving desktop auth"
         );
+    }
+
+    /// #3193-F acceptance: the transport commands refuse to execute when
+    /// invoked directly (bypassing the executor) with no handle, and a handle
+    /// minted for a different command cannot be redeemed for this one.
+    #[tokio::test]
+    async fn subprocess_transports_refuse_without_a_matching_dispatch_handle() {
+        let app = mock_app_with_api_key(None);
+
+        let no_handle = execute_shell_command(
+            app.handle().clone(),
+            "echo hi".to_string(),
+            Some(5),
+            None,
+            None,
+        )
+        .await;
+        assert!(no_handle.is_err(), "direct invocation without a handle must refuse");
+
+        let wrong_command = handle_for_command(&app, "echo something-else");
+        let mismatched = execute_shell_command(
+            app.handle().clone(),
+            "echo hi".to_string(),
+            Some(5),
+            None,
+            wrong_command,
+        )
+        .await;
+        assert!(mismatched.is_err(), "a handle for another command must refuse");
+
+        let streaming = execute_shell_command_streaming(
+            app.handle().clone(),
+            "echo hi".to_string(),
+            Some(5),
+            None,
+            "tool-1".to_string(),
+            None,
+        )
+        .await;
+        assert!(streaming.is_err(), "the streaming transport enforces identically");
+
+        let skill = run_skill_script(
+            app.handle().clone(),
+            "demo".to_string(),
+            "/tmp".to_string(),
+            vec!["node".to_string(), "run.js".to_string()],
+            None,
+            Some(5),
+            None,
+            None,
+        )
+        .await;
+        assert!(skill.is_err(), "skill scripts refuse without a handle");
+    }
+
+    /// The happy path still works end-to-end: a handle minted for the exact
+    /// command redeems once, and a replay of the same spent handle refuses.
+    #[tokio::test]
+    async fn subprocess_transport_redeems_a_matching_handle_exactly_once() {
+        let app = mock_app_with_api_key(None);
+        let auth_handle = handle_for_command(&app, "echo hi");
+
+        let result = execute_shell_command(
+            app.handle().clone(),
+            "echo hi".to_string(),
+            Some(5),
+            None,
+            auth_handle.clone(),
+        )
+        .await
+        .expect("a matching handle executes");
+        assert_eq!(result.exit_code, Some(0));
+
+        let replay = execute_shell_command(
+            app.handle().clone(),
+            "echo hi".to_string(),
+            Some(5),
+            None,
+            auth_handle,
+        )
+        .await;
+        assert!(replay.is_err(), "a spent handle must not execute again");
     }
 
     #[test]
@@ -881,6 +1034,7 @@ mod tests {
             print_seren_key_env_command().to_string(),
             Some(5),
             None,
+            handle_for_command(&app, print_seren_key_env_command()),
         )
         .await
         .expect("command succeeds");
@@ -898,6 +1052,7 @@ mod tests {
             print_seren_key_env_command().to_string(),
             Some(5),
             Some(true),
+            handle_for_command(&app, print_seren_key_env_command()),
         )
         .await
         .expect("command succeeds");

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::approval_continuation::{
     self, ContinuationRow, ContinuationScope, ContinuationState, ContinuationView,
@@ -114,16 +115,27 @@ pub struct AuthorizationDecision {
     pub operation_class: String,
     pub description: String,
     pub is_destructive: bool,
+    /// Host-minted dispatch handle, present only on "allow" (#3193-F). The
+    /// transports refuse to execute without it; the renderer can only ferry it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+    /// Opaque host-computed operation binding, present on "prompt" so the
+    /// renderer can echo it into the suspended continuation. Tampering with it
+    /// yields a handle that no transport will accept (fail-closed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binding: Option<String>,
 }
 
 impl AuthorizationDecision {
-    fn allow(class: OperationClass) -> Self {
+    fn allow(class: OperationClass, handle: Option<String>) -> Self {
         Self {
             decision: "allow".to_string(),
             prompt_kind: None,
             operation_class: class.as_wire().to_string(),
             description: String::new(),
             is_destructive: false,
+            handle,
+            binding: None,
         }
     }
 
@@ -134,16 +146,131 @@ impl AuthorizationDecision {
             operation_class: class.as_wire().to_string(),
             description: String::new(),
             is_destructive: false,
+            handle: None,
+            binding: None,
         }
     }
 
-    fn prompt(class: OperationClass, kind: &str, description: String, is_destructive: bool) -> Self {
+    fn prompt(
+        class: OperationClass,
+        kind: &str,
+        description: String,
+        is_destructive: bool,
+        binding: Option<String>,
+    ) -> Self {
         Self {
             decision: "prompt".to_string(),
             prompt_kind: Some(kind.to_string()),
             operation_class: class.as_wire().to_string(),
             description,
             is_destructive,
+            handle: None,
+            binding,
+        }
+    }
+}
+
+// ============================================================================
+// Dispatch handles (#3193-F) — the enforcement seam that makes the gate
+// non-bypassable. Every side-effecting transport command refuses to execute
+// without a live handle minted by this store for that exact operation, so a
+// renderer path that skips the gate cannot reach a transport.
+// ============================================================================
+
+/// How long a minted handle stays redeemable. Long enough for the x402 payment
+/// UI round-trip between the first dispatch and its retry; short enough that a
+/// leaked handle is not a standing capability.
+const DISPATCH_HANDLE_TTL_SECS: i64 = 300;
+
+/// Redemptions per handle. Gateway operations legitimately re-dispatch after an
+/// x402 402 (signed-payment retry, or a SerenBucks retry) without re-consulting
+/// the gate, so one authorization covers the initial call plus those retries.
+/// Every other route is strictly one dispatch per authorization.
+fn handle_uses_for_route(route: ToolRoute) -> i64 {
+    match route {
+        ToolRoute::Gateway => 3,
+        _ => 1,
+    }
+}
+
+/// Gateway metadata keys excluded from the operation binding: they are added,
+/// moved, or stripped between the gate consultation and the wire dispatch
+/// (account selection, payment retries) without changing which operation the
+/// user authorized.
+const BINDING_EXCLUDED_KEYS: &[&str] = &["_x402_payment", "connection_id"];
+
+fn binding_digest(material: &str) -> String {
+    hex::encode(Sha256::digest(material.as_bytes()))
+}
+
+/// serde_json (without `preserve_order`) stores objects as BTreeMaps, so
+/// serializing a `Value` is already key-sorted and canonical for our purposes.
+/// Both the mint side and the verify side normalize with this same function, so
+/// no cross-language canonicalization is involved.
+fn normalized_args_json(args: &serde_json::Value) -> String {
+    match args {
+        serde_json::Value::Object(map) => {
+            let filtered: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .filter(|(key, _)| !BINDING_EXCLUDED_KEYS.contains(&key.as_str()))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+            serde_json::Value::Object(filtered).to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Operation binding for the publisher-style routes (gateway, built-in seren,
+/// local MCP): the exact normalized tool arguments.
+pub fn binding_for_publisher_args(args: &serde_json::Value) -> String {
+    binding_digest(&format!("args\u{0}{}", normalized_args_json(args)))
+}
+
+/// Operation binding for shell execution: the exact command line.
+pub fn binding_for_command(command: &str) -> String {
+    binding_digest(&format!("cmd\u{0}{command}"))
+}
+
+/// Operation binding for a skill script: the skill identity plus its exact argv
+/// (kept as an array so `["a", "b c"]` and `["a", "b", "c"]` stay distinct).
+pub fn binding_for_skill(skill_slug: &str, argv: &[String]) -> String {
+    let material = serde_json::json!({ "argv": argv, "skillSlug": skill_slug });
+    binding_digest(&format!("skill\u{0}{material}"))
+}
+
+/// Operation binding for a web fetch: the exact URL.
+pub fn binding_for_url(url: &str) -> String {
+    binding_digest(&format!("url\u{0}{url}"))
+}
+
+/// Compute the binding for a call at gate time from the renderer-supplied
+/// argument payload. `None` means the material needed to bind this route was
+/// not provided — no handle can be minted, and the dispatch will be refused.
+fn binding_for_operation(
+    route: ToolRoute,
+    context: &OperationContext,
+    call_args: Option<&serde_json::Value>,
+) -> Option<String> {
+    match route {
+        ToolRoute::Shell => context.command.as_deref().map(binding_for_command),
+        ToolRoute::Skill => {
+            let args = call_args?;
+            let skill_slug = args.get("skill_slug")?.as_str()?;
+            let argv: Vec<String> = args
+                .get("argv")?
+                .as_array()?
+                .iter()
+                .map(|item| item.as_str().map(str::to_string))
+                .collect::<Option<Vec<String>>>()?;
+            Some(binding_for_skill(skill_slug, &argv))
+        }
+        ToolRoute::Web => {
+            let url = call_args?.get("url")?.as_str()?;
+            Some(binding_for_url(url))
+        }
+        ToolRoute::Gateway | ToolRoute::Seren | ToolRoute::Mcp => {
+            call_args.map(binding_for_publisher_args)
         }
     }
 }
@@ -206,6 +333,11 @@ const TRUSTED_READ_OPERATIONS: &[(&str, &str)] = &[
     ("seren", "get_project"),
     ("seren", "search_projects"),
     ("seren", "get_status"),
+    // Gateway catalog discovery (#3193-F): pure metadata reads the app performs
+    // at connect time. They ride the same enforced MCP transport as model
+    // dispatch, so they authorize through the gate like everything else.
+    ("seren", "list_agent_publishers"),
+    ("seren", "list_mcp_tools"),
 ];
 
 /// Leading verb tokens that denote a side-effect-free read.
@@ -506,11 +638,15 @@ impl ToolAuthorizationState {
         tool_name: &str,
         conversation_id: &str,
         context: &OperationContext,
+        call_args: Option<&serde_json::Value>,
     ) -> Result<AuthorizationDecision, String> {
         let class = classify_for_route(route, publisher_slug, tool_name);
+        let binding = binding_for_operation(route, context, call_args);
 
         if class == OperationClass::TrustedRead {
-            return Ok(AuthorizationDecision::allow(class));
+            let handle =
+                self.mint_handle(conversation_id, route, publisher_slug, tool_name, &binding, None)?;
+            return Ok(AuthorizationDecision::allow(class, handle));
         }
 
         let request = OperationRequest {
@@ -525,7 +661,17 @@ impl ToolAuthorizationState {
         };
         match self.evaluate_and_charge_leases(conversation_id, &request)? {
             LeaseOutcome::Deny => return Ok(AuthorizationDecision::deny(class)),
-            LeaseOutcome::Allow(_) => return Ok(AuthorizationDecision::allow(class)),
+            LeaseOutcome::Allow(lease_id) => {
+                let handle = self.mint_handle(
+                    conversation_id,
+                    route,
+                    publisher_slug,
+                    tool_name,
+                    &binding,
+                    Some(&lease_id),
+                )?;
+                return Ok(AuthorizationDecision::allow(class, handle));
+            }
             LeaseOutcome::Escalate => {}
         }
 
@@ -536,13 +682,24 @@ impl ToolAuthorizationState {
                 "one-shot",
                 description,
                 is_destructive,
+                binding,
             ));
         }
 
         // Unclassified: honor any durable conversation-scoped decision.
         match self.stored_decision(conversation_id, publisher_slug, tool_name)? {
             Some(StoredDecision::Denied) => Ok(AuthorizationDecision::deny(class)),
-            Some(StoredDecision::Granted) => Ok(AuthorizationDecision::allow(class)),
+            Some(StoredDecision::Granted) => {
+                let handle = self.mint_handle(
+                    conversation_id,
+                    route,
+                    publisher_slug,
+                    tool_name,
+                    &binding,
+                    None,
+                )?;
+                Ok(AuthorizationDecision::allow(class, handle))
+            }
             None => {
                 let (description, is_destructive) =
                     prompt_metadata(class, publisher_slug, tool_name);
@@ -551,9 +708,170 @@ impl ToolAuthorizationState {
                     "session",
                     description,
                     is_destructive,
+                    binding,
                 ))
             }
         }
+    }
+
+    /// Mint a dispatch handle for an allowed operation. Returns `None` (allow
+    /// without a redeemable handle — the dispatch will be refused) when the
+    /// caller supplied no binding material for the route: an unbindable allow
+    /// must fail closed at the transport, never widen into "any args".
+    fn mint_handle(
+        &self,
+        conversation_id: &str,
+        route: ToolRoute,
+        publisher_slug: &str,
+        tool_name: &str,
+        binding: &Option<String>,
+        lease_id: Option<&str>,
+    ) -> Result<Option<String>, String> {
+        let Some(binding) = binding else {
+            return Ok(None);
+        };
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            mint_dispatch_handle(
+                conn,
+                conversation_id,
+                route,
+                publisher_slug,
+                tool_name,
+                binding,
+                lease_id,
+                &now,
+            )
+            .map(Some)
+        })
+    }
+
+    /// Verify and redeem a dispatch handle for the exact operation a transport
+    /// is about to execute. Fail-closed on every mismatch: unknown or expired
+    /// handle, spent handle, wrong route/publisher/tool, wrong argument binding,
+    /// or a lease-bound handle whose lease has since been revoked or lapsed.
+    ///
+    /// Runs entirely under the store's single connection lock, so the check and
+    /// the redemption are atomic — two racing dispatches cannot both spend the
+    /// last use of a handle.
+    pub fn consume_dispatch_handle(
+        &self,
+        handle_id: &str,
+        route: ToolRoute,
+        publisher_slug: &str,
+        tool_name: &str,
+        binding: &str,
+    ) -> Result<(), String> {
+        const REFUSED: &str =
+            "Dispatch refused: no valid host authorization for this operation.";
+        if handle_id.trim().is_empty() {
+            return Err(REFUSED.to_string());
+        }
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let row: Option<(String, String, String, String, Option<String>, i64, String)> = conn
+                .query_row(
+                    "SELECT route, publisher_slug, tool_name, binding, lease_id, \
+                            uses_remaining, expires_at \
+                     FROM dispatch_handles WHERE id = ?1",
+                    rusqlite::params![handle_id],
+                    |r| {
+                        Ok((
+                            r.get(0)?,
+                            r.get(1)?,
+                            r.get(2)?,
+                            r.get(3)?,
+                            r.get(4)?,
+                            r.get(5)?,
+                            r.get(6)?,
+                        ))
+                    },
+                )
+                .map(Some)
+                .or_else(|err| match err {
+                    rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                    other => Err(other.to_string()),
+                })?;
+            let Some((
+                stored_route,
+                stored_publisher,
+                stored_tool,
+                stored_binding,
+                lease_id,
+                uses_remaining,
+                expires_at,
+            )) = row
+            else {
+                return Err(REFUSED.to_string());
+            };
+            if uses_remaining <= 0
+                || expires_at.as_str() <= now.as_str()
+                || stored_route != route.as_wire()
+                || stored_publisher != publisher_slug
+                || stored_tool != tool_name
+                || stored_binding != binding
+            {
+                return Err(REFUSED.to_string());
+            }
+            // A lease-bound handle is only as alive as its lease: revocation or
+            // expiry between authorize and dispatch must stop the dispatch.
+            if let Some(lease_id) = lease_id {
+                let lease_json: Option<String> = conn
+                    .query_row(
+                        "SELECT lease_json FROM capability_leases WHERE id = ?1",
+                        rusqlite::params![lease_id],
+                        |r| r.get(0),
+                    )
+                    .map(Some)
+                    .or_else(|err| match err {
+                        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                        other => Err(other.to_string()),
+                    })?;
+                let live = lease_json
+                    .and_then(|json| serde_json::from_str::<CapabilityLease>(&json).ok())
+                    .map(|lease| !lease.revoked && lease.expires_at.as_str() > now.as_str())
+                    .unwrap_or(false);
+                if !live {
+                    return Err(REFUSED.to_string());
+                }
+            }
+            conn.execute(
+                "UPDATE dispatch_handles SET uses_remaining = uses_remaining - 1 WHERE id = ?1",
+                rusqlite::params![handle_id],
+            )
+            .map_err(|e| e.to_string())?;
+            conn.execute(
+                "DELETE FROM dispatch_handles WHERE uses_remaining <= 0 OR expires_at <= ?1",
+                rusqlite::params![now],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+    }
+
+    /// Test-only mint so transport-level tests can exercise the real
+    /// verify/consume path without driving a full approval flow.
+    #[cfg(test)]
+    pub fn mint_dispatch_handle_for_test(
+        &self,
+        route: ToolRoute,
+        publisher_slug: &str,
+        tool_name: &str,
+        binding: &str,
+    ) -> Result<String, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            mint_dispatch_handle(
+                conn,
+                "test-conversation",
+                route,
+                publisher_slug,
+                tool_name,
+                binding,
+                None,
+                &now,
+            )
+        })
     }
 
     /// Read the active leases for a conversation, evaluate the call, and — when a
@@ -818,6 +1136,7 @@ impl ToolAuthorizationState {
                     changed: false,
                     state: row.state,
                     task_state: row.state.task_state(row.scope),
+                    dispatch_handle: None,
                 });
             }
             if row.expires_at.as_str() <= now.as_str() {
@@ -840,6 +1159,7 @@ impl ToolAuthorizationState {
                     changed,
                     state: ContinuationState::Expired,
                     task_state: ContinuationState::Expired.task_state(row.scope),
+                    dispatch_handle: None,
                 });
             }
             let new_state = decision.settled_state();
@@ -863,10 +1183,21 @@ impl ToolAuthorizationState {
                     &now,
                 );
             }
+            // A pending→approved settle is the post-approval mint point (#3193-F):
+            // the handle is bound to the continuation's registered operation, so a
+            // resolver cannot redeem an approval for different work. Idempotent
+            // replays and already-settled rows never mint — resolving is not a
+            // handle faucet.
+            let dispatch_handle = if changed && new_state == ContinuationState::Approved {
+                mint_handle_for_capability(conn, &row, &now)?
+            } else {
+                None
+            };
             Ok(ResolveOutcome {
                 changed,
                 state: new_state,
                 task_state: new_state.task_state(row.scope),
+                dispatch_handle,
             })
         })
     }
@@ -887,6 +1218,7 @@ impl ToolAuthorizationState {
                     changed: false,
                     state: row.state,
                     task_state: row.state.task_state(row.scope),
+                    dispatch_handle: None,
                 });
             }
             let changed = approval_continuation::settle_if_pending(
@@ -908,6 +1240,7 @@ impl ToolAuthorizationState {
                 changed,
                 state: ContinuationState::Expired,
                 task_state: ContinuationState::Expired.task_state(row.scope),
+                dispatch_handle: None,
             })
         })
     }
@@ -1028,9 +1361,82 @@ impl ToolAuthorizationState {
             let audit_rows = conn
                 .execute("DELETE FROM authorization_audit", [])
                 .map_err(|e| e.to_string())?;
-            Ok(decisions + leases + continuations + audit_rows)
+            let handles = conn
+                .execute("DELETE FROM dispatch_handles", [])
+                .map_err(|e| e.to_string())?;
+            Ok(decisions + leases + continuations + audit_rows + handles)
         })
     }
+}
+
+/// Insert one dispatch-handle row and return its host-minted id. Expired rows
+/// are swept opportunistically so the table stays bounded by live traffic.
+#[allow(clippy::too_many_arguments)]
+fn mint_dispatch_handle(
+    conn: &Connection,
+    conversation_id: &str,
+    route: ToolRoute,
+    publisher_slug: &str,
+    tool_name: &str,
+    binding: &str,
+    lease_id: Option<&str>,
+    now: &str,
+) -> Result<String, String> {
+    conn.execute(
+        "DELETE FROM dispatch_handles WHERE expires_at <= ?1",
+        rusqlite::params![now],
+    )
+    .map_err(|e| e.to_string())?;
+    let handle_id = uuid::Uuid::new_v4().to_string();
+    let expires_at = timestamp_plus_seconds(conn, DISPATCH_HANDLE_TTL_SECS)?;
+    conn.execute(
+        "INSERT INTO dispatch_handles \
+           (id, conversation_id, route, publisher_slug, tool_name, binding, \
+            lease_id, uses_remaining, expires_at, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            handle_id,
+            conversation_id,
+            route.as_wire(),
+            publisher_slug,
+            tool_name,
+            binding,
+            lease_id,
+            handle_uses_for_route(route),
+            expires_at,
+            now,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(handle_id)
+}
+
+/// Mint the post-approval handle for a resolved continuation, bound to the
+/// capability that was registered when the gate blocked the call. A capability
+/// registered without a binding cannot mint — the dispatch fails closed rather
+/// than run unbound.
+fn mint_handle_for_capability(
+    conn: &Connection,
+    row: &ContinuationRow,
+    now: &str,
+) -> Result<Option<String>, String> {
+    let Ok(route) = ToolRoute::parse(&row.requested.route) else {
+        return Ok(None);
+    };
+    let Some(binding) = row.requested.binding.as_deref() else {
+        return Ok(None);
+    };
+    mint_dispatch_handle(
+        conn,
+        &row.conversation_id,
+        route,
+        &row.requested.publisher_slug,
+        &row.requested.tool_name,
+        binding,
+        None,
+        now,
+    )
+    .map(Some)
 }
 
 /// Append one audit row, logging (never failing) on error: the audit trail lives
@@ -1195,6 +1601,24 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_capability_leases_conversation \
          ON capability_leases(conversation_id)",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    // Dispatch handles (#3193-F): host-minted, short-lived proofs of a gate
+    // decision that every side-effecting transport requires before executing.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatch_handles (
+            id              TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            route           TEXT NOT NULL,
+            publisher_slug  TEXT NOT NULL,
+            tool_name       TEXT NOT NULL,
+            binding         TEXT NOT NULL,
+            lease_id        TEXT,
+            uses_remaining  INTEGER NOT NULL,
+            expires_at      TEXT NOT NULL,
+            created_at      TEXT NOT NULL
+        )",
         [],
     )
     .map_err(|e| e.to_string())?;
@@ -1380,7 +1804,7 @@ mod tests {
     fn trusted_read_allows_silently() {
         let s = state();
         let decision = s
-            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "allow");
         assert_eq!(decision.prompt_kind, None);
@@ -1391,7 +1815,7 @@ mod tests {
         let s = state();
         for _ in 0..2 {
             let decision = s
-                .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx())
+                .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx(), None)
                 .unwrap();
             assert_eq!(decision.decision, "prompt");
             assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
@@ -1408,7 +1832,7 @@ mod tests {
         )
         .unwrap();
         let decision = s
-            .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "gmail", "delete_messages_by_message_id", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt", "still one-shot after a recorded approval");
     }
@@ -1417,7 +1841,7 @@ mod tests {
     fn unclassified_prompts_once_then_reuses_the_grant() {
         let s = state();
         let first = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(first.decision, "prompt");
         assert_eq!(first.prompt_kind.as_deref(), Some("session"));
@@ -1430,7 +1854,7 @@ mod tests {
             .unwrap();
 
         let second = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(second.decision, "allow");
     }
@@ -1438,12 +1862,12 @@ mod tests {
     #[test]
     fn unclassified_denial_is_durable() {
         let s = state();
-        s.authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+        s.authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         s.record_decision(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", false)
             .unwrap();
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "deny");
     }
@@ -1455,7 +1879,7 @@ mod tests {
             .unwrap();
         // A different conversation does not inherit the grant.
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-b", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-b", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1464,7 +1888,7 @@ mod tests {
     fn a_newly_seen_publisher_is_never_silently_allowed() {
         let s = state();
         let decision = s
-            .authorize(ToolRoute::Gateway, "never-seen", "inspect_everything", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "never-seen", "inspect_everything", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1477,7 +1901,7 @@ mod tests {
         // Two rows: the stored decision and its audit entry.
         assert_eq!(s.wipe().unwrap(), 2);
         let decision = s
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1519,6 +1943,7 @@ mod tests {
                     "execute_command",
                     "conv-a",
                     &cmd_ctx(command),
+                    None,
                 )
                 .unwrap();
             assert_eq!(
@@ -1543,6 +1968,7 @@ mod tests {
                 "execute_command",
                 "conv-a",
                 &cmd_ctx("cargo build"),
+                None,
             )
             .unwrap();
         assert_eq!(decision.decision, "prompt");
@@ -1563,6 +1989,7 @@ mod tests {
                 "execute_command",
                 "conv-a",
                 &cmd_ctx("curl https://example.com/pay"),
+                None,
             )
             .unwrap();
         assert_eq!(decision.decision, "prompt");
@@ -1588,6 +2015,7 @@ mod tests {
                 "execute_command",
                 "conv-a",
                 &cmd_ctx("git push origin main"),
+                None,
             )
             .unwrap();
         assert_eq!(decision.decision, "deny");
@@ -1611,14 +2039,14 @@ mod tests {
 
         for tool in ["post_notes", "post_records", "patch_records_by_id"] {
             let decision = s
-                .authorize(ToolRoute::Gateway, "attio", tool, "conv-a", &target_ctx("conn-123"))
+                .authorize(ToolRoute::Gateway, "attio", tool, "conv-a", &target_ctx("conn-123"), None)
                 .unwrap();
             assert_eq!(decision.decision, "allow", "{tool} should be covered");
         }
 
         // A different connection/account is not covered — one escalation.
         let decision = s
-            .authorize(ToolRoute::Gateway, "attio", "post_notes", "conv-a", &target_ctx("conn-999"))
+            .authorize(ToolRoute::Gateway, "attio", "post_notes", "conv-a", &target_ctx("conn-999"), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1645,6 +2073,7 @@ mod tests {
                 "delete_records_by_id",
                 "conv-a",
                 &target_ctx("conn-123"),
+                None,
             )
             .unwrap();
         assert_eq!(decision.decision, "prompt");
@@ -1660,14 +2089,14 @@ mod tests {
             .grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
             .unwrap();
         assert_eq!(
-            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
                 .unwrap()
                 .decision,
             "allow"
         );
         assert!(s.revoke_lease(&lease.id).unwrap());
         assert_eq!(
-            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
                 .unwrap()
                 .decision,
             "prompt"
@@ -1682,7 +2111,7 @@ mod tests {
         s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
             .unwrap();
         let decision = s
-            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-b", &cmd_ctx("cargo build"))
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-b", &cmd_ctx("cargo build"), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1707,7 +2136,7 @@ mod tests {
             s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(500))
                 .unwrap();
             assert_eq!(
-                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
                     .unwrap()
                     .decision,
                 "allow"
@@ -1721,7 +2150,7 @@ mod tests {
             assert_eq!(leases.len(), 1);
             assert_eq!(leases[0].budgets.calls_used, 1, "budget spend persisted to disk");
             assert_eq!(
-                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo test"))
+                s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo test"), None)
                     .unwrap()
                     .decision,
                 "allow"
@@ -1753,7 +2182,7 @@ mod tests {
         assert!(s.wipe().unwrap() >= 1);
         assert!(s.list_leases("conv-a").unwrap().is_empty());
         let decision = s
-            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
             .unwrap();
         assert_eq!(decision.decision, "prompt");
     }
@@ -1784,7 +2213,7 @@ mod tests {
         // A brand-new state (no shared connection) at the same path.
         let second = ToolAuthorizationState::new(db_path);
         let decision = second
-            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx())
+            .authorize(ToolRoute::Gateway, "new-publisher", "inspect_records", "conv-a", &ctx(), None)
             .unwrap();
         assert_eq!(
             decision.decision, "allow",
@@ -1805,6 +2234,7 @@ mod tests {
             command: None,
             host: None,
             target: None,
+            binding: None,
         }
     }
 
@@ -1819,6 +2249,7 @@ mod tests {
             command: Some(command.to_string()),
             host: None,
             target: None,
+            binding: None,
         }
     }
 
@@ -2082,7 +2513,7 @@ mod tests {
             .grant_lease("conv-a", "Coding lease", 3600, command_rules(&["cargo"]), call_budget(10))
             .unwrap();
         let decision = s
-            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"))
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
             .unwrap();
         assert_eq!(decision.decision, "allow");
         assert!(s.revoke_lease(&lease.id).unwrap());
@@ -2112,7 +2543,7 @@ mod tests {
         s.grant_lease("conv-a", "lease", 3600, command_rules(&["curl"]), call_budget(10))
             .unwrap();
         let secret_command = "curl -H 'Authorization: Bearer sk-live-SECRET' https://api.example.com";
-        s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx(secret_command))
+        s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx(secret_command), None)
             .unwrap();
 
         let entries = s.list_audit("conv-a", 100).unwrap();
@@ -2136,7 +2567,7 @@ mod tests {
         s.grant_lease("conv-a", "lease", 3600, predicates, call_budget(10))
             .unwrap();
         let decision = s
-            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("git push"))
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("git push"), None)
             .unwrap();
         assert_eq!(decision.decision, "deny");
         assert_eq!(audit_events(&s, "conv-a"), vec!["lease_denied", "lease_granted"]);
@@ -2238,5 +2669,339 @@ mod tests {
         assert!(!s.list_audit("conv-a", 10).unwrap().is_empty());
         s.wipe().unwrap();
         assert!(s.list_audit("conv-a", 10).unwrap().is_empty());
+    }
+
+    // ---- dispatch-handle enforcement (#3193-F) -----------------------------
+
+    fn gmail_read_args() -> serde_json::Value {
+        serde_json::json!({ "q": "from:example" })
+    }
+
+    /// A silent allow mints a handle the transport can redeem for that exact
+    /// operation; a gateway handle budgets the x402 retry pair, then exhausts.
+    #[test]
+    fn allow_mints_a_redeemable_handle_that_exhausts() {
+        let s = state();
+        let args = gmail_read_args();
+        let decision = s
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx(), Some(&args))
+            .unwrap();
+        assert_eq!(decision.decision, "allow");
+        let handle = decision.handle.expect("allow carries a dispatch handle");
+        let binding = binding_for_publisher_args(&args);
+
+        s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+            .unwrap();
+        s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+            .unwrap();
+        s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+            .unwrap();
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+                .is_err(),
+            "a spent handle must be refused"
+        );
+    }
+
+    /// A transport invoked with no handle, a forged handle, or an expired
+    /// handle is refused — the bypass path this ticket exists to close.
+    #[test]
+    fn transports_refuse_missing_forged_and_expired_handles() {
+        let s = state();
+        let binding = binding_for_publisher_args(&gmail_read_args());
+        assert!(
+            s.consume_dispatch_handle("", ToolRoute::Gateway, "gmail", "get_messages", &binding)
+                .is_err(),
+            "no handle"
+        );
+        assert!(
+            s.consume_dispatch_handle(
+                "11111111-2222-3333-4444-555555555555",
+                ToolRoute::Gateway,
+                "gmail",
+                "get_messages",
+                &binding
+            )
+            .is_err(),
+            "forged handle"
+        );
+
+        let args = gmail_read_args();
+        let decision = s
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx(), Some(&args))
+            .unwrap();
+        let handle = decision.handle.unwrap();
+        // Force the handle's window closed.
+        s.with_conn(|conn| {
+            conn.execute(
+                "UPDATE dispatch_handles SET expires_at = '2000-01-01T00:00:00.000Z' WHERE id = ?1",
+                rusqlite::params![handle],
+            )
+            .map_err(|e| e.to_string())
+        })
+        .unwrap();
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+                .is_err(),
+            "expired handle"
+        );
+    }
+
+    /// A handle for one operation cannot be replayed for a different operation,
+    /// route, publisher, or argument payload.
+    #[test]
+    fn handle_is_bound_to_route_operation_and_args() {
+        let s = state();
+        let args = gmail_read_args();
+        let handle = s
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx(), Some(&args))
+            .unwrap()
+            .handle
+            .unwrap();
+        let binding = binding_for_publisher_args(&args);
+        let other_binding =
+            binding_for_publisher_args(&serde_json::json!({ "q": "from:someone-else" }));
+
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "delete_messages", &binding)
+                .is_err(),
+            "different operation"
+        );
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Mcp, "gmail", "get_messages", &binding)
+                .is_err(),
+            "different route"
+        );
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "attio", "get_messages", &binding)
+                .is_err(),
+            "different publisher"
+        );
+        assert!(
+            s.consume_dispatch_handle(
+                &handle,
+                ToolRoute::Gateway,
+                "gmail",
+                "get_messages",
+                &other_binding
+            )
+            .is_err(),
+            "different args"
+        );
+        // The exact operation still redeems.
+        s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "get_messages", &binding)
+            .unwrap();
+    }
+
+    /// The operation binding ignores dispatch metadata (`connection_id`,
+    /// `_x402_payment`) that legitimately changes between the gate consultation
+    /// and the wire dispatch, and nothing else.
+    #[test]
+    fn binding_normalization_excludes_only_dispatch_metadata() {
+        let base = serde_json::json!({ "q": "x" });
+        let with_meta = serde_json::json!({
+            "q": "x",
+            "connection_id": "conn-1",
+            "_x402_payment": "header",
+        });
+        let different = serde_json::json!({ "q": "y" });
+        assert_eq!(
+            binding_for_publisher_args(&base),
+            binding_for_publisher_args(&with_meta)
+        );
+        assert_ne!(
+            binding_for_publisher_args(&base),
+            binding_for_publisher_args(&different)
+        );
+    }
+
+    /// Non-gateway routes are strictly one dispatch per authorization.
+    #[test]
+    fn non_gateway_handles_are_single_use() {
+        let s = state();
+        s.grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(10))
+            .unwrap();
+        let handle = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("cargo build"),
+                None,
+            )
+            .unwrap()
+            .handle
+            .unwrap();
+        let binding = binding_for_command("cargo build");
+        s.consume_dispatch_handle(&handle, ToolRoute::Shell, "seren", "execute_command", &binding)
+            .unwrap();
+        assert!(
+            s.consume_dispatch_handle(&handle, ToolRoute::Shell, "seren", "execute_command", &binding)
+                .is_err()
+        );
+    }
+
+    /// A lease-bound handle dies with its lease: revocation between authorize
+    /// and dispatch stops the dispatch.
+    #[test]
+    fn lease_bound_handle_is_refused_after_revocation() {
+        let s = state();
+        let lease = s
+            .grant_lease("conv-a", "coding", 3600, command_rules(&["cargo"]), call_budget(10))
+            .unwrap();
+        let handle = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("cargo build"),
+                None,
+            )
+            .unwrap()
+            .handle
+            .unwrap();
+        assert!(s.revoke_lease(&lease.id).unwrap());
+        assert!(
+            s.consume_dispatch_handle(
+                &handle,
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                &binding_for_command("cargo build")
+            )
+            .is_err(),
+            "a revoked lease must invalidate its outstanding handles"
+        );
+    }
+
+    /// The prompt decision carries the host-computed binding; the approved
+    /// continuation mints a handle bound to exactly that operation, exactly
+    /// once — a replayed resolve is not a handle faucet.
+    #[test]
+    fn approved_continuation_mints_the_post_approval_handle_once() {
+        let s = state();
+        let args = serde_json::json!({ "to": "a@example.com" });
+        let decision = s
+            .authorize(ToolRoute::Gateway, "gmail", "post_send", "conv-a", &ctx(), Some(&args))
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        let binding = decision.binding.expect("prompt carries the operation binding");
+        assert_eq!(binding, binding_for_publisher_args(&args));
+
+        let mut cap = send_cap();
+        cap.binding = Some(binding.clone());
+        let r = s
+            .register_continuation("conv-a", cap, ContinuationScope::Linear, 300)
+            .unwrap();
+        let outcome = s
+            .resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        assert!(outcome.changed);
+        let handle = outcome
+            .dispatch_handle
+            .expect("pending→approved settle mints the dispatch handle");
+        s.consume_dispatch_handle(&handle, ToolRoute::Gateway, "gmail", "post_send", &binding)
+            .unwrap();
+
+        // Idempotent replay of the resolve mints nothing.
+        let replay = s
+            .resolve_continuation(&r.approval_id, &r.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        assert!(!replay.changed);
+        assert!(replay.dispatch_handle.is_none());
+    }
+
+    /// Deny/skip settles never mint; a capability registered without a binding
+    /// cannot mint either (the dispatch fails closed instead).
+    #[test]
+    fn non_approve_settles_and_unbound_capabilities_mint_nothing() {
+        let s = state();
+        let denied = s
+            .register_continuation("conv-a", shell_cap("git push"), ContinuationScope::Linear, 300)
+            .unwrap();
+        let outcome = s
+            .resolve_continuation(&denied.approval_id, &denied.resume_token, ResolveDecision::Deny)
+            .unwrap();
+        assert!(outcome.dispatch_handle.is_none());
+
+        // send_cap() has no binding: approval settles but cannot mint.
+        let unbound = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        let outcome = s
+            .resolve_continuation(&unbound.approval_id, &unbound.resume_token, ResolveDecision::Approve)
+            .unwrap();
+        assert!(outcome.changed);
+        assert!(outcome.dispatch_handle.is_none());
+    }
+
+    /// Distinct argument payloads for the same tool are distinct pending
+    /// requests — a differently-argued retry must not inherit a continuation
+    /// whose post-approval handle it can never redeem.
+    #[test]
+    fn continuation_dedup_keys_on_the_operation_binding() {
+        let s = state();
+        let mut first = send_cap();
+        first.binding = Some("binding-a".to_string());
+        let mut second = send_cap();
+        second.binding = Some("binding-b".to_string());
+
+        let a = s
+            .register_continuation("conv-a", first.clone(), ContinuationScope::Linear, 300)
+            .unwrap();
+        let b = s
+            .register_continuation("conv-a", second, ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(!b.deduplicated, "different args are a different request");
+        assert_ne!(a.approval_id, b.approval_id);
+
+        // The same args still dedup.
+        let retry = s
+            .register_continuation("conv-a", first, ContinuationScope::Linear, 300)
+            .unwrap();
+        assert!(retry.deduplicated);
+        assert_eq!(retry.approval_id, a.approval_id);
+    }
+
+    /// Gateway catalog discovery reads are trusted and mint silently — the
+    /// enforced MCP transport must not break gateway initialization.
+    #[test]
+    fn gateway_catalog_reads_mint_silently() {
+        let s = state();
+        for (tool, args) in [
+            ("list_agent_publishers", serde_json::json!({})),
+            ("list_mcp_tools", serde_json::json!({ "publisher": "gmail" })),
+        ] {
+            let decision = s
+                .authorize(ToolRoute::Seren, "seren", tool, "gateway-catalog", &ctx(), Some(&args))
+                .unwrap();
+            assert_eq!(decision.decision, "allow", "{tool} should be a trusted read");
+            assert!(decision.handle.is_some(), "{tool} should carry a handle");
+        }
+    }
+
+    /// Wipe clears outstanding handles: after erase-all nothing is redeemable.
+    #[test]
+    fn wipe_clears_dispatch_handles() {
+        let s = state();
+        let args = gmail_read_args();
+        let handle = s
+            .authorize(ToolRoute::Gateway, "gmail", "get_messages", "conv-a", &ctx(), Some(&args))
+            .unwrap()
+            .handle
+            .unwrap();
+        s.wipe().unwrap();
+        assert!(
+            s.consume_dispatch_handle(
+                &handle,
+                ToolRoute::Gateway,
+                "gmail",
+                "get_messages",
+                &binding_for_publisher_args(&args)
+            )
+            .is_err()
+        );
     }
 }

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -147,9 +147,14 @@ function createMcpClient() {
 
   /**
    * Call a tool on an MCP server.
+   *
+   * `authHandle` is the host-minted dispatch handle from the authorization
+   * gate (#3193-F). The Rust transport refuses tool execution without a live
+   * handle for the exact server, tool, and arguments.
    */
   type CallToolOptions = {
     signal?: AbortSignal;
+    authHandle?: string;
   };
 
   type RetryToolOptions = CallToolOptions & {
@@ -198,6 +203,7 @@ function createMcpClient() {
       serverName,
       toolName: call.name,
       arguments: call.arguments,
+      authHandle: options?.authHandle,
     }).catch((error) => {
       throw parseMcpError(error, serverName);
     });
@@ -439,6 +445,7 @@ function createMcpClient() {
       serverName,
       toolName: call.name,
       arguments: call.arguments,
+      authHandle: options?.authHandle,
     }).catch((error) => {
       throw parseMcpError(error, serverName);
     });

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -900,6 +900,37 @@ export async function executeTool(
     // Check if this is a built-in Seren tool (seren__toolName)
     if (name.startsWith("seren__")) {
       const serenToolName = name.slice("seren__".length);
+      // `call_publisher` is an envelope around a publisher operation. It is
+      // authorized and dispatched AS that operation (#3193-F): the transport
+      // unwraps the envelope to verify the dispatch handle, and classifying
+      // the wrapped operation directly means a high-risk publisher call
+      // cannot ride an "unclassified call_publisher" session grant.
+      if (serenToolName === "call_publisher") {
+        const publisher =
+          typeof args.publisher === "string" ? args.publisher : "";
+        const tool = typeof args.tool === "string" ? args.tool : "";
+        const toolArgs =
+          args.tool_args &&
+          typeof args.tool_args === "object" &&
+          !Array.isArray(args.tool_args)
+            ? (args.tool_args as Record<string, unknown>)
+            : {};
+        if (!publisher || !tool) {
+          return {
+            tool_call_id: toolCall.id,
+            content:
+              "call_publisher requires string `publisher` and `tool` arguments",
+            is_error: true,
+          };
+        }
+        return await executeGatewayTool(
+          toolCall.id,
+          publisher,
+          tool,
+          toolArgs,
+          conversationId,
+        );
+      }
       const auth = await authorizeToolOperation(
         "seren",
         "seren",

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { mcpClient } from "@/lib/mcp/client";
 import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
+import { reportError } from "@/lib/support/hook";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { type PaymentRequirements, parsePaymentRequirements } from "@/lib/x402";
 import {
@@ -69,6 +70,13 @@ interface AuthorizationDecision {
   operationClass: "trusted-read" | "high-risk" | "unclassified";
   description: string;
   isDestructive: boolean;
+  /** Host-minted dispatch handle, present only on "allow" (#3193-F). The
+   * transports refuse to execute without it; this code only ferries it. */
+  handle?: string | null;
+  /** Opaque host-computed operation binding, present on "prompt". Echoed into
+   * the suspended continuation so the post-approval handle is bound to the
+   * exact operation the gate blocked. */
+  binding?: string | null;
 }
 
 // A gate failure must never become a silent allow.
@@ -141,6 +149,8 @@ interface RequestedCapability {
   command?: string;
   host?: string;
   target?: string;
+  /** Opaque host-computed operation binding from the gate's prompt decision. */
+  binding?: string;
 }
 
 /**
@@ -159,12 +169,26 @@ interface RegisteredContinuation {
 }
 
 /**
- * Outcome of authorizing one tool call. On a block, the structured tool result
- * is ready to return to the model — never a generic "not approved" string, so a
- * denial, expiry, and skip are distinguishable and the model can adapt.
+ * The host's answer to settling a continuation. `dispatchHandle` is present
+ * only on the single pending→approved settle (#3193-F) — it is the proof the
+ * transports require before executing the approved operation.
+ */
+interface ResolveOutcome {
+  changed: boolean;
+  state: "pending" | "approved" | "denied" | "skipped" | "expired";
+  taskState: string;
+  dispatchHandle?: string | null;
+}
+
+/**
+ * Outcome of authorizing one tool call. On approval the host-minted dispatch
+ * `handle` accompanies it — every transport refuses to execute without one. On
+ * a block, the structured tool result is ready to return to the model — never a
+ * generic "not approved" string, so a denial, expiry, and skip are
+ * distinguishable and the model can adapt.
  */
 type ToolAuthorization =
-  | { approved: true; connectionId?: string | null }
+  | { approved: true; handle: string; connectionId?: string | null }
   | { approved: false; toolResult: ToolResult };
 
 type BlockedKind = "denied" | "expired" | "skipped";
@@ -173,7 +197,8 @@ type BlockedKind = "denied" | "expired" | "skipped";
  * Register a host-owned suspended continuation for a blocked action, so the
  * paused action becomes a visible, resumable record (never a hung tool call) and
  * equivalent retries dedup to one pending request. Returns null if the host is
- * unavailable — the approval UI still runs; only the persisted state is skipped.
+ * unavailable — the action then fails closed, since only a settled continuation
+ * can mint the dispatch handle the transports require (#3193-F).
  */
 async function registerApprovalContinuation(
   route: ToolRoute,
@@ -193,6 +218,7 @@ async function registerApprovalContinuation(
     command: context.command,
     host: context.host,
     target: context.target,
+    binding: decision.binding ?? undefined,
   };
   try {
     return await invoke<RegisteredContinuation>(
@@ -216,30 +242,32 @@ async function registerApprovalContinuation(
 /**
  * Settle a suspended continuation exactly once. Approve/deny/skip are user
  * decisions; expire is the system outcome of a lapsed approval UI. Idempotent
- * host-side, so a failed settle is safe to ignore.
+ * host-side. Returns the host outcome — an approve settle carries the
+ * dispatch handle the transports require — or null when the host call failed
+ * (the dispatch then fails closed for lack of a handle).
  */
 async function settleApprovalContinuation(
   registered: RegisteredContinuation,
   kind: "approve" | "deny" | "skip" | "expire",
-): Promise<void> {
+): Promise<ResolveOutcome | null> {
   try {
     if (kind === "expire") {
-      await invoke("expire_approval_continuation", {
+      return await invoke<ResolveOutcome>("expire_approval_continuation", {
         approvalId: registered.approvalId,
         resumeToken: registered.resumeToken,
-      });
-    } else {
-      await invoke("resolve_approval_continuation", {
-        approvalId: registered.approvalId,
-        resumeToken: registered.resumeToken,
-        decision: kind,
       });
     }
+    return await invoke<ResolveOutcome>("resolve_approval_continuation", {
+      approvalId: registered.approvalId,
+      resumeToken: registered.resumeToken,
+      decision: kind,
+    });
   } catch (err) {
     console.error(
       "[Tool Executor] Failed to settle approval continuation:",
       err,
     );
+    return null;
   }
 }
 
@@ -287,6 +315,7 @@ async function consultAuthorizationGate(
   toolName: string,
   conversationId: string,
   context: OperationContext,
+  callArgs: Record<string, unknown>,
 ): Promise<AuthorizationDecision> {
   try {
     return await invoke<AuthorizationDecision>("authorize_tool_operation", {
@@ -295,6 +324,9 @@ async function consultAuthorizationGate(
       toolName,
       conversationId,
       context,
+      // The host derives the exact-operation binding from the full argument
+      // payload; without it no dispatch handle can be minted (#3193-F).
+      callArgs,
     });
   } catch (err) {
     console.error("[Tool Executor] Authorization gate unavailable:", err);
@@ -521,11 +553,24 @@ async function authorizeToolOperation(
     toolName,
     sessionId,
     context,
+    args,
   );
   const capability = `${publisherSlug}/${toolName}`;
 
   if (decision.decision === "allow") {
-    return { approved: true };
+    // An allow without a redeemable handle cannot dispatch — fail closed
+    // rather than let the transport produce a confusing refusal.
+    if (!decision.handle) {
+      reportError(
+        "ToolDispatchHandleMissing",
+        `Host allowed ${capability} but minted no dispatch handle`,
+      );
+      return {
+        approved: false,
+        toolResult: blockedToolResult(toolCallId, "denied", capability),
+      };
+    }
+    return { approved: true, handle: decision.handle };
   }
   if (decision.decision === "deny") {
     console.log(`[Tool Executor] Host denied ${publisherSlug}/${toolName}`);
@@ -537,7 +582,9 @@ async function authorizeToolOperation(
 
   // A prompt suspends the action: record it host-side so the block is visible and
   // resumable (never a hung call), then run the approval UI and settle it exactly
-  // once with the outcome.
+  // once with the outcome. The continuation is also where the post-approval
+  // dispatch handle is minted (#3193-F), so registration failing means the
+  // action cannot proceed even if the user approves — fail closed up front.
   const registered = await registerApprovalContinuation(
     route,
     publisherSlug,
@@ -546,6 +593,12 @@ async function authorizeToolOperation(
     context,
     sessionId,
   );
+  if (!registered) {
+    return {
+      approved: false,
+      toolResult: blockedToolResult(toolCallId, "denied", capability),
+    };
+  }
 
   const approval = await requestGatewayApproval(
     publisherSlug,
@@ -557,7 +610,7 @@ async function authorizeToolOperation(
       isDestructive: decision.isDestructive,
       operationClass: decision.operationClass,
     },
-    { threadId: sessionId, continuationId: registered?.approvalId },
+    { threadId: sessionId, continuationId: registered.approvalId },
   );
 
   // Only an explicit approve/deny is durable. A timeout is an expiry and a skip
@@ -575,10 +628,27 @@ async function authorizeToolOperation(
   }
 
   if (approval.approved) {
-    if (registered) {
-      await settleApprovalContinuation(registered, "approve");
+    const settled = await settleApprovalContinuation(registered, "approve");
+    // Only the pending→approved settle mints a handle. A deduped duplicate or
+    // a host-side expiry yields none — the dispatch fails closed and the model
+    // may retry through a fresh gate consultation.
+    if (!settled?.dispatchHandle) {
+      const kind: BlockedKind = settled?.state === "expired" ? "expired" : "denied";
+      return {
+        approved: false,
+        toolResult: blockedToolResult(
+          toolCallId,
+          kind,
+          capability,
+          registered.approvalId,
+        ),
+      };
     }
-    return { approved: true, connectionId: approval.connectionId };
+    return {
+      approved: true,
+      handle: settled.dispatchHandle,
+      connectionId: approval.connectionId,
+    };
   }
 
   const kind: BlockedKind = approval.timedOut
@@ -586,19 +656,17 @@ async function authorizeToolOperation(
     : approval.skipped
       ? "skipped"
       : "denied";
-  if (registered) {
-    await settleApprovalContinuation(
-      registered,
-      approval.timedOut ? "expire" : approval.skipped ? "skip" : "deny",
-    );
-  }
+  await settleApprovalContinuation(
+    registered,
+    approval.timedOut ? "expire" : approval.skipped ? "skip" : "deny",
+  );
   return {
     approved: false,
     toolResult: blockedToolResult(
       toolCallId,
       kind,
       capability,
-      registered?.approvalId,
+      registered.approvalId,
     ),
   };
 }
@@ -614,6 +682,7 @@ async function authorizeSubprocess(
   route: "shell" | "skill",
   toolName: string,
   command: string,
+  args: Record<string, unknown>,
   conversationId: string | null,
   toolCallId: string,
   runApprovalUi: (link: ApprovalLink) => Promise<GatewayApprovalResult>,
@@ -626,6 +695,7 @@ async function authorizeSubprocess(
     toolName,
     sessionId,
     context,
+    args,
   );
   // The lease/gate key a subprocess on its leading program token; use that as the
   // capability label so a block names what the user actually saw.
@@ -638,9 +708,21 @@ async function authorizeSubprocess(
     };
   }
   if (decision.decision === "allow") {
-    return { approved: true };
+    if (!decision.handle) {
+      reportError(
+        "ToolDispatchHandleMissing",
+        `Host allowed ${capability} but minted no dispatch handle`,
+      );
+      return {
+        approved: false,
+        toolResult: blockedToolResult(toolCallId, "denied", capability),
+      };
+    }
+    return { approved: true, handle: decision.handle };
   }
 
+  // The continuation mints the post-approval dispatch handle (#3193-F);
+  // without it an approval cannot execute, so registration is required.
   const registered = await registerApprovalContinuation(
     route,
     "seren",
@@ -649,16 +731,32 @@ async function authorizeSubprocess(
     context,
     sessionId,
   );
+  if (!registered) {
+    return {
+      approved: false,
+      toolResult: blockedToolResult(toolCallId, "denied", capability),
+    };
+  }
   const outcome = await runApprovalUi({
     threadId: sessionId,
-    continuationId: registered?.approvalId,
+    continuationId: registered.approvalId,
   });
 
   if (outcome.approved) {
-    if (registered) {
-      await settleApprovalContinuation(registered, "approve");
+    const settled = await settleApprovalContinuation(registered, "approve");
+    if (!settled?.dispatchHandle) {
+      const kind: BlockedKind = settled?.state === "expired" ? "expired" : "denied";
+      return {
+        approved: false,
+        toolResult: blockedToolResult(
+          toolCallId,
+          kind,
+          capability,
+          registered.approvalId,
+        ),
+      };
     }
-    return { approved: true };
+    return { approved: true, handle: settled.dispatchHandle };
   }
 
   const kind: BlockedKind = outcome.timedOut
@@ -666,19 +764,17 @@ async function authorizeSubprocess(
     : outcome.skipped
       ? "skipped"
       : "denied";
-  if (registered) {
-    await settleApprovalContinuation(
-      registered,
-      outcome.timedOut ? "expire" : outcome.skipped ? "skip" : "deny",
-    );
-  }
+  await settleApprovalContinuation(
+    registered,
+    outcome.timedOut ? "expire" : outcome.skipped ? "skip" : "deny",
+  );
   return {
     approved: false,
     toolResult: blockedToolResult(
       toolCallId,
       kind,
       capability,
-      registered?.approvalId,
+      registered.approvalId,
     ),
   };
 }
@@ -813,7 +909,7 @@ export async function executeTool(
       if (!auth.approved) {
         return auth.toolResult;
       }
-      const response = await callSerenTool(serenToolName, args);
+      const response = await callSerenTool(serenToolName, args, auth.handle);
       const content =
         typeof response.result === "string"
           ? response.result
@@ -894,7 +990,7 @@ export async function executeTool(
           url: string;
           status: number;
           truncated: boolean;
-        }>("web_fetch", { url, timeoutMs });
+        }>("web_fetch", { url, timeoutMs, authHandle: auth.handle });
 
         if (response.status >= 400) {
           result = `Error: HTTP ${response.status} for ${response.url}`;
@@ -924,6 +1020,7 @@ export async function executeTool(
           "shell",
           "execute_command",
           command,
+          args,
           conversationId,
           toolCall.id,
           (link) => requestShellApproval(command, timeoutSecs, link),
@@ -943,7 +1040,10 @@ export async function executeTool(
           stderr: string;
           exit_code: number | null;
           timed_out: boolean;
-        }>("execute_shell_command_streaming", invokeArgs);
+        }>("execute_shell_command_streaming", {
+          ...invokeArgs,
+          authHandle: auth.handle,
+        });
 
         if (cmdResult.timed_out) {
           result = `Command timed out after ${timeoutSecs} seconds.\nstderr: ${cmdResult.stderr}`;
@@ -982,6 +1082,7 @@ export async function executeTool(
           "skill",
           "run_skill_script",
           argv.join(" "),
+          args,
           conversationId,
           toolCall.id,
           (link) => requestShellApproval(preview, timeoutSecs, link),
@@ -1019,7 +1120,7 @@ export async function executeTool(
           stderr: string;
           exit_code: number | null;
           timed_out: boolean;
-        }>("run_skill_script", invokeArgs);
+        }>("run_skill_script", { ...invokeArgs, authHandle: auth.handle });
 
         if (cmdResult.timed_out) {
           result = `Skill script timed out after ${timeoutSecs} seconds.\nstderr: ${cmdResult.stderr}`;
@@ -1083,10 +1184,14 @@ async function executeMcpTool(
       return auth.toolResult;
     }
 
-    const result = await mcpClient.callTool(serverName, {
-      name: toolName,
-      arguments: args,
-    });
+    const result = await mcpClient.callTool(
+      serverName,
+      {
+        name: toolName,
+        arguments: args,
+      },
+      { authHandle: auth.handle },
+    );
 
     // Convert MCP result content to string
     let content = "";
@@ -1177,6 +1282,9 @@ async function executeGatewayTool(
       console.log("[Tool Executor] Operation blocked before execution");
       return auth.toolResult;
     }
+    // One authorization covers the initial dispatch plus its x402 payment
+    // retries — the host-minted handle carries that exact allowance.
+    const authHandle = auth.handle;
 
     if (auth.connectionId) {
       callArgs = { ...args, connection_id: auth.connectionId };
@@ -1197,7 +1305,12 @@ async function executeGatewayTool(
     }
     callArgs = resolvedArgs.args;
 
-    const response = await callGatewayTool(publisherSlug, toolName, callArgs);
+    const response = await callGatewayTool(
+      publisherSlug,
+      toolName,
+      callArgs,
+      authHandle,
+    );
 
     // Check if this is a payment proxy response (requires client-side signing)
     if (response.is_error && response.payment_proxy) {
@@ -1243,6 +1356,7 @@ async function executeGatewayTool(
           publisherSlug,
           toolName,
           retryArgs,
+          authHandle,
         );
 
         const retryContent =
@@ -1272,6 +1386,7 @@ async function executeGatewayTool(
           publisherSlug,
           toolName,
           callArgs,
+          authHandle,
         );
 
         const retryContent =

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -5,8 +5,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { mcpClient } from "@/lib/mcp/client";
 import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
-import { reportError } from "@/lib/support/hook";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
+import { reportError } from "@/lib/support/hook";
 import { type PaymentRequirements, parsePaymentRequirements } from "@/lib/x402";
 import {
   callGatewayTool,
@@ -633,7 +633,8 @@ async function authorizeToolOperation(
     // a host-side expiry yields none — the dispatch fails closed and the model
     // may retry through a fresh gate consultation.
     if (!settled?.dispatchHandle) {
-      const kind: BlockedKind = settled?.state === "expired" ? "expired" : "denied";
+      const kind: BlockedKind =
+        settled?.state === "expired" ? "expired" : "denied";
       return {
         approved: false,
         toolResult: blockedToolResult(
@@ -745,7 +746,8 @@ async function authorizeSubprocess(
   if (outcome.approved) {
     const settled = await settleApprovalContinuation(registered, "approve");
     if (!settled?.dispatchHandle) {
-      const kind: BlockedKind = settled?.state === "expired" ? "expired" : "denied";
+      const kind: BlockedKind =
+        settled?.state === "expired" ? "expired" : "denied";
       return {
         approved: false,
         toolResult: blockedToolResult(

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -1,6 +1,7 @@
 // ABOUTME: MCP Gateway service for connecting to Seren MCP gateway via MCP protocol.
 // ABOUTME: Uses rmcp HTTP streaming transport to connect to mcp.serendb.com/mcp.
 
+import { invoke } from "@tauri-apps/api/core";
 import {
   API_BASE,
   MCP_GATEWAY_INITIALIZE_METHOD,
@@ -162,6 +163,37 @@ async function connectGatewayWithRetry(apiKey: string): Promise<void> {
 }
 
 /**
+ * Authorize a gateway catalog read (list_agent_publishers / list_mcp_tools)
+ * through the host gate and return the dispatch handle the MCP transport
+ * requires (#3193-F). These are host-classified trusted reads, so the gate
+ * allows them silently; anything else — including a gate failure — refuses.
+ */
+async function catalogReadHandle(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const decision = await invoke<{ decision: string; handle?: string | null }>(
+    "authorize_tool_operation",
+    {
+      route: "seren",
+      publisherSlug: "seren",
+      toolName,
+      conversationId: "gateway-catalog",
+      context: {},
+      callArgs: args,
+    },
+  );
+  if (decision.decision !== "allow" || !decision.handle) {
+    throw new McpGatewayError(
+      `Gateway catalog read ${toolName} was not authorized`,
+      403,
+      MCP_GATEWAY_URL,
+    );
+  }
+  return decision.handle;
+}
+
+/**
  * Parse publisher slug from MCP tool name.
  * Publisher tools are named like "mcp__publisher-slug__tool-name".
  * Returns null for built-in gateway tools (no mcp__ prefix).
@@ -210,6 +242,7 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
   const pubResult: McpToolResult = await mcpClient.callToolHttp(
     SEREN_MCP_SERVER_NAME,
     { name: "list_agent_publishers", arguments: {} },
+    { authHandle: await catalogReadHandle("list_agent_publishers", {}) },
   );
 
   if (pubResult.isError || !pubResult.content) {
@@ -271,6 +304,11 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
       const toolResult: McpToolResult = await mcpClient.callToolHttp(
         SEREN_MCP_SERVER_NAME,
         { name: "list_mcp_tools", arguments: { publisher: slug } },
+        {
+          authHandle: await catalogReadHandle("list_mcp_tools", {
+            publisher: slug,
+          }),
+        },
       );
       if (toolResult.isError || !toolResult.content) {
         console.warn(
@@ -500,6 +538,7 @@ export function getBuiltinToolSchemas(): McpToolInfo[] {
 export async function callSerenTool(
   toolName: string,
   args: Record<string, unknown>,
+  authHandle?: string,
 ) {
   if (!isConnected) {
     throw new McpGatewayError(
@@ -509,10 +548,14 @@ export async function callSerenTool(
     );
   }
   const startTime = Date.now();
-  const result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
-    name: toolName,
-    arguments: args,
-  });
+  const result = await mcpClient.callToolHttp(
+    SEREN_MCP_SERVER_NAME,
+    {
+      name: toolName,
+      arguments: args,
+    },
+    { authHandle },
+  );
   const executionTime = Date.now() - startTime;
   return {
     result: result.content,
@@ -649,6 +692,7 @@ async function callSelectedPublisherTool(
   connectionId: string,
   payment: unknown,
   startTime: number,
+  authHandle?: string,
 ): Promise<McpToolCallResponse> {
   const url = `${API_BASE}/publishers/${encodeURIComponent(
     publisherSlug,
@@ -658,6 +702,11 @@ async function callSelectedPublisherTool(
     "Content-Type": "application/json",
     "x-seren-oauth-connection-id": connectionId,
   };
+  // Dispatch handle for the Rust gateway bridge (#3193-F). The bridge consumes
+  // and strips this header before the request leaves the app.
+  if (authHandle) {
+    headers["x-seren-auth-handle"] = authHandle;
+  }
 
   if (typeof payment === "string" && payment.length > 0) {
     headers[x402PaymentHeaderName(payment)] = payment;
@@ -712,6 +761,7 @@ export async function callGatewayTool(
   publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
+  authHandle?: string,
 ): Promise<McpToolCallResponse> {
   if (!isConnected) {
     throw new McpGatewayError(
@@ -739,6 +789,7 @@ export async function callGatewayTool(
         connection_id,
         _x402_payment,
         startTime,
+        authHandle,
       );
     }
 
@@ -751,10 +802,14 @@ export async function callGatewayTool(
 
     let result: McpToolResult;
     if (nativeName) {
-      result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
-        name: nativeName,
-        arguments: toolArgs,
-      });
+      result = await mcpClient.callToolHttp(
+        SEREN_MCP_SERVER_NAME,
+        {
+          name: nativeName,
+          arguments: toolArgs,
+        },
+        { authHandle },
+      );
     } else {
       const dispatchArgs: Record<string, unknown> = {
         publisher: publisherSlug,
@@ -764,10 +819,14 @@ export async function callGatewayTool(
       if (_x402_payment !== undefined) {
         dispatchArgs._x402_payment = _x402_payment;
       }
-      result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
-        name: "call_publisher",
-        arguments: dispatchArgs,
-      });
+      result = await mcpClient.callToolHttp(
+        SEREN_MCP_SERVER_NAME,
+        {
+          name: "call_publisher",
+          arguments: dispatchArgs,
+        },
+        { authHandle },
+      );
     }
 
     const executionTime = Date.now() - startTime;

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -5,6 +5,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const gatewayFetchMock = vi.hoisted(() => vi.fn());
 
+// The gateway catalog reads authorize through the host gate before dispatch
+// (#3193-F); return a live allow+handle so discovery proceeds.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async (cmd: string) => {
+    if (cmd === "authorize_tool_operation") {
+      return { decision: "allow", handle: "handle-catalog" };
+    }
+    return undefined;
+  }),
+}));
+
 // Mock tauri-bridge to avoid localStorage dependency in Node.
 vi.mock("@/lib/tauri-bridge", () => ({
   getSerenApiKey: vi.fn().mockResolvedValue("test-api-key"),
@@ -258,10 +269,14 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     const result = await callGatewayTool("test", "test-tool", {});
 
     // Should call directly with the original MCP name, NOT through call_publisher
-    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
-      name: "mcp__test__test-tool",
-      arguments: {},
-    });
+    expect(callToolMock).toHaveBeenCalledWith(
+      "seren-gateway",
+      {
+        name: "mcp__test__test-tool",
+        arguments: {},
+      },
+      { authHandle: undefined },
+    );
     expect(result.is_error).toBe(false);
   });
 
@@ -328,14 +343,18 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     });
 
     // Should dispatch through call_publisher, not direct MCP call
-    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
-      name: "call_publisher",
-      arguments: {
-        publisher: "kraken",
-        tool: "get_balance",
-        tool_args: { currency: "USD" },
+    expect(callToolMock).toHaveBeenCalledWith(
+      "seren-gateway",
+      {
+        name: "call_publisher",
+        arguments: {
+          publisher: "kraken",
+          tool: "get_balance",
+          tool_args: { currency: "USD" },
+        },
       },
-    });
+      { authHandle: undefined },
+    );
     expect(result.is_error).toBe(false);
   });
 
@@ -466,10 +485,14 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     });
 
     // Native call should NOT include _x402_payment in arguments
-    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
-      name: "mcp__test__test-tool",
-      arguments: { some_arg: "value" },
-    });
+    expect(callToolMock).toHaveBeenCalledWith(
+      "seren-gateway",
+      {
+        name: "mcp__test__test-tool",
+        arguments: { some_arg: "value" },
+      },
+      { authHandle: undefined },
+    );
   });
 });
 

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -444,18 +444,56 @@ describe("tool executor authorization gate", () => {
     const { executeTool } = await import("@/lib/tools/executor");
     mocks.authorizeDecision.decision = "allow";
 
-    await executeTool(serenCall("call_publisher"), "conv-a");
+    await executeTool(serenCall("run_sql"), "conv-a");
 
     expect(authorizeCalls()[0]).toMatchObject({
       route: "seren",
       publisherSlug: "seren",
-      toolName: "call_publisher",
+      toolName: "run_sql",
     });
     expect(mocks.callSerenTool).toHaveBeenCalledWith(
-      "call_publisher",
+      "run_sql",
       { value: "test" },
       "handle-allow",
     );
+  });
+
+  it("authorizes seren__call_publisher as its wrapped publisher operation", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision.decision = "allow";
+
+    await executeTool(
+      {
+        id: "seren-call-publisher",
+        type: "function",
+        function: {
+          name: "seren__call_publisher",
+          arguments: JSON.stringify({
+            publisher: "gmail",
+            tool: "post_send",
+            tool_args: { to: "a@example.com" },
+          }),
+        },
+      },
+      "conv-a",
+    );
+
+    // The gate must classify the REAL operation (gmail/post_send), not the
+    // generic call_publisher envelope, so a high-risk publisher call cannot
+    // ride an unclassified-call_publisher session grant. The transport
+    // unwraps the same envelope, so the handle binding matches.
+    expect(authorizeCalls()[0]).toMatchObject({
+      route: "gateway",
+      publisherSlug: "gmail",
+      toolName: "post_send",
+    });
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "gmail",
+      "post_send",
+      { to: "a@example.com" },
+      "handle-allow",
+    );
+    expect(mocks.callSerenTool).not.toHaveBeenCalled();
   });
 
   it("routes local MCP dispatch through the gate under the mcp route", async () => {

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -21,8 +21,11 @@ const mocks = vi.hoisted(() => ({
       | "unclassified",
     description: "",
     isDestructive: false,
+    handle: "handle-allow" as string | null,
+    binding: "binding-1" as string | null,
   },
   authorizeError: false,
+  registerError: false,
   callGatewayTool: vi.fn(),
   callMcpTool: vi.fn(),
   callSerenTool: vi.fn(),
@@ -47,6 +50,13 @@ vi.mock("@/lib/mcp/client", () => ({
 
 vi.mock("@/services/publisher-oauth", () => ({
   computeAgentOAuthRouting: mocks.computeAgentOAuthRouting,
+}));
+
+// The allow-without-handle guard reports through the support pipeline; keep it
+// a no-op here so the fire-and-forget capture cannot leak into Node (which has
+// no localStorage) as an unhandled rejection.
+vi.mock("@/lib/support/hook", () => ({
+  reportError: vi.fn(),
 }));
 
 vi.mock("@/stores/conversation.store", () => ({
@@ -178,12 +188,15 @@ describe("tool executor authorization gate", () => {
     mocks.shellApprovalId = "";
     mocks.shellApprovalResponse = true;
     mocks.authorizeError = false;
+    mocks.registerError = false;
     mocks.authorizeDecision = {
       decision: "allow",
       promptKind: null,
       operationClass: "trusted-read",
       description: "",
       isDestructive: false,
+      handle: "handle-allow",
+      binding: "binding-1",
     };
     mocks.computeAgentOAuthRouting.mockResolvedValue({
       publishers: {},
@@ -197,12 +210,47 @@ describe("tool executor authorization gate", () => {
     });
     mocks.callSerenTool.mockResolvedValue({ result: "ok", is_error: false });
 
-    mocks.invoke.mockImplementation(async (cmd: string) => {
+    mocks.invoke.mockImplementation(async (cmd: string, args?: unknown) => {
       if (cmd === "authorize_tool_operation") {
         if (mocks.authorizeError) throw new Error("gate unavailable");
         return mocks.authorizeDecision;
       }
       if (cmd === "record_tool_operation_decision") return undefined;
+      if (cmd === "register_approval_continuation") {
+        if (mocks.registerError) throw new Error("host unavailable");
+        return {
+          approvalId: "approval-1",
+          resumeToken: "resume-1",
+          blockedScope: "linear",
+          taskState: "waiting_for_approval",
+          deduplicated: false,
+          modelResult: { status: "approval_pending" },
+        };
+      }
+      if (cmd === "resolve_approval_continuation") {
+        const decision = (args as { decision: string }).decision;
+        if (decision === "approve") {
+          // The pending→approved settle is the post-approval mint (#3193-F).
+          return {
+            changed: true,
+            state: "approved",
+            taskState: "running",
+            dispatchHandle: "handle-approved",
+          };
+        }
+        return {
+          changed: true,
+          state: decision === "skip" ? "skipped" : "denied",
+          taskState: "running",
+        };
+      }
+      if (cmd === "expire_approval_continuation") {
+        return {
+          changed: true,
+          state: "expired",
+          taskState: "approval_expired",
+        };
+      }
       if (cmd === "web_fetch") {
         return {
           content: "web-ok",
@@ -403,9 +451,11 @@ describe("tool executor authorization gate", () => {
       publisherSlug: "seren",
       toolName: "call_publisher",
     });
-    expect(mocks.callSerenTool).toHaveBeenCalledWith("call_publisher", {
-      value: "test",
-    });
+    expect(mocks.callSerenTool).toHaveBeenCalledWith(
+      "call_publisher",
+      { value: "test" },
+      "handle-allow",
+    );
   });
 
   it("routes local MCP dispatch through the gate under the mcp route", async () => {
@@ -499,6 +549,8 @@ describe("tool executor authorization gate", () => {
       operationClass: "high-risk",
       description: "High-risk operation on seren/run_skill_script",
       isDestructive: false,
+      handle: null,
+      binding: "binding-1",
     };
 
     const result = await executeTool(skillCall(), "conv-a");
@@ -509,5 +561,101 @@ describe("tool executor authorization gate", () => {
       toolName: "run_skill_script",
     });
     expect(shellPromptCount()).toBe(1);
+  });
+
+  // ---- dispatch-handle enforcement (#3193-F) ------------------------------
+
+  it("threads the host-minted handle into a silently allowed dispatch", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision.decision = "allow";
+
+    await executeTool(webFetchCall(), "conv-a");
+
+    const webCall = mocks.invoke.mock.calls.find(([cmd]) => cmd === "web_fetch");
+    expect(webCall?.[1]).toMatchObject({ authHandle: "handle-allow" });
+  });
+
+  it("dispatches an approved prompt with the handle minted at resolution", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision = {
+      decision: "prompt",
+      promptKind: "one-shot",
+      operationClass: "high-risk",
+      description: "High-risk operation on seren/execute_command",
+      isDestructive: false,
+      handle: null,
+      binding: "binding-1",
+    };
+
+    const result = await executeTool(shellCall(), "conv-a");
+
+    expect(result.is_error).toBe(false);
+    const shellDispatch = mocks.invoke.mock.calls.find(
+      ([cmd]) => cmd === "execute_shell_command_streaming",
+    );
+    expect(shellDispatch?.[1]).toMatchObject({
+      authHandle: "handle-approved",
+    });
+  });
+
+  it("fails closed when the host allows but mints no dispatch handle", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision.decision = "allow";
+    mocks.authorizeDecision.handle = null;
+
+    const result = await executeTool(
+      gatewayCall("gmail", "get_messages"),
+      "conv-a",
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the suspended continuation cannot be registered", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision = {
+      decision: "prompt",
+      promptKind: "session",
+      operationClass: "unclassified",
+      description: "Unclassified operation",
+      isDestructive: false,
+      handle: null,
+      binding: "binding-1",
+    };
+    mocks.registerError = true;
+
+    const result = await executeTool(
+      gatewayCall("new-publisher", "inspect_records"),
+      "conv-a",
+    );
+
+    // No continuation → no post-approval handle is possible → the action is
+    // refused without even prompting, rather than executing unbound.
+    expect(result.is_error).toBe(true);
+    expect(gatewayPromptCount()).toBe(0);
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("echoes the gate's operation binding into the registered continuation", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.authorizeDecision = {
+      decision: "prompt",
+      promptKind: "session",
+      operationClass: "unclassified",
+      description: "Unclassified operation",
+      isDestructive: false,
+      handle: null,
+      binding: "binding-xyz",
+    };
+
+    await executeTool(gatewayCall("new-publisher", "inspect_records"), "conv-a");
+
+    const register = mocks.invoke.mock.calls.find(
+      ([cmd]) => cmd === "register_approval_continuation",
+    );
+    expect(register?.[1]).toMatchObject({
+      requested: expect.objectContaining({ binding: "binding-xyz" }),
+    });
   });
 });

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -63,7 +63,8 @@ describe("tool executor OAuth account routing", () => {
       is_error: false,
     });
     // These tests exercise OAuth account routing, not classification: let the
-    // host gate allow the Gmail read so the routing logic under test runs.
+    // host gate allow the Gmail read (with a dispatch handle, #3193-F) so the
+    // routing logic under test runs.
     mocks.invoke.mockImplementation(async (cmd: string) => {
       if (cmd === "authorize_tool_operation") {
         return {
@@ -72,6 +73,7 @@ describe("tool executor OAuth account routing", () => {
           operationClass: "trusted-read",
           description: "",
           isDestructive: false,
+          handle: "handle-allow",
         };
       }
       return undefined;
@@ -105,10 +107,15 @@ describe("tool executor OAuth account routing", () => {
     });
 
     expect(result.is_error).toBe(false);
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "get_messages", {
-      q: "from:example",
-      connection_id: "conn-google-personal",
-    });
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "gmail",
+      "get_messages",
+      {
+        q: "from:example",
+        connection_id: "conn-google-personal",
+      },
+      "handle-allow",
+    );
   });
 
   it("resolves the owning run's OAuth account, not the chat the user is viewing", async () => {
@@ -145,10 +152,15 @@ describe("tool executor OAuth account routing", () => {
     );
 
     expect(result.is_error).toBe(false);
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "get_messages", {
-      q: "from:example",
-      connection_id: "conn-google-personal",
-    });
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "gmail",
+      "get_messages",
+      {
+        q: "from:example",
+        connection_id: "conn-google-personal",
+      },
+      "handle-allow",
+    );
   });
 
   it("fails closed before dispatch when multiple accounts have no default or chat selection", async () => {
@@ -245,7 +257,10 @@ describe("tool executor OAuth account routing", () => {
         q: "safe-read",
         connection_id: "conn-google-personal",
       },
+      "handle-allow",
     );
+    // The x402 retry redeems the SAME host-minted handle — one authorization
+    // covers the dispatch plus its payment retry (#3193-F).
     expect(mocks.callGatewayTool).toHaveBeenNthCalledWith(
       2,
       "gmail",
@@ -255,6 +270,7 @@ describe("tool executor OAuth account routing", () => {
         connection_id: "conn-google-personal",
         _x402_payment: signedV2Payment,
       },
+      "handle-allow",
     );
   });
 });


### PR DESCRIPTION
Closes #3276. Slice **F** of epic #3193. Does **not** close #3193.

## What this does

Makes the host authorization gate **non-bypassable**: every side-effecting Rust transport now refuses to execute unless the caller redeems a live, host-minted **dispatch handle** for that exact operation. A renderer path that skips the gate — a bug, an alternate routing path, or prompt-injection-driven code — can no longer reach a transport. Fail-closed everywhere.

### Before (audited, `main`)
The gate decision (#3267) and the dispatch were two independent renderer→host calls with nothing binding them. Every transport executed for **any** caller with **no proof** of a prior authorization: `mcp_call_tool` / `mcp_call_tool_http` (`src-tauri/src/mcp.rs`), `execute_shell_command` (registered with **zero** renderer callers — a pure bypass), `execute_shell_command_streaming`, `run_skill_script` (`src-tauri/src/shell.rs`), `web_fetch` (`src-tauri/src/commands/web.rs`), and the Gateway bridge's publisher tool-dispatch path (`src-tauri/src/commands/gateway_http.rs`).

### After — host-owned dispatch handles (`src-tauri/src/tool_authorization.rs`)

**Minting** (host-only; UUIDv4 id, recorded in the same SQLite store):
- silent `allow` (trusted read / durable session grant) mints at authorize time;
- lease-covered `allow` mints a **lease-bound** handle — the lease is re-checked at redemption, so revocation between authorize and dispatch stops the dispatch;
- a prompt mints **only** on the single pending→approved continuation settle (`resolve_approval_continuation`), bound to the capability registered when the gate blocked the call. Idempotent replays, deny/skip/expire settles, and already-settled rows never mint.

**Binding.** Each handle is bound to `(route, publisher, tool, operation binding)` where the binding is a host-computed SHA-256 over route-specific material: exact canonical tool args for gateway/seren/local-MCP (excluding only `connection_id`/`_x402_payment`, which legitimately move between authorize and wire dispatch), the exact command line for shell, `skill_slug` + exact argv for skills, and the exact URL for web fetch. Both mint and verify normalize host-side — the renderer only ferries opaque strings, and tampering fails closed.

**Redemption.** Single-use, 5-minute expiry, checked and decremented atomically under the store's one connection lock. Gateway-route handles carry 3 uses so one authorization covers the initial dispatch plus its x402 signed-payment/SerenBucks retries without re-prompting. `mcp_call_tool_http` unwraps `call_publisher` envelopes and native `mcp__{publisher}__{tool}` names, so wrapping a call cannot dodge the binding. The Gateway bridge enforces on `/publishers/{slug}/_mcp/tools/{tool}` and always strips the `x-seren-auth-handle` header before the request leaves the app; other Gateway paths (auth, chat, billing, catalog) are app-level API traffic and pass through unchanged.

**Renderer** (`src/lib/tools/executor.ts`, `src/services/mcp-gateway.ts`, `src/lib/mcp/client.ts`): threads the handle from the gate decision (or the approve settle) into every dispatch; continuation registration is now mandatory on the prompt path (no continuation → no post-approval handle → refuse); gateway catalog discovery reads (`list_agent_publishers`, `list_mcp_tools`) authorize through the gate like everything else and are host-classified trusted reads.

### Behavior notes
- Continuation dedup now keys on the operation binding too: retries with identical args still dedup; a differently-argued retry gets its own pending record (previously it inherited a coarser record — which under enforcement would have made its approval unredeemable).
- An exact-duplicate tool call issued in parallel (same conversation, tool, args) now executes once; the duplicate is refused rather than double-executed (e.g. no double email send). The model gets a structured blocked result and can retry through the gate.
- The unmounted MCP panels (`McpToolsPanel`, `McpToolCallApproval`, `mcp-chat.store`) call `mcpClient.callTool` without a handle; they are dead code (nothing mounts them) and now refuse at the transport if ever revived — flagging rather than silently widening them.
- Residual trust boundary (unchanged from #3267, disclosed for review): the approval UI itself still lives in the renderer. A fully compromised renderer could register-and-self-resolve a continuation to induce a mint — but that now leaves host-side pending-approval records and audit rows, versus today's completely silent direct transport call. Host-owned approval UI is beyond this ticket's scope.

## Acceptance criteria
- [x] Every side-effecting transport refuses without a valid host-issued handle for that exact route + operation.
- [x] No handle / expired handle / forged handle → refused, proven by tests that call the transport commands directly, bypassing the executor (`shell.rs` command-level tests; `tool_authorization.rs` consume tests).
- [x] A one-shot handle cannot be replayed for a different operation or different normalized args; a lease-bound handle is honored only while its lease is live.
- [x] The handle is host-owned (minted only inside `ToolAuthorizationState`, UUIDv4, host-side store); the renderer cannot mint or forge one.
- [x] Normal executor path works unchanged on every route — full frontend suite (2713 passed) incl. gateway/seren/local-MCP/shell/skill/web dispatch, OAuth account routing, and x402 retry reusing one authorization.
- [x] End-to-end proof an external write cannot occur without prior authorization: live in-app functional walkthrough (see below, posted as a follow-up comment with evidence).

## Networked path
**No new outbound calls.** Handles are local state (SQLite + Tauri IPC). The only wire-adjacent change is the `x-seren-auth-handle` request header on the pre-existing `POST /publishers/{slug}/_mcp/tools/{tool}` dispatch, which the Rust bridge consumes and strips before egress — pinned by `auth_handle_header_never_reaches_the_wire`. The gateway discovery slugs consulted (`list_agent_publishers`, `list_mcp_tools` on the built-in `seren-gateway` MCP connection) are the same calls the app already makes at connect time, now authorized through the gate first.

## Verification
- Rust: `cargo test` full suite **1119 passed / 0 failed** (10 new enforcement tests in `tool_authorization.rs`, 2 transport-level bypass/redeem tests in `shell.rs`, 3 dispatch-identity tests in `mcp.rs`, 2 bridge tests in `gateway_http.rs`).
- Frontend: full suite **2713 passed / 15 skipped**; `tsc` clean on changed files; Biome clean.
- Live functional walkthrough on macOS (real app, no mocks) to follow as a PR comment before merge.

## Out of scope
Standing-policy pre-authorization (#3274), lease predicates/budgets (#3262, done), approval inbox/audit UI (#3264, done). Host-owned approval UI (the residual boundary above) is future work under #3193.

Refs #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
