### PR TITLE
fix(security): gate ChatModelWorker web fetch via frontend (#3285)

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1242,6 +1242,12 @@ created if missing.",
     /// Check if a tool name refers to a locally-executable tool.
     /// Non-local tools (gateway__, mcp__) are routed to the frontend.
     fn is_local_tool(name: &str) -> bool {
+        // Only file tools run directly in this Rust loop; they are gated by the
+        // project-root file-access policy. Every other model-originated tool —
+        // including `seren_web_fetch` (open-world data egress) and
+        // `execute_command` — must route to the frontend so the host
+        // authorization gate mints and the transport enforces a dispatch handle
+        // (#3193-F, #3285). A directly-executed web fetch would bypass the gate.
         matches!(
             name,
             "read_file"
@@ -1251,7 +1257,6 @@ created if missing.",
                 | "list_directory"
                 | "path_exists"
                 | "create_directory"
-                | "seren_web_fetch"
         )
     }
 
@@ -3054,6 +3059,19 @@ mod tests {
             !ChatModelWorker::is_local_tool("execute_command"),
             "execute_command must not execute directly in the Rust chat loop; \
              it has to route through the frontend shell approval path"
+        );
+    }
+
+    /// #3285: open-world web egress must pass the host authorization gate. If
+    /// `seren_web_fetch` is treated as a local tool it runs directly via
+    /// `fetch_web_content`, skipping the gate — an unapproved exfiltration path.
+    /// It has to route to the frontend like `execute_command`.
+    #[test]
+    fn seren_web_fetch_routes_to_frontend_for_gate_approval() {
+        assert!(
+            !ChatModelWorker::is_local_tool("seren_web_fetch"),
+            "seren_web_fetch must not execute directly in the Rust chat loop; \
+             it has to route through the gated frontend egress path"
         );
     }
 


### PR DESCRIPTION
Closes #3285. Follow-up found during the #3276 code-path audit.

## Problem

The Rust `ChatModelWorker` agent loop routed tool calls three ways:
- file tools → `execute_model_file_tool` (project-root file-access policy)
- `is_local_tool(name)` → `execute_tool_with_app` (**runs in-process, no gate**)
- everything else → `execute_frontend_tool` → renderer `executeTool` → **host authorization gate**

`is_local_tool` returned true for the file tools **and `seren_web_fetch`**, but not for `execute_command`/`run_skill_script`. So shell/skill/gateway/MCP were gated, but `seren_web_fetch` reached `execute_tool_with_app` → `crate::commands::web::fetch_web_content(...)` directly, bypassing `authorize_tool_operation` entirely. A model driving a chat-model provider could perform arbitrary open-world data egress (an exfiltration vector under prompt injection) with no user approval and no dispatch handle.

Pre-existing — not introduced by #3276; that PR preserved the behavior. #3193 lists "alternate routing paths cannot bypass the gate" as an acceptance criterion.

## Fix

Remove `seren_web_fetch` from `is_local_tool`, so it takes the same `execute_frontend_tool` route `execute_command` already takes. The renderer then gates it (open-world `web` egress: prompt-once-per-session) and, post-#3276, the `web_fetch` transport requires a host-minted dispatch handle bound to the exact URL. This mirrors the existing pattern exactly — `execute_command` is likewise absent from `is_local_tool` while keeping a defensive branch in `execute_tool_with_app`, guarded by `execute_command_routes_to_frontend_for_shell_approval`.

## Test

New regression test `seren_web_fetch_routes_to_frontend_for_gate_approval` asserts `seren_web_fetch` is not a directly-executed local tool — the exact assertion that would have caught this. Full orchestrator suite: **298 passed**.

## Networked path
No new outbound calls. This only reroutes `seren_web_fetch` from an ungated host-side call to the already-existing gated frontend → `web_fetch` transport path.

Refs #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
