### PR TITLE
fix(agent): drain tool bridge on reload so workers never hang (#3287)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -717,6 +717,33 @@ pub fn run() {
                         window_config.label
                     );
                 }
+                // A reload of the main webview (crash-recovery reload, a manual
+                // reload, or dev HMR) destroys the renderer that owns any in-flight
+                // frontend tool calls, so their results can never be submitted. Drain
+                // the tool bridge as the new page begins loading so each stranded
+                // worker await resolves with an explicit interrupted result instead
+                // of hanging forever (serenorg/seren-desktop#3287). Scoped to the main
+                // window — a secondary window's reload must not abandon main's calls —
+                // and a no-op on first load, where nothing is pending yet.
+                if window_config.label == "main" {
+                    window_builder = window_builder.on_page_load(|window, payload| {
+                        if payload.event() != tauri::webview::PageLoadEvent::Started {
+                            return;
+                        }
+                        let app = window.app_handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            let drained = app
+                                .state::<orchestrator::tool_bridge::ToolResultBridge>()
+                                .drain()
+                                .await;
+                            if drained > 0 {
+                                log::warn!(
+                                    "[ToolResultBridge] Drained {drained} pending frontend tool call(s) on main view reload"
+                                );
+                            }
+                        });
+                    });
+                }
                 window_builder.build()?;
             }
 

--- a/src-tauri/src/orchestrator/tool_bridge.rs
+++ b/src-tauri/src/orchestrator/tool_bridge.rs
@@ -48,7 +48,35 @@ impl ToolResultBridge {
             false
         }
     }
+
+    /// Abandon every pending frontend tool call, completing each waiting worker
+    /// with an explicit interrupted result. Called when the main webview
+    /// (re)loads: the renderer that owned these calls — and any approval it was
+    /// awaiting — is gone, so `submit_tool_result` can never arrive and a worker
+    /// blocked in `execute_frontend_tool` would otherwise wait forever on a
+    /// result that will never be sent (an authorization block must never look
+    /// like a hung agent). Draining resolves each stranded await so the worker's
+    /// turn finishes with the interruption disclosed. Returns how many calls were
+    /// drained (0 on a first load, where nothing is pending).
+    pub async fn drain(&self) -> usize {
+        let mut pending = self.pending.lock().await;
+        let drained = pending.len();
+        for (_tool_call_id, tx) in pending.drain() {
+            let _ = tx.send(ToolExecutionResult {
+                content: INTERRUPTED_RESULT.to_string(),
+                is_error: true,
+            });
+        }
+        drained
+    }
 }
+
+/// The result a worker sees when its pending frontend tool call is abandoned
+/// because the renderer that owned it reloaded or crashed. Explicit so the
+/// interrupted turn discloses the interruption instead of hanging on a result
+/// that will never arrive.
+const INTERRUPTED_RESULT: &str = "Tool execution was interrupted because the app view reloaded \
+     before the result returned. The action did not complete; ask again to retry.";
 
 #[cfg(test)]
 mod tests {
@@ -91,6 +119,36 @@ mod tests {
         let result = rx.await.unwrap();
         assert_eq!(result.content, "tool failed");
         assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn drain_completes_stranded_awaits_instead_of_hanging() {
+        // The renderer-loss hang (#3287): a worker registers a pending frontend
+        // tool call and awaits its receiver. If the renderer never submits (a
+        // reload/crash), the sender lingers and `rx.await` would hang forever.
+        // `drain()` — invoked on the main webview's page-load — must complete the
+        // await with an explicit interrupted error so the worker's turn finishes.
+        let bridge = ToolResultBridge::new();
+        let rx_a = bridge.register("tc_a").await;
+        let rx_b = bridge.register("tc_b").await;
+
+        let drained = bridge.drain().await;
+        assert_eq!(drained, 2, "both stranded calls should be drained");
+
+        for rx in [rx_a, rx_b] {
+            let result = rx
+                .await
+                .expect("drained await resolves rather than hanging");
+            assert!(result.is_error, "an interrupted call is an error result");
+            assert!(
+                result.content.contains("reloaded"),
+                "the result discloses the view reload, got: {}",
+                result.content
+            );
+        }
+
+        // A subsequent drain is a harmless no-op (idempotent; first-load safe).
+        assert_eq!(bridge.drain().await, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #3287. The concrete, definitive **hang** inside gap 3 of #3263 (slice C of #3193). Does **not** close #3263 — full host-owned re-drive resumability remains open there.

## Problem (root cause)

`ChatModelWorker` routes non-local tool calls to the renderer over the `ToolResultBridge`: `register(tool_call_id)` parks a `oneshot::Sender` in a `HashMap`, and `execute_frontend_tool` awaits the receiver **with no timeout** (`chat_model_worker.rs:1730`), by design — a user may take a long time to review an approval. The renderer runs the tool (gate → suspended approval continuation → approval UI) and finally calls `submit_tool_result`, which removes the sender and completes the receiver.

If the renderer is **lost mid-call** — a webview reload, the "Workspace is recovering" crash-and-reload, or a manual reload — the JS context is destroyed, so `submit_tool_result` never runs. The sender lingers in the bridge map (nothing drops it), so `rx.await` **never resolves**: the worker task hangs forever, the turn never reaches `Complete`, and its suspended-approval continuation orphans as `pending`. That is precisely the "hung agent" #3193-C exists to prevent, at the Rust layer.

## Fix (narrow, host-owned)

`ToolResultBridge::drain()` abandons every pending call, completing each waiting worker with an explicit interrupted result (`is_error = true`). It is wired to the **main** webview's `on_page_load(Started)` in `lib.rs`, so a reload drains the prior renderer's stranded calls as the new page begins loading. Each worker's turn then finishes with the interruption disclosed (the model receives a plain-language tool error and can retry) instead of hanging. First-load drains nothing (harmless no-op); scoped to the `main` window so a secondary window's reload never abandons main's in-flight calls. Orphaned `pending` continuations already self-heal via their TTL (`expire_overdue_audited`).

This is the targeted fix for the hang only. Persisting the suspended dispatch and re-driving it after a reload (true resumability) remains under #3263 gap 3.

## Scope / reachability

`ChatModelWorker`'s frontend-tool path (chat-model providers with gateway/MCP/shell/skill/web tool calls). The Claude Code ACP path handles approvals through its own permission flow and is unaffected.

## Networked paths

None. This is entirely local: an in-process bridge drain triggered by a local webview lifecycle event. No outbound publisher/API slug, method, or path changes.

## Validation

- New regression test `drain_completes_stranded_awaits_instead_of_hanging` exercises the **real** bridge (no mocks): registers two pending calls, drains, and asserts both receivers resolve to an interrupted error result rather than hanging, and that a second drain is a no-op. Non-vacuous — without `drain()` those receivers never complete.
- `cargo test --lib tool_bridge` green; `cargo check` green (compiles the `on_page_load` wiring).
- Real-app functional check on macOS: reload the main view and confirm the drain hook fires (host log `Drained N pending frontend tool call(s) on main view reload`) — evidence posted as a PR comment.

Refs #3263 #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
