### PR TITLE
fix(agent): expire orphaned approval continuations on reload (#3289)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -573,6 +573,28 @@ pub fn expire_overdue_all(conn: &Connection, now: &str) -> Result<Vec<Continuati
     Ok(overdue)
 }
 
+/// Expire every pending row across all conversations, regardless of TTL. A full
+/// renderer reload destroys the single webview that held every host-minted resume
+/// token, so a pending block that survives the reload can never be settled from
+/// the new page — it is orphaned, not merely waiting. Expiring it immediately
+/// (rather than leaving it dangling until `expire_overdue_all` reaches its TTL)
+/// clears the stale `waiting_for_approval` state at once. Like `expire_overdue_all`
+/// it returns the rows it expired so the caller can audit each lapse (#3193-D),
+/// and it moves them to `Expired` — never `Denied` — so no durable denial is
+/// recorded and a later re-attempt re-prompts.
+pub fn expire_all_pending(conn: &Connection, now: &str) -> Result<Vec<ContinuationRow>, String> {
+    let sql =
+        format!("SELECT {SELECT_COLUMNS} FROM approval_continuations WHERE state = 'pending'");
+    let pending = collect_rows(conn, &sql, [])?;
+    conn.execute(
+        "UPDATE approval_continuations SET state = 'expired', resolved_at = ?1 \
+         WHERE state = 'pending'",
+        rusqlite::params![now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(pending)
+}
+
 /// Every live pending row across all conversations, oldest first — the global
 /// approval-inbox listing. Callers expire overdue rows first.
 pub fn read_pending_all(conn: &Connection) -> Result<Vec<ContinuationRow>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -741,6 +741,29 @@ pub fn run() {
                                     "[ToolResultBridge] Drained {drained} pending frontend tool call(s) on main view reload"
                                 );
                             }
+                            // The reload also orphaned every suspended approval: the
+                            // webview that held each resume token is gone, so those
+                            // continuations can never be settled from the new page.
+                            // Expire them host-side so the task returns to `running`
+                            // at once, instead of showing a stale "waiting for
+                            // approval" until its TTL (serenorg/seren-desktop#3289).
+                            // try_state: the authorization store is managed inside
+                            // setup, so at the very first page load it may not be
+                            // registered yet — reconciliation simply no-ops then,
+                            // since nothing is pending at startup anyway.
+                            if let Some(auth) = app
+                                .try_state::<tool_authorization::ToolAuthorizationState>()
+                            {
+                                match auth.expire_all_pending_continuations() {
+                                    Ok(expired) if expired > 0 => log::warn!(
+                                        "[ToolAuthorization] Expired {expired} orphaned approval continuation(s) on main view reload"
+                                    ),
+                                    Ok(_) => {}
+                                    Err(err) => log::warn!(
+                                        "[ToolAuthorization] Failed to expire orphaned continuations on reload: {err}"
+                                    ),
+                                }
+                            }
                         });
                     });
                 }

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -1331,6 +1331,32 @@ impl ToolAuthorizationState {
         })
     }
 
+    /// Expire every pending continuation across all conversations, host-authoritative
+    /// (no resume token, like the TTL sweep in `list_pending_continuations_all`).
+    /// Called when the renderer is lost to a reload: the single webview that held
+    /// every host-minted resume token is gone, so a surviving pending block can
+    /// never be settled from the new page. Expiring it clears the stale
+    /// `waiting_for_approval` state at once instead of leaving it dangling until its
+    /// TTL. Fail-safe — it only revokes a pending approval opportunity, never grants
+    /// authority, and records an expiry (not a denial), so a later re-attempt
+    /// re-prompts. Each lapse is audited (#3193-D). Returns the count expired.
+    pub fn expire_all_pending_continuations(&self) -> Result<usize, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let expired = approval_continuation::expire_all_pending(conn, &now)?;
+            for row in &expired {
+                audit(
+                    conn,
+                    &row.conversation_id,
+                    AuditEvent::ApprovalExpired,
+                    &audit_context_for_row(row),
+                    &now,
+                );
+            }
+            Ok(expired.len())
+        })
+    }
+
     /// The newest audit rows for a conversation (lease lifecycle, approval
     /// outcomes, durable decisions). Lease expiries are refreshed first so an
     /// expired-but-unobserved lease still shows its expiry event.
@@ -2430,6 +2456,62 @@ mod tests {
             .unwrap();
         assert!(!fresh.deduplicated);
         assert_ne!(fresh.approval_id, r.approval_id);
+    }
+
+    /// A view reload orphans every live approval: the renderer that held each
+    /// resume token is gone. The host-authoritative reconciliation expires them all
+    /// — across conversations, regardless of TTL — so each task returns to `running`
+    /// at once instead of showing a stale `waiting_for_approval` until its window
+    /// lapses. It is an expiry (audited, re-promptable), never a denial, and settled
+    /// rows are untouched.
+    #[test]
+    fn reload_reconciliation_expires_all_live_pending_across_conversations() {
+        let s = state();
+        // Long TTLs: these are not overdue, so only the reload reconciliation — not
+        // the ordinary TTL sweep — can expire them.
+        s.register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 3600)
+            .unwrap();
+        s.register_continuation("conv-b", shell_cap("git push"), ContinuationScope::Branch, 3600)
+            .unwrap();
+        // A previously-settled block must stay settled, not be reopened or re-expired.
+        let approved = s
+            .register_continuation("conv-a", shell_cap("cargo build"), ContinuationScope::Linear, 3600)
+            .unwrap();
+        s.resolve_continuation(&approved.approval_id, &approved.resume_token, ResolveDecision::Approve)
+            .unwrap();
+
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::WaitingForApproval
+        );
+        assert_eq!(
+            s.task_execution_state("conv-b").unwrap(),
+            TaskExecutionState::RunningWithBlockedActions
+        );
+
+        // Two live pending blocks (the approved one is already settled) are expired.
+        assert_eq!(s.expire_all_pending_continuations().unwrap(), 2);
+
+        // Both tasks are released; nothing blocks completion.
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::Running
+        );
+        assert_eq!(
+            s.task_execution_state("conv-b").unwrap(),
+            TaskExecutionState::Running
+        );
+        let summary_a = s.resolution_summary("conv-a").unwrap();
+        assert!(summary_a.can_complete());
+        assert_eq!(summary_a.expired, 1, "the pending block was expired, not the approved one");
+        assert_eq!(summary_a.approved, 1, "a settled decision is left intact");
+
+        // The lapse is audited as an expiry (not a denial), so a later attempt re-prompts.
+        assert!(audit_events(&s, "conv-a").contains(&"approval_expired".to_string()));
+        assert!(audit_events(&s, "conv-b").contains(&"approval_expired".to_string()));
+
+        // Idempotent: nothing pending remains, so a second reconciliation is a no-op.
+        assert_eq!(s.expire_all_pending_continuations().unwrap(), 0);
     }
 
     /// An independent branch block keeps the task running-with-blocked-actions,


### PR DESCRIPTION
## What & why

Closes #3289. Direct follow-up to #3287 / #3288 (slice **C** of epic #3193).

#3288 drains the `ToolResultBridge` on a main-view reload so a stranded `ChatModelWorker` await resolves with an explicit interrupted result instead of hanging. That freed the **worker**, but left the suspended approval **continuation** it was blocked on sitting `pending` in the host authorization store.

A full webview reload destroys the single renderer that held every host-minted `resume_token`, so a surviving pending row can never be settled from the new page (settle/expire are token-gated and the token is gone). It therefore lingered as `pending` — keeping the conversation in `waiting_for_approval` and rendering a non-actionable "Waiting for approval" strip/read-only card — until its TTL (`GATEWAY_APPROVAL_TIMEOUT_MS + 60s` ≈ 6 min) lapsed via the overdue sweep.

## Change

Extend the same `on_page_load(Started)` reload hook: after draining the bridge, reconcile the orphaned continuations host-side.

- **`approval_continuation::expire_all_pending`** — mirrors `expire_overdue_all` minus the `expires_at` deadline filter, since a reload orphans *every* live row, not just overdue ones. Moves them to `Expired` (never `Denied`) and returns the rows for auditing.
- **`ToolAuthorizationState::expire_all_pending_continuations`** — host-authoritative (no resume token, like the existing TTL sweep in `list_pending_continuations_all`); audits each lapse (`approval_expired`, #3193-D) and returns the count.
- **`lib.rs`** — the reload hook calls it after the drain, via `try_state` (the authorization store is managed inside `setup`, so at the very first page load it may not be registered yet — reconciliation no-ops then, and nothing is pending at startup anyway).

Now a reload returns the task to `running` and clears the stale strip **at once** instead of after ~6 min.

## Safety

Fail-safe: it can only revoke a *pending* approval opportunity, never grant authority; it records an **expiry, not a denial**, so no durable session denial is persisted and a later re-attempt re-prompts (consistent with #3273). Same `Started`-before-new-page-JS race-freedom as the drain; scoped to the `main` window.

## Networked path

None. Entirely local — SQLite continuation store + a local webview lifecycle event. No outbound publisher/API slug, method, or path changed.

## Validation

- New real-SQLite store test (no mocks) `reload_reconciliation_expires_all_live_pending_across_conversations`: two live pending blocks across two conversations (both with long, non-overdue TTLs, so only the reload reconciliation — not the TTL sweep — can expire them) are expired; both tasks return to `running`; a previously-approved block is left intact; each lapse is audited as `approval_expired`; and a second call is a no-op (idempotent).
- Full `cargo test --lib` green; full lib compiles (the wired `lib.rs` hook builds).

The reload trigger itself is the same `on_page_load(Started)` seam validated in #3288; this PR only adds a second host-side action on that seam.

Refs #3263 #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
