### PR TITLE
feat(security): live monetary metering for lease budgets (#3277)

### DIFF
--- a/src-tauri/src/capability_lease.rs
+++ b/src-tauri/src/capability_lease.rs
@@ -112,6 +112,43 @@ impl LeaseBudgets {
         }
         true
     }
+
+    /// Whether this budget can absorb `cost_micros` of `asset` spend, independent
+    /// of the call-count budget. Used when the realized price of a call is known
+    /// only after the gate has already charged the call slot (the x402 402), so
+    /// re-checking `admits` would spuriously fail on the last call of a
+    /// call-metered lease. Asset-aware: a lease that pins an `asset` only absorbs
+    /// spend in that asset — a mismatch is not admitted (the caller escalates
+    /// rather than mis-charging a differently-denominated budget). A lease with no
+    /// pinned `asset` treats its ceiling as denominating whatever is charged.
+    pub fn admits_spend(&self, cost_micros: u64, asset: &str) -> bool {
+        if cost_micros == 0 {
+            return true;
+        }
+        if let Some(granted) = &self.asset
+            && !granted.eq_ignore_ascii_case(asset)
+        {
+            return false;
+        }
+        match self.max_spend_micros {
+            // A priced call with no monetary allowance is not covered.
+            None => false,
+            Some(max) => self.spend_used_micros.saturating_add(cost_micros) <= max,
+        }
+    }
+
+    /// Consume `cost_micros` of the monetary budget. Saturating so a settlement
+    /// that reconciles upward can never wrap the counter.
+    pub fn charge_spend(&mut self, cost_micros: u64) {
+        self.spend_used_micros = self.spend_used_micros.saturating_add(cost_micros);
+    }
+
+    /// Release `cost_micros` previously charged (a reservation whose payment never
+    /// settled, or the over-reserved portion of a settlement). Saturating so a
+    /// double release can never underflow the counter below zero.
+    pub fn release_spend(&mut self, cost_micros: u64) {
+        self.spend_used_micros = self.spend_used_micros.saturating_sub(cost_micros);
+    }
 }
 
 /// A persisted, thread-scoped capability lease. Bound to a conversation (the only
@@ -325,6 +362,76 @@ pub fn evaluate_for_conversation(
     }
 
     LeaseOutcome::Escalate
+}
+
+/// The matcher's verdict for charging a realized monetary cost against the lease
+/// that already authorized a call. Distinct from `LeaseOutcome`: by the time a
+/// price is realized (the x402 402), the call has already passed the gate — this
+/// decides only whether the covering lease's *monetary* budget absorbs the cost.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpendOutcome {
+    /// A covering lease absorbs the cost; `String` is the lease id to charge.
+    Charge(String),
+    /// A lease covers the call's predicates but cannot absorb this spend (no
+    /// monetary allowance, over budget, a mismatched asset, or an exclusion) —
+    /// the caller escalates *before* paying rather than silently overspending.
+    Escalate,
+    /// No active lease covers the call: it is not running inside a lease
+    /// envelope, so no lease budget applies and the caller uses its own payment
+    /// gate (the x402 approval UI), exactly as before this wiring existed.
+    Uncovered,
+}
+
+/// Decide how a realized `cost_micros` of `asset` charges against the leases
+/// bound to `conversation_id` for a call that has already been authorized.
+///
+/// Resolution mirrors `evaluate_for_conversation`'s `deny > allow` ordering: a
+/// matching exclusion on any active lease escalates (a covered-then-excluded call
+/// must never silently pay). Otherwise the first lease that covers the predicates
+/// *and* whose monetary budget admits the spend is charged; if a lease covers the
+/// predicates but none admits the spend, the verdict is `Escalate`; if nothing
+/// covers the predicates, the verdict is `Uncovered`.
+pub fn spend_for_conversation(
+    leases: &[CapabilityLease],
+    req: &OperationRequest,
+    asset: &str,
+    cost_micros: u64,
+    conversation_id: &str,
+    now: &str,
+) -> SpendOutcome {
+    let active: Vec<&CapabilityLease> = leases
+        .iter()
+        .filter(|lease| lease.is_active(conversation_id, now))
+        .collect();
+
+    // Deny still beats everything: a call an exclusion would deny must not
+    // silently pay under a broader allow.
+    for lease in &active {
+        if lease
+            .predicates
+            .exclusions
+            .iter()
+            .any(|exclusion| exclusion_matches(exclusion, req))
+        {
+            return SpendOutcome::Escalate;
+        }
+    }
+
+    let mut covered = false;
+    for lease in &active {
+        if predicates_cover(lease, req) {
+            covered = true;
+            if lease.budgets.admits_spend(cost_micros, asset) {
+                return SpendOutcome::Charge(lease.id.clone());
+            }
+        }
+    }
+
+    if covered {
+        SpendOutcome::Escalate
+    } else {
+        SpendOutcome::Uncovered
+    }
 }
 
 // ============================================================================
@@ -690,6 +797,159 @@ mod tests {
         let mut priced = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
         priced.cost_micros = 5_000_000; // 8M + 5M > 10M
         assert_eq!(eval(&[l], &priced, NOW), LeaseOutcome::Escalate);
+    }
+
+    // ---- realized-cost spend matcher (the x402 402 charge point) ----------
+
+    fn funded_publisher_lease(max_spend: u64, spend_used: u64, asset: &str) -> CapabilityLease {
+        lease(
+            LeasePredicates {
+                publisher_ops: vec![PublisherRule {
+                    publisher_slug: "*".to_string(),
+                    allow_high_risk: true,
+                    target: None,
+                }],
+                ..Default::default()
+            },
+            LeaseBudgets {
+                max_calls: Some(100),
+                max_spend_micros: Some(max_spend),
+                spend_used_micros: spend_used,
+                asset: Some(asset.to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn spend(
+        leases: &[CapabilityLease],
+        req: &OperationRequest,
+        asset: &str,
+        cost_micros: u64,
+    ) -> SpendOutcome {
+        spend_for_conversation(leases, req, asset, cost_micros, "conv-a", NOW)
+    }
+
+    #[test]
+    fn realized_cost_charges_the_covering_lease() {
+        let l = funded_publisher_lease(10_000_000, 0, "USDC");
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(
+            spend(&[l], &req, "USDC", 4_000_000),
+            SpendOutcome::Charge("lease-1".to_string()),
+        );
+    }
+
+    #[test]
+    fn realized_cost_over_remaining_budget_escalates() {
+        // 8M used of 10M → a 5M call cannot be absorbed.
+        let l = funded_publisher_lease(10_000_000, 8_000_000, "USDC");
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(spend(&[l], &req, "USDC", 5_000_000), SpendOutcome::Escalate);
+    }
+
+    #[test]
+    fn priced_call_with_no_allowance_escalates() {
+        let l = lease(
+            LeasePredicates {
+                publisher_ops: vec![PublisherRule {
+                    publisher_slug: "*".to_string(),
+                    allow_high_risk: true,
+                    target: None,
+                }],
+                ..Default::default()
+            },
+            LeaseBudgets { max_calls: Some(100), ..Default::default() },
+        );
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(spend(&[l], &req, "USDC", 1_000_000), SpendOutcome::Escalate);
+    }
+
+    #[test]
+    fn mismatched_asset_escalates_rather_than_mischarging() {
+        // Budget is denominated in USDC; a DAI-priced call must not decrement it.
+        let l = funded_publisher_lease(10_000_000, 0, "USDC");
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(spend(&[l], &req, "DAI", 1_000_000), SpendOutcome::Escalate);
+    }
+
+    #[test]
+    fn unpinned_asset_budget_charges_any_asset() {
+        // A monetary ceiling with no pinned asset denominates whatever is charged.
+        let mut l = funded_publisher_lease(10_000_000, 0, "USDC");
+        l.budgets.asset = None;
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(
+            spend(&[l], &req, "DAI", 1_000_000),
+            SpendOutcome::Charge("lease-1".to_string()),
+        );
+    }
+
+    #[test]
+    fn uncovered_call_is_not_lease_scoped() {
+        // A lease that does not cover the publisher predicates yields Uncovered,
+        // so the caller falls back to its own payment gate rather than escalating.
+        let l = lease(
+            LeasePredicates {
+                network_hosts: vec!["example.com".to_string()],
+                ..Default::default()
+            },
+            LeaseBudgets {
+                max_calls: Some(100),
+                max_spend_micros: Some(10_000_000),
+                asset: Some("USDC".to_string()),
+                ..Default::default()
+            },
+        );
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(spend(&[l], &req, "USDC", 1_000_000), SpendOutcome::Uncovered);
+    }
+
+    #[test]
+    fn spend_admission_is_independent_of_an_exhausted_call_budget() {
+        // The call slot is charged at the gate; by the 402 the last call may have
+        // exhausted `max_calls`. Re-checking `admits` would wrongly reject it —
+        // `admits_spend` must only weigh the monetary budget.
+        let budgets = LeaseBudgets {
+            max_calls: Some(1),
+            calls_used: 1,
+            max_spend_micros: Some(10_000_000),
+            spend_used_micros: 0,
+            asset: Some("USDC".to_string()),
+        };
+        assert!(!budgets.admits(1_000_000), "call budget is exhausted");
+        assert!(
+            budgets.admits_spend(1_000_000, "USDC"),
+            "spend admission ignores the call budget",
+        );
+    }
+
+    #[test]
+    fn charge_and_release_spend_saturate() {
+        let mut budgets = LeaseBudgets {
+            max_spend_micros: Some(u64::MAX),
+            spend_used_micros: 5,
+            ..Default::default()
+        };
+        budgets.charge_spend(10);
+        assert_eq!(budgets.spend_used_micros, 15);
+        budgets.release_spend(100); // saturating: never below zero
+        assert_eq!(budgets.spend_used_micros, 0);
+        budgets.spend_used_micros = u64::MAX;
+        budgets.charge_spend(10); // saturating: never wraps
+        assert_eq!(budgets.spend_used_micros, u64::MAX);
+    }
+
+    #[test]
+    fn spend_exclusion_beats_a_covering_allowance() {
+        // A call an exclusion would deny must escalate the spend, not pay silently.
+        let mut l = funded_publisher_lease(10_000_000, 0, "USDC");
+        l.predicates.exclusions = vec![Exclusion {
+            publisher_slug: Some("some-dex".to_string()),
+            ..Default::default()
+        }];
+        let req = gateway_req("some-dex", "post_swap", OperationClass::HighRisk);
+        assert_eq!(spend(&[l], &req, "USDC", 1_000_000), SpendOutcome::Escalate);
     }
 
     // ---- lifetime binding ------------------------------------------------

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -13,7 +13,7 @@ use crate::capability_lease::{
 };
 use crate::orchestrator::types::TaskExecutionState;
 use crate::tool_authorization::{
-    AuthorizationDecision, OperationContext, ToolAuthorizationState, ToolRoute,
+    AuthorizationDecision, OperationContext, SpendReservation, ToolAuthorizationState, ToolRoute,
 };
 
 /// Classify a model-originated tool call and return the host's decision. The
@@ -64,6 +64,52 @@ pub fn record_tool_operation_decision(
 ) -> Result<(), String> {
     let route = ToolRoute::parse(&route)?;
     state.record_decision(route, &publisher_slug, &tool_name, &conversation_id, approved)
+}
+
+/// Reserve a priced call's realized monetary cost against the lease that covers
+/// it (#3193-G), at the x402 payment gate and *before* any payment is signed. The
+/// renderer calls this once the 402 reveals the real price. `"charged"` carries a
+/// `reservationId` the renderer settles once the payment resolves; `"escalate"`
+/// tells the renderer to force an explicit approval (the silent budget cannot
+/// absorb this spend) rather than paying; `"uncovered"` means no lease applies and
+/// the renderer uses its own payment gate. Charging is host-owned and persisted —
+/// the renderer never supplies the amount charged.
+#[tauri::command]
+pub fn reserve_lease_spend(
+    state: State<'_, ToolAuthorizationState>,
+    route: String,
+    publisher_slug: String,
+    tool_name: String,
+    conversation_id: String,
+    context: Option<OperationContext>,
+    asset: String,
+    cost_micros: u64,
+) -> Result<SpendReservation, String> {
+    let route = ToolRoute::parse(&route)?;
+    let context = context.unwrap_or_default();
+    state.reserve_lease_spend(
+        route,
+        &publisher_slug,
+        &tool_name,
+        &conversation_id,
+        &context,
+        &asset,
+        cost_micros,
+    )
+}
+
+/// Settle a spend reservation once its payment resolves (#3193-G). `settledMicros`
+/// omitted (`None`) releases the whole reservation — the payment never completed;
+/// a value reconciles the lease's spend from the reserved estimate to the amount
+/// actually paid. Idempotent: settling an unknown or already-settled reservation
+/// is a no-op.
+#[tauri::command]
+pub fn settle_lease_spend(
+    state: State<'_, ToolAuthorizationState>,
+    reservation_id: String,
+    settled_micros: Option<u64>,
+) -> Result<(), String> {
+    state.settle_lease_spend(&reservation_id, settled_micros)
 }
 
 /// Derive a *proposed* capability bundle for a task. This is read-only: it grants

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1141,6 +1141,8 @@ pub fn run() {
             commands::credential_lease::credential_lease_revoke_all,
             commands::tool_authorization::authorize_tool_operation,
             commands::tool_authorization::record_tool_operation_decision,
+            commands::tool_authorization::reserve_lease_spend,
+            commands::tool_authorization::settle_lease_spend,
             commands::tool_authorization::propose_capability_bundle,
             commands::tool_authorization::grant_capability_lease,
             commands::tool_authorization::list_capability_leases,

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -15,6 +15,7 @@ use crate::approval_continuation::{
 use crate::authorization_audit::{self, AuditContext, AuditEntry, AuditEvent};
 use crate::capability_lease::{
     self, CapabilityLease, LeaseBudgets, LeaseOutcome, LeasePredicates, OperationRequest,
+    SpendOutcome,
 };
 use crate::orchestrator::types::TaskExecutionState;
 
@@ -170,6 +171,47 @@ impl AuthorizationDecision {
     }
 }
 
+/// The host's verdict on reserving a call's realized monetary cost against its
+/// covering lease (#3193-G). Returned to the renderer at the x402 payment gate
+/// *before* any payment is signed. `outcome` is authoritative:
+/// - `"charged"` — the cost was decremented from the covering lease's budget and
+///   persisted; `reservation_id` settles it once the payment resolves.
+/// - `"escalate"` — a lease covers the call but cannot absorb this spend (over
+///   budget / mismatched asset); the caller must surface an explicit approval
+///   instead of silently paying.
+/// - `"uncovered"` — no lease covers the call; the caller uses its own payment
+///   gate exactly as before this wiring existed.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpendReservation {
+    pub outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reservation_id: Option<String>,
+}
+
+impl SpendReservation {
+    fn charged(reservation_id: String) -> Self {
+        Self {
+            outcome: "charged".to_string(),
+            reservation_id: Some(reservation_id),
+        }
+    }
+
+    fn escalate() -> Self {
+        Self {
+            outcome: "escalate".to_string(),
+            reservation_id: None,
+        }
+    }
+
+    fn uncovered() -> Self {
+        Self {
+            outcome: "uncovered".to_string(),
+            reservation_id: None,
+        }
+    }
+}
+
 // ============================================================================
 // Dispatch handles (#3193-F) — the enforcement seam that makes the gate
 // non-bypassable. Every side-effecting transport command refuses to execute
@@ -181,6 +223,12 @@ impl AuthorizationDecision {
 /// UI round-trip between the first dispatch and its retry; short enough that a
 /// leaked handle is not a standing capability.
 const DISPATCH_HANDLE_TTL_SECS: i64 = 300;
+
+/// How long a spend reservation stays reconcilable before it is swept as stale.
+/// A reserve→settle round-trip closes within one payment approval window
+/// (minutes); an hour is comfortably beyond that, so only reservations orphaned
+/// by a crash are ever pruned — and their charge is left standing, never released.
+const SPEND_RESERVATION_TTL_SECS: i64 = 3600;
 
 /// Redemptions per handle. Gateway operations legitimately re-dispatch after an
 /// x402 402 (signed-payment retry, or a SerenBucks retry) without re-consulting
@@ -930,6 +978,114 @@ impl ToolAuthorizationState {
         })
     }
 
+    /// Reserve a call's *realized* monetary cost against the lease that covers it
+    /// (#3193-G). Called at the x402 payment gate once the 402 reveals the real
+    /// price, before any payment is signed. Charging the reservation (decrementing
+    /// `spend_used_micros`) and recording it happen under one connection lock, so
+    /// two concurrent priced calls cannot both slip past the last of a budget.
+    ///
+    /// The call has already cleared the gate, so this weighs only the *monetary*
+    /// budget (via `admits_spend`), never the call budget — re-charging a call
+    /// slot here would double-count, and the last call of a call-metered lease
+    /// would spuriously fail. `cost_micros` must be > 0; a free call never reaches
+    /// a 402 and must not consume a reservation.
+    pub fn reserve_lease_spend(
+        &self,
+        route: ToolRoute,
+        publisher_slug: &str,
+        tool_name: &str,
+        conversation_id: &str,
+        context: &OperationContext,
+        asset: &str,
+        cost_micros: u64,
+    ) -> Result<SpendReservation, String> {
+        if cost_micros == 0 {
+            // A zero cost is free: nothing to reserve, nothing to escalate.
+            return Ok(SpendReservation::uncovered());
+        }
+        let class = classify_for_route(route, publisher_slug, tool_name);
+        let request = OperationRequest {
+            route,
+            class,
+            publisher_slug: publisher_slug.to_string(),
+            tool_name: tool_name.to_string(),
+            command: context.command.clone(),
+            host: context.host.clone(),
+            target: context.target.clone(),
+            cost_micros,
+        };
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            record_lease_expiries_audited(conn, conversation_id, &now);
+            let leases = read_leases(conn, conversation_id)?;
+            match capability_lease::spend_for_conversation(
+                &leases,
+                &request,
+                asset,
+                cost_micros,
+                conversation_id,
+                &now,
+            ) {
+                SpendOutcome::Charge(lease_id) => {
+                    // The matcher already proved this lease admits the spend; the
+                    // `find` cannot miss unless a lease vanished mid-lock (it
+                    // cannot — we hold the only connection), so a miss is a safe
+                    // fall-through to "uncovered" rather than a charge on nothing.
+                    let Some(mut lease) = leases.into_iter().find(|l| l.id == lease_id) else {
+                        return Ok(SpendReservation::uncovered());
+                    };
+                    lease.budgets.charge_spend(cost_micros);
+                    write_lease(conn, &lease)?;
+                    let reservation_id = uuid::Uuid::new_v4().to_string();
+                    insert_spend_reservation(
+                        conn,
+                        &reservation_id,
+                        conversation_id,
+                        &lease_id,
+                        cost_micros,
+                        asset,
+                        &now,
+                    )?;
+                    Ok(SpendReservation::charged(reservation_id))
+                }
+                SpendOutcome::Escalate => Ok(SpendReservation::escalate()),
+                SpendOutcome::Uncovered => Ok(SpendReservation::uncovered()),
+            }
+        })
+    }
+
+    /// Settle a reservation once its payment resolves (#3193-G). `settled_micros`
+    /// is the amount actually paid: `None` means the payment never completed, so
+    /// the whole reservation is released back to the budget; `Some(amount)`
+    /// reconciles the lease's spend from the reserved estimate to the true settled
+    /// amount (releasing the over-reserved portion, or charging the shortfall).
+    /// Idempotent: an unknown or already-settled reservation is a no-op, so a
+    /// retried settle never double-releases.
+    pub fn settle_lease_spend(
+        &self,
+        reservation_id: &str,
+        settled_micros: Option<u64>,
+    ) -> Result<(), String> {
+        self.with_conn(|conn| {
+            let Some((lease_id, reserved)) = take_spend_reservation(conn, reservation_id)? else {
+                return Ok(());
+            };
+            let settled = settled_micros.unwrap_or(0);
+            if settled == reserved {
+                return Ok(());
+            }
+            if let Some(mut lease) = read_lease(conn, &lease_id)? {
+                if settled < reserved {
+                    lease.budgets.release_spend(reserved - settled);
+                } else {
+                    lease.budgets.charge_spend(settled - reserved);
+                }
+                write_lease(conn, &lease)?;
+            }
+            Ok(())
+        })
+    }
+
     /// Persist a user-approved lease. Called only from the host-side grant command
     /// a human approval invokes — never from a model tool call — so model output
     /// can never mint or widen a lease. The host owns the id, timestamps, and
@@ -1390,7 +1546,10 @@ impl ToolAuthorizationState {
             let handles = conn
                 .execute("DELETE FROM dispatch_handles", [])
                 .map_err(|e| e.to_string())?;
-            Ok(decisions + leases + continuations + audit_rows + handles)
+            let reservations = conn
+                .execute("DELETE FROM spend_reservations", [])
+                .map_err(|e| e.to_string())?;
+            Ok(decisions + leases + continuations + audit_rows + handles + reservations)
         })
     }
 }
@@ -1595,6 +1754,90 @@ fn write_lease(conn: &Connection, lease: &CapabilityLease) -> Result<(), String>
     Ok(())
 }
 
+/// One live capability lease by id, or `None` if it is unknown or unreadable.
+/// A settlement reconciles the exact lease its reservation charged, so it reads
+/// by id rather than re-running the conversation matcher.
+fn read_lease(conn: &Connection, lease_id: &str) -> Result<Option<CapabilityLease>, String> {
+    let json: Option<String> = conn
+        .query_row(
+            "SELECT lease_json FROM capability_leases WHERE id = ?1",
+            rusqlite::params![lease_id],
+            |row| row.get(0),
+        )
+        .map(Some)
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other.to_string()),
+        })?;
+    Ok(json.and_then(|json| serde_json::from_str::<CapabilityLease>(&json).ok()))
+}
+
+/// Record a live spend reservation so a later settle reconciles against the
+/// host-owned reserved amount rather than a renderer-supplied one. Stale rows
+/// (older than the sweep window) are pruned opportunistically so a crash between
+/// reserve and settle cannot grow the table without bound — the already-persisted
+/// charge stays (a conservative over-charge, never a silent release).
+fn insert_spend_reservation(
+    conn: &Connection,
+    reservation_id: &str,
+    conversation_id: &str,
+    lease_id: &str,
+    reserved_micros: u64,
+    asset: &str,
+    now: &str,
+) -> Result<(), String> {
+    let cutoff = timestamp_plus_seconds(conn, -SPEND_RESERVATION_TTL_SECS)?;
+    conn.execute(
+        "DELETE FROM spend_reservations WHERE created_at <= ?1",
+        rusqlite::params![cutoff],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO spend_reservations \
+           (id, conversation_id, lease_id, reserved_micros, asset, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            reservation_id,
+            conversation_id,
+            lease_id,
+            reserved_micros as i64,
+            asset,
+            now,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Load and remove a reservation atomically (under the store lock), returning its
+/// lease id and reserved amount. `None` if the reservation is unknown or already
+/// settled — the source of settle's idempotency.
+fn take_spend_reservation(
+    conn: &Connection,
+    reservation_id: &str,
+) -> Result<Option<(String, u64)>, String> {
+    let row: Option<(String, i64)> = conn
+        .query_row(
+            "SELECT lease_id, reserved_micros FROM spend_reservations WHERE id = ?1",
+            rusqlite::params![reservation_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .map(Some)
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other.to_string()),
+        })?;
+    let Some((lease_id, reserved)) = row else {
+        return Ok(None);
+    };
+    conn.execute(
+        "DELETE FROM spend_reservations WHERE id = ?1",
+        rusqlite::params![reservation_id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(Some((lease_id, reserved.max(0) as u64)))
+}
+
 fn init_schema(conn: &Connection) -> Result<(), String> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS tool_decisions (
@@ -1643,6 +1886,21 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
             lease_id        TEXT,
             uses_remaining  INTEGER NOT NULL,
             expires_at      TEXT NOT NULL,
+            created_at      TEXT NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    // Spend reservations (#3193-G): a live reserve→settle record so the realized
+    // cost charged at the x402 payment gate is reconciled against a host-owned
+    // amount once the payment resolves, not a renderer-supplied one.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS spend_reservations (
+            id              TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            lease_id        TEXT NOT NULL,
+            reserved_micros INTEGER NOT NULL,
+            asset           TEXT,
             created_at      TEXT NOT NULL
         )",
         [],
@@ -2183,6 +2441,210 @@ mod tests {
             );
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- live monetary metering (reserve → settle, #3193-G) --------------
+
+    fn funded_publisher_predicates() -> LeasePredicates {
+        LeasePredicates {
+            publisher_ops: vec![capability_lease::PublisherRule {
+                publisher_slug: "some-dex".to_string(),
+                allow_high_risk: true,
+                target: None,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn money_budget(max_spend: u64, asset: &str) -> LeaseBudgets {
+        LeaseBudgets {
+            max_calls: Some(100),
+            max_spend_micros: Some(max_spend),
+            asset: Some(asset.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn spend_used(s: &ToolAuthorizationState) -> u64 {
+        s.list_leases("conv-a").unwrap()[0].budgets.spend_used_micros
+    }
+
+    fn reserve(
+        s: &ToolAuthorizationState,
+        asset: &str,
+        cost_micros: u64,
+    ) -> SpendReservation {
+        s.reserve_lease_spend(
+            ToolRoute::Gateway,
+            "some-dex",
+            "post_swap",
+            "conv-a",
+            &ctx(),
+            asset,
+            cost_micros,
+        )
+        .unwrap()
+    }
+
+    /// A priced call charges its realized cost against the covering lease's
+    /// monetary budget — the core wiring this ticket adds.
+    #[test]
+    fn realized_cost_is_charged_against_the_covering_lease() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 4_000_000);
+        assert_eq!(reservation.outcome, "charged");
+        assert!(reservation.reservation_id.is_some());
+        assert_eq!(spend_used(&s), 4_000_000, "the realized cost decremented the budget");
+    }
+
+    /// A priced call whose cost would exceed the remaining budget escalates
+    /// (before any payment) and leaves the budget untouched.
+    #[test]
+    fn over_budget_priced_call_escalates_without_charging() {
+        let s = state();
+        let mut budget = money_budget(10_000_000, "USDC");
+        budget.spend_used_micros = 8_000_000;
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), budget)
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 5_000_000); // 8M + 5M > 10M
+        assert_eq!(reservation.outcome, "escalate");
+        assert!(reservation.reservation_id.is_none());
+        assert_eq!(spend_used(&s), 8_000_000, "an escalated call must not charge");
+    }
+
+    /// A payment in a different asset than the budget pins escalates rather than
+    /// mis-charging the wrong-asset budget.
+    #[test]
+    fn mismatched_asset_escalates_without_charging() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "DAI", 1_000_000);
+        assert_eq!(reservation.outcome, "escalate");
+        assert_eq!(spend_used(&s), 0);
+    }
+
+    /// A priced call no lease covers is not lease-scoped: `uncovered`, so the
+    /// caller falls back to its own payment gate. No budget is touched.
+    #[test]
+    fn priced_call_with_no_covering_lease_is_uncovered() {
+        let s = state();
+        // A lease that covers a *different* publisher does not cover this call.
+        let other = LeasePredicates {
+            publisher_ops: vec![capability_lease::PublisherRule {
+                publisher_slug: "attio".to_string(),
+                allow_high_risk: true,
+                target: None,
+            }],
+            ..Default::default()
+        };
+        s.grant_lease("conv-a", "crm", 3600, other, money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 1_000_000);
+        assert_eq!(reservation.outcome, "uncovered");
+        assert!(reservation.reservation_id.is_none());
+    }
+
+    /// A zero-cost (free) call reserves nothing and never escalates — free calls
+    /// behave exactly as before this wiring existed.
+    #[test]
+    fn free_call_reserves_nothing() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 0);
+        assert_eq!(reservation.outcome, "uncovered");
+        assert_eq!(spend_used(&s), 0);
+    }
+
+    /// A cancelled/failed payment releases its reservation, so the lease budget is
+    /// not permanently consumed by a payment that never happened.
+    #[test]
+    fn settle_releases_a_reservation_when_payment_fails() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 4_000_000);
+        assert_eq!(spend_used(&s), 4_000_000);
+        s.settle_lease_spend(reservation.reservation_id.as_deref().unwrap(), None)
+            .unwrap();
+        assert_eq!(spend_used(&s), 0, "a failed payment released the reservation");
+    }
+
+    /// Reserve → settle reconciles the lease spend when the settled amount is less
+    /// than the reserved estimate (the over-reserved portion is released).
+    #[test]
+    fn settle_reconciles_a_lower_settled_amount() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 10_000_000);
+        assert_eq!(spend_used(&s), 10_000_000);
+        s.settle_lease_spend(reservation.reservation_id.as_deref().unwrap(), Some(6_000_000))
+            .unwrap();
+        assert_eq!(spend_used(&s), 6_000_000, "spend reconciled down to the settled amount");
+    }
+
+    /// Settling is idempotent: a replayed settle never double-releases.
+    #[test]
+    fn settle_is_idempotent() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 4_000_000);
+        let id = reservation.reservation_id.unwrap();
+        s.settle_lease_spend(&id, None).unwrap();
+        assert_eq!(spend_used(&s), 0);
+        // A second settle of the same reservation is a no-op, not a double-release.
+        s.settle_lease_spend(&id, None).unwrap();
+        assert_eq!(spend_used(&s), 0);
+    }
+
+    /// The realized cost charged at the 402 survives the store being closed and
+    /// reopened on the same on-disk database — spend persistence, not just calls.
+    #[test]
+    fn charged_spend_persists_across_store_reopen_on_disk() {
+        let dir = std::env::temp_dir().join(format!("seren-authz-spend-{}", uuid::Uuid::new_v4()));
+        let db = dir.join("tool_authorization.db");
+        {
+            let s = ToolAuthorizationState::new(db.clone());
+            s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+                .unwrap();
+            let reservation = s
+                .reserve_lease_spend(
+                    ToolRoute::Gateway,
+                    "some-dex",
+                    "post_swap",
+                    "conv-a",
+                    &ctx(),
+                    "USDC",
+                    4_000_000,
+                )
+                .unwrap();
+            assert_eq!(reservation.outcome, "charged");
+        }
+        {
+            let s = ToolAuthorizationState::new(db.clone());
+            let leases = s.list_leases("conv-a").unwrap();
+            assert_eq!(leases[0].budgets.spend_used_micros, 4_000_000, "charged spend persisted to disk");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The erase-all flow removes live spend reservations too.
+    #[test]
+    fn wipe_clears_spend_reservations() {
+        let s = state();
+        s.grant_lease("conv-a", "trading", 3600, funded_publisher_predicates(), money_budget(10_000_000, "USDC"))
+            .unwrap();
+        let reservation = reserve(&s, "USDC", 4_000_000);
+        let id = reservation.reservation_id.unwrap();
+        s.wipe().unwrap();
+        // The reservation is gone, so settling it is a no-op against a fresh store.
+        s.settle_lease_spend(&id, None).unwrap();
+        assert!(s.list_leases("conv-a").unwrap().is_empty());
     }
 
     /// The renderer sends the operation context as camelCase; pin `costMicros`.

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -7,7 +7,11 @@ import { mcpClient } from "@/lib/mcp/client";
 import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { reportError } from "@/lib/support/hook";
-import { type PaymentRequirements, parsePaymentRequirements } from "@/lib/x402";
+import {
+  type PaymentRequirements,
+  parsePaymentRequirements,
+  resolvePaymentCharge,
+} from "@/lib/x402";
 import {
   callGatewayTool,
   callSerenTool,
@@ -268,6 +272,67 @@ async function settleApprovalContinuation(
       err,
     );
     return null;
+  }
+}
+
+/**
+ * The host's verdict on reserving a priced call's realized cost against its
+ * covering lease (#3193-G). Mirrors `SpendReservation` in
+ * `src-tauri/src/tool_authorization.rs`.
+ */
+interface SpendReservation {
+  outcome: "charged" | "escalate" | "uncovered";
+  reservationId?: string;
+}
+
+/**
+ * Reserve a priced call's realized cost against the lease that covers it, at the
+ * x402 payment gate and before any payment is signed. Fails closed: if the host
+ * cannot verify the budget, the call is treated as an escalation (an explicit
+ * prompt) rather than a silent payment.
+ */
+async function reserveLeaseSpend(
+  publisherSlug: string,
+  toolName: string,
+  conversationId: string,
+  context: OperationContext,
+  costMicros: number,
+  asset: string,
+): Promise<SpendReservation> {
+  try {
+    return await invoke<SpendReservation>("reserve_lease_spend", {
+      route: "gateway",
+      publisherSlug,
+      toolName,
+      conversationId,
+      context,
+      asset,
+      costMicros,
+    });
+  } catch (err) {
+    console.error("[Tool Executor] Failed to reserve lease spend:", err);
+    return { outcome: "escalate" };
+  }
+}
+
+/**
+ * Settle a spend reservation once its payment resolves. `settledMicros` null
+ * releases the whole reservation (the payment never completed); a number
+ * reconciles the lease's spend to the amount actually paid. Best-effort: a failed
+ * settle leaves the reserved charge standing (a conservative over-charge), never a
+ * silent release.
+ */
+async function settleLeaseSpend(
+  reservationId: string,
+  settledMicros: number | null,
+): Promise<void> {
+  try {
+    await invoke("settle_lease_spend", {
+      reservationId,
+      settledMicros: settledMicros ?? undefined,
+    });
+  } catch (err) {
+    console.error("[Tool Executor] Failed to settle lease spend:", err);
   }
 }
 
@@ -1361,19 +1426,65 @@ async function executeGatewayTool(
         };
       }
 
+      // Meter the realized cost against the covering lease's monetary budget
+      // BEFORE any payment is signed (#3193-G). The 402 is the first point the
+      // real price is known, so this is where the host-owned budget is charged.
+      const charge = resolvePaymentCharge(requirements);
+      if (!charge) {
+        return {
+          tool_call_id: toolCallId,
+          content:
+            "Payment required but the charge amount could not be determined; refusing to pay an indeterminable cost.",
+          is_error: true,
+        };
+      }
+      // Match the same context the initial authorize used (the original args,
+      // before OAuth connection_id resolution) so the charge lands on the exact
+      // lease that authorized this call.
+      const leaseContext = contextForPublisherRoute("gateway", args);
+      const reservation = await reserveLeaseSpend(
+        publisherSlug,
+        toolName,
+        sessionConversationId(conversationId),
+        leaseContext,
+        charge.micros,
+        charge.asset,
+      );
+      // Over budget (or a mismatched asset) under a lease → force an explicit
+      // prompt so an over-budget payment is never signed silently. Within budget
+      // → the reservation is charged and settled once the payment resolves. No
+      // lease → the x402 approval UI remains the gate, exactly as before.
+      const requireApproval = reservation.outcome === "escalate";
+      const reservationId =
+        reservation.outcome === "charged"
+          ? (reservation.reservationId ?? null)
+          : null;
+
       // Use the x402 service to handle payment (shows UI, signs, etc.)
       const paymentResult = await x402Service.handlePaymentRequired(
         `seren-gateway/${publisherSlug}`,
         toolName,
         new Error(JSON.stringify(response.payment_proxy)),
+        { requireApproval },
       );
 
       if (!paymentResult?.success) {
+        // The payment never completed — release the reserved budget so a
+        // cancelled or failed payment does not permanently consume the lease.
+        if (reservationId) {
+          await settleLeaseSpend(reservationId, null);
+        }
         return {
           tool_call_id: toolCallId,
           content: paymentResult?.error || "Payment was cancelled or failed",
           is_error: true,
         };
+      }
+
+      // Payment committed: finalize the reservation once (keeps the charge; a
+      // delta only arises if a pre-call estimate was reserved earlier).
+      if (reservationId) {
+        await settleLeaseSpend(reservationId, charge.micros);
       }
 
       // If crypto payment was signed, retry with the payment header

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -300,7 +300,7 @@ async function reserveLeaseSpend(
   asset: string,
 ): Promise<SpendReservation> {
   try {
-    return await invoke<SpendReservation>("reserve_lease_spend", {
+    const reservation = await invoke<SpendReservation>("reserve_lease_spend", {
       route: "gateway",
       publisherSlug,
       toolName,
@@ -309,6 +309,16 @@ async function reserveLeaseSpend(
       asset,
       costMicros,
     });
+    // A malformed response cannot be trusted to have metered the budget:
+    // fail closed to an explicit prompt rather than a silent payment.
+    if (
+      reservation?.outcome === "charged" ||
+      reservation?.outcome === "escalate" ||
+      reservation?.outcome === "uncovered"
+    ) {
+      return reservation;
+    }
+    return { outcome: "escalate" };
   } catch (err) {
     console.error("[Tool Executor] Failed to reserve lease spend:", err);
     return { outcome: "escalate" };

--- a/src/lib/x402/index.ts
+++ b/src/lib/x402/index.ts
@@ -9,9 +9,11 @@ export {
   hasX402Option,
   type InsufficientCredit,
   isInsufficientCredit,
+  type PaymentCharge,
   type PaymentOption,
   type PaymentRequirements,
   parsePaymentRequirements,
+  resolvePaymentCharge,
   type X402PaymentOption,
   type X402ResourceInfo,
 } from "./types";

--- a/src/lib/x402/types.ts
+++ b/src/lib/x402/types.ts
@@ -181,6 +181,43 @@ export function isInsufficientCredit(
 }
 
 /**
+ * The realized monetary charge of a 402, in the micro-units the host lease budget
+ * meters (a 6-decimal stablecoin's base unit is already a micro-unit), plus an
+ * asset identifier for the budget's asset guard.
+ */
+export interface PaymentCharge {
+  micros: number;
+  asset: string;
+}
+
+/**
+ * Resolve the realized charge of a 402 for lease metering: the token amount and
+ * asset of the first x402 option, or the prepaid minimum when only credit is
+ * accepted. Returns null when no amount can be determined or it is not a safe
+ * integer count of micro-units — the caller then refuses to pay an
+ * indeterminable amount rather than metering a wrong one.
+ */
+export function resolvePaymentCharge(
+  requirements: PaymentRequirements,
+): PaymentCharge | null {
+  const option = getX402Option(requirements);
+  if (option) {
+    const micros = Number(option.amount);
+    if (!Number.isSafeInteger(micros) || micros < 0) return null;
+    return { micros, asset: option.asset };
+  }
+  const minimum = requirements.insufficientCredit?.minimumRequired;
+  if (minimum !== undefined) {
+    const micros = Number(minimum);
+    if (!Number.isSafeInteger(micros) || micros < 0) return null;
+    // Prepaid credit is USD-denominated SerenBucks, distinct from any on-chain
+    // asset a lease might pin.
+    return { micros, asset: "serenbucks" };
+  }
+  return null;
+}
+
+/**
  * Format amount in USDC (6 decimals) to human-readable string.
  */
 export function formatUsdcAmount(amountRaw: string): string {

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -258,6 +258,17 @@ function createX402Service() {
   }
 
   /**
+   * Options controlling how a payment-required error is handled.
+   */
+  interface HandlePaymentOptions {
+    /** Force an explicit approval prompt, suppressing the crypto auto-approve
+     * threshold. The host lease gate sets this when a call's realized cost would
+     * exceed the task's remaining monetary budget, so an over-budget payment can
+     * never be signed silently (#3193-G). */
+    requireApproval?: boolean;
+  }
+
+  /**
    * Handle an x402 payment required error.
    *
    * Returns the payment result including which method was used.
@@ -266,6 +277,7 @@ function createX402Service() {
     serverName: string,
     toolName: string,
     error: unknown,
+    options?: HandlePaymentOptions,
   ): Promise<X402PaymentResult | null> {
     // Extract payment requirements from the error
     const extracted = extractRequirements(error);
@@ -287,8 +299,11 @@ function createX402Service() {
       return null;
     }
 
-    // Check for auto-approve with crypto (only if crypto is available and preferred)
+    // Check for auto-approve with crypto (only if crypto is available and
+    // preferred). A budget-driven escalation suppresses this so an over-budget
+    // payment always faces an explicit prompt instead of signing silently.
     if (
+      !options?.requireApproval &&
       hasCrypto &&
       x402Option &&
       settingsState.app.preferredPaymentMethod === "crypto"

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -76,6 +76,12 @@ describe("tool executor OAuth account routing", () => {
           handle: "handle-allow",
         };
       }
+      // No lease is granted in these routing tests, so a 402's realized cost is
+      // not lease-scoped: the host reports `uncovered` and the payment gate is
+      // unchanged (#3193-G).
+      if (cmd === "reserve_lease_spend") {
+        return { outcome: "uncovered" };
+      }
       return undefined;
     });
   });
@@ -212,8 +218,28 @@ describe("tool executor OAuth account routing", () => {
 
   it("retains the owning OAuth connection when retrying a signed x402 payment", async () => {
     const { executeTool } = await import("@/lib/tools/executor");
+    // A real 402 carries a payable amount; the host meters it against any
+    // covering lease before signing (#3193-G). This call has no lease, so the
+    // reserve is a passthrough (`uncovered`) and the retry proceeds unchanged.
     const paymentRequiredHeader = btoa(
-      JSON.stringify({ x402Version: 2, accepts: [] }),
+      JSON.stringify({
+        x402Version: 2,
+        resource: {
+          url: "https://gateway/pay",
+          description: "paid read",
+          mimeType: "application/json",
+        },
+        accepts: [
+          {
+            scheme: "exact",
+            network: "base",
+            asset: "0xUSDC",
+            amount: "1000000",
+            payTo: "0x0000000000000000000000000000000000000000",
+            maxTimeoutSeconds: 60,
+          },
+        ],
+      }),
     );
     const signedV2Payment = btoa(JSON.stringify({ x402Version: 2 }));
     mocks.computeAgentOAuthRouting.mockResolvedValue({

--- a/tests/unit/x402-payment-charge.test.ts
+++ b/tests/unit/x402-payment-charge.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Tests resolvePaymentCharge — the realized-cost parser that gates a lease's
+// ABOUTME: monetary budget (#3193-G). A wrong amount/asset would mis-charge real money.
+
+import { describe, expect, it } from "vitest";
+import {
+  type PaymentRequirements,
+  resolvePaymentCharge,
+} from "@/lib/x402";
+
+function x402Requirements(
+  amount: string,
+  asset: string,
+): PaymentRequirements {
+  return {
+    x402Version: 1,
+    accepts: [
+      {
+        type: "x402",
+        option: {
+          scheme: "exact",
+          network: "base",
+          asset,
+          amount,
+          payTo: "0x0000000000000000000000000000000000000000",
+          maxTimeoutSeconds: 60,
+        },
+      },
+    ],
+  };
+}
+
+describe("resolvePaymentCharge", () => {
+  it("reads the amount and asset from the first x402 option", () => {
+    const charge = resolvePaymentCharge(
+      x402Requirements("2500000", "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+    );
+    expect(charge).toEqual({
+      micros: 2_500_000,
+      asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    });
+  });
+
+  it("reads the prepaid minimum as a SerenBucks charge when only credit is accepted", () => {
+    const requirements: PaymentRequirements = {
+      accepts: [{ type: "prepaid" }],
+      insufficientCredit: {
+        minimumRequired: "1500000",
+        currentBalance: "0",
+      },
+    };
+    expect(resolvePaymentCharge(requirements)).toEqual({
+      micros: 1_500_000,
+      asset: "serenbucks",
+    });
+  });
+
+  it("prefers the x402 option amount when both crypto and prepaid are offered", () => {
+    const requirements = x402Requirements("750000", "USDC");
+    requirements.accepts.push({ type: "prepaid" });
+    expect(resolvePaymentCharge(requirements)?.micros).toBe(750_000);
+  });
+
+  it("refuses an amount that is not a safe integer count of micro-units", () => {
+    // 10^18 wei-style value overflows JS safe-integer range — must not be metered
+    // as a truncated (wrong) micro amount.
+    expect(
+      resolvePaymentCharge(x402Requirements("1000000000000000000", "USDC")),
+    ).toBeNull();
+  });
+
+  it("refuses a non-numeric amount rather than metering NaN", () => {
+    expect(resolvePaymentCharge(x402Requirements("not-a-number", "USDC"))).toBeNull();
+  });
+
+  it("returns null when no amount is present at all", () => {
+    expect(resolvePaymentCharge({ accepts: [{ type: "prepaid" }] })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3277 (slice **G** of #3193; does not close the epic).

## Problem

The capability-lease monetary budget (`max_spend_micros`) was modeled, persisted, and unit-tested in #3270 — but **never charged**. `OperationContext.cost_micros` is *"0 when free/unknown"* and nothing ever set it: the gate built every request with `cost_micros: 0`, so every priced call passed `admits(0)`, `spend_used_micros` never moved, and a lease with a spend ceiling gave **no real protection**. The real price is realized only *during dispatch, after the gate* — in the x402 branch of `executeGatewayTool`.

## Fix

Charge the realized per-call cost against the host-owned lease budget at the x402 payment gate — the first point the real price is known — **before any payment is signed**.

### Rust (host-owned, persisted)
- **`capability_lease.rs`** — `LeaseBudgets::admits_spend` (asset-aware, independent of the call budget which is charged once at the gate), `charge_spend` / `release_spend` saturating mutators, and a pure `spend_for_conversation` matcher returning `SpendOutcome::{Charge, Escalate, Uncovered}` with the same `deny > allow` resolution as the authorize matcher.
- **`tool_authorization.rs`** — `reserve_lease_spend` / `settle_lease_spend` backed by a new `spend_reservations` table. Reserve reads leases, charges the covering lease, and records a host-owned reservation **under one connection lock** so two concurrent priced calls cannot both slip past the last of a budget. Settle reconciles the lease spend to the amount actually paid (releasing on payment failure), keyed by an opaque host-owned reservation id — the renderer never supplies the reserved amount. `wipe` clears reservations.
- **`commands/tool_authorization.rs` + `lib.rs`** — the two commands, registered.

### Frontend
- **`x402/types.ts`** — `resolvePaymentCharge` surfaces the micro-denominated amount + asset from the 402; **refuses an unsafe-integer amount** rather than metering a truncated (wrong) value.
- **`x402.ts`** — `handlePaymentRequired` gains `requireApproval` to suppress the crypto auto-approve threshold. That threshold was the concrete silent-overspend hole: many sub-threshold payments could accumulate past a lease's ceiling with no prompt.
- **`executor.ts`** — at the 402, reserve the realized cost against the covering lease **before** `handlePaymentRequired` signs:
  - **within budget** → charge, then settle once the payment resolves (release on failure);
  - **over budget / mismatched asset** → force an explicit prompt instead of paying silently (one scope-escalation);
  - **no lease** → the x402 approval UI stays the gate, exactly as before.

## Acceptance criteria
- [x] A priced call charges its realized cost against the covering lease; spend persists across an on-disk reopen.
- [x] An over-budget priced call escalates **before** any payment is signed/settled — never a silent overspend.
- [x] Asset-aware: spend decrements the granted asset; a mismatched asset escalates rather than mis-charging. A lease with no pinned asset meters against its ceiling regardless.
- [x] Reserve → settle reconciles when the settled amount differs from the reserved estimate, and releases a reservation whose payment never completed.
- [x] Free / unknown-cost calls behave as today (charge 0, no gating).
- [x] Tests cover realized-cost decrement, over-budget escalation, on-disk persistence, asset mismatch, reserve→settle reconciliation, and both crypto x402 + SerenBucks paths.

## Scope notes
- **Pre-call gating is plumbed but dormant.** `OperationContext.costMicros` / `admits()` gate up-front when a price is known before the call, but **no publisher pricing metadata is exposed to the client today**, so the active path is the 402 reserve→settle. The reserve→settle reconciliation mechanism a future pricing source would use is implemented and unit-tested (`settle_reconciles_a_lower_settled_amount`).
- **No new networked path.** `reserve_lease_spend` / `settle_lease_spend` are local Tauri commands. The existing outbound gateway payment dispatch (`callGatewayTool` → the gateway) is unchanged — no new publisher slug/path.
- Non-monetary budgets (#3262) and approval/audit UI (#3264) remain out of scope.

## Validation
- `cargo test --lib` — **1141 passed, 0 failed** (includes new reserve/settle/matcher tests).
- `pnpm vitest run` on the executor + new x402 charge tests — **25 passed** (existing tool-executor approval suite still green).
- Biome clean; `tsc` introduces no new errors in changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
