### PR TITLE
feat(security): standing-policy auto-leases for unattended runs (#3274)

### DIFF
--- a/src-tauri/src/authorization_audit.rs
+++ b/src-tauri/src/authorization_audit.rs
@@ -14,6 +14,9 @@ use crate::tool_authorization::ToolRoute;
 pub enum AuditEvent {
     /// A user-approved capability lease was persisted.
     LeaseGranted,
+    /// A lease was auto-materialized from an owner-defined standing policy at
+    /// task start, with no human present (#3193-E).
+    LeaseAutoGranted,
     /// A covered call ran silently under a lease (its budget was charged).
     LeaseUsed,
     /// A lease exclusion denied a call outright.
@@ -38,6 +41,7 @@ impl AuditEvent {
     pub fn as_wire(self) -> &'static str {
         match self {
             Self::LeaseGranted => "lease_granted",
+            Self::LeaseAutoGranted => "lease_auto_granted",
             Self::LeaseUsed => "lease_used",
             Self::LeaseDenied => "lease_denied",
             Self::LeaseExpired => "lease_expired",
@@ -94,6 +98,21 @@ impl AuditContext {
         Self {
             subject_id: Some(lease.id.clone()),
             detail: Some(lease.label.clone()),
+            ..Default::default()
+        }
+    }
+
+    /// Context for an auto-granted lease (#3193-E): the lease id, its reviewed
+    /// label, and the standing policy it was materialized from, so the trail can
+    /// say "auto-granted from standing policy <id>". Credential-safe: the policy
+    /// id and label were both authored by the owner.
+    pub fn for_auto_lease(lease: &CapabilityLease, policy_id: &str) -> Self {
+        Self {
+            subject_id: Some(lease.id.clone()),
+            detail: Some(format!(
+                "{} — auto-granted from standing policy {policy_id}",
+                lease.label
+            )),
             ..Default::default()
         }
     }

--- a/src-tauri/src/capability_lease.rs
+++ b/src-tauri/src/capability_lease.rs
@@ -168,6 +168,14 @@ pub struct CapabilityLease {
     pub expires_at: String,
     #[serde(default)]
     pub revoked: bool,
+    /// The standing policy this lease was auto-materialized from (#3193-E), or
+    /// `None` for a human-granted lease. Purely attributive: it lets the audit
+    /// trail say "auto-granted from standing policy <id>" and lets the resolver
+    /// avoid re-minting a fresh lease for a policy that already produced one for
+    /// this conversation (so an exhausted budget or expiry re-escalates instead
+    /// of silently regranting).
+    #[serde(default)]
+    pub source_policy_id: Option<String>,
     pub predicates: LeasePredicates,
     pub budgets: LeaseBudgets,
 }
@@ -562,6 +570,7 @@ mod tests {
             created_at: NOW.to_string(),
             expires_at: LATER.to_string(),
             revoked: false,
+            source_policy_id: None,
             predicates,
             budgets,
         }

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -12,6 +12,7 @@ use crate::capability_lease::{
     BundleRequest, CapabilityLease, LeaseBudgets, LeasePredicates, ProposedBundle, derive_bundle,
 };
 use crate::orchestrator::types::TaskExecutionState;
+use crate::standing_policy::{StandingPolicy, StandingPolicyInput};
 use crate::tool_authorization::{
     AuthorizationDecision, OperationContext, SpendReservation, ToolAuthorizationState, ToolRoute,
 };
@@ -155,6 +156,52 @@ pub fn revoke_capability_lease(
     lease_id: String,
 ) -> Result<bool, String> {
     state.revoke_lease(&lease_id)
+}
+
+/// Every standing policy, newest first, for the owner settings surface (#3193-E).
+/// Read-only inspection; authoring happens through the create/update/delete
+/// commands below.
+#[tauri::command]
+pub fn list_standing_policies(
+    state: State<'_, ToolAuthorizationState>,
+) -> Result<Vec<StandingPolicy>, String> {
+    state.list_standing_policies()
+}
+
+/// Create an owner-authored standing policy that auto-materializes a bounded lease
+/// for a matching unattended/long-running task (#3193-E). Invoked **only** from
+/// the owner settings surface — there is no model tool or dispatch path that
+/// reaches this command, so model output can never create or widen a standing
+/// policy. The host owns the id and timestamps; the caller supplies only the
+/// reviewed predicates/budgets/duration.
+#[tauri::command]
+pub fn create_standing_policy(
+    state: State<'_, ToolAuthorizationState>,
+    input: StandingPolicyInput,
+) -> Result<StandingPolicy, String> {
+    state.create_standing_policy(input)
+}
+
+/// Update an existing standing policy in place — edit its envelope or toggle it
+/// on/off. Owner-only. Returns `None` if the id is unknown. Disabling stops all
+/// future auto-grants from the policy immediately.
+#[tauri::command]
+pub fn update_standing_policy(
+    state: State<'_, ToolAuthorizationState>,
+    policy_id: String,
+    input: StandingPolicyInput,
+) -> Result<Option<StandingPolicy>, String> {
+    state.update_standing_policy(&policy_id, input)
+}
+
+/// Delete a standing policy. Owner-only. Idempotent — returns whether a policy was
+/// actually removed.
+#[tauri::command]
+pub fn delete_standing_policy(
+    state: State<'_, ToolAuthorizationState>,
+    policy_id: String,
+) -> Result<bool, String> {
+    state.delete_standing_policy(&policy_id)
 }
 
 /// Register a suspended continuation for an authorization-blocked action so the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,7 @@ mod provider_runtime;
 mod secret_broker;
 mod shell;
 mod skills;
+pub mod standing_policy;
 mod support;
 mod sync;
 mod terminal;
@@ -1147,6 +1148,10 @@ pub fn run() {
             commands::tool_authorization::grant_capability_lease,
             commands::tool_authorization::list_capability_leases,
             commands::tool_authorization::revoke_capability_lease,
+            commands::tool_authorization::list_standing_policies,
+            commands::tool_authorization::create_standing_policy,
+            commands::tool_authorization::update_standing_policy,
+            commands::tool_authorization::delete_standing_policy,
             commands::tool_authorization::register_approval_continuation,
             commands::tool_authorization::resolve_approval_continuation,
             commands::tool_authorization::expire_approval_continuation,

--- a/src-tauri/src/standing_policy.rs
+++ b/src-tauri/src/standing_policy.rs
@@ -1,0 +1,160 @@
+// ABOUTME: Owner/org-defined standing policies that auto-materialize bounded capability leases (#3193-E).
+// ABOUTME: A policy holds the same predicates + budgets a human grant does; the resolver mints a lease within them, never wider.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability_lease::{CapabilityLease, LeaseBudgets, LeasePredicates};
+
+/// A persistent, owner-defined pre-authorization. Unlike a `CapabilityLease` it
+/// is **not** conversation-scoped: it lives until the owner disables or deletes
+/// it, and the resolver materializes a fresh conversation-scoped lease from it at
+/// task start (zero prompts, no human present).
+///
+/// A policy expresses authority in the *exact same vocabulary* a human "Approve
+/// for this task" grant does (`LeasePredicates` + `LeaseBudgets`), so it can only
+/// ever pre-authorize *within* those predicates — never widen a call beyond them.
+/// The model can `request` scope but can never create, widen, or self-approve a
+/// standing policy: policies are written only by the owner settings commands.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StandingPolicy {
+    pub id: String,
+    /// Human-readable summary shown in the owner settings surface.
+    pub label: String,
+    /// Disabled policies are ignored by the resolver, so toggling this off stops
+    /// all future auto-grants immediately (already-materialized leases live out
+    /// their own expiry or are revoked separately).
+    pub enabled: bool,
+    /// Lifetime, in seconds, stamped onto each lease this policy materializes.
+    pub max_duration_secs: i64,
+    pub predicates: LeasePredicates,
+    pub budgets: LeaseBudgets,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// The reviewed envelope the owner settings surface submits to create or update a
+/// policy. The host owns the id and timestamps; the caller supplies only the
+/// authored fields. Deserialized from the renderer as camelCase.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StandingPolicyInput {
+    pub label: String,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub max_duration_secs: i64,
+    #[serde(default)]
+    pub predicates: LeasePredicates,
+    #[serde(default)]
+    pub budgets: LeaseBudgets,
+}
+
+/// Copy a policy's budget *limits* into a fresh counter set: a materialized lease
+/// always starts unused, so an edit to the policy's `callsUsed`/`spendUsedMicros`
+/// (renderer noise) can never pre-charge a new lease, and each conversation gets
+/// the policy's full allowance.
+fn fresh_budgets(budgets: &LeaseBudgets) -> LeaseBudgets {
+    LeaseBudgets {
+        max_calls: budgets.max_calls,
+        calls_used: 0,
+        max_spend_micros: budgets.max_spend_micros,
+        spend_used_micros: 0,
+        asset: budgets.asset.clone(),
+    }
+}
+
+/// Build the lease a policy would materialize for `conversation_id`. Pure: the
+/// store supplies the host-minted id, the `now` timestamp, and the pre-computed
+/// `expires_at` (`now + max_duration_secs`) so lease lifetime uses the same DB
+/// clock every other lease does. The lease carries the policy id so the audit
+/// trail and the resolver's idempotency guard can attribute it.
+pub fn candidate_lease(
+    policy: &StandingPolicy,
+    conversation_id: &str,
+    lease_id: &str,
+    now: &str,
+    expires_at: &str,
+) -> CapabilityLease {
+    CapabilityLease {
+        id: lease_id.to_string(),
+        conversation_id: conversation_id.to_string(),
+        label: policy.label.clone(),
+        created_at: now.to_string(),
+        expires_at: expires_at.to_string(),
+        revoked: false,
+        source_policy_id: Some(policy.id.clone()),
+        predicates: policy.predicates.clone(),
+        budgets: fresh_budgets(&policy.budgets),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability_lease::CommandRule;
+
+    fn policy() -> StandingPolicy {
+        StandingPolicy {
+            id: "policy-1".to_string(),
+            label: "Unattended coding".to_string(),
+            enabled: true,
+            max_duration_secs: 4 * 3600,
+            predicates: LeasePredicates {
+                command_rules: vec![CommandRule {
+                    program: "cargo".to_string(),
+                }],
+                ..Default::default()
+            },
+            budgets: LeaseBudgets {
+                max_calls: Some(200),
+                calls_used: 999,
+                max_spend_micros: Some(5_000_000),
+                spend_used_micros: 777,
+                asset: Some("USDC".to_string()),
+            },
+            created_at: "2026-07-24T00:00:00Z".to_string(),
+            updated_at: "2026-07-24T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn candidate_lease_starts_unused_and_is_attributed_to_the_policy() {
+        let lease = candidate_lease(
+            &policy(),
+            "conv-a",
+            "lease-1",
+            "2026-07-24T00:00:00Z",
+            "2026-07-24T04:00:00Z",
+        );
+        assert_eq!(lease.conversation_id, "conv-a");
+        assert_eq!(lease.source_policy_id.as_deref(), Some("policy-1"));
+        // Fresh counters regardless of any used values carried on the policy.
+        assert_eq!(lease.budgets.calls_used, 0);
+        assert_eq!(lease.budgets.spend_used_micros, 0);
+        // Limits and predicates copy through verbatim.
+        assert_eq!(lease.budgets.max_calls, Some(200));
+        assert_eq!(lease.budgets.max_spend_micros, Some(5_000_000));
+        assert_eq!(lease.predicates.command_rules.len(), 1);
+    }
+
+    #[test]
+    fn policy_uses_the_camel_case_wire_contract() {
+        let input: StandingPolicyInput = serde_json::from_value(serde_json::json!({
+            "label": "Unattended coding",
+            "enabled": true,
+            "maxDurationSecs": 14_400,
+            "predicates": { "commandRules": [{ "program": "cargo" }] },
+            "budgets": { "maxCalls": 200 },
+        }))
+        .expect("camelCase policy input deserializes");
+        assert_eq!(input.max_duration_secs, 14_400);
+        assert!(input.enabled);
+        assert_eq!(input.predicates.command_rules.len(), 1);
+
+        let value = serde_json::to_value(policy()).expect("policy serializes");
+        assert!(value.get("maxDurationSecs").is_some());
+        assert!(value.get("enabled").is_some());
+        assert!(value["predicates"].get("commandRules").is_some());
+    }
+}

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -18,6 +18,7 @@ use crate::capability_lease::{
     SpendOutcome,
 };
 use crate::orchestrator::types::TaskExecutionState;
+use crate::standing_policy::{self, StandingPolicy, StandingPolicyInput};
 
 /// The small argument slice the gate needs to evaluate lease predicates for a
 /// call. Extracted from the tool arguments by the renderer per route: `command`
@@ -723,6 +724,33 @@ impl ToolAuthorizationState {
             LeaseOutcome::Escalate => {}
         }
 
+        // No active lease covers this call. Before escalating (which, with no
+        // human present, would only time out and stall the task), consult the
+        // owner-defined standing policies (#3193-E): a matching enabled policy
+        // deterministically auto-materializes a bounded, conversation-scoped
+        // lease from the same predicates + budgets a human grant produces — no
+        // UI, no prompt. The call then runs silently under that lease exactly as
+        // it would under a human-granted one. Out-of-policy work still falls
+        // through to the escalation below.
+        if self
+            .try_materialize_standing_policy(conversation_id, &request)?
+            .is_some()
+        {
+            if let LeaseOutcome::Allow(lease_id) =
+                self.evaluate_and_charge_leases(conversation_id, &request)?
+            {
+                let handle = self.mint_handle(
+                    conversation_id,
+                    route,
+                    publisher_slug,
+                    tool_name,
+                    &binding,
+                    Some(&lease_id),
+                )?;
+                return Ok(AuthorizationDecision::allow(class, handle));
+            }
+        }
+
         if class == OperationClass::HighRisk {
             let (description, is_destructive) = prompt_metadata(class, publisher_slug, tool_name);
             return Ok(AuthorizationDecision::prompt(
@@ -1113,6 +1141,8 @@ impl ToolAuthorizationState {
                 created_at: now.clone(),
                 expires_at,
                 revoked: false,
+                // A human-granted lease has no source policy.
+                source_policy_id: None,
                 predicates: predicates.clone(),
                 budgets: budgets.clone(),
             };
@@ -1176,6 +1206,166 @@ impl ToolAuthorizationState {
                 &now,
             );
             Ok(true)
+        })
+    }
+
+    /// Consult the owner-defined standing policies and, if one matches, mint the
+    /// bounded conversation-scoped lease it pre-authorizes (#3193-E). Returns the
+    /// materialized lease, or `None` when nothing matches (the caller then
+    /// escalates exactly as before).
+    ///
+    /// Everything runs under one connection lock, so two racing first-calls for a
+    /// conversation cannot both mint a lease from the same policy. Guardrails:
+    /// - Only **enabled** policies are considered — disabling one stops all future
+    ///   auto-grants at once.
+    /// - A policy that already produced a lease for this conversation is skipped,
+    ///   even if that lease is now exhausted, expired, or revoked. This is what
+    ///   makes an out-of-budget or expired auto-lease re-escalate instead of
+    ///   silently regranting itself on the next call.
+    /// - Coverage is decided by the *same* deterministic matcher a human lease
+    ///   uses (`evaluate_for_conversation` on the candidate). A policy can only
+    ///   pre-authorize *within* its predicates + budgets: a high-risk, priced, or
+    ///   out-of-scope call that the policy does not cover yields no lease, so it
+    ///   still escalates to a one-shot approval.
+    fn try_materialize_standing_policy(
+        &self,
+        conversation_id: &str,
+        request: &OperationRequest,
+    ) -> Result<Option<CapabilityLease>, String> {
+        self.with_conn(|conn| {
+            let policies = read_standing_policies(conn)?;
+            if policies.iter().all(|policy| !policy.enabled) {
+                return Ok(None);
+            }
+            let now = current_timestamp(conn)?;
+            let existing = read_leases(conn, conversation_id)?;
+            let already: std::collections::HashSet<String> = existing
+                .iter()
+                .filter_map(|lease| lease.source_policy_id.clone())
+                .collect();
+
+            for policy in policies.iter().filter(|policy| policy.enabled) {
+                if already.contains(&policy.id) {
+                    continue;
+                }
+                let lease_id = uuid::Uuid::new_v4().to_string();
+                let expires_at = timestamp_plus_seconds(conn, policy.max_duration_secs.max(1))?;
+                let candidate = standing_policy::candidate_lease(
+                    policy,
+                    conversation_id,
+                    &lease_id,
+                    &now,
+                    &expires_at,
+                );
+                // The candidate is evaluated with the exact matcher a granted
+                // lease is, so a policy can never authorize a call its predicates
+                // + budgets do not already cover.
+                if let LeaseOutcome::Allow(_) = capability_lease::evaluate_for_conversation(
+                    std::slice::from_ref(&candidate),
+                    request,
+                    conversation_id,
+                    &now,
+                ) {
+                    write_lease(conn, &candidate)?;
+                    audit(
+                        conn,
+                        conversation_id,
+                        AuditEvent::LeaseAutoGranted,
+                        &AuditContext::for_auto_lease(&candidate, &policy.id),
+                        &now,
+                    );
+                    return Ok(Some(candidate));
+                }
+            }
+            Ok(None)
+        })
+    }
+
+    /// Every standing policy, newest first, for the owner settings surface.
+    pub fn list_standing_policies(&self) -> Result<Vec<StandingPolicy>, String> {
+        self.with_conn(read_standing_policies)
+    }
+
+    /// Persist a new owner-authored standing policy. Invoked only by the settings
+    /// command an owner drives — never from a model tool call — so model output
+    /// can never create or widen a standing policy. The host owns the id and
+    /// timestamps; the caller supplies only the reviewed envelope.
+    pub fn create_standing_policy(
+        &self,
+        input: StandingPolicyInput,
+    ) -> Result<StandingPolicy, String> {
+        if input.label.trim().is_empty() {
+            return Err("A standing policy needs a label.".to_string());
+        }
+        if input.max_duration_secs <= 0 {
+            return Err("A standing policy needs a positive lease duration.".to_string());
+        }
+        let policy_id = uuid::Uuid::new_v4().to_string();
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let policy = StandingPolicy {
+                id: policy_id.clone(),
+                label: input.label.clone(),
+                enabled: input.enabled,
+                max_duration_secs: input.max_duration_secs,
+                predicates: input.predicates.clone(),
+                budgets: input.budgets.clone(),
+                created_at: now.clone(),
+                updated_at: now,
+            };
+            write_standing_policy(conn, &policy)?;
+            Ok(policy)
+        })
+    }
+
+    /// Update an existing standing policy in place (edit its envelope, or toggle
+    /// `enabled`). Owner-only, like `create_standing_policy`. Returns the updated
+    /// policy, or `None` if the id is unknown. Disabling a policy here stops every
+    /// future auto-grant from it; leases it already materialized are unaffected
+    /// (revoke those separately).
+    pub fn update_standing_policy(
+        &self,
+        policy_id: &str,
+        input: StandingPolicyInput,
+    ) -> Result<Option<StandingPolicy>, String> {
+        if input.label.trim().is_empty() {
+            return Err("A standing policy needs a label.".to_string());
+        }
+        if input.max_duration_secs <= 0 {
+            return Err("A standing policy needs a positive lease duration.".to_string());
+        }
+        self.with_conn(|conn| {
+            let Some(existing) = read_standing_policy(conn, policy_id)? else {
+                return Ok(None);
+            };
+            let now = current_timestamp(conn)?;
+            let policy = StandingPolicy {
+                id: existing.id,
+                label: input.label.clone(),
+                enabled: input.enabled,
+                max_duration_secs: input.max_duration_secs,
+                predicates: input.predicates.clone(),
+                budgets: input.budgets.clone(),
+                created_at: existing.created_at,
+                updated_at: now,
+            };
+            write_standing_policy(conn, &policy)?;
+            Ok(Some(policy))
+        })
+    }
+
+    /// Delete a standing policy. Owner-only. Idempotent — returns whether a policy
+    /// was actually removed. Future auto-grants from it stop immediately; any
+    /// lease it already materialized lives out its own expiry unless revoked.
+    pub fn delete_standing_policy(&self, policy_id: &str) -> Result<bool, String> {
+        self.with_conn(|conn| {
+            let removed = conn
+                .execute(
+                    "DELETE FROM standing_policies WHERE id = ?1",
+                    rusqlite::params![policy_id],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(removed > 0)
         })
     }
 
@@ -1525,10 +1715,12 @@ impl ToolAuthorizationState {
         })
     }
 
-    /// Erase every stored decision, capability lease, suspended continuation, and
-    /// audit row. Backs the one-shot "erase all local conversation data" flow; the
-    /// next access lazily reopens an empty store. Returns the total number of rows
-    /// removed across all tables.
+    /// Erase every stored decision, capability lease, standing policy, suspended
+    /// continuation, and audit row. Backs the one-shot "erase all local
+    /// conversation data" flow; the next access lazily reopens an empty store.
+    /// Standing policies are cleared too, so a full wipe never leaves a standing
+    /// pre-authorization silently minting leases afterward. Returns the total
+    /// number of rows removed across all tables.
     pub fn wipe(&self) -> Result<usize, String> {
         self.with_conn(|conn| {
             let decisions = conn
@@ -1536,6 +1728,9 @@ impl ToolAuthorizationState {
                 .map_err(|e| e.to_string())?;
             let leases = conn
                 .execute("DELETE FROM capability_leases", [])
+                .map_err(|e| e.to_string())?;
+            let policies = conn
+                .execute("DELETE FROM standing_policies", [])
                 .map_err(|e| e.to_string())?;
             let continuations = conn
                 .execute("DELETE FROM approval_continuations", [])
@@ -1549,7 +1744,7 @@ impl ToolAuthorizationState {
             let reservations = conn
                 .execute("DELETE FROM spend_reservations", [])
                 .map_err(|e| e.to_string())?;
-            Ok(decisions + leases + continuations + audit_rows + handles + reservations)
+            Ok(decisions + leases + policies + continuations + audit_rows + handles + reservations)
         })
     }
 }
@@ -1772,6 +1967,72 @@ fn read_lease(conn: &Connection, lease_id: &str) -> Result<Option<CapabilityLeas
     Ok(json.and_then(|json| serde_json::from_str::<CapabilityLease>(&json).ok()))
 }
 
+/// Every standing policy, newest first. A single corrupt row is logged and
+/// skipped rather than blinding the resolver to the rest.
+fn read_standing_policies(conn: &Connection) -> Result<Vec<StandingPolicy>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT policy_json FROM standing_policies ORDER BY created_at DESC, id DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    let mut policies = Vec::new();
+    for row in rows {
+        let json = row.map_err(|e| e.to_string())?;
+        match serde_json::from_str::<StandingPolicy>(&json) {
+            Ok(policy) => policies.push(policy),
+            Err(err) => {
+                log::warn!("[tool-authorization] Skipping unreadable standing policy row: {err}")
+            }
+        }
+    }
+    Ok(policies)
+}
+
+/// One standing policy by id, or `None` if unknown or unreadable.
+fn read_standing_policy(conn: &Connection, policy_id: &str) -> Result<Option<StandingPolicy>, String> {
+    let json: Option<String> = conn
+        .query_row(
+            "SELECT policy_json FROM standing_policies WHERE id = ?1",
+            rusqlite::params![policy_id],
+            |row| row.get(0),
+        )
+        .map(Some)
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other.to_string()),
+        })?;
+    Ok(json.and_then(|json| serde_json::from_str::<StandingPolicy>(&json).ok()))
+}
+
+/// Insert or replace a standing policy. The JSON blob is the source of truth;
+/// `enabled` is mirrored to a column only so the resolver can cheaply skip
+/// disabled policies without parsing every blob.
+fn write_standing_policy(conn: &Connection, policy: &StandingPolicy) -> Result<(), String> {
+    let json = serde_json::to_string(policy)
+        .map_err(|e| format!("Standing policy could not be encoded: {e}"))?;
+    conn.execute(
+        "INSERT INTO standing_policies \
+           (id, enabled, policy_json, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5) \
+         ON CONFLICT(id) DO UPDATE SET \
+           enabled = excluded.enabled, \
+           policy_json = excluded.policy_json, \
+           updated_at = excluded.updated_at",
+        rusqlite::params![
+            policy.id,
+            policy.enabled as i64,
+            json,
+            policy.created_at,
+            policy.updated_at,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Record a live spend reservation so a later settle reconciles against the
 /// host-owned reserved amount rather than a renderer-supplied one. Stale rows
 /// (older than the sweep window) are pruned opportunistically so a crash between
@@ -1870,6 +2131,22 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_capability_leases_conversation \
          ON capability_leases(conversation_id)",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    // Standing policies (#3193-E): owner-defined, **non-conversation-scoped**
+    // pre-authorizations that auto-materialize a bounded lease for a matching
+    // task at start. The full policy (predicates + budgets + duration) lives in
+    // the JSON blob; the `enabled` column exists only so the resolver can skip
+    // disabled policies without parsing every blob.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS standing_policies (
+            id          TEXT PRIMARY KEY,
+            enabled     INTEGER NOT NULL DEFAULT 1,
+            policy_json TEXT NOT NULL,
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL
+        )",
         [],
     )
     .map_err(|e| e.to_string())?;
@@ -3546,6 +3823,273 @@ mod tests {
                 &binding_for_publisher_args(&args)
             )
             .is_err()
+        );
+    }
+
+    // ---- standing policies (#3193-E) — headless pre-authorization -----------
+
+    fn standing_policy_input(
+        label: &str,
+        enabled: bool,
+        duration_secs: i64,
+        predicates: LeasePredicates,
+        budgets: LeaseBudgets,
+    ) -> StandingPolicyInput {
+        StandingPolicyInput {
+            label: label.to_string(),
+            enabled,
+            max_duration_secs: duration_secs,
+            predicates,
+            budgets,
+        }
+    }
+
+    /// The core headless path: a conversation with **no prior lease** and no human
+    /// present runs an in-policy shell command end-to-end with zero prompts,
+    /// because the owner's enabled standing policy auto-materializes a bounded
+    /// lease. The materialized lease is attributed to its source policy and its
+    /// budget is charged, and the audit trail records both the auto-grant and the
+    /// use.
+    #[test]
+    fn standing_policy_auto_materializes_a_lease_for_an_unattended_conversation() {
+        let s = state();
+        let policy = s
+            .create_standing_policy(standing_policy_input(
+                "Unattended coding",
+                true,
+                4 * 3600,
+                command_rules(&["cargo", "pnpm", "git"]),
+                call_budget(500),
+            ))
+            .unwrap();
+
+        // No lease exists yet for this fresh conversation.
+        assert!(s.list_leases("conv-unattended").unwrap().is_empty());
+
+        let decision = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-unattended",
+                &cmd_ctx("cargo test --manifest-path src-tauri/Cargo.toml"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "allow", "in-policy work must not prompt");
+        assert!(decision.handle.is_some(), "an allow must carry a dispatch handle");
+
+        // Exactly one lease was minted, attributed to the policy, and charged.
+        let leases = s.list_leases("conv-unattended").unwrap();
+        assert_eq!(leases.len(), 1, "one auto-materialized lease");
+        assert_eq!(leases[0].source_policy_id.as_deref(), Some(policy.id.as_str()));
+        assert_eq!(leases[0].budgets.calls_used, 1);
+
+        // A second in-policy call runs silently under the same lease (no re-mint).
+        let second = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-unattended", &cmd_ctx("pnpm check"), None)
+            .unwrap();
+        assert_eq!(second.decision, "allow");
+        assert_eq!(s.list_leases("conv-unattended").unwrap().len(), 1, "still one lease");
+
+        let events: Vec<String> = s
+            .list_audit("conv-unattended", 50)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.event)
+            .collect();
+        assert!(events.iter().any(|e| e == "lease_auto_granted"), "auto-grant audited");
+        assert!(events.iter().any(|e| e == "lease_used"), "use audited");
+    }
+
+    /// A standing policy pre-authorizes only within its predicates: a command it
+    /// does not list, and a high-risk publisher op it did not opt into, both still
+    /// produce a single scope-escalation rather than a silent auto-grant.
+    #[test]
+    fn standing_policy_only_pre_authorizes_within_its_predicates() {
+        let s = state();
+        s.create_standing_policy(standing_policy_input(
+            "Unattended coding",
+            true,
+            3600,
+            command_rules(&["cargo"]),
+            call_budget(500),
+        ))
+        .unwrap();
+
+        // An unlisted program is out of policy — one escalation, no lease minted.
+        let out = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("rm -rf /"), None)
+            .unwrap();
+        assert_eq!(out.decision, "prompt");
+        assert_eq!(out.prompt_kind.as_deref(), Some("one-shot"));
+        assert!(s.list_leases("conv-a").unwrap().is_empty(), "no lease for out-of-policy work");
+    }
+
+    /// A high-risk / outbound-send publisher op is not silently pre-authorized by
+    /// a policy that did not explicitly opt into high-risk for that publisher — it
+    /// still requires an explicit one-shot approval.
+    #[test]
+    fn standing_policy_does_not_auto_cover_unopted_high_risk_ops() {
+        let s = state();
+        let predicates = LeasePredicates {
+            publisher_ops: vec![capability_lease::PublisherRule {
+                publisher_slug: "gmail".to_string(),
+                allow_high_risk: false,
+                target: None,
+            }],
+            ..Default::default()
+        };
+        s.create_standing_policy(standing_policy_input("Gmail reads", true, 3600, predicates, call_budget(100)))
+            .unwrap();
+        // Sending mail is high-risk; the policy did not opt into it.
+        let decision = s
+            .authorize(ToolRoute::Gateway, "gmail", "post_send", "conv-a", &ctx(), Some(&serde_json::json!({"to": "x"})))
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+        assert!(s.list_leases("conv-a").unwrap().is_empty());
+    }
+
+    /// A disabled policy grants nothing: in-policy work escalates exactly as if no
+    /// policy existed, and enabling it (via update) then makes the same call run
+    /// silently — proving the toggle is the control point.
+    #[test]
+    fn disabled_standing_policy_grants_nothing_until_enabled() {
+        let s = state();
+        let policy = s
+            .create_standing_policy(standing_policy_input(
+                "Unattended coding",
+                false,
+                3600,
+                command_rules(&["cargo"]),
+                call_budget(500),
+            ))
+            .unwrap();
+        let blocked = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(blocked.decision, "prompt", "a disabled policy must not auto-grant");
+        assert!(s.list_leases("conv-a").unwrap().is_empty());
+
+        // Enabling it makes the same call run silently on a fresh conversation.
+        s.update_standing_policy(
+            &policy.id,
+            standing_policy_input("Unattended coding", true, 3600, command_rules(&["cargo"]), call_budget(500)),
+        )
+        .unwrap()
+        .expect("policy exists");
+        let allowed = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-b", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(allowed.decision, "allow");
+    }
+
+    /// Deleting a policy stops future auto-grants immediately.
+    #[test]
+    fn deleting_a_standing_policy_stops_auto_grants() {
+        let s = state();
+        let policy = s
+            .create_standing_policy(standing_policy_input(
+                "Unattended coding",
+                true,
+                3600,
+                command_rules(&["cargo"]),
+                call_budget(500),
+            ))
+            .unwrap();
+        assert!(s.delete_standing_policy(&policy.id).unwrap());
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-fresh", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert!(!s.delete_standing_policy(&policy.id).unwrap(), "second delete is a no-op");
+    }
+
+    /// An auto-lease is bounded: once its budget is exhausted the next in-policy
+    /// call re-escalates rather than silently minting a *fresh* lease from the same
+    /// policy. Exactly one lease is ever materialized per conversation+policy.
+    #[test]
+    fn exhausted_auto_lease_budget_re_escalates_without_reminting() {
+        let s = state();
+        s.create_standing_policy(standing_policy_input(
+            "One-shot budget",
+            true,
+            3600,
+            command_rules(&["cargo"]),
+            call_budget(1),
+        ))
+        .unwrap();
+
+        let first = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(first.decision, "allow", "first in-budget call runs silently");
+
+        let second = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo test"), None)
+            .unwrap();
+        assert_eq!(second.decision, "prompt", "exhausted budget re-escalates");
+        assert_eq!(
+            s.list_leases("conv-a").unwrap().len(),
+            1,
+            "the policy must not re-mint a fresh lease to dodge its own budget",
+        );
+    }
+
+    /// Revoking an auto-materialized lease is immediate and durable: the policy
+    /// does not silently re-grant a replacement on the next call.
+    #[test]
+    fn revoking_an_auto_lease_is_not_undone_by_the_policy() {
+        let s = state();
+        s.create_standing_policy(standing_policy_input(
+            "Unattended coding",
+            true,
+            3600,
+            command_rules(&["cargo"]),
+            call_budget(500),
+        ))
+        .unwrap();
+        s.authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        let lease = s.list_leases("conv-a").unwrap().remove(0);
+        assert!(s.revoke_lease(&lease.id).unwrap());
+        let after = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(after.decision, "prompt", "a revoked auto-lease is not silently re-granted");
+        assert_eq!(s.list_leases("conv-a").unwrap().len(), 1, "no replacement lease minted");
+    }
+
+    /// The model reaches the host only through `authorize` (and dispatch/reserve/
+    /// settle). None of those write a policy: with an empty policy store, an
+    /// in-policy-looking call still escalates — the model can never conjure a
+    /// standing policy or a lease. Only the owner `create_standing_policy` path
+    /// writes one.
+    #[test]
+    fn the_gate_path_cannot_author_a_standing_policy() {
+        let s = state();
+        // No owner policy exists.
+        assert!(s.list_standing_policies().unwrap().is_empty());
+        let decision = s
+            .authorize(ToolRoute::Shell, "seren", "execute_command", "conv-a", &cmd_ctx("cargo build"), None)
+            .unwrap();
+        assert_eq!(decision.decision, "prompt", "the gate cannot self-author a policy");
+        assert!(s.list_standing_policies().unwrap().is_empty(), "authorize wrote no policy");
+        assert!(s.list_leases("conv-a").unwrap().is_empty());
+    }
+
+    /// Validation guards: a policy needs a label and a positive lease duration.
+    #[test]
+    fn create_standing_policy_rejects_invalid_input() {
+        let s = state();
+        assert!(
+            s.create_standing_policy(standing_policy_input("", true, 3600, LeasePredicates::default(), call_budget(1)))
+                .is_err()
+        );
+        assert!(
+            s.create_standing_policy(standing_policy_input("x", true, 0, LeasePredicates::default(), call_budget(1)))
+                .is_err()
         );
     }
 }

--- a/src/components/approvals/CapabilityLeasePanel.tsx
+++ b/src/components/approvals/CapabilityLeasePanel.tsx
@@ -22,6 +22,7 @@ interface CapabilityLeasePanelProps {
 
 const AUDIT_EVENT_LABELS: Record<string, string> = {
   lease_granted: "Lease granted",
+  lease_auto_granted: "Lease auto-granted from policy",
   lease_used: "Ran under lease",
   lease_denied: "Denied by lease exclusion",
   lease_expired: "Lease expired",

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -72,6 +72,7 @@ import { OAuthLogins } from "./OAuthLogins";
 import { ProviderSettings } from "./ProviderSettings";
 import { RecordingsSettings } from "./RecordingsSettings";
 import { SearchableModelSelect } from "./SearchableModelSelect";
+import { StandingPoliciesSettings } from "./StandingPoliciesSettings";
 import { ToolsetsSettings } from "./ToolsetsSettings";
 
 type SettingsSection =
@@ -1719,6 +1720,8 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 </div>
               </label>
             </div>
+
+            <StandingPoliciesSettings />
           </section>
         </Show>
 

--- a/src/components/settings/StandingPoliciesSettings.tsx
+++ b/src/components/settings/StandingPoliciesSettings.tsx
@@ -1,0 +1,581 @@
+// ABOUTME: Owner settings surface to author standing policies that pre-authorize bounded leases for unattended agents (#3193-E).
+// ABOUTME: This is the ONLY authoring path for standing policies — the model can never reach these commands.
+
+import {
+  type Component,
+  createResource,
+  createSignal,
+  For,
+  Show,
+} from "solid-js";
+import { createStore } from "solid-js/store";
+import {
+  createStandingPolicy,
+  deleteStandingPolicy,
+  listStandingPolicies,
+  type PublisherRule,
+  type StandingPolicy,
+  type StandingPolicyInput,
+  updateStandingPolicy,
+} from "@/services/tool-authorization";
+
+/** A publisher-op row in the editor, before it becomes a `PublisherRule`. */
+interface PublisherOpDraft {
+  publisherSlug: string;
+  allowHighRisk: boolean;
+  target: string;
+}
+
+interface PolicyDraft {
+  label: string;
+  enabled: boolean;
+  durationHours: number;
+  commandPrograms: string;
+  networkHosts: string;
+  excludedPrograms: string;
+  maxCalls: number;
+  maxSpend: number;
+  asset: string;
+  publisherOps: PublisherOpDraft[];
+}
+
+const EMPTY_DRAFT: PolicyDraft = {
+  label: "",
+  enabled: true,
+  durationHours: 4,
+  commandPrograms: "",
+  networkHosts: "",
+  excludedPrograms: "",
+  maxCalls: 500,
+  maxSpend: 0,
+  asset: "",
+  publisherOps: [],
+};
+
+/** Split a comma/whitespace list into trimmed, non-empty, lowercased tokens. */
+function parseList(value: string): string[] {
+  return value
+    .split(/[,\n]/)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length > 0);
+}
+
+function draftToInput(draft: PolicyDraft): StandingPolicyInput {
+  const publisherOps: PublisherRule[] = draft.publisherOps
+    .filter((op) => op.publisherSlug.trim().length > 0)
+    .map((op) => ({
+      publisherSlug: op.publisherSlug.trim(),
+      allowHighRisk: op.allowHighRisk,
+      target: op.target.trim() ? op.target.trim() : null,
+    }));
+
+  const maxSpendMicros =
+    draft.maxSpend > 0 ? Math.round(draft.maxSpend * 1_000_000) : null;
+
+  return {
+    label: draft.label.trim(),
+    enabled: draft.enabled,
+    maxDurationSecs: Math.max(1, Math.round(draft.durationHours * 3600)),
+    predicates: {
+      commandRules: parseList(draft.commandPrograms).map((program) => ({
+        program,
+      })),
+      networkHosts: parseList(draft.networkHosts),
+      publisherOps,
+      exclusions: parseList(draft.excludedPrograms).map((program) => ({
+        program,
+      })),
+    },
+    budgets: {
+      maxCalls: draft.maxCalls > 0 ? draft.maxCalls : null,
+      maxSpendMicros,
+      asset:
+        maxSpendMicros != null && draft.asset.trim()
+          ? draft.asset.trim()
+          : null,
+    },
+  };
+}
+
+function describePolicy(policy: StandingPolicy): string {
+  const parts: string[] = [];
+  const commands = policy.predicates.commandRules ?? [];
+  if (commands.length > 0) {
+    parts.push(`commands: ${commands.map((rule) => rule.program).join(", ")}`);
+  }
+  const hosts = policy.predicates.networkHosts ?? [];
+  if (hosts.length > 0) parts.push(`hosts: ${hosts.join(", ")}`);
+  const ops = policy.predicates.publisherOps ?? [];
+  if (ops.length > 0) {
+    parts.push(
+      `publishers: ${ops
+        .map(
+          (op) =>
+            op.publisherSlug +
+            (op.target ? ` (${op.target})` : "") +
+            (op.allowHighRisk ? " incl. high-risk" : ""),
+        )
+        .join(", ")}`,
+    );
+  }
+  const exclusions = policy.predicates.exclusions ?? [];
+  if (exclusions.length > 0) parts.push(`${exclusions.length} exclusion(s)`);
+  return parts.join(" · ") || "no predicates";
+}
+
+function describeBudget(policy: StandingPolicy): string {
+  const hours = Math.round((policy.maxDurationSecs / 3600) * 10) / 10;
+  const calls =
+    policy.budgets.maxCalls != null
+      ? `${policy.budgets.maxCalls} calls`
+      : "unmetered calls";
+  const spend =
+    policy.budgets.maxSpendMicros != null
+      ? ` · ${policy.budgets.maxSpendMicros / 1_000_000} ${policy.budgets.asset ?? ""} max spend`
+      : "";
+  return `${calls}${spend} · ${hours}h lease`;
+}
+
+/**
+ * Owner-only authoring surface for standing policies (#3193-E): persistent,
+ * non-conversation-scoped pre-authorizations that auto-materialize a bounded
+ * capability lease for a matching unattended/long-running agent at task start —
+ * zero prompts, no human present. In-policy work then runs silently through the
+ * gate; out-of-policy work still escalates. The model can request scope but can
+ * never create, widen, or self-approve a policy: this settings surface is the
+ * only path that writes one.
+ */
+export const StandingPoliciesSettings: Component = () => {
+  const [revision, setRevision] = createSignal(0);
+  const [policies] = createResource(revision, () => listStandingPolicies());
+  const [draft, setDraft] = createStore<PolicyDraft>({ ...EMPTY_DRAFT });
+  const [editingId, setEditingId] = createSignal<string | null>(null);
+  const [busy, setBusy] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const resetForm = () => {
+    setDraft({ ...EMPTY_DRAFT, publisherOps: [] });
+    setEditingId(null);
+    setError(null);
+  };
+
+  const beginEdit = (policy: StandingPolicy) => {
+    setEditingId(policy.id);
+    setError(null);
+    setDraft({
+      label: policy.label,
+      enabled: policy.enabled,
+      durationHours: Math.round((policy.maxDurationSecs / 3600) * 10) / 10,
+      commandPrograms: (policy.predicates.commandRules ?? [])
+        .map((rule) => rule.program)
+        .join(", "),
+      networkHosts: (policy.predicates.networkHosts ?? []).join(", "),
+      excludedPrograms: (policy.predicates.exclusions ?? [])
+        .map((exclusion) => exclusion.program ?? "")
+        .filter((program) => program.length > 0)
+        .join(", "),
+      maxCalls: policy.budgets.maxCalls ?? 0,
+      maxSpend:
+        policy.budgets.maxSpendMicros != null
+          ? policy.budgets.maxSpendMicros / 1_000_000
+          : 0,
+      asset: policy.budgets.asset ?? "",
+      publisherOps: (policy.predicates.publisherOps ?? []).map((op) => ({
+        publisherSlug: op.publisherSlug,
+        allowHighRisk: op.allowHighRisk ?? false,
+        target: op.target ?? "",
+      })),
+    });
+  };
+
+  const addPublisherOp = () => {
+    setDraft("publisherOps", (ops) => [
+      ...ops,
+      { publisherSlug: "", allowHighRisk: false, target: "" },
+    ]);
+  };
+
+  const removePublisherOp = (index: number) => {
+    setDraft("publisherOps", (ops) => ops.filter((_, i) => i !== index));
+  };
+
+  const save = async () => {
+    if (busy()) return;
+    const input = draftToInput(draft);
+    if (!input.label) {
+      setError("A policy needs a label.");
+      return;
+    }
+    const hasPredicate =
+      (input.predicates.commandRules?.length ?? 0) > 0 ||
+      (input.predicates.networkHosts?.length ?? 0) > 0 ||
+      (input.predicates.publisherOps?.length ?? 0) > 0;
+    if (!hasPredicate) {
+      setError(
+        "Add at least one command, host, or publisher to pre-authorize.",
+      );
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const id = editingId();
+      if (id) {
+        await updateStandingPolicy(id, input);
+      } else {
+        await createStandingPolicy(input);
+      }
+      resetForm();
+      setRevision((n) => n + 1);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleEnabled = async (policy: StandingPolicy) => {
+    setBusy(true);
+    try {
+      await updateStandingPolicy(policy.id, {
+        label: policy.label,
+        enabled: !policy.enabled,
+        maxDurationSecs: policy.maxDurationSecs,
+        predicates: policy.predicates,
+        budgets: policy.budgets,
+      });
+      setRevision((n) => n + 1);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (policy: StandingPolicy) => {
+    setBusy(true);
+    try {
+      await deleteStandingPolicy(policy.id);
+      if (editingId() === policy.id) resetForm();
+      setRevision((n) => n + 1);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const inputClass =
+    "w-full px-2.5 py-1.5 text-[0.85rem] rounded-md bg-surface-3/60 border border-border text-foreground";
+
+  return (
+    <div class="mt-8 pt-6 border-t border-border">
+      <h4 class="m-0 mb-1 text-[1.05rem] font-semibold text-foreground">
+        Standing pre-authorization policies
+      </h4>
+      <p class="m-0 mb-4 text-[0.85rem] text-muted-foreground leading-normal">
+        Pre-authorize bounded work so unattended and long-running agents run
+        in-policy tasks without a prompt. At task start a matching enabled
+        policy auto-materializes a capability lease with these exact predicates
+        and budgets — nothing wider. Out-of-policy work still asks for approval.
+        Only you can author a policy here; the model can never create or widen
+        one.
+      </p>
+
+      <div class="flex flex-col gap-2 mb-6">
+        <Show
+          when={(policies() ?? []).length > 0}
+          fallback={
+            <span class="text-[0.85rem] text-muted-foreground">
+              No standing policies yet. Unattended agents will prompt (and
+              pause) on the first out-of-lease action until you add one.
+            </span>
+          }
+        >
+          <For each={policies()}>
+            {(policy) => (
+              <div class="border border-border rounded-lg px-3 py-2.5 flex flex-col gap-1.5">
+                <div class="flex items-center gap-2">
+                  <span class="text-[0.9rem] text-foreground font-medium">
+                    {policy.label}
+                  </span>
+                  <span
+                    class={`text-[0.72rem] font-medium rounded px-1.5 py-0.5 border ${
+                      policy.enabled
+                        ? "text-success border-success/40"
+                        : "text-muted-foreground border-border"
+                    }`}
+                  >
+                    {policy.enabled ? "enabled" : "disabled"}
+                  </span>
+                  <div class="ml-auto flex gap-2">
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[0.78rem] rounded-md cursor-pointer bg-transparent text-foreground border border-border hover:bg-surface-3/60 disabled:opacity-50"
+                      onClick={() => void toggleEnabled(policy)}
+                      disabled={busy()}
+                    >
+                      {policy.enabled ? "Disable" : "Enable"}
+                    </button>
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[0.78rem] rounded-md cursor-pointer bg-transparent text-foreground border border-border hover:bg-surface-3/60 disabled:opacity-50"
+                      onClick={() => beginEdit(policy)}
+                      disabled={busy()}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[0.78rem] rounded-md cursor-pointer bg-transparent text-destructive border border-destructive/40 hover:bg-destructive/10 disabled:opacity-50"
+                      onClick={() => void remove(policy)}
+                      disabled={busy()}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {describePolicy(policy)}
+                </span>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {describeBudget(policy)}
+                </span>
+              </div>
+            )}
+          </For>
+        </Show>
+      </div>
+
+      <div class="border border-border rounded-lg p-4 flex flex-col gap-3">
+        <span class="text-[0.9rem] font-semibold text-foreground">
+          {editingId() ? "Edit policy" : "New policy"}
+        </span>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[0.8rem] text-muted-foreground">Label</span>
+          <input
+            class={inputClass}
+            type="text"
+            placeholder="e.g. Unattended coding tasks"
+            value={draft.label}
+            onInput={(e) => setDraft("label", e.currentTarget.value)}
+          />
+        </label>
+
+        <div class="grid grid-cols-2 gap-3">
+          <label class="flex flex-col gap-1">
+            <span class="text-[0.8rem] text-muted-foreground">
+              Lease duration (hours)
+            </span>
+            <input
+              class={inputClass}
+              type="number"
+              min="0.1"
+              step="0.5"
+              value={draft.durationHours}
+              onInput={(e) =>
+                setDraft("durationHours", Number(e.currentTarget.value))
+              }
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-[0.8rem] text-muted-foreground">
+              Max calls (0 = unmetered)
+            </span>
+            <input
+              class={inputClass}
+              type="number"
+              min="0"
+              step="1"
+              value={draft.maxCalls}
+              onInput={(e) =>
+                setDraft("maxCalls", Number(e.currentTarget.value))
+              }
+            />
+          </label>
+        </div>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[0.8rem] text-muted-foreground">
+            Command programs (comma-separated, e.g. cargo, pnpm, git)
+          </span>
+          <input
+            class={inputClass}
+            type="text"
+            placeholder="cargo, pnpm, npm, node, git"
+            value={draft.commandPrograms}
+            onInput={(e) => setDraft("commandPrograms", e.currentTarget.value)}
+          />
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[0.8rem] text-muted-foreground">
+            Network hosts for web fetch (comma-separated)
+          </span>
+          <input
+            class={inputClass}
+            type="text"
+            placeholder="registry.npmjs.org, docs.rs"
+            value={draft.networkHosts}
+            onInput={(e) => setDraft("networkHosts", e.currentTarget.value)}
+          />
+        </label>
+
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center justify-between">
+            <span class="text-[0.8rem] text-muted-foreground">
+              Publisher operations
+            </span>
+            <button
+              type="button"
+              class="px-2 py-0.5 text-[0.75rem] rounded cursor-pointer bg-transparent text-foreground border border-border hover:bg-surface-3/60"
+              onClick={addPublisherOp}
+            >
+              + Add publisher
+            </button>
+          </div>
+          <For each={draft.publisherOps}>
+            {(op, index) => (
+              <div class="flex items-center gap-2">
+                <input
+                  class={inputClass}
+                  type="text"
+                  placeholder="publisher slug (e.g. github)"
+                  value={op.publisherSlug}
+                  onInput={(e) =>
+                    setDraft(
+                      "publisherOps",
+                      index(),
+                      "publisherSlug",
+                      e.currentTarget.value,
+                    )
+                  }
+                />
+                <input
+                  class={inputClass}
+                  type="text"
+                  placeholder="target (optional, e.g. org/repo)"
+                  value={op.target}
+                  onInput={(e) =>
+                    setDraft(
+                      "publisherOps",
+                      index(),
+                      "target",
+                      e.currentTarget.value,
+                    )
+                  }
+                />
+                <label class="flex items-center gap-1 text-[0.75rem] text-muted-foreground whitespace-nowrap">
+                  <input
+                    type="checkbox"
+                    checked={op.allowHighRisk}
+                    onChange={(e) =>
+                      setDraft(
+                        "publisherOps",
+                        index(),
+                        "allowHighRisk",
+                        e.currentTarget.checked,
+                      )
+                    }
+                    class="w-3.5 h-3.5 accent-[var(--color-primary,#6366f1)]"
+                  />
+                  high-risk
+                </label>
+                <button
+                  type="button"
+                  class="px-2 py-1 text-[0.75rem] rounded cursor-pointer bg-transparent text-destructive border border-destructive/40 hover:bg-destructive/10"
+                  onClick={() => removePublisherOp(index())}
+                >
+                  ✕
+                </button>
+              </div>
+            )}
+          </For>
+        </div>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[0.8rem] text-muted-foreground">
+            Excluded programs (deny — beats every allow above)
+          </span>
+          <input
+            class={inputClass}
+            type="text"
+            placeholder="rm, curl"
+            value={draft.excludedPrograms}
+            onInput={(e) => setDraft("excludedPrograms", e.currentTarget.value)}
+          />
+        </label>
+
+        <div class="grid grid-cols-2 gap-3">
+          <label class="flex flex-col gap-1">
+            <span class="text-[0.8rem] text-muted-foreground">
+              Max spend (major units, 0 = none)
+            </span>
+            <input
+              class={inputClass}
+              type="number"
+              min="0"
+              step="0.01"
+              value={draft.maxSpend}
+              onInput={(e) =>
+                setDraft("maxSpend", Number(e.currentTarget.value))
+              }
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-[0.8rem] text-muted-foreground">
+              Spend asset (e.g. USDC)
+            </span>
+            <input
+              class={inputClass}
+              type="text"
+              placeholder="USDC"
+              value={draft.asset}
+              onInput={(e) => setDraft("asset", e.currentTarget.value)}
+            />
+          </label>
+        </div>
+
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={draft.enabled}
+            onChange={(e) => setDraft("enabled", e.currentTarget.checked)}
+            class="w-4 h-4 accent-[var(--color-primary,#6366f1)]"
+          />
+          <span class="text-[0.85rem] text-foreground">
+            Enabled (auto-materialize leases for matching tasks)
+          </span>
+        </label>
+
+        <Show when={error()}>
+          <span class="text-[0.8rem] text-destructive">{error()}</span>
+        </Show>
+
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="px-3.5 py-1.5 text-[0.85rem] font-medium rounded-md cursor-pointer bg-primary text-white border-none hover:opacity-90 disabled:opacity-50"
+            onClick={() => void save()}
+            disabled={busy()}
+          >
+            {editingId() ? "Save changes" : "Create policy"}
+          </button>
+          <Show when={editingId()}>
+            <button
+              type="button"
+              class="px-3.5 py-1.5 text-[0.85rem] rounded-md cursor-pointer bg-transparent text-foreground border border-border hover:bg-surface-3/60"
+              onClick={resetForm}
+              disabled={busy()}
+            >
+              Cancel
+            </button>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StandingPoliciesSettings;

--- a/src/services/tool-authorization.ts
+++ b/src/services/tool-authorization.ts
@@ -49,6 +49,9 @@ export interface CapabilityLease {
   createdAt: string;
   expiresAt: string;
   revoked: boolean;
+  /** The standing policy this lease was auto-materialized from, or null/absent
+   * for a human-granted lease (#3193-E). */
+  sourcePolicyId?: string | null;
   predicates: LeasePredicates;
   budgets: LeaseBudgets;
 }
@@ -123,6 +126,66 @@ export interface ProposedBundle {
   durationSecs: number;
   predicates: LeasePredicates;
   budgets: LeaseBudgets;
+}
+
+/** Mirrors `StandingPolicy` in `src-tauri/src/standing_policy.rs`. */
+export interface StandingPolicy {
+  id: string;
+  label: string;
+  enabled: boolean;
+  maxDurationSecs: number;
+  predicates: LeasePredicates;
+  budgets: LeaseBudgets;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Mirrors `StandingPolicyInput` in `src-tauri/src/standing_policy.rs`. */
+export interface StandingPolicyInput {
+  label: string;
+  enabled: boolean;
+  maxDurationSecs: number;
+  predicates: LeasePredicates;
+  budgets: LeaseBudgets;
+}
+
+/**
+ * Every standing policy, newest first. Standing policies are the owner-defined,
+ * non-conversation-scoped pre-authorizations that auto-materialize a bounded
+ * lease for a matching unattended/long-running task (#3193-E).
+ */
+export async function listStandingPolicies(): Promise<StandingPolicy[]> {
+  return invoke<StandingPolicy[]>("list_standing_policies");
+}
+
+/**
+ * Create an owner-authored standing policy. Only ever invoked from the owner
+ * settings surface — there is no model tool or dispatch path that reaches this,
+ * so model output can never create or widen a standing policy.
+ */
+export async function createStandingPolicy(
+  input: StandingPolicyInput,
+): Promise<StandingPolicy> {
+  return invoke<StandingPolicy>("create_standing_policy", { input });
+}
+
+/**
+ * Update a standing policy in place (edit its envelope or toggle `enabled`).
+ * Resolves to the updated policy, or `null` if the id is unknown.
+ */
+export async function updateStandingPolicy(
+  policyId: string,
+  input: StandingPolicyInput,
+): Promise<StandingPolicy | null> {
+  return invoke<StandingPolicy | null>("update_standing_policy", {
+    policyId,
+    input,
+  });
+}
+
+/** Delete a standing policy. Idempotent — resolves to whether one was removed. */
+export async function deleteStandingPolicy(policyId: string): Promise<boolean> {
+  return invoke<boolean>("delete_standing_policy", { policyId });
 }
 
 /** Every capability lease bound to a conversation, newest first. */


### PR DESCRIPTION
Closes #3274 (P0 #3193-E). Builds on the merged capability-lease system (#3262/#3270) and suspended continuations (#3263/#3271).

## Problem
The lease gate already lets in-lease work run silently, but a lease could only be created by an **interactive human grant** (`grant_capability_lease`), and every lease is conversation-scoped. An agent with **no human at the keyboard** (cron/scheduled local runs, remote-triggered runs, background tasks, or simply the first task in a fresh conversation) had no active lease, so its first out-of-lease action (e.g. the first build/test command — always high-risk) returned `prompt`, timed out after 5 min → expiry, and re-escalated on retry. The task stalled with no progress. There was no owner-defined standing policy to pre-authorize a lease (grep for `standing.policy|pre.?author|persistent.rule|unattended` returned nothing).

## Approach
A persistent, **owner-defined standing policy** deterministically **auto-materializes a bounded capability lease** for a matching task at start — zero prompts, no human present. The resolver runs at the single gate chokepoint: when `authorize()` would otherwise escalate a call for a conversation with no covering lease, it consults the enabled standing policies and, if one covers the call **within its predicates + budgets**, materializes a conversation-scoped lease via the *same* deterministic matcher a human grant uses, then re-evaluates. In-policy work then runs silently through the existing gate; out-of-policy work still escalates exactly as before.

This satisfies the ticket's "and/or on first `Escalate` for a conversation with no lease" — one chokepoint every route (renderer executor, cron, remote, fresh conversation) passes through, so no per-entrypoint task-start wiring was needed.

## Hard invariants
- A standing policy pre-authorizes **only within** its predicates/budgets — a high-risk, priced, or out-of-scope call it does not cover still produces one scope-escalation.
- A policy that already produced a lease for a conversation is **never re-minted** (the lease carries `source_policy_id`), so an exhausted budget or expiry **re-escalates** instead of silently regranting.
- Standing policies are written **only** by the owner settings commands. There is no model tool or dispatch path that can create, widen, or self-approve a policy or a lease. Disabling/deleting a policy stops all future auto-grants; existing auto-leases stay **immediately revocable**.
- Auto-materialized leases carry their source policy id and are audited as `lease_auto_granted` for attribution.
- Irreversible/monetary/credential/outbound-send actions still require explicit one-shot approval unless a policy narrowly and explicitly opts them in (e.g. `allowHighRisk` on a specific publisher) — inherited from the proven matcher.

## Changes
**Rust**
- New `standing_policy.rs` module: `StandingPolicy` / `StandingPolicyInput` (reusing `LeasePredicates` + `LeaseBudgets`), pure `candidate_lease` builder (fresh budget counters, source-policy attribution).
- New **non-conversation-scoped** `standing_policies` table in the authorization DB; `wipe()` clears it too.
- Resolver `try_materialize_standing_policy` hooked into `authorize()` after the `Escalate` branch; owner-only `list/create/update/delete_standing_policy` store methods + Tauri commands, registered in `lib.rs`.
- `CapabilityLease.source_policy_id` tag; `AuditEvent::LeaseAutoGranted` + `AuditContext::for_auto_lease`.

**Renderer**
- `services/tool-authorization.ts`: `StandingPolicy`/`StandingPolicyInput` types + list/create/update/delete wrappers; `sourcePolicyId` on the lease mirror.
- New `StandingPoliciesSettings.tsx` — the **only** authoring surface — mounted under the **Agent** settings section, mirroring the "Approve for this task" predicate/budget vocabulary.
- `CapabilityLeasePanel`: `lease_auto_granted` audit label.

## Networked path
**None.** This feature is entirely local (SQLite authorization store + local settings UI). It adds no outbound publisher/API call. A policy can *cover* publisher ops, but authoring/resolving a policy makes no network request.

## Acceptance criteria
- [x] Unattended agent with a matching enabled policy runs an in-policy shell/build/test/publisher task end-to-end with **zero prompts**.
- [x] No matching policy → no hang; the call escalates (unchanged #3263 behavior), retries dedup.
- [x] Pre-authorizes only within predicates/budgets; out-of-scope escalates; exhausted budget/expiry re-escalates.
- [x] The model cannot create, widen, or self-approve a policy or lease through any tool/dispatch path — owner-only via settings.
- [x] Irreversible/monetary/credential/outbound-send still one-shot unless a policy narrowly opts them in.
- [x] Auto-materialized leases attributable (`source_policy_id` + `lease_auto_granted`) and immediately revocable; disabling stops future auto-grants.
- [x] Tests (below).

## Validation (live, no mocks)
- **Rust gate — real layer:** 9 new tests drive the **real** `ToolAuthorizationState` (real rusqlite engine, real schema, real matcher, real audit) through the production `authorize()` path — no mocks/stubs. All pass; full authorization suite `108 passed; 0 failed`.
  - `standing_policy_auto_materializes_a_lease_for_an_unattended_conversation`
  - `standing_policy_only_pre_authorizes_within_its_predicates`
  - `standing_policy_does_not_auto_cover_unopted_high_risk_ops`
  - `disabled_standing_policy_grants_nothing_until_enabled`
  - `deleting_a_standing_policy_stops_auto_grants`
  - `exhausted_auto_lease_budget_re_escalates_without_reminting`
  - `revoking_an_auto_lease_is_not_undone_by_the_policy`
  - `the_gate_path_cannot_author_a_standing_policy`
  - `create_standing_policy_rejects_invalid_input`
- **Settings UI:** the real `SettingsPanel` (with `StandingPoliciesSettings` mounted) renders cleanly in the existing jsdom settings suites (`settings-scroll-ownership`, `appearance-settings-ui`, `keys-settings-ui` — all green). Biome clean; changed files type-clean.
- **Layer that can only be exercised in the running signed-in app** (a live agent with no human present, verifying zero visible prompts end-to-end): the gate returns `allow` + a dispatch handle exactly as it does for a human-granted lease, so the executor proceeds with no renderer change. That full in-app agent E2E is noted as requiring a running signed-in build; it is not mocked here.
