### PR TITLE
fix(security): native OS notification for backgrounded approvals (#3279)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-log": "^2.9.0",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@tauri-apps/plugin-log':
         specifier: ^2.9.0
         version: 2.9.0
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -2433,6 +2436,9 @@ packages:
 
   '@tauri-apps/plugin-log@2.9.0':
     resolution: {integrity: sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw==}
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -8306,6 +8312,10 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-log@2.9.0':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2378,7 +2378,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2792,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3927,7 +3927,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4791,6 +4791,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,7 +5023,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5146,6 +5160,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "notify-types"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,7 +5254,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5770,7 +5798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7337,7 +7365,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7410,7 +7438,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7958,6 +7986,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -8347,7 +8376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9062,6 +9091,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9282,6 +9330,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.19",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "teloxide"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9361,7 +9420,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9950,7 +10009,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11153,7 +11212,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-http = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 zeroize = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "process:default",
     "process:allow-restart",
     "log:default",
+    "notification:default",
     {
       "identifier": "opener:default",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -613,7 +613,8 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_shell::init());
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_notification::init());
 
     // Note: deep-link plugin disabled on Windows due to WiX bundler ICE03 registry errors
     // See: https://github.com/tauri-apps/tauri/issues/10453

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Native OS desktop notifications via the Tauri notification plugin, so
+// ABOUTME: stores can post privacy-safe banners without touching the plugin API directly.
+
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+/**
+ * Resolve to true only when the OS grants this app permission to post
+ * notifications, requesting it once if the user has not yet decided. The
+ * WebView `Notification` API is denied by default in this app's macOS webview,
+ * so all OS banners must route through the native plugin.
+ */
+export async function ensureNotificationPermission(): Promise<boolean> {
+  if (await isPermissionGranted()) return true;
+  const permission = await requestPermission();
+  return permission === "granted";
+}
+
+/**
+ * Post one OS notification when permission allows. Silently no-ops when
+ * permission is absent or the plugin is unavailable, so callers never branch on
+ * platform support.
+ */
+export async function postNotification(
+  title: string,
+  body: string,
+): Promise<void> {
+  try {
+    if (!(await ensureNotificationPermission())) return;
+    sendNotification({ title, body });
+  } catch (err) {
+    console.warn("[Notifications] Failed to post notification:", err);
+  }
+}

--- a/src/stores/approvals.store.ts
+++ b/src/stores/approvals.store.ts
@@ -3,6 +3,7 @@
 
 import { emit, listen } from "@tauri-apps/api/event";
 import { createStore, reconcile } from "solid-js/store";
+import { postNotification } from "@/services/notifications";
 import {
   type ContinuationView,
   listPendingApprovals,
@@ -201,23 +202,10 @@ function maybeNotifyBackgrounded(pending: ContinuationView[]): void {
 }
 
 async function showApprovalNotification(): Promise<void> {
-  try {
-    if (typeof Notification === "undefined") return;
-    const title = "Approval needed";
-    const body = "Seren is waiting for your approval to continue a task.";
-    if (Notification.permission === "granted") {
-      new Notification(title, { body });
-      return;
-    }
-    if (Notification.permission !== "denied") {
-      const permission = await Notification.requestPermission();
-      if (permission === "granted") {
-        new Notification(title, { body });
-      }
-    }
-  } catch (err) {
-    console.warn("[Approvals Store] Failed to show notification:", err);
-  }
+  await postNotification(
+    "Approval needed",
+    "Seren is waiting for your approval to continue a task.",
+  );
 }
 
 /**

--- a/tests/unit/notifications-service.test.ts
+++ b/tests/unit/notifications-service.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Unit tests for the native notification service permission gating.
+// ABOUTME: Protects the fix that routes OS banners through the Tauri plugin only when granted.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isPermissionGrantedMock = vi.fn<() => Promise<boolean>>();
+const requestPermissionMock = vi.fn<() => Promise<string>>();
+const sendNotificationMock = vi.fn<(options: unknown) => void>();
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted: isPermissionGrantedMock,
+  requestPermission: requestPermissionMock,
+  sendNotification: sendNotificationMock,
+}));
+
+describe("notifications service permission gating", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isPermissionGrantedMock.mockReset();
+    requestPermissionMock.mockReset();
+    sendNotificationMock.mockReset();
+  });
+
+  it("sends once and skips the prompt when permission is already granted", async () => {
+    isPermissionGrantedMock.mockResolvedValue(true);
+    const { postNotification } = await import("@/services/notifications");
+
+    await postNotification("Approval needed", "Waiting for approval.");
+
+    expect(requestPermissionMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).toHaveBeenCalledWith({
+      title: "Approval needed",
+      body: "Waiting for approval.",
+    });
+  });
+
+  it("never posts a banner when permission is denied", async () => {
+    isPermissionGrantedMock.mockResolvedValue(false);
+    requestPermissionMock.mockResolvedValue("denied");
+    const { postNotification } = await import("@/services/notifications");
+
+    await postNotification("Approval needed", "Waiting for approval.");
+
+    expect(requestPermissionMock).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("requests permission when undecided and posts once after a grant", async () => {
+    isPermissionGrantedMock.mockResolvedValue(false);
+    requestPermissionMock.mockResolvedValue("granted");
+    const { postNotification } = await import("@/services/notifications");
+
+    await postNotification("Approval needed", "Waiting for approval.");
+
+    expect(requestPermissionMock).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows plugin errors so callers never fail", async () => {
+    isPermissionGrantedMock.mockRejectedValue(new Error("plugin unavailable"));
+    const { postNotification } = await import("@/services/notifications");
+
+    await expect(
+      postNotification("Approval needed", "Waiting for approval."),
+    ).resolves.toBeUndefined();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Backgrounded approval requests never produced an OS banner on macOS. This routes the notification through the first-party `@tauri-apps/plugin-notification` (native OS notification center) instead of the Web `Notification` API.

Closes #3279.

## Root cause (audited, not from memory)
`src/stores/approvals.store.ts` posted the banner via the Web `Notification` API. In this app's macOS WebView that API is **denied by default**:

- The app ships **wry 0.55.1**. Its `WryWebViewUIDelegate` (`wry/src/wkwebview/class/wry_web_view_ui_delegate.rs`) implements only three `WKUIDelegate` methods — `runOpenPanelWithParameters` (file upload), `requestMediaCapturePermissionForOrigin` (camera/mic, auto-grant), and `createWebViewWithConfiguration` (new window). **There is no notification-permission delegate.**
- WebKit denies web notifications when the host app doesn't handle that delegate, so `Notification.permission === "denied"` and `Notification.requestPermission()` resolves to `denied`. `new Notification()` never paints a banner.
- This is production reality on macOS, not an artifact of the isolated validation instance — which is exactly why slice D (#3264) observed `denied`.

The dedup + backgrounding logic was correct; only the display sink was non-functional.

## Fix
- Add `tauri-plugin-notification` (Rust) + `@tauri-apps/plugin-notification` (JS), register the plugin, and grant `notification:default` in the main window capability.
- New `src/services/notifications.ts` owns the permission gate (`isPermissionGranted` → `requestPermission` → `sendNotification`) so the store stays declarative and the gating logic is unit-testable (all Gateway/Tauri calls live in `services/` per repo convention).
- `approvals.store.ts` `showApprovalNotification` now calls `postNotification`. Dedup (`notifiedApprovalIds`) and the `isBackgrounded()` gate are unchanged.

## Verification
- `cargo check` (worktree, mcp-servers staged): **pass** — plugin compiles and `notification:default` resolves against the plugin's permission schema (tauri-build hard-errors on unknown permissions).
- `pnpm vitest run tests/unit/notifications-service.test.ts`: **4/4 pass** — granted → sends once & skips prompt; denied → never sends; undecided → requests then sends; plugin error → swallowed.
- `biome check` on changed source: clean. `tsc` introduces no new errors in the changed files.
- Lockfile churn is minimal (only `@tauri-apps/plugin-notification@2.3.3` added).

## Remaining interactive validation (needs an authorized macOS session)
macOS notification permission is granted by a **user click** on the system consent dialog — it structurally cannot be automated, and the validation harness is signed-out. The one step left is a human-observed run:
1. Launch a real install, grant the notification prompt (exercises the `requestPermission` path).
2. Background the app, trigger a pending capability approval → observe **exactly one** OS banner.
3. Foreground / deduped-retry → **no** banner.

## Follow-ups
`wallet.store.ts` and `agent.store.ts` use the identical (also-broken-on-macOS) Web `Notification` pattern — filed separately, out of scope for this ticket.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
