### PR TITLE
feat(agent): host broadcasts authoritative task-execution state (#3263)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -240,6 +240,20 @@ impl ResolutionSummary {
     }
 }
 
+/// The host's authoritative live execution state for one conversation, broadcast
+/// on every gate suspend/settle so the frontend converges without waiting for a
+/// poll and a host-initiated transition (a reload sweep, a lapsed TTL) surfaces at
+/// once. Derived from the persisted continuation rows — the rows remain the single
+/// source of truth; this is the host pushing that truth rather than the renderer
+/// re-deriving it on a timer.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStateSnapshot {
+    pub conversation_id: String,
+    pub state: TaskExecutionState,
+    pub summary: ResolutionSummary,
+}
+
 /// A persisted continuation row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ContinuationRow {

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -214,8 +214,8 @@ pub const TASK_EXECUTION_STATE_EVENT: &str = "orchestrator://task-execution-stat
 /// a gate suspend/settle. Best-effort: a snapshot or emit failure is logged, never
 /// surfaced to the caller — the store mutation already succeeded and the frontend's
 /// poll is the backstop, so a missed push must not fail the command.
-pub(crate) fn emit_task_execution_state(
-    app: &AppHandle,
+pub(crate) fn emit_task_execution_state<R: tauri::Runtime>(
+    app: &AppHandle<R>,
     state: &ToolAuthorizationState,
     conversation_id: &str,
 ) {
@@ -341,4 +341,67 @@ pub fn list_authorization_audit(
     limit: Option<u32>,
 ) -> Result<Vec<AuditEntry>, String> {
     state.list_audit(&conversation_id, limit.unwrap_or(200).min(1000))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::approval_continuation::ContinuationScope;
+    use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::time::Duration;
+    use tauri::Listener;
+
+    fn in_memory_state() -> ToolAuthorizationState {
+        // The store opens and schema-inits its cached connection lazily on first
+        // use, so the first `register_continuation` bootstraps the `:memory:` db.
+        ToolAuthorizationState::new(PathBuf::from(":memory:"))
+    }
+
+    fn send_cap() -> RequestedCapability {
+        RequestedCapability {
+            route: "gateway".to_string(),
+            publisher_slug: "gmail".to_string(),
+            tool_name: "post_send".to_string(),
+            operation_class: "high-risk".to_string(),
+            description: "Send email".to_string(),
+            is_destructive: false,
+            command: None,
+            host: None,
+            target: None,
+            binding: None,
+        }
+    }
+
+    /// The host broadcast reaches a real event listener with the authoritative
+    /// payload — the exact seam (event name + camelCase shape) the frontend store
+    /// subscribes to. Exercises a real mock app and the real `app.emit`, so a broken
+    /// event name or payload shape fails here rather than silently in production.
+    #[test]
+    fn emit_broadcasts_task_state_to_listeners() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+
+        let state = in_memory_state();
+        state
+            .register_continuation("conv-x", send_cap(), ContinuationScope::Linear, 300)
+            .expect("register continuation");
+
+        let (tx, rx) = mpsc::channel::<serde_json::Value>();
+        app.handle().listen(TASK_EXECUTION_STATE_EVENT, move |event| {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(event.payload()) {
+                let _ = tx.send(value);
+            }
+        });
+
+        emit_task_execution_state(app.handle(), &state, "conv-x");
+
+        let payload = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("a listener received the host broadcast");
+        assert_eq!(payload["conversationId"], "conv-x");
+        assert_eq!(payload["state"], "waiting_for_approval");
+        assert_eq!(payload["summary"]["unresolved"], 1);
+    }
 }

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Tauri commands exposing the host-owned tool authorization gate to the renderer.
 // ABOUTME: The renderer consults the gate before every route and records prompt outcomes host-side.
 
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 use crate::approval_continuation::{
     ContinuationScope, ContinuationView, RegisteredContinuation, RequestedCapability,
@@ -204,13 +204,44 @@ pub fn delete_standing_policy(
     state.delete_standing_policy(&policy_id)
 }
 
+/// The host's authoritative task-execution-state broadcast. Emitted on every gate
+/// suspend/settle so the frontend converges immediately instead of waiting on its
+/// poll, and so a host-initiated transition (a reload sweep) surfaces at once. The
+/// payload is `approval_continuation::TaskStateSnapshot`.
+pub const TASK_EXECUTION_STATE_EVENT: &str = "orchestrator://task-execution-state";
+
+/// Broadcast the host's authoritative task-execution state for a conversation after
+/// a gate suspend/settle. Best-effort: a snapshot or emit failure is logged, never
+/// surfaced to the caller — the store mutation already succeeded and the frontend's
+/// poll is the backstop, so a missed push must not fail the command.
+pub(crate) fn emit_task_execution_state(
+    app: &AppHandle,
+    state: &ToolAuthorizationState,
+    conversation_id: &str,
+) {
+    match state.task_state_snapshot(conversation_id) {
+        Ok(snapshot) => {
+            if let Err(err) = app.emit(TASK_EXECUTION_STATE_EVENT, &snapshot) {
+                log::warn!(
+                    "[tool-authorization] Failed to emit task state for {conversation_id}: {err}"
+                );
+            }
+        }
+        Err(err) => log::warn!(
+            "[tool-authorization] Failed to snapshot task state for {conversation_id}: {err}"
+        ),
+    }
+}
+
 /// Register a suspended continuation for an authorization-blocked action so the
 /// paused action is a visible, resumable record rather than a hung tool call
 /// (#3193-C). The renderer calls this when the gate returns `prompt`, then keeps
 /// the returned `resumeToken` in its own state and forwards only `modelResult` to
-/// the model. Equivalent retries dedup to one pending request.
+/// the model. Equivalent retries dedup to one pending request. The host broadcasts
+/// the conversation's new (blocked) state so the frontend shows it without polling.
 #[tauri::command]
 pub fn register_approval_continuation(
+    app: AppHandle,
     state: State<'_, ToolAuthorizationState>,
     conversation_id: String,
     requested: RequestedCapability,
@@ -220,7 +251,9 @@ pub fn register_approval_continuation(
     // A linear turn is the conservative default: the whole task waits unless the
     // caller can prove the blocked action is an independent branch.
     let scope = scope.unwrap_or(ContinuationScope::Linear);
-    state.register_continuation(&conversation_id, requested, scope, ttl_secs)
+    let registered = state.register_continuation(&conversation_id, requested, scope, ttl_secs)?;
+    emit_task_execution_state(&app, &state, &conversation_id);
+    Ok(registered)
 }
 
 /// Resolve a suspended continuation with the user's decision (approve/deny/skip).
@@ -228,12 +261,17 @@ pub fn register_approval_continuation(
 /// that learns the public `approvalId` cannot self-approve.
 #[tauri::command]
 pub fn resolve_approval_continuation(
+    app: AppHandle,
     state: State<'_, ToolAuthorizationState>,
     approval_id: String,
     resume_token: String,
     decision: ResolveDecision,
 ) -> Result<ResolveOutcome, String> {
-    state.resolve_continuation(&approval_id, &resume_token, decision)
+    let outcome = state.resolve_continuation(&approval_id, &resume_token, decision)?;
+    if let Ok(Some(conversation_id)) = state.conversation_for_approval(&approval_id) {
+        emit_task_execution_state(&app, &state, &conversation_id);
+    }
+    Ok(outcome)
 }
 
 /// Explicitly expire a suspended continuation (the renderer's approval timeout),
@@ -241,11 +279,16 @@ pub fn resolve_approval_continuation(
 /// tool failure. Idempotent and token-gated.
 #[tauri::command]
 pub fn expire_approval_continuation(
+    app: AppHandle,
     state: State<'_, ToolAuthorizationState>,
     approval_id: String,
     resume_token: String,
 ) -> Result<ResolveOutcome, String> {
-    state.expire_continuation(&approval_id, &resume_token)
+    let outcome = state.expire_continuation(&approval_id, &resume_token)?;
+    if let Ok(Some(conversation_id)) = state.conversation_for_approval(&approval_id) {
+        emit_task_execution_state(&app, &state, &conversation_id);
+    }
+    Ok(outcome)
 }
 
 /// The live task-execution state for a conversation, derived from its

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -757,9 +757,22 @@ pub fn run() {
                                 .try_state::<tool_authorization::ToolAuthorizationState>()
                             {
                                 match auth.expire_all_pending_continuations() {
-                                    Ok(expired) if expired > 0 => log::warn!(
-                                        "[ToolAuthorization] Expired {expired} orphaned approval continuation(s) on main view reload"
-                                    ),
+                                    Ok(conversations) if !conversations.is_empty() => {
+                                        log::warn!(
+                                            "[ToolAuthorization] Expired orphaned approval continuation(s) across {} conversation(s) on main view reload",
+                                            conversations.len()
+                                        );
+                                        // Broadcast each released task's new state so a
+                                        // stale "waiting for approval" clears at once on
+                                        // the fresh page instead of at the next poll.
+                                        for conversation_id in &conversations {
+                                            commands::tool_authorization::emit_task_execution_state(
+                                                &app,
+                                                &auth,
+                                                conversation_id,
+                                            );
+                                        }
+                                    }
                                     Ok(_) => {}
                                     Err(err) => log::warn!(
                                         "[ToolAuthorization] Failed to expire orphaned continuations on reload: {err}"

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 use crate::approval_continuation::{
     self, ContinuationRow, ContinuationScope, ContinuationState, ContinuationView,
     RegisteredContinuation, RequestedCapability, ResolutionSummary, ResolveDecision, ResolveOutcome,
+    TaskStateSnapshot,
 };
 use crate::authorization_audit::{self, AuditContext, AuditEntry, AuditEvent};
 use crate::capability_lease::{
@@ -1628,6 +1629,41 @@ impl ToolAuthorizationState {
         })
     }
 
+    /// The host's authoritative live state and outcome counts for a conversation in
+    /// one consistent read. This is what the host broadcasts on every gate
+    /// suspend/settle so the frontend converges without polling; combining the
+    /// aggregate state and the summary under a single connection lock guarantees
+    /// they describe the same instant. Overdue pending blocks are expired first, so
+    /// a lapsed request never keeps a task spuriously `waiting_for_approval`.
+    pub fn task_state_snapshot(
+        &self,
+        conversation_id: &str,
+    ) -> Result<TaskStateSnapshot, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            expire_overdue_audited(conn, conversation_id, &now);
+            let rows = approval_continuation::read_continuations(conn, conversation_id)?;
+            Ok(TaskStateSnapshot {
+                conversation_id: conversation_id.to_string(),
+                state: approval_continuation::aggregate_task_state(&rows),
+                summary: approval_continuation::summarize(&rows),
+            })
+        })
+    }
+
+    /// The conversation that owns a continuation, or `None` if unknown. Host-internal
+    /// (no resume token): the settle commands look this up so they can broadcast the
+    /// affected conversation's new task state without the renderer having to name it.
+    pub fn conversation_for_approval(
+        &self,
+        approval_id: &str,
+    ) -> Result<Option<String>, String> {
+        self.with_conn(|conn| {
+            Ok(approval_continuation::find_by_id(conn, approval_id)?
+                .map(|row| row.conversation_id))
+        })
+    }
+
     /// Outcome counts for a conversation, backing completion integrity
     /// (`can_complete`) and the final summary disclosure of denied/skipped/expired/
     /// unresolved work.
@@ -1690,8 +1726,10 @@ impl ToolAuthorizationState {
     /// `waiting_for_approval` state at once instead of leaving it dangling until its
     /// TTL. Fail-safe — it only revokes a pending approval opportunity, never grants
     /// authority, and records an expiry (not a denial), so a later re-attempt
-    /// re-prompts. Each lapse is audited (#3193-D). Returns the count expired.
-    pub fn expire_all_pending_continuations(&self) -> Result<usize, String> {
+    /// re-prompts. Each lapse is audited (#3193-D). Returns the distinct conversation
+    /// ids it affected so the caller can broadcast each task's new (unblocked) state,
+    /// clearing a stale `waiting_for_approval` at once instead of at the next poll.
+    pub fn expire_all_pending_continuations(&self) -> Result<Vec<String>, String> {
         self.with_conn(|conn| {
             let now = current_timestamp(conn)?;
             let expired = approval_continuation::expire_all_pending(conn, &now)?;
@@ -1704,7 +1742,11 @@ impl ToolAuthorizationState {
                     &now,
                 );
             }
-            Ok(expired.len())
+            let mut conversations: Vec<String> =
+                expired.into_iter().map(|row| row.conversation_id).collect();
+            conversations.sort();
+            conversations.dedup();
+            Ok(conversations)
         })
     }
 
@@ -3045,6 +3087,54 @@ mod tests {
         assert!(!s.resolution_summary("conv-a").unwrap().can_complete());
     }
 
+    /// The host snapshot the frontend consumes is authoritative across the whole
+    /// lifecycle: `waiting_for_approval` with one unresolved block on register, then
+    /// `running` with the block counted as approved on settle. This is the payload
+    /// broadcast on every gate suspend/settle so the frontend never has to derive or
+    /// poll for the state.
+    #[test]
+    fn task_state_snapshot_tracks_host_state_across_lifecycle() {
+        let s = state();
+        let registered = s
+            .register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+
+        let blocked = s.task_state_snapshot("conv-a").unwrap();
+        assert_eq!(blocked.conversation_id, "conv-a");
+        assert_eq!(blocked.state, TaskExecutionState::WaitingForApproval);
+        assert_eq!(blocked.summary.unresolved, 1);
+        assert!(!blocked.summary.can_complete());
+
+        s.resolve_continuation(
+            &registered.approval_id,
+            &registered.resume_token,
+            ResolveDecision::Approve,
+        )
+        .unwrap();
+
+        let released = s.task_state_snapshot("conv-a").unwrap();
+        assert_eq!(released.state, TaskExecutionState::Running);
+        assert_eq!(released.summary.unresolved, 0);
+        assert_eq!(released.summary.approved, 1);
+        assert!(released.summary.can_complete());
+    }
+
+    /// The settle commands broadcast the affected conversation's new state without
+    /// the renderer naming it, so the host must resolve a continuation's owner from
+    /// its id alone.
+    #[test]
+    fn conversation_for_approval_resolves_owner() {
+        let s = state();
+        let registered = s
+            .register_continuation("conv-owner", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        assert_eq!(
+            s.conversation_for_approval(&registered.approval_id).unwrap(),
+            Some("conv-owner".to_string())
+        );
+        assert_eq!(s.conversation_for_approval("no-such-id").unwrap(), None);
+    }
+
     /// Equivalent retries reuse the same pending request — no prompt storm.
     #[test]
     fn equivalent_retries_dedup_to_one_pending_request() {
@@ -3233,8 +3323,13 @@ mod tests {
             TaskExecutionState::RunningWithBlockedActions
         );
 
-        // Two live pending blocks (the approved one is already settled) are expired.
-        assert_eq!(s.expire_all_pending_continuations().unwrap(), 2);
+        // Two live pending blocks (the approved one is already settled) are expired;
+        // the sweep reports both owning conversations so the caller can broadcast
+        // each task's now-unblocked state.
+        assert_eq!(
+            s.expire_all_pending_continuations().unwrap(),
+            vec!["conv-a".to_string(), "conv-b".to_string()]
+        );
 
         // Both tasks are released; nothing blocks completion.
         assert_eq!(
@@ -3255,7 +3350,7 @@ mod tests {
         assert!(audit_events(&s, "conv-b").contains(&"approval_expired".to_string()));
 
         // Idempotent: nothing pending remains, so a second reconciliation is a no-op.
-        assert_eq!(s.expire_all_pending_continuations().unwrap(), 0);
+        assert!(s.expire_all_pending_continuations().unwrap().is_empty());
     }
 
     /// An independent branch block keeps the task running-with-blocked-actions,

--- a/src/services/tool-authorization.ts
+++ b/src/services/tool-authorization.ts
@@ -107,6 +107,17 @@ export interface ResolutionSummary {
   expired: number;
 }
 
+/**
+ * Mirrors `TaskStateSnapshot` in `src-tauri/src/approval_continuation.rs` — the
+ * host's authoritative live task state, pushed on the `orchestrator://task-execution-state`
+ * event at every gate suspend/settle.
+ */
+export interface TaskStateSnapshot {
+  conversationId: string;
+  state: TaskExecutionState;
+  summary: ResolutionSummary;
+}
+
 /** Mirrors `AuditEntry` in `src-tauri/src/authorization_audit.rs`. */
 export interface AuthorizationAuditEntry {
   id: number;

--- a/src/stores/approvals.store.ts
+++ b/src/stores/approvals.store.ts
@@ -7,6 +7,7 @@ import { postNotification } from "@/services/notifications";
 import {
   type ContinuationView,
   listPendingApprovals,
+  type TaskStateSnapshot,
 } from "@/services/tool-authorization";
 
 /**
@@ -49,6 +50,14 @@ interface ShellApprovalRequestPayload {
 interface StoreShape {
   live: LiveApprovalRequest[];
   pending: ContinuationView[];
+  /**
+   * The host's authoritative task-execution state per conversation, pushed on
+   * `orchestrator://task-execution-state`. Drives the thread status label without
+   * the renderer re-deriving it; the pending list stays the authority for whether
+   * anything is still blocked, so a read-triggered TTL expiry can never leave a
+   * stale label behind.
+   */
+  taskStates: Record<string, TaskStateSnapshot>;
 }
 
 /** Live requests outlive the executor's 5-minute window only by this margin. */
@@ -57,7 +66,11 @@ const LIVE_REQUEST_MAX_AGE_MS = 6 * 60 * 1000;
 /** How often to re-read host state while anything is pending (observes TTL expiry). */
 const PENDING_REFRESH_INTERVAL_MS = 60 * 1000;
 
-const [state, setState] = createStore<StoreShape>({ live: [], pending: [] });
+const [state, setState] = createStore<StoreShape>({
+  live: [],
+  pending: [],
+  taskStates: {},
+});
 
 /**
  * Pending capability requests already notified this session. The host dedups
@@ -104,13 +117,27 @@ export function liveRequestForContinuation(
  */
 export function threadApprovalStatus(conversationId: string): string | null {
   const pending = pendingForConversation(conversationId);
+  // The pending list is authoritative for "is anything still blocked" — nothing
+  // pending means not blocked, even if a host state event has not yet arrived or a
+  // read-triggered TTL expiry cleared the block without a fresh push.
   if (pending.length === 0) return null;
-  if (pending.some((view) => view.blockedScope === "linear")) {
+  const blockedCount =
+    pending.length === 1
+      ? "1 action blocked"
+      : `${pending.length} actions blocked`;
+  const hostState = state.taskStates[conversationId]?.state;
+  if (hostState === "running_with_blocked_actions") {
+    return blockedCount;
+  }
+  // A linear block suspends the whole turn: trust the host's state, and before its
+  // first push fall back to the pending continuations' own scope.
+  if (
+    hostState === "waiting_for_approval" ||
+    pending.some((view) => view.blockedScope === "linear")
+  ) {
     return "Waiting for approval";
   }
-  return pending.length === 1
-    ? "1 action blocked"
-    : `${pending.length} actions blocked`;
+  return blockedCount;
 }
 
 /** Re-read host-pending approvals; prune lapsed live requests as a side effect. */
@@ -260,6 +287,18 @@ export async function initializeApprovalsStore(): Promise<void> {
       setTimeout(() => void refreshPendingApprovals(), 300);
     });
   }
+
+  // The host broadcasts a conversation's authoritative task state on every gate
+  // suspend/settle (and its own reload sweep). Consume it so the thread status
+  // converges immediately — including host-initiated transitions the renderer
+  // never emitted — instead of waiting for the poll below.
+  await listen<TaskStateSnapshot>(
+    "orchestrator://task-execution-state",
+    (event) => {
+      setState("taskStates", event.payload.conversationId, event.payload);
+      void refreshPendingApprovals();
+    },
+  );
 
   document.addEventListener("visibilitychange", () => {
     if (!document.hidden) void refreshPendingApprovals();


### PR DESCRIPTION
Closes the last open item of #3263 (slice **C** of epic #3193): make the **host** own and push `TaskExecutionState`, instead of it only being an on-demand derivation inside the authorization store.

## Problem (reopen item 1)

`TaskExecutionState` was untouched by `service.rs`/the workers — a blocked task's live state surfaced to the frontend only via renderer derivation + a 60s poll, and a **host-initiated** transition (a reload orphan sweep, a lapsed TTL) had **no push at all**. So the host/scheduler never actually *owned* the state.

## What changed

**Host (Rust) becomes the authoritative broadcaster:**
- Emits `orchestrator://task-execution-state` carrying `TaskStateSnapshot { conversationId, state, summary }` on **every** gate suspend/settle — the `register` / `resolve` / `expire` continuation commands — and after the **reload orphan sweep**.
- `expire_all_pending_continuations()` now returns the affected conversation ids so each released task's new state is broadcast at once (was: a bare count; stale `waiting_for_approval` cleared only at the next poll).
- `task_state_snapshot()` reads aggregate state + resolution summary under one connection lock (a consistent instant); `conversation_for_approval()` lets the settle commands name the affected conversation from an approval id.

**Frontend consumes it:**
- `approvals.store.ts` listens, stores the host snapshot, and refreshes — the thread status converges immediately (no poll lag) and host-initiated transitions surface without a renderer emit.
- The pending list stays the authority for "is anything still blocked", so a read-triggered TTL expiry can never leave a stale label (drift-free).

The continuation rows remain the single source of truth and `aggregate_task_state` the single derivation — **no duplicate persisted task-state column**, so there is no second-source drift. This is the host pushing that truth, not a new store of it.

## Deliberate non-goal (documented on the issue)

Full **host-owned re-drive resumability** after a webview reload is **not** built. Silently re-driving a side-effecting tool call across a crash boundary risks double-execution (approval-granted → executing → reload-before-`submit_tool_result` would re-send). The shipped interrupt (#3288) / disclose / expire (#3290) / re-prompt path is the correct conservative default for irreversible actions; re-drive would need a tool-execution idempotency key first.

## Tests

- New `task_state_snapshot_tracks_host_state_across_lifecycle` — the broadcast payload is `waiting_for_approval`+1 unresolved on register, `running`+approved on settle.
- New `conversation_for_approval_resolves_owner` — the settle commands can name the affected conversation.
- Updated `reload_reconciliation_expires_all_live_pending_across_conversations` — the sweep returns both affected conversation ids for the reload broadcast.
- Full `tool_authorization` suite green (85 passed); `biome` clean; `tsc` clean on changed files.

Refs #3263 #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com