### PR TITLE
test(memory): pin delete_memories_by_source in tool assertion (#3306)

### DIFF
--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -867,6 +867,7 @@ mod tests {
                 "memory_timeline",
                 "consolidate",
                 "configure_publishers",
+                "delete_memories_by_source",
             ]
         );
     }


### PR DESCRIPTION
## Summary

Fixes the red `test-rust` on `main` (#3306) introduced by #3305.

#3305 added `delete_memories_by_source` to `MEMORY_MCP_TOOLS` (to wire the conversation-delete cloud-memory cascade) but did not update the pinned assertion in `commands::memory::tests::exposes_all_live_memory_mcp_tools`, which hardcodes the expected tool list. `assert_eq!` failed on the extra entry.

This adds `"delete_memories_by_source"` to the test's expected list, matching the constant's order (appended last).

## Root cause of the escape

Only the `commands::chat::tests` filter was run locally before #3305 merged — not the full suite — and #3305's `test-rust` job had not finished when the PR merged, so the break landed on main.

## Validation

Full suite, no filter:
- `cargo test --manifest-path src-tauri/Cargo.toml` → exit 0.
- `commands::memory::tests::exposes_all_live_memory_mcp_tools ... ok` (10 passed in the module).

Closes #3306

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
