### PR TITLE
fix(privacy): erase recorded meetings in "Erase all conversation data" (#3314)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1711,6 +1711,22 @@ pub fn delete_meeting_record(conn: &Connection, id: &str) -> Result<usize> {
     Ok(deleted)
 }
 
+/// Erase every recorded meeting (with its transcript segments and speaker
+/// assignments) from `chat.db` in the full-erase flow, enqueueing sync
+/// tombstones so the delete propagates to the remote replica. Returns the
+/// number of meetings removed. The transcript vector index lives in a separate
+/// DB and is cleared by the caller.
+pub fn clear_all_meetings(conn: &Connection) -> Result<usize> {
+    let meeting_ids = conn
+        .prepare("SELECT id FROM meetings")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    for id in &meeting_ids {
+        delete_meeting_record(conn, id)?;
+    }
+    Ok(meeting_ids.len())
+}
+
 pub fn update_meeting_status_record(
     conn: &Connection,
     id: &str,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2482,8 +2482,12 @@ pub async fn erase_all_conversation_data(
             .collect::<rusqlite::Result<Vec<String>>>()?;
         let targets = collect_agent_transcript_targets(conn, &conversation_ids)?;
         delete_conversation_records(conn, &conversation_ids)?;
+        // Recorded meetings are communications too (#3314): erase every meeting
+        // and its transcript segments / speaker assignments before the VACUUM so
+        // the freed transcript pages are reclaimed in the same pass.
+        let meetings_removed = crate::commands::audio::clear_all_meetings(conn)?;
         vacuum_database(conn)?;
-        Ok((conversation_ids, targets))
+        Ok((conversation_ids, targets, meetings_removed))
     })
     .await;
 
@@ -2491,7 +2495,7 @@ pub async fn erase_all_conversation_data(
     // conversation's retained cloud-memory sources below.
     let mut erased_conversation_ids: Vec<String> = Vec::new();
     let transcript_targets = match chat_result {
-        Ok((conversation_ids, targets)) => {
+        Ok((conversation_ids, targets, meetings_removed)) => {
             reports.push(EraseTargetReport::new(
                 "local_chat_db",
                 "ok",
@@ -2500,14 +2504,45 @@ pub async fn erase_all_conversation_data(
                     conversation_ids.len()
                 )),
             ));
+            reports.push(EraseTargetReport::new(
+                "meeting_recordings",
+                "ok",
+                Some(format!(
+                    "{meetings_removed} recorded meeting(s) and their transcript segments removed"
+                )),
+            ));
             erased_conversation_ids = conversation_ids;
             targets
         }
         Err(err) => {
             reports.push(EraseTargetReport::new("local_chat_db", "failed", Some(err)));
+            // The meeting purge shares the chat.db transaction path, so a chat.db
+            // failure means it did not run either — report it honestly.
+            reports.push(EraseTargetReport::new(
+                "meeting_recordings",
+                "failed",
+                Some("chat.db erase failed; meeting recordings were not removed".to_string()),
+            ));
             Vec::new()
         }
     };
+
+    // Transcript search index (separate vector DB): clear every chunk/embedding
+    // and reclaim the freed pages, matching the conversation-index target.
+    let transcript_index_result =
+        crate::services::transcript_vectors::open_transcript_db(&app).and_then(|conn| {
+            crate::services::transcript_vectors::clear_all_chunks(&conn)?;
+            vacuum_database(&conn)?;
+            Ok(())
+        });
+    match transcript_index_result {
+        Ok(()) => reports.push(EraseTargetReport::new("transcript_search_index", "ok", None)),
+        Err(err) => reports.push(EraseTargetReport::new(
+            "transcript_search_index",
+            "failed",
+            Some(err.to_string()),
+        )),
+    }
 
     // Conversation index: clear all chunks and reclaim the freed pages.
     let index_result = open_index_db(&app).and_then(|conn| {
@@ -3082,6 +3117,73 @@ mod tests {
                         .windows(CANARY.len())
                         .any(|window| window == CANARY.as_bytes()),
                     "cleared input_history canary remained in {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    // Live no-mocks proof against a real on-disk `chat.db`: erasing all recorded
+    // meetings (#3314) must leave no recoverable verbatim transcript text in the
+    // file. Runs the real `clear_all_meetings` + VACUUM the erase-all flow uses.
+    #[test]
+    fn true_deletion_erase_all_meetings_removes_transcript_content_from_chat_db_file() {
+        const CANARY: &str = "meeting-canary-4b8e1d2c-77a9-4f30-b6e1-5c9d0a2f13ab";
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("chat.db");
+        let wal_path = temp_dir.path().join("chat.db-wal");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            configure_connection(&conn).unwrap();
+            setup_schema(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO meetings (id, title, started_at, status, created_at, updated_at)
+                 VALUES ('mtg1', 'Board call', 1, 'completed', 1, 1)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO transcript_segments
+                   (id, meeting_id, seq, speaker, text, start_ms, end_ms, status, created_at)
+                 VALUES ('seg1', 'mtg1', 0, 'A', ?1, 0, 1000, 'final', 1)",
+                params![CANARY],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO meeting_speaker_assignments
+                   (id, meeting_id, source, source_key, display_name, scope, created_at, updated_at)
+                 VALUES ('asn1', 'mtg1', 'manual', 'A', 'Alice', 'meeting', 1, 1)",
+                [],
+            )
+            .unwrap();
+            // Land the canary in the main db file before the erase.
+            crate::services::database::checkpoint_wal(
+                &conn,
+                crate::services::database::WalCheckpointMode::Truncate,
+            )
+            .unwrap();
+
+            let removed = crate::commands::audio::clear_all_meetings(&conn).unwrap();
+            assert_eq!(removed, 1, "one meeting should be removed");
+            vacuum_database(&conn).unwrap();
+
+            for table in ["meetings", "transcript_segments", "meeting_speaker_assignments"] {
+                let remaining: i64 = conn
+                    .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get(0))
+                    .unwrap();
+                assert_eq!(remaining, 0, "{table} must be empty after erase-all");
+            }
+        }
+
+        for path in [&db_path, &wal_path] {
+            if path.exists() {
+                let bytes = std::fs::read(path).unwrap();
+                assert!(
+                    !bytes
+                        .windows(CANARY.len())
+                        .any(|window| window == CANARY.as_bytes()),
+                    "erased transcript canary remained in {}",
                     path.display()
                 );
             }

--- a/src-tauri/src/services/transcript_vectors.rs
+++ b/src-tauri/src/services/transcript_vectors.rs
@@ -104,6 +104,17 @@ pub fn delete_meeting_chunks(conn: &Connection, meeting_id: &str) -> Result<()> 
     Ok(())
 }
 
+/// Remove every indexed transcript chunk and its embedding in the full-erase
+/// flow. `secure_delete=ON` on this connection zeroes the freed rows; the
+/// caller VACUUMs to reclaim the pages.
+pub fn clear_all_chunks(conn: &Connection) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM transcript_embeddings", [])?;
+    tx.execute("DELETE FROM transcript_chunks", [])?;
+    tx.commit()?;
+    Ok(())
+}
+
 /// Insert one transcript chunk and its embedding, returning the chunk id.
 pub fn insert_transcript_chunk(
     conn: &Connection,


### PR DESCRIPTION
## Summary

Closes #3314. Extends the one-shot **"Erase all conversation data"** flow (`erase_all_conversation_data`) to also erase **recorded meetings** — per Taariq's scope call that recordings are communications and therefore in scope for #3197's "delete means delete everywhere" guarantee.

Previously the flow erased conversations/messages, the conversation index, CLI transcripts, tool-authorization records, and cloud memory — but left every recorded meeting's verbatim transcript in `chat.db` and the transcript vector index, and did not even list them in its per-target report (breaking the flow's honest-reporting contract from #3259).

## Change

- `erase_all_conversation_data` now purges meeting recordings, with two new per-target report entries:
  - **`meeting_recordings`** — bulk-erases every meeting via the new `audio::clear_all_meetings`, which reuses the shipped per-meeting `delete_meeting_record` (transcript_segments + meeting_speaker_assignments + meetings, with sync tombstones). Runs inside the same `chat.db` connection *before* the existing VACUUM, so the freed transcript pages are reclaimed in the same pass.
  - **`transcript_search_index`** — clears the separate transcript vector DB (`transcript_chunks` + `transcript_embeddings`) via the new `transcript_vectors::clear_all_chunks` and VACUUMs it (`secure_delete=ON` already set on that connection), matching the `conversation_index` target.
- A `chat.db` failure reports `meeting_recordings` as `failed` (not silently ok), since the meeting purge shares that connection.

## Networked path

No new outbound path. `clear_all_meetings` reuses `delete_meeting_record`, which enqueues the same sync tombstones the shipped per-meeting `delete_meeting` already produces. Those flow through `history_sync::push_tombstone` → the remote `seren_desktop.meetings` / `transcript_segments` / `meeting_speaker_assignments` rows, whose tombstone SQL already does `SET content = NULL, payload = '{}'::jsonb, deleted_at = …` — so erase-all now also content-erases meetings on the remote replica. Verified the tombstone-erase SQL set (`TOMBSTONE_MEETING_SQL`, `TOMBSTONE_TRANSCRIPT_SEGMENT_SQL`, `TOMBSTONE_MEETING_SPEAKER_ASSIGNMENT_SQL`) covers all three tables.

## Tests (critical regression only)

- `true_deletion_erase_all_meetings_removes_transcript_content_from_chat_db_file` — real on-disk `chat.db`: seeds a meeting + verbatim transcript segment + speaker assignment, checkpoints the canary into the main file, runs the real `clear_all_meetings` + VACUUM, asserts all three tables are empty and the transcript text is unrecoverable from the db/WAL bytes (no mocks).

Refs #3197
