### PR TITLE
fix(privacy): erase seren-notes cloud note on meeting delete (#3317)

### DIFF
--- a/src-tauri/src/audio/seren_notes_publish.rs
+++ b/src-tauri/src/audio/seren_notes_publish.rs
@@ -373,6 +373,93 @@ fn parse_update_response_body(text: &str) -> Result<(), PublishError> {
     Ok(())
 }
 
+/// Delete a meeting's published cloud note so a deleted recording leaves no
+/// verbatim residue on `seren-notes` (#3317). A 404 is treated as success — the
+/// note is already gone, which is the desired end state (idempotent). Verified
+/// live against the real service: `DELETE /notes/{id}` returns 204 and a
+/// subsequent GET returns 404.
+pub async fn delete_meeting_note(app: &AppHandle, note_id: &str) -> Result<(), PublishError> {
+    if !has_stored_credentials(app) {
+        return Err(PublishError::NotAuthenticated);
+    }
+    if !is_uuid(note_id) {
+        return Err(PublishError::Other(format!(
+            "refusing to DELETE seren-notes with non-uuid note id: {note_id}"
+        )));
+    }
+    let client = Client::new();
+    let url = format!("{PUBLISH_URL}/{note_id}");
+    publish_with_retry(&RETRY_BACKOFFS, || attempt_delete_note(app, &client, &url)).await
+}
+
+/// Summed outcome of erasing a batch of published cloud notes. `deleted` and
+/// `failed` partition the batch; `not_authenticated` records that the batch was
+/// cut short because the user is signed out (the remaining notes could not be
+/// erased under this identity).
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct MeetingNoteEraseCounts {
+    pub deleted: usize,
+    pub failed: usize,
+    pub not_authenticated: bool,
+}
+
+/// Erase each published cloud note, returning per-outcome counts so the caller
+/// can report honestly. Stops early on `NotAuthenticated`: the remaining notes
+/// cannot be erased under this identity, and every unerased note is counted as
+/// `failed` so the caller never reports a false-clean result.
+pub async fn erase_meeting_notes(app: &AppHandle, note_ids: &[String]) -> MeetingNoteEraseCounts {
+    let mut counts = MeetingNoteEraseCounts::default();
+    for (idx, note_id) in note_ids.iter().enumerate() {
+        match delete_meeting_note(app, note_id).await {
+            Ok(()) => counts.deleted += 1,
+            Err(PublishError::NotAuthenticated) => {
+                counts.failed += note_ids.len() - idx;
+                counts.not_authenticated = true;
+                break;
+            }
+            Err(err) => {
+                counts.failed += 1;
+                log::warn!(
+                    "[meeting] seren-notes note delete failed for {note_id}: {}",
+                    err.into_message()
+                );
+            }
+        }
+    }
+    counts
+}
+
+async fn attempt_delete_note(
+    app: &AppHandle,
+    client: &Client,
+    url: &str,
+) -> Result<(), PublishError> {
+    let response = authenticated_request(app, client, |c, token| c.delete(url).bearer_auth(token))
+        .await
+        .map_err(PublishError::Other)?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|err| PublishError::Other(format!("seren-notes read body failed: {err}")))?;
+    if status.as_u16() == 408 || status.is_server_error() {
+        return Err(PublishError::Server {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+    // 404 = already deleted = the intended end state (idempotent).
+    if status.as_u16() == 404 {
+        return Ok(());
+    }
+    if !status.is_success() {
+        return Err(PublishError::Other(format!(
+            "seren-notes delete returned {status}: {text}"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -71,11 +71,15 @@ pub async fn list_meetings(app: AppHandle, limit: Option<i32>) -> Result<Vec<Mee
 #[tauri::command]
 pub async fn delete_meeting(app: AppHandle, id: String) -> Result<(), String> {
     let deleted_id = id.clone();
-    run_db(app.clone(), move |conn| {
+    // Capture the published cloud-note id before the row is deleted so the
+    // remote note can be erased too (#3317).
+    let note_ids = run_db(app.clone(), move |conn| {
+        let note_ids = collect_meeting_note_ids(conn, std::slice::from_ref(&id))?;
         delete_meeting_record(conn, &id)?;
-        Ok(())
+        Ok(note_ids)
     })
     .await?;
+    spawn_seren_note_deletes_best_effort(&app, note_ids);
     // Drop the transcript search index for this meeting too, so a delete can't
     // orphan its vectors. Best-effort: a missing index isn't a delete failure.
     let app_for_index = app.clone();
@@ -1725,6 +1729,50 @@ pub fn clear_all_meetings(conn: &Connection) -> Result<usize> {
         delete_meeting_record(conn, id)?;
     }
     Ok(meeting_ids.len())
+}
+
+/// The published seren-notes ids for the given meetings that have a cloud note.
+/// Captured before the meeting rows are deleted so the caller can erase the
+/// matching cloud notes (#3317).
+pub fn collect_meeting_note_ids(conn: &Connection, meeting_ids: &[String]) -> Result<Vec<String>> {
+    if meeting_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = meeting_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT seren_notes_id FROM meetings
+         WHERE id IN ({placeholders}) AND seren_notes_id IS NOT NULL"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = stmt
+        .query_map(rusqlite::params_from_iter(meeting_ids), |row| {
+            row.get::<_, String>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    Ok(ids)
+}
+
+/// Every published seren-notes id across all meetings, for the full-erase flow.
+pub fn collect_all_meeting_note_ids(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt =
+        conn.prepare("SELECT seren_notes_id FROM meetings WHERE seren_notes_id IS NOT NULL")?;
+    let ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    Ok(ids)
+}
+
+/// Fire-and-forget erase of the given meetings' published cloud notes so an
+/// interactive delete stays responsive. The local delete has committed; this
+/// cleans up the remote copy in the background. Non-fatal by design.
+pub fn spawn_seren_note_deletes_best_effort(app: &AppHandle, note_ids: Vec<String>) {
+    if note_ids.is_empty() {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let _ = crate::audio::seren_notes_publish::erase_meeting_notes(&app, &note_ids).await;
+    });
 }
 
 pub fn update_meeting_status_record(

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -362,19 +362,29 @@ fn spawn_memory_source_erase_best_effort(app: &AppHandle, conversation_ids: Vec<
     });
 }
 
+/// Ids removed by the linked-meeting cascade: the meeting ids (to drop the
+/// separate transcript vector index) and the published seren-notes ids (to
+/// erase the cloud notes, #3317). Both are captured before the rows are deleted.
+#[derive(Default)]
+pub(crate) struct LinkedMeetingErasure {
+    pub meeting_ids: Vec<String>,
+    pub note_ids: Vec<String>,
+}
+
 /// Erase every recorded meeting captured in the given conversations — linked via
 /// `meetings.agent_conversation_id` — from chat.db, returning the meeting ids so
-/// the caller can drop their transcript search vectors (a separate DB). The
-/// meeting rows still carry the conversation id after `delete_conversation_records`
-/// because no FK cascade is configured, so this runs on the same connection.
-/// Reuses `delete_meeting_record`, which enqueues sync tombstones for remote
-/// erasure, so a per-conversation delete matches the per-meeting delete.
+/// the caller can drop their transcript search vectors and cloud notes (both in
+/// separate stores). Runs before `delete_conversation_records`: the enforced
+/// `meetings.agent_conversation_id` FK (no ON DELETE CASCADE) would otherwise
+/// fail the conversation delete. Reuses `delete_meeting_record`, which enqueues
+/// sync tombstones for remote erasure, so a per-conversation delete matches the
+/// per-meeting delete.
 fn cascade_delete_linked_meetings(
     conn: &Connection,
     conversation_ids: &[String],
-) -> rusqlite::Result<Vec<String>> {
+) -> rusqlite::Result<LinkedMeetingErasure> {
     if conversation_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok(LinkedMeetingErasure::default());
     }
     let placeholders = conversation_ids
         .iter()
@@ -389,10 +399,15 @@ fn cascade_delete_linked_meetings(
         })?
         .collect::<rusqlite::Result<Vec<String>>>()?;
     drop(stmt);
+    // Capture cloud-note ids before the rows are deleted.
+    let note_ids = crate::commands::audio::collect_meeting_note_ids(conn, &meeting_ids)?;
     for id in &meeting_ids {
         crate::commands::audio::delete_meeting_record(conn, id)?;
     }
-    Ok(meeting_ids)
+    Ok(LinkedMeetingErasure {
+        meeting_ids,
+        note_ids,
+    })
 }
 
 /// Clear the transcript search vectors for the given meetings from the separate
@@ -952,25 +967,27 @@ pub async fn archive_conversation(app: AppHandle, id: String) -> Result<(), Stri
 #[tauri::command]
 pub async fn delete_conversation(app: AppHandle, id: String) -> Result<(), String> {
     let index_id = id.clone();
-    let (transcript_targets, meeting_ids) = run_db(app.clone(), move |conn| {
+    let (transcript_targets, meetings) = run_db(app.clone(), move |conn| {
         let ids = vec![id];
         let targets = collect_agent_transcript_targets(conn, &ids)?;
         // Recorded meetings captured in this conversation are communications
         // too (#3316). Erase them BEFORE the conversation: `meetings
         // .agent_conversation_id` is a foreign key with no ON DELETE CASCADE and
         // the bundled SQLite enforces foreign keys, so deleting the conversation
-        // while a meeting still references it would fail. Returns the meeting ids
-        // so the transcript search vectors (a separate DB) can be cleared below.
-        let meeting_ids = cascade_delete_linked_meetings(conn, &ids)?;
+        // while a meeting still references it would fail. Returns the meeting +
+        // cloud-note ids so the transcript vectors and cloud notes (both in
+        // separate stores) can be cleared below.
+        let meetings = cascade_delete_linked_meetings(conn, &ids)?;
         delete_conversation_records(conn, &ids)?;
         vacuum_database(conn)?;
-        Ok((targets, meeting_ids))
+        Ok((targets, meetings))
     })
     .await?;
     delete_conversation_index_best_effort(&app, &index_id);
     vacuum_conversation_index_best_effort(&app);
     delete_agent_transcripts_best_effort(&transcript_targets);
-    delete_meeting_transcript_vectors_best_effort(&app, &meeting_ids);
+    delete_meeting_transcript_vectors_best_effort(&app, &meetings.meeting_ids);
+    crate::commands::audio::spawn_seren_note_deletes_best_effort(&app, meetings.note_ids);
     spawn_memory_source_erase_best_effort(&app, vec![index_id]);
     Ok(())
 }
@@ -980,7 +997,7 @@ pub async fn delete_conversations_by_employee(
     app: AppHandle,
     employee_id: String,
 ) -> Result<i64, String> {
-    let (deleted, conversation_ids, transcript_targets, meeting_ids) =
+    let (deleted, conversation_ids, transcript_targets, meetings) =
         run_db(app.clone(), move |conn| {
             let mut stmt = conn.prepare("SELECT id FROM conversations WHERE employee_id = ?1")?;
             let conversation_ids = stmt
@@ -989,10 +1006,10 @@ pub async fn delete_conversations_by_employee(
             drop(stmt);
             let targets = collect_agent_transcript_targets(conn, &conversation_ids)?;
             // Meetings first — the conversations FK is enforced (see delete_conversation).
-            let meeting_ids = cascade_delete_linked_meetings(conn, &conversation_ids)?;
+            let meetings = cascade_delete_linked_meetings(conn, &conversation_ids)?;
             let deleted = delete_conversation_records(conn, &conversation_ids)?;
             vacuum_database(conn)?;
-            Ok((deleted as i64, conversation_ids, targets, meeting_ids))
+            Ok((deleted as i64, conversation_ids, targets, meetings))
         })
         .await?;
     for conversation_id in &conversation_ids {
@@ -1000,7 +1017,8 @@ pub async fn delete_conversations_by_employee(
     }
     vacuum_conversation_index_best_effort(&app);
     delete_agent_transcripts_best_effort(&transcript_targets);
-    delete_meeting_transcript_vectors_best_effort(&app, &meeting_ids);
+    delete_meeting_transcript_vectors_best_effort(&app, &meetings.meeting_ids);
+    crate::commands::audio::spawn_seren_note_deletes_best_effort(&app, meetings.note_ids);
     spawn_memory_source_erase_best_effort(&app, conversation_ids);
     Ok(deleted)
 }
@@ -2557,18 +2575,24 @@ pub async fn erase_all_conversation_data(
         // conversation while a linked meeting still references it would fail
         // (#3316). The VACUUM then reclaims the freed transcript pages in the
         // same pass.
+        // Capture published cloud-note ids before the meeting rows are deleted
+        // so the remote seren-notes copies can be erased too (#3317).
+        let meeting_note_ids = crate::commands::audio::collect_all_meeting_note_ids(conn)?;
         let meetings_removed = crate::commands::audio::clear_all_meetings(conn)?;
         delete_conversation_records(conn, &conversation_ids)?;
         vacuum_database(conn)?;
-        Ok((conversation_ids, targets, meetings_removed))
+        Ok((conversation_ids, targets, meetings_removed, meeting_note_ids))
     })
     .await;
 
     // Conversation ids captured before deletion, reused to erase each
     // conversation's retained cloud-memory sources below.
     let mut erased_conversation_ids: Vec<String> = Vec::new();
+    // Cloud-note ids captured before deletion, erased from seren-notes below.
+    let mut meeting_note_ids: Vec<String> = Vec::new();
     let transcript_targets = match chat_result {
-        Ok((conversation_ids, targets, meetings_removed)) => {
+        Ok((conversation_ids, targets, meetings_removed, note_ids)) => {
+            meeting_note_ids = note_ids;
             reports.push(EraseTargetReport::new(
                 "local_chat_db",
                 "ok",
@@ -2677,6 +2701,39 @@ pub async fn erase_all_conversation_data(
         "cloud_memories",
         memory_status,
         Some(memory_detail),
+    ));
+    // Cloud meeting notes: erase the seren-notes copies of the deleted meetings.
+    // Reported honestly — any failure (offline / signed out) means notes may
+    // remain, so the target is `failed`, not a false green `ok` (#3317).
+    let note_total = meeting_note_ids.len();
+    let note_counts =
+        crate::audio::seren_notes_publish::erase_meeting_notes(&app, &meeting_note_ids).await;
+    let (notes_status, notes_detail) = if note_counts.failed == 0 {
+        (
+            "ok",
+            format!("{} cloud meeting note(s) erased", note_counts.deleted),
+        )
+    } else if note_counts.not_authenticated {
+        (
+            "failed",
+            format!(
+                "signed out of the notes service — {} of {note_total} cloud meeting note(s) may remain",
+                note_counts.failed
+            ),
+        )
+    } else {
+        (
+            "failed",
+            format!(
+                "{} of {note_total} cloud meeting note(s) could not be erased (notes service unreachable) — {} erased before the failure(s)",
+                note_counts.failed, note_counts.deleted
+            ),
+        )
+    };
+    reports.push(EraseTargetReport::new(
+        "cloud_meeting_notes",
+        notes_status,
+        Some(notes_detail),
     ));
     reports.push(EraseTargetReport::new(
         "claude_agent_preferences",
@@ -2987,7 +3044,7 @@ mod tests {
 
         let ids = vec!["c1".to_string()];
         let erased = cascade_delete_linked_meetings(&conn, &ids).unwrap();
-        assert_eq!(erased, vec!["mtg1".to_string()]);
+        assert_eq!(erased.meeting_ids, vec!["mtg1".to_string()]);
         delete_conversation_records(&conn, &ids).unwrap();
 
         // The linked meeting and its transcript are gone.
@@ -3025,6 +3082,42 @@ mod tests {
             )
             .unwrap();
         assert_eq!(mtg2, 1, "unrelated meeting must survive");
+    }
+
+    // The linked-meeting cascade must capture each meeting's published
+    // seren-notes id BEFORE deleting the row, so the cloud note can be erased
+    // (#3317). Only meetings that actually have a published note contribute an
+    // id — a meeting with no cloud note must not.
+    #[test]
+    fn cascade_captures_linked_meeting_cloud_note_ids_before_deleting_rows() {
+        let conn = open();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind) VALUES ('c1', 't', 0, 'agent')",
+            [],
+        )
+        .unwrap();
+        let note_uuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+        conn.execute(
+            "INSERT INTO meetings
+               (id, title, started_at, status, created_at, updated_at, agent_conversation_id, seren_notes_id)
+             VALUES ('mtg1', 'Published', 1, 'completed', 1, 1, 'c1', ?1)",
+            params![note_uuid],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO meetings
+               (id, title, started_at, status, created_at, updated_at, agent_conversation_id)
+             VALUES ('mtg2', 'Unpublished', 1, 'completed', 1, 1, 'c1')",
+            [],
+        )
+        .unwrap();
+
+        let erased = cascade_delete_linked_meetings(&conn, &["c1".to_string()]).unwrap();
+        let mut mids = erased.meeting_ids.clone();
+        mids.sort();
+        assert_eq!(mids, vec!["mtg1".to_string(), "mtg2".to_string()]);
+        // Only the meeting with a published note yields a cloud-note id to erase.
+        assert_eq!(erased.note_ids, vec![note_uuid.to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #3317. Deleting a recorded meeting now erases its auto-published **seren-notes cloud note**. Previously `delete_meeting`, the bulk `clear_all_meetings` (erase-all), and the per-conversation meeting cascade deleted the local meeting rows + transcript vectors but left the meeting's verbatim notes at `seren-notes` forever — the exact cloud-side residue #3197 exists to prevent (the same failure mode fixed for cloud memory in #3305).

## Verified fix path (live, no mocks)

Against the real `seren-notes` publisher: `POST /notes` → 201, `DELETE /notes/{id}` → 204, `GET /notes/{id}` → 404 "Note not found." So the delete genuinely erases.

## Change

- `seren_notes_publish::delete_meeting_note(app, note_id)` — `DELETE /notes/{id}` via the existing `authenticated_request` + retry path; **404 is treated as success** (idempotent). UUID-guarded; skips when signed out.
- `seren_notes_publish::erase_meeting_notes(app, note_ids) -> MeetingNoteEraseCounts` — erases a batch, returning `deleted`/`failed`/`not_authenticated` for honest reporting; stops early when signed out and counts the rest as `failed` (never a false-clean result).
- `audio::collect_meeting_note_ids` / `collect_all_meeting_note_ids` capture the `seren_notes_id`s **before** the meeting rows are deleted; `audio::spawn_seren_note_deletes_best_effort` fires the erase in the background for interactive deletes.
- Wired into all meeting-delete entry points:
  - `delete_meeting` (single) — fire-and-forget best-effort.
  - `delete_conversation` / `delete_conversations_by_employee` (linked-meeting cascade, #3316) — fire-and-forget.
  - `erase_all_conversation_data` — **awaited** with a new honest per-target report line `cloud_meeting_notes` (ok / failed with counts).

## Networked path

`DELETE https://api.serendb.com/publishers/seren-notes/notes/{note_id}` via `authenticated_request` (Bearer `seren_api_key`) — the same publisher/base the meeting notes are published to. Verified against the live publisher (above).

## Tests (critical regression only)

- `cascade_captures_linked_meeting_cloud_note_ids_before_deleting_rows` — locks that the cascade captures a published meeting's `seren_notes_id` before the row is deleted, and that a meeting with no published note contributes no id. (The real DELETE round-trip is verified live above, per the repo no-mocks rule; the network call itself isn't unit-mocked.)

Refs #3197
