### PR TITLE
fix(privacy): cascade cloud-memory + VACUUM on clear-history (#3318)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2322,6 +2322,42 @@ pub async fn get_messages(
     .await
 }
 
+/// Delete a single conversation's messages and events, enqueueing sync
+/// tombstones so the delete propagates to other devices. Mirrors
+/// `clear_all_history_records` for the per-conversation "Clear history" path so
+/// the deletion is unit-testable without an `AppHandle`.
+pub(crate) fn clear_conversation_history_records(
+    conn: &Connection,
+    conversation_id: &str,
+) -> rusqlite::Result<()> {
+    let mut event_stmt =
+        conn.prepare("SELECT id FROM message_events WHERE conversation_id = ?1")?;
+    let event_ids = event_stmt
+        .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(event_stmt);
+    let mut message_stmt = conn.prepare("SELECT id FROM messages WHERE conversation_id = ?1")?;
+    let message_ids = message_stmt
+        .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(message_stmt);
+    for event_id in &event_ids {
+        enqueue_sync_tombstone(conn, "message_events", event_id)?;
+    }
+    for message_id in &message_ids {
+        enqueue_sync_tombstone(conn, "messages", message_id)?;
+    }
+    conn.execute(
+        "DELETE FROM message_events WHERE conversation_id = ?1",
+        params![conversation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM messages WHERE conversation_id = ?1",
+        params![conversation_id],
+    )?;
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn clear_conversation_history(
     app: AppHandle,
@@ -2329,36 +2365,21 @@ pub async fn clear_conversation_history(
 ) -> Result<(), String> {
     let index_id = conversation_id.clone();
     run_db(app.clone(), move |conn| {
-        let mut event_stmt =
-            conn.prepare("SELECT id FROM message_events WHERE conversation_id = ?1")?;
-        let event_ids = event_stmt
-            .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        drop(event_stmt);
-        let mut message_stmt =
-            conn.prepare("SELECT id FROM messages WHERE conversation_id = ?1")?;
-        let message_ids = message_stmt
-            .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        drop(message_stmt);
-        for event_id in &event_ids {
-            enqueue_sync_tombstone(conn, "message_events", event_id)?;
-        }
-        for message_id in &message_ids {
-            enqueue_sync_tombstone(conn, "messages", message_id)?;
-        }
-        conn.execute(
-            "DELETE FROM message_events WHERE conversation_id = ?1",
-            params![conversation_id],
-        )?;
-        conn.execute(
-            "DELETE FROM messages WHERE conversation_id = ?1",
-            params![conversation_id],
-        )?;
+        clear_conversation_history_records(conn, &conversation_id)?;
+        // Reclaim and zero the freed pages so the cleared messages don't linger
+        // in the chat.db file, matching the per-conversation delete and
+        // erase-all paths.
+        vacuum_database(conn)?;
         Ok(())
     })
     .await?;
     delete_conversation_index_best_effort(&app, &index_id);
+    vacuum_conversation_index_best_effort(&app);
+    // Cascade the cloud-memory retained-source erasure so clearing a
+    // conversation's history leaves no verbatim transcript or derived memory on
+    // the memory service, matching `delete_conversation`. Best-effort and never
+    // fatal: the local clear has already committed.
+    spawn_memory_source_erase_best_effort(&app, vec![index_id]);
     Ok(())
 }
 
@@ -2648,7 +2669,8 @@ mod tests {
         archive_agent_conversation_in_db, archive_happy_provider_session_in_db,
         claim_happy_provider_session_owner_in_db,
         claim_happy_provider_session_owner_with_provenance_in_db, clear_all_history_records,
-        cloud_memory_erase_report, collect_agent_transcript_targets, conversation_source_uri,
+        clear_conversation_history_records, cloud_memory_erase_report,
+        collect_agent_transcript_targets, conversation_source_uri,
         delete_conversation_records, emit_happy_archive_event,
         emit_happy_provider_archive_event,
         is_happy_provider_session_archived_in_db, list_legacy_happy_restoration_candidates_in_db,
@@ -3068,6 +3090,89 @@ mod tests {
                 );
             }
         }
+    }
+
+    // Live no-mocks proof against a real on-disk `chat.db`: the per-conversation
+    // "Clear history" path (`clear_conversation_history_records` + VACUUM) must
+    // erase the cleared conversation's verbatim message text from the file while
+    // leaving every other conversation intact. Guards the residue #3318 found:
+    // the command skipped VACUUM (and the cloud-memory cascade) that its sibling
+    // delete paths run.
+    #[test]
+    fn true_deletion_clear_conversation_history_erases_message_canary_and_scopes_to_target() {
+        const CANARY: &str = "clear-conv-canary-9f2c1b7a-4d0e-4c93-8a55-1e6b3f0d84cc";
+        const SURVIVOR: &str = "survivor-2a7d3e10-5c88-4b21-9f6e-0d1a2b3c4d5e";
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("chat.db");
+        let wal_path = temp_dir.path().join("chat.db-wal");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            configure_connection(&conn).unwrap();
+            setup_schema(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO conversations (id, title, created_at) VALUES ('c1', 'Chat', 1), ('c2', 'Keep', 1)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, role, content, timestamp)
+                 VALUES ('m1', 'c1', 'user', ?1, 2), ('m2', 'c2', 'user', ?2, 2)",
+                params![CANARY, SURVIVOR],
+            )
+            .unwrap();
+            // Land both messages in the main db file before the clear, mirroring
+            // a real session that has checkpointed prior turns.
+            crate::services::database::checkpoint_wal(
+                &conn,
+                crate::services::database::WalCheckpointMode::Truncate,
+            )
+            .unwrap();
+
+            clear_conversation_history_records(&conn, "c1").unwrap();
+            vacuum_database(&conn).unwrap();
+
+            // The target conversation's messages are gone; the untouched
+            // conversation's message survives.
+            let cleared: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM messages WHERE conversation_id = 'c1'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(cleared, 0, "target conversation messages must be cleared");
+            let kept: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM messages WHERE conversation_id = 'c2'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(kept, 1, "other conversation messages must be preserved");
+        }
+
+        for path in [&db_path, &wal_path] {
+            if path.exists() {
+                let bytes = std::fs::read(path).unwrap();
+                assert!(
+                    !bytes
+                        .windows(CANARY.len())
+                        .any(|window| window == CANARY.as_bytes()),
+                    "cleared conversation canary remained in {}",
+                    path.display()
+                );
+            }
+        }
+        // The untouched conversation's content must survive the clear, proving
+        // the erase is scoped and not a full wipe.
+        let db_bytes = std::fs::read(&db_path).unwrap();
+        assert!(
+            db_bytes
+                .windows(SURVIVOR.len())
+                .any(|window| window == SURVIVOR.as_bytes()),
+            "untouched conversation content must remain in the chat.db file"
+        );
     }
 
     // Live no-mocks proof against a real on-disk `chat.db`: after "Clear all


### PR DESCRIPTION
## Summary

Closes #3318.

The per-conversation **"Clear Chat"** / **"Clear Agent Chat"** action (`clear_conversation_history`, `src-tauri/src/commands/chat.rs`) wiped local messages but — unlike every sibling conversation-delete path — left two kinds of residue behind:

1. **Cloud-memory residue.** It never fired `spawn_memory_source_erase_best_effort`, so the conversation's retained verbatim sources and their derived memories persisted on the Seren Memory service (`DELETE /publishers/seren-memory/memories/by-source`, keyed on `source_uri = seren://desktop/conversations/<id>`). Same class as the `clear_all_history` gap fixed in #3310/#3311.
2. **Free-page residue.** It skipped `vacuum_database`, so cleared message text lingered in freed `chat.db` pages. Same class as #3312/#3313.

## Fix

Bring `clear_conversation_history` to parity with `delete_conversation`:
- `vacuum_database` inside the db closure + `vacuum_conversation_index_best_effort` after, and
- `spawn_memory_source_erase_best_effort(&app, vec![conversation_id])` (best-effort, non-fatal — the local clear has already committed).

All three user-facing callers surface as "Clear all … chat history" (`ChatContent`, `AgentChat`, `chatStore`); context-preserving resets are served by the separate **compact** flow, so a clean slate is the correct intent. Fixing at the command level covers every caller, matching how #3311 fixed `clear_all_history`.

Extracted `clear_conversation_history_records` so the deletion is unit-testable without an `AppHandle` (mirrors `clear_all_history_records`).

## Networked path (verified live)

`DELETE https://api.serendb.com/publishers/seren-memory/memories/by-source` with `{ "source_uri": "seren://desktop/conversations/<id>" }` → `{ data: { sources_deleted, memories_deleted } }`. Confirmed against the live `seren-memory` OpenAPI document and the `delete_memories_by_source` MCP tool; request/response schemas match the desktop's `MemorySourceEraseResponse`/`MemorySourceEraseCounts` structs.

## Validation (no mocks)

**Rust regression test** (`true_deletion_clear_conversation_history_erases_message_canary_and_scopes_to_target`) — runs the real `clear_conversation_history_records` + `VACUUM` against an on-disk `chat.db`, asserts the cleared conversation's canary is gone from the file/WAL bytes, and that an untouched conversation's content survives (scoping). All 6 `true_deletion` tests pass.

**Live cascade round-trip** against the real memory service (the exact contract this cascade invokes, same identity for create + delete):
- `process_conversation(retain_source=true, source_uri=X)` → created 1 retained source + 4 derived memories.
- `delete_memories_by_source(source_uri=X)` → `sources_deleted: 1, memories_deleted: 4`.
- repeat `delete_memories_by_source(source_uri=X)` → `0 / 0` — no server-side residue.

## Scope

One-line behavioral change plus its test; no API surface change. `src/api/generated/` untouched.
