### PR TITLE
fix(wallet): native OS banner for received transfers (#3300)

### DIFF
--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -8,6 +8,7 @@ import {
   type DailyClaimResponse,
   fetchDailyEligibility,
 } from "@/services/dailyClaim";
+import { postNotification } from "@/services/notifications";
 import {
   fetchBalance,
   markWalletNotificationRead,
@@ -242,29 +243,12 @@ export function markLatestReceivedTransferSeen(
 async function notifyReceivedTransfer(
   transfer: LatestReceivedTransfer,
 ): Promise<void> {
-  try {
-    if (typeof Notification === "undefined") {
-      return;
-    }
-
-    const title = "SerenBucks received";
-    const body = `${transfer.sender_display_name || transfer.sender_email} sent ${transfer.amount_usd}`;
-
-    if (Notification.permission === "granted") {
-      new Notification(title, { body });
-      return;
-    }
-
-    if (Notification.permission !== "denied") {
-      const permission = await Notification.requestPermission();
-      if (permission === "granted") {
-        new Notification(title, { body });
-      }
-    }
-  } catch (error) {
-    console.warn("[Wallet Store] Failed to show transfer notification:", error);
-    // Notification support varies by runtime; balance refresh should not fail.
-  }
+  const title = "SerenBucks received";
+  const body = `${transfer.sender_display_name || transfer.sender_email} sent ${transfer.amount_usd}`;
+  // The Web Notification API is denied by default in this app's macOS WebView,
+  // so OS banners must route through the native plugin. postNotification owns
+  // the permission gate and swallows failures, so balance refresh cannot break.
+  await postNotification(title, body);
 }
 
 async function handleReceivedTransferNotification(

--- a/tests/unit/wallet-received-notification-batch.test.ts
+++ b/tests/unit/wallet-received-notification-batch.test.ts
@@ -8,6 +8,10 @@ const walletMocks = vi.hoisted(() => ({
   markWalletNotificationRead: vi.fn(),
 }));
 
+const notificationMocks = vi.hoisted(() => ({
+  postNotification: vi.fn(),
+}));
+
 vi.mock("@/services/dailyClaim", () => ({
   claimDailyCredits: vi.fn(),
   fetchDailyEligibility: vi.fn(),
@@ -18,37 +22,25 @@ vi.mock("@/services/wallet", () => ({
   markWalletNotificationRead: walletMocks.markWalletNotificationRead,
 }));
 
+vi.mock("@/services/notifications", () => ({
+  postNotification: notificationMocks.postNotification,
+}));
+
 import { refreshBalance, resetWalletState } from "@/stores/wallet.store";
 
-interface NotificationCall {
-  title: string;
-  body: string | undefined;
-}
-
 describe("wallet received-transfer notification batches", () => {
-  const notificationCalls: NotificationCall[] = [];
-
   beforeEach(() => {
-    notificationCalls.length = 0;
     walletMocks.fetchBalance.mockReset();
     walletMocks.markWalletNotificationRead.mockReset();
     walletMocks.markWalletNotificationRead.mockResolvedValue(undefined);
+    notificationMocks.postNotification.mockReset();
+    notificationMocks.postNotification.mockResolvedValue(undefined);
     resetWalletState();
 
     // Pin the clock inside the 24h notify window for the fixture timestamps below.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date("2026-05-20T22:33:00Z"));
 
-    class MockNotification {
-      static permission = "granted";
-      static requestPermission = vi.fn();
-
-      constructor(title: string, options?: NotificationOptions) {
-        notificationCalls.push({ title, body: options?.body });
-      }
-    }
-
-    vi.stubGlobal("Notification", MockNotification);
     vi.stubGlobal("localStorage", {
       getItem: () => null,
       setItem: vi.fn(),
@@ -101,12 +93,22 @@ describe("wallet received-transfer notification batches", () => {
 
     await vi.waitFor(() => {
       expect(walletMocks.markWalletNotificationRead).toHaveBeenCalledTimes(3);
-      expect(notificationCalls).toHaveLength(3);
+      expect(notificationMocks.postNotification).toHaveBeenCalledTimes(3);
     });
 
     expect(walletMocks.markWalletNotificationRead.mock.calls.map(([id]) => id))
       .toEqual(["notification-old", "notification-mid", "notification-new"]);
-    expect(notificationCalls.map((call) => call.body)).toEqual([
+    // Native path posts (title, body); assert both fire oldest-first.
+    expect(
+      notificationMocks.postNotification.mock.calls.map(([title]) => title),
+    ).toEqual([
+      "SerenBucks received",
+      "SerenBucks received",
+      "SerenBucks received",
+    ]);
+    expect(
+      notificationMocks.postNotification.mock.calls.map(([, body]) => body),
+    ).toEqual([
       "Old Sender sent $1.00",
       "Mid Sender sent $2.00",
       "New Sender sent $3.00",


### PR DESCRIPTION
## Summary
Received-transfer desktop notifications silently never displayed on macOS. This routes the banner through the first-party `@tauri-apps/plugin-notification` (native OS notification center) instead of the Web `Notification` API.

Closes #3300.

## Root cause (audited, not from memory)
`src/stores/wallet.store.ts` `notifyReceivedTransfer` posted the banner via the Web `Notification` API (`new Notification(...)`, gated on `Notification.permission`). In this app's macOS WebView that API is **denied by default** — the identical failure #3279/#3299 proved and fixed for approvals:

- The app ships **wry 0.55.1**. Its `WryWebViewUIDelegate` implements no notification-permission `WKUIDelegate` method, so WebKit reports `Notification.permission === "denied"` and `Notification.requestPermission()` resolves to `denied`. `new Notification()` never paints an OS banner on macOS.

The dedup/ordering logic (`markLatestReceivedTransferSeen`, oldest-first batch replay) was correct; only the display sink was non-functional.

## Fix (matches #3299)
- `notifyReceivedTransfer` now calls `postNotification(title, body)` from `src/services/notifications.ts`. That service already owns the permission gate (`isPermissionGranted` → `requestPermission` → `sendNotification`) and swallows plugin failures, so balance refresh cannot break.
- Dropped the now-dead `typeof Notification` guard and the local try/catch — `postNotification` handles both.
- Plugin (Rust + JS) and the `notification:default` capability already landed in #3299, so this is a **store-only** change (no new dependency, no capability change).

## Networked path
The notification-display path is **local-only**: `notifyReceivedTransfer → postNotification → @tauri-apps/plugin-notification → native Tauri IPC → OS notification center`. **No outbound Seren publisher/API slug is involved in the changed code.** The upstream data (`fetchBalance`, `markWalletNotificationRead` in `src/services/wallet.ts`) is unchanged by this fix.

## Verification
- `pnpm vitest run tests/unit/wallet-received-notification-batch.test.ts tests/unit/notifications-service.test.ts`: **5/5 pass**. The batch test was updated to mock `@/services/notifications` and assert the native path posts oldest-first (`SerenBucks received` / oldest→newest bodies) and marks each row read — replacing the Web `Notification` global stub, which no longer exercises the real code path.
- `biome check` on the changed source: clean.
- `tsc --noEmit`: no new type errors in the changed files.

## Remaining interactive validation (needs an authorized macOS session)
macOS notification permission is granted by a **user click** on the system consent dialog — it structurally cannot be automated, and the validation harness is signed-out. The human-observed step:
1. On a notification-authorized macOS install, background the app.
2. Receive a SerenBucks transfer → observe **exactly one** OS banner: title `SerenBucks received`, body `<sender> sent <amount>`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
