### PR TITLE
fix(agent): native OS banner for CLI-update notifications (#3301)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -440,6 +440,7 @@ import {
   getCachedModelContextWindow,
   recordModelContextWindow,
 } from "@/services/modelContextCache";
+import { postNotification } from "@/services/notifications";
 import type {
   AgentEvent,
   AgentInfo,
@@ -952,27 +953,14 @@ function subscribeToCliScanRejections(): void {
       console.warn(
         `[cli-updater] scan rejected for ${rejection.packageName} v${rejection.to}; flags=${rejection.flags.join(",")}`,
       );
-      // System notification — minimum surface required by #1646. Falls
-      // back silently when the platform denies permission.
-      try {
-        if (typeof Notification !== "undefined") {
-          if (Notification.permission === "granted") {
-            new Notification("Seren blocked a CLI update", {
-              body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
-            });
-          } else if (Notification.permission !== "denied") {
-            void Notification.requestPermission().then((perm) => {
-              if (perm === "granted") {
-                new Notification("Seren blocked a CLI update", {
-                  body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
-                });
-              }
-            });
-          }
-        }
-      } catch {
-        // Silent — best-effort surface, never fail the subscriber.
-      }
+      // System notification — minimum surface required by #1646. Routed
+      // through the native plugin because the WebView Notification API is
+      // denied by default in this app's macOS webview (#3301). Falls back
+      // silently when the platform denies permission.
+      void postNotification(
+        "Seren blocked a CLI update",
+        `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
+      );
     },
   );
 }
@@ -1023,21 +1011,16 @@ function applyCliUpdateAction(payload: unknown, notify = true): void {
   console.warn(
     `[cli-updater] action required for ${action.packageName}; reason=${action.reason}`,
   );
-  try {
-    if (
-      notify &&
-      typeof Notification !== "undefined" &&
-      Notification.permission === "granted"
-    ) {
-      const notification = new Notification(`${action.label} needs attention`, {
-        body: "Seren kept the previous verified version. Retry or review the official installation instructions in Seren.",
-      });
-      notification.onclick = () => {
-        void openExternalLink(action.officialInstructionsUrl);
-      };
-    }
-  } catch {
-    // Best-effort OS notification; the in-app recovery card remains.
+  // Routed through the native plugin because the WebView Notification API is
+  // denied by default in this app's macOS webview (#3301). The click-to-open
+  // affordance is intentionally dropped: the plugin's desktop notifications
+  // fire-and-forget with no click/action event, and the in-app recovery card
+  // already links to the official instructions the body text names.
+  if (notify) {
+    void postNotification(
+      `${action.label} needs attention`,
+      "Seren kept the previous verified version. Retry or review the official installation instructions in Seren.",
+    );
   }
 }
 

--- a/tests/unit/agent-cli-update-native-notification.test.ts
+++ b/tests/unit/agent-cli-update-native-notification.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Guard for #3301 — the CLI-update-block and needs-attention OS banners
+// ABOUTME: must route through the native notification plugin, not the WebView Notification API.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#3301 — CLI-update notifications use the native path", () => {
+  // The Web `Notification` API is denied-by-default in this app's macOS
+  // WebView (wry 0.55.1 implements no notification WKUIDelegate), so
+  // `new Notification()` never paints a banner. If a future change
+  // reintroduces it for these CLI-update surfaces, the banners silently
+  // stop displaying on macOS again — exactly the #3301 regression.
+  it("never posts CLI-update banners through the WebView Notification API", () => {
+    expect(agentStoreSource).not.toMatch(/new Notification\(/);
+    expect(agentStoreSource).not.toMatch(/Notification\.permission/);
+    expect(agentStoreSource).not.toMatch(/Notification\.requestPermission/);
+  });
+
+  it("routes the #1646 CLI-update block banner through postNotification", () => {
+    expect(agentStoreSource).toMatch(
+      /postNotification\(\s*"Seren blocked a CLI update"/,
+    );
+  });
+
+  it("routes the needs-attention banner through postNotification", () => {
+    expect(agentStoreSource).toMatch(
+      /postNotification\(\s*`\$\{action\.label\} needs attention`/,
+    );
+  });
+
+  it("imports postNotification from the native notifications service", () => {
+    expect(agentStoreSource).toMatch(
+      /import\s*\{\s*postNotification\s*\}\s*from\s*"@\/services\/notifications"/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
The CLI-update notifications in `src/stores/agent.store.ts` never displayed on macOS. This routes them through the first-party `@tauri-apps/plugin-notification` (native OS notification center) instead of the Web `Notification` API.

Closes #3301.

## Root cause (audited, not from memory)
`agent.store.ts` posted two OS banners via the Web `Notification` API, gated on `Notification.permission`:
- `subscribeToCliScanRejections` — "Seren blocked a CLI update" (#1646)
- `applyCliUpdateAction` — "{label} needs attention"

In this app's macOS WebView that API is **denied by default** — the same root cause #3279/#3299 proved: the app ships **wry 0.55.1**, whose `WryWebViewUIDelegate` implements no notification-permission `WKUIDelegate`, so WebKit reports `Notification.permission === "denied"` and `new Notification()` never paints a banner. Both surfaces silently never displayed on macOS.

## Fix
- Both banners now call `postNotification(title, body)` from `src/services/notifications.ts` (the native plugin path added in #3299). The permission gate, request-once behavior, and error-swallowing all live in that service.
- The `applyCliUpdateAction` **click-to-open** affordance (`Notification.onclick` → open official instructions) is intentionally dropped. The plugin's `onAction` JS listener is the nominal equivalent, but the desktop implementation (`tauri-plugin-notification-2.3.3/src/desktop.rs`, `show()` → `let _ = notify_rust::...show()`) **fires-and-forgets and emits no click/action event on macOS desktop** — so `onAction` would be dead code on the exact platform this bug targets. Not lost functionality: the in-app recovery card (`state.cliUpdateActionRequired`) already links to the official instructions, and the notification body still says "review the official installation instructions in Seren." This is one of the two options the issue explicitly enumerated.

## Networked path
None. The triggers are local Tauri runtime events (`provider://cli-scan-rejected` and the CLI-update-action event) emitted by the Rust provider runtime; the banner is a local OS notification via the plugin. No Gateway publisher slug / method / path is involved.

## Verification
- `pnpm vitest run tests/unit/agent-cli-update-native-notification.test.ts`: **4/4 pass** — asserts no `new Notification(` / `Notification.permission` / `Notification.requestPermission` remain, both banners route through `postNotification`, and the service import is present. (Source-level guard, matching the established `agent-store-context-window-tier-guard.test.ts` pattern for this heavy module.)
- `biome check src/stores/agent.store.ts`: clean.
- `tsc --noEmit`: no new errors in the changed files.

## Remaining interactive validation (needs an authorized macOS session)
macOS notification permission is granted by a **user click** on the system consent dialog — it can't be automated. The one step left is a human-observed run on a notification-authorized macOS install: background the app, trigger a blocked CLI update → observe the OS banner. No mocks.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
