### PR TITLE
fix(orchestrator): enforce completion integrity for blocked tasks (#3263 items 1+2)

### DIFF
--- a/src-tauri/src/approval_continuation.rs
+++ b/src-tauri/src/approval_continuation.rs
@@ -240,6 +240,39 @@ impl ResolutionSummary {
     }
 }
 
+/// The outcome of settling a conversation's still-pending continuations at task
+/// completion (#3193-C, completion integrity): how many blocks this settle
+/// expired, and the resulting outcome counts — whose `unresolved` is necessarily
+/// zero, which is the invariant a completed task must hold.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionSettlement {
+    pub newly_expired: usize,
+    pub summary: ResolutionSummary,
+}
+
+impl CompletionSettlement {
+    /// A plain-language disclosure for a task's final summary when completion
+    /// expired one or more still-pending approvals, or `None` when nothing was
+    /// pending (a clean completion is left untouched). Explicit about the lapse —
+    /// never a generic failure — so the un-performed work is disclosed rather than
+    /// hidden behind a clean-looking finish.
+    pub fn completion_notice(&self) -> Option<String> {
+        if self.newly_expired == 0 {
+            return None;
+        }
+        let (actions, they) = if self.newly_expired == 1 {
+            ("action", "it was")
+        } else {
+            ("actions", "they were")
+        };
+        Some(format!(
+            "\n\n_This response finished with {} {} still awaiting approval; {} marked expired and not performed._",
+            self.newly_expired, actions, they
+        ))
+    }
+}
+
 /// The host's authoritative live execution state for one conversation, broadcast
 /// on every gate suspend/settle so the frontend converges without waiting for a
 /// poll and a host-initiated transition (a reload sweep, a lapsed TTL) surfaces at
@@ -604,6 +637,33 @@ pub fn expire_all_pending(conn: &Connection, now: &str) -> Result<Vec<Continuati
         "UPDATE approval_continuations SET state = 'expired', resolved_at = ?1 \
          WHERE state = 'pending'",
         rusqlite::params![now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(pending)
+}
+
+/// Expire every pending row for one conversation regardless of TTL, returning the
+/// rows this call expired. Backs host-owned completion settlement: because a worker
+/// blocks on its own linear approval before it can emit a completion, any block
+/// still pending when a completion arrives is an orphan no continuation will
+/// resume. Expiring it (rather than leaving it dangling until its TTL) keeps the
+/// completion-integrity invariant true — a completed task carries no unresolved
+/// approval — and, like the reload sweep, records an expiry, never a denial, so a
+/// later re-attempt re-prompts.
+pub fn expire_pending_for_conversation(
+    conn: &Connection,
+    conversation_id: &str,
+    now: &str,
+) -> Result<Vec<ContinuationRow>, String> {
+    let sql = format!(
+        "SELECT {SELECT_COLUMNS} FROM approval_continuations \
+         WHERE conversation_id = ?1 AND state = 'pending'"
+    );
+    let pending = collect_rows(conn, &sql, rusqlite::params![conversation_id])?;
+    conn.execute(
+        "UPDATE approval_continuations SET state = 'expired', resolved_at = ?2 \
+         WHERE conversation_id = ?1 AND state = 'pending'",
+        rusqlite::params![conversation_id, now],
     )
     .map_err(|e| e.to_string())?;
     Ok(pending)

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -166,18 +166,31 @@ async fn persist_completion_message(app: AppHandle, mut message: PersistedMessag
     }
 }
 
-/// Completion integrity (#3193-C): consult the host continuation store and, when a
-/// task still has an approval pending, append a notice to its final summary so it
-/// cannot silently report a clean finish. Applied to the `Complete` event before
-/// it is persisted or forwarded, so both the stored message and the frontend see
-/// the same disclosed text.
+/// Completion integrity (#3193-C, acceptance criterion: a task with an unresolved
+/// required approval cannot report `completed`). Applied to the `Complete` event
+/// before it is persisted or forwarded, so both the stored message and the frontend
+/// see the same enforced outcome.
 ///
-/// The guard never blocks a legitimate completion: a store error, a missing state,
-/// or nothing pending leaves the event untouched. It fires when a completion
-/// coexists with a pending approval — a settle failure that leaves a stuck pending
-/// record, or a future parallel/branch flow — rather than the common linear path,
-/// where the renderer holds the tool call open until the approval resolves.
-fn guard_completion(app: &AppHandle, conversation_id: &str, event: WorkerEvent) -> WorkerEvent {
+/// A worker blocks on its own linear approval (the tool call awaits the host
+/// result) before it can ever emit a completion, so any approval still pending when
+/// a `Complete` arrives is an orphan no continuation will resume — a settle failure
+/// that stranded a pending record, not a live wait. The host therefore *settles*
+/// those orphans here rather than merely disclosing them: it expires them (audited),
+/// making the invariant `unresolved == 0` hold at the instant of completion, and
+/// broadcasts the now-cleared task state on the real worker path so the thread
+/// status converges at once instead of at the next renderer poll. The final summary
+/// discloses the lapsed, un-performed work.
+///
+/// The host never hard-blocks the completion event: there is no terminal
+/// "not-completed" worker event, so suppressing `Complete` would leave the turn with
+/// no terminal frame — the exact hung-agent symptom this ticket exists to prevent.
+/// A store error or a missing state leaves the event untouched (fail-open on the
+/// disclosure, never on the completion itself).
+fn guard_completion<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    conversation_id: &str,
+    event: WorkerEvent,
+) -> WorkerEvent {
     let WorkerEvent::Complete {
         final_content,
         thinking,
@@ -189,24 +202,35 @@ fn guard_completion(app: &AppHandle, conversation_id: &str, event: WorkerEvent) 
     };
     let notice = app
         .try_state::<crate::tool_authorization::ToolAuthorizationState>()
-        .and_then(
-            |state| match state.resolution_summary(conversation_id) {
-                Ok(summary) => summary.completion_notice(),
+        .and_then(|state| {
+            match state.settle_conversation_on_completion(conversation_id) {
+                Ok(settlement) => {
+                    if settlement.newly_expired > 0 {
+                        log::warn!(
+                            "[Orchestrator] Task {conversation_id} reached completion with {} approval(s) still pending; expired and disclosed",
+                            settlement.newly_expired
+                        );
+                        // Host-owned transition on the real completion path: the
+                        // pending block is gone, so broadcast the cleared task state
+                        // now rather than waiting for the renderer's poll.
+                        crate::commands::tool_authorization::emit_task_execution_state(
+                            app,
+                            state.inner(),
+                            conversation_id,
+                        );
+                    }
+                    settlement.completion_notice()
+                }
                 Err(err) => {
                     log::warn!(
-                        "[Orchestrator] Completion-integrity check failed for {conversation_id}: {err}"
+                        "[Orchestrator] Completion-integrity settle failed for {conversation_id}: {err}"
                     );
                     None
                 }
-            },
-        );
+            }
+        });
     let final_content = match notice {
-        Some(note) => {
-            log::warn!(
-                "[Orchestrator] Task {conversation_id} completed with an approval still pending"
-            );
-            format!("{final_content}{note}")
-        }
+        Some(note) => format!("{final_content}{note}"),
         None => final_content,
     };
     WorkerEvent::Complete {
@@ -1905,5 +1929,131 @@ mod tests {
         let sessions = state.active_sessions.lock().await;
         assert!(sessions.contains_key("test-conv"));
         assert!(*sessions.get("test-conv").unwrap().borrow());
+    }
+
+    // =========================================================================
+    // Completion Integrity (#3193-C)
+    // =========================================================================
+
+    fn send_cap() -> crate::approval_continuation::RequestedCapability {
+        crate::approval_continuation::RequestedCapability {
+            route: "gateway".to_string(),
+            publisher_slug: "gmail".to_string(),
+            tool_name: "post_send".to_string(),
+            operation_class: "high-risk".to_string(),
+            description: "Send email".to_string(),
+            is_destructive: false,
+            command: None,
+            host: None,
+            target: None,
+            binding: None,
+        }
+    }
+
+    /// The real completion path (`guard_completion` over the real
+    /// `ToolAuthorizationState`) enforces criterion #6: when a `Complete` arrives
+    /// with an approval still pending, the host settles that orphan and the emitted
+    /// completion carries no unresolved required approval. The event stays a
+    /// `Complete` (never suppressed — that would leave the turn with no terminal
+    /// frame, the hung-agent symptom), its summary discloses the lapsed work, and
+    /// the store reports the block terminally expired. No mocks: a real mock Tauri
+    /// app with a real in-memory authorization store.
+    #[test]
+    fn guard_completion_settles_pending_approval_before_completing() {
+        use tauri::Manager;
+
+        let app = tauri::test::mock_builder()
+            .manage(crate::tool_authorization::ToolAuthorizationState::new(
+                std::path::PathBuf::from(":memory:"),
+            ))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+
+        let state = app.state::<crate::tool_authorization::ToolAuthorizationState>();
+        state
+            .register_continuation(
+                "conv-a",
+                send_cap(),
+                crate::approval_continuation::ContinuationScope::Linear,
+                300,
+            )
+            .expect("register continuation");
+        // Precondition: the task genuinely cannot complete while the block is open.
+        assert!(!state.resolution_summary("conv-a").unwrap().can_complete());
+
+        let completed = guard_completion(
+            app.handle(),
+            "conv-a",
+            WorkerEvent::Complete {
+                final_content: "Done.".to_string(),
+                thinking: None,
+                cost: None,
+                rlm_steps: None,
+            },
+        );
+
+        // The event is still a completion (not suppressed) and discloses the lapse.
+        let WorkerEvent::Complete { final_content, .. } = completed else {
+            panic!("guard_completion must keep the completion event, never suppress it");
+        };
+        assert!(final_content.starts_with("Done."));
+        assert!(final_content.contains("still awaiting approval"));
+        assert!(final_content.contains("expired"));
+
+        // The invariant now holds in the store: a completed task carries no
+        // unresolved required approval, and the block is terminally `expired`.
+        let summary = state.resolution_summary("conv-a").unwrap();
+        assert_eq!(summary.unresolved, 0);
+        assert_eq!(summary.expired, 1);
+        assert!(summary.can_complete());
+        let views = state.list_continuations("conv-a").unwrap();
+        assert_eq!(views.len(), 1);
+        assert_eq!(
+            views[0].state,
+            crate::approval_continuation::ContinuationState::Expired
+        );
+    }
+
+    /// A clean completion (nothing pending) is forwarded untouched — no spurious
+    /// disclosure, no wasted mutation. Guards against the enforcement path bleeding
+    /// into the common healthy turn.
+    #[test]
+    fn guard_completion_leaves_clean_completions_untouched() {
+        use tauri::Manager;
+
+        let app = tauri::test::mock_builder()
+            .manage(crate::tool_authorization::ToolAuthorizationState::new(
+                std::path::PathBuf::from(":memory:"),
+            ))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+        // Touch the state so its in-memory store is bootstrapped like production.
+        let _ = app
+            .state::<crate::tool_authorization::ToolAuthorizationState>()
+            .resolution_summary("conv-clean");
+
+        let completed = guard_completion(
+            app.handle(),
+            "conv-clean",
+            WorkerEvent::Complete {
+                final_content: "All good.".to_string(),
+                thinking: Some("t".to_string()),
+                cost: Some(1.5),
+                rlm_steps: None,
+            },
+        );
+
+        let WorkerEvent::Complete {
+            final_content,
+            thinking,
+            cost,
+            ..
+        } = completed
+        else {
+            panic!("expected a completion event");
+        };
+        assert_eq!(final_content, "All good.");
+        assert_eq!(thinking.as_deref(), Some("t"));
+        assert_eq!(cost, Some(1.5));
     }
 }

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::approval_continuation::{
-    self, ContinuationRow, ContinuationScope, ContinuationState, ContinuationView,
-    RegisteredContinuation, RequestedCapability, ResolutionSummary, ResolveDecision, ResolveOutcome,
-    TaskStateSnapshot,
+    self, CompletionSettlement, ContinuationRow, ContinuationScope, ContinuationState,
+    ContinuationView, RegisteredContinuation, RequestedCapability, ResolutionSummary,
+    ResolveDecision, ResolveOutcome, TaskStateSnapshot,
 };
 use crate::authorization_audit::{self, AuditContext, AuditEntry, AuditEvent};
 use crate::capability_lease::{
@@ -1676,6 +1676,45 @@ impl ToolAuthorizationState {
         })
     }
 
+    /// Host-owned completion settlement (#3193-C, completion integrity): drive a
+    /// conversation's still-pending approvals to a terminal state at task
+    /// completion, so a completed task can never carry an unresolved required
+    /// approval. Because a worker blocks on its own linear approval before it can
+    /// emit a completion (the tool call awaits the host result), any block still
+    /// pending here is an orphan no continuation will resume; expiring it (audited)
+    /// makes `unresolved == 0` hold at completion without hard-blocking the
+    /// completion event — which would recreate the very hung agent this ticket
+    /// exists to prevent — and records an expiry, never a denial, so a later
+    /// re-attempt re-prompts. Returns the count expired by this call plus the
+    /// resulting outcome counts, so the caller can disclose the lapsed work.
+    pub fn settle_conversation_on_completion(
+        &self,
+        conversation_id: &str,
+    ) -> Result<CompletionSettlement, String> {
+        self.with_conn(|conn| {
+            let now = current_timestamp(conn)?;
+            let expired = approval_continuation::expire_pending_for_conversation(
+                conn,
+                conversation_id,
+                &now,
+            )?;
+            for row in &expired {
+                audit(
+                    conn,
+                    &row.conversation_id,
+                    AuditEvent::ApprovalExpired,
+                    &audit_context_for_row(row),
+                    &now,
+                );
+            }
+            let rows = approval_continuation::read_continuations(conn, conversation_id)?;
+            Ok(CompletionSettlement {
+                newly_expired: expired.len(),
+                summary: approval_continuation::summarize(&rows),
+            })
+        })
+    }
+
     /// Every continuation for a conversation, redacted (no resume tokens), for the
     /// inspection surface. Overdue pending blocks are expired first so the listing
     /// reflects true live state.
@@ -3085,6 +3124,50 @@ mod tests {
             TaskExecutionState::WaitingForApproval
         );
         assert!(!s.resolution_summary("conv-a").unwrap().can_complete());
+    }
+
+    /// Completion integrity is *enforced*, not merely disclosed: an approval still
+    /// pending when a task completes is an orphan no worker awaits (a worker blocks
+    /// on its own approval before it can complete), so the host settles it on
+    /// completion — expiring it, driving `unresolved` to zero so the task no longer
+    /// carries an unresolved required approval, and surfacing a disclosure of the
+    /// lapsed work. The lapse is an explicit expiry (auditable), never a durable
+    /// denial, so a later re-attempt re-prompts.
+    #[test]
+    fn completion_settles_orphaned_pending_approvals() {
+        let s = state();
+        s.register_continuation("conv-a", send_cap(), ContinuationScope::Linear, 300)
+            .unwrap();
+        // Before completion the task honestly cannot complete — one block is open.
+        assert!(!s.resolution_summary("conv-a").unwrap().can_complete());
+
+        let settlement = s.settle_conversation_on_completion("conv-a").unwrap();
+        assert_eq!(settlement.newly_expired, 1);
+        // The invariant a completed task must hold: no unresolved required approval.
+        assert_eq!(settlement.summary.unresolved, 0);
+        assert_eq!(settlement.summary.expired, 1);
+        assert!(settlement.summary.can_complete());
+        let notice = settlement
+            .completion_notice()
+            .expect("an expired-on-completion block is disclosed");
+        assert!(notice.contains("still awaiting approval"));
+        assert!(notice.contains("expired"));
+
+        // Host-owned and terminal: the store now reports the task runnable (no
+        // stranded `waiting_for_approval`), and the block is `expired`, not `denied`.
+        assert!(s.resolution_summary("conv-a").unwrap().can_complete());
+        assert_eq!(
+            s.task_execution_state("conv-a").unwrap(),
+            TaskExecutionState::Running
+        );
+        let views = s.list_continuations("conv-a").unwrap();
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].state, ContinuationState::Expired);
+
+        // A clean completion (nothing pending) is left untouched — no spurious notice.
+        let clean = s.settle_conversation_on_completion("conv-a").unwrap();
+        assert_eq!(clean.newly_expired, 0);
+        assert_eq!(clean.completion_notice(), None);
     }
 
     /// The host snapshot the frontend consumes is authoritative across the whole


### PR DESCRIPTION
## Summary

Delivers **items 1 and 2** of the #3263 reopen (`main` @ `8acbc3e6`). Does **not** close #3263 — item 3 (host-owned re-drive across renderer loss) remains, tracked separately.

The reopen's item 1: `guard_completion` appended a disclosure notice but still returned `WorkerEvent::Complete`, so a task could report `completed` with an approval still unresolved — #3193-C acceptance criterion #6 (*"a task with an unresolved required approval cannot report `completed`"*) was **not enforced in code**.

## Root cause / key insight

A worker blocks on its own linear approval — the tool call awaits the host result via the `ToolResultBridge` oneshot — **before it can ever emit a completion**. So any approval still pending when a `Complete` arrives is an **orphan** (a stranded / settle-failed pending record), never a live wait. Confirmed by tracing: `modelResult` never short-circuits; the worker always blocks in `execute_frontend_tool`.

## What this does

On the **real** worker completion path (`service.rs` forward loop + RLM fast path), the host now *settles* those orphans instead of merely disclosing them:

- **Expires** the still-pending continuation(s) for the conversation (audited), so `resolution_summary(conv).unresolved == 0` holds at the instant of completion — the invariant criterion #6 requires.
- **Broadcasts** the now-cleared `orchestrator://task-execution-state` — a host-owned transition on the scheduler path (item 2), so the thread status converges without waiting for the renderer's 60s poll.
- **Discloses** the lapsed, un-performed work in the final summary. Expiry is explicit (criterion #8), never a durable denial, so a later re-attempt re-prompts.

The completion event is **never hard-suppressed**: there is no terminal "not-completed" worker event, so dropping `Complete` would leave the turn with no terminal frame — the exact hung-agent symptom this ticket exists to prevent.

## Changes

- `approval_continuation.rs`: `CompletionSettlement` (+ disclosure notice) and `expire_pending_for_conversation`.
- `tool_authorization.rs`: `settle_conversation_on_completion` (host-owned, audited).
- `orchestrator/service.rs`: `guard_completion` enforces + broadcasts on the real completion path; made generic over `Runtime` so it is exercised by a real mock app.

## Tests (no store mocks)

Real mock Tauri app + real in-memory authorization store:

- `guard_completion_settles_pending_approval_before_completing` — a `Complete` with a pending approval keeps the completion event, discloses the lapse, drives `unresolved` to 0, and leaves the block terminally `expired`.
- `guard_completion_leaves_clean_completions_untouched` — a healthy completion is forwarded verbatim (no spurious disclosure / mutation).
- `completion_settles_orphaned_pending_approvals` — the store method, end-to-end.

`cargo test --lib`: **1164 passed, 0 failed**. Full `cargo check` (lib + bin) green.

## Networked path

No new outbound publisher / API path. The change is host-internal (authorization SQLite store + a local Tauri event broadcast); it settles existing continuation rows and emits `orchestrator://task-execution-state`, which the frontend already consumes.

## Follow-up

Item 3 (host-owned exactly-once re-drive / reject across renderer loss) is filed separately — it needs a tool-execution idempotency key before a side-effecting call can be safely re-driven across a crash boundary.

## Validation

Rust real-path tests above prove the enforcement invariant against the real store (the orphan case cannot be manufactured from the UI). A signed-in in-app walkthrough confirms no regression to the normal completion + gate flow.

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
