### PR TITLE
fix(security): spend cap in the approve-for-task lease editor (#3327)

### DIFF
--- a/src/components/approvals/ApprovalActions.tsx
+++ b/src/components/approvals/ApprovalActions.tsx
@@ -2,6 +2,8 @@
 // ABOUTME: this task with editable limits, deny, skip action, and stop task.
 
 import { type Component, createSignal, Show } from "solid-js";
+import { leaseBudgetsFromInputs } from "@/components/approvals/leaseBudgets";
+import type { LeaseBudgets } from "@/services/tool-authorization";
 
 /** Requested lease lifetimes the editor offers, in hours. */
 const DURATION_CHOICES_HOURS = [1, 4, 8, 24];
@@ -17,7 +19,7 @@ interface ApprovalActionsProps {
   /** Human summary of what an approve-for-this-task lease will cover. */
   leaseSummary: string;
   onApproveOnce: () => void;
-  onApproveForTask: (durationSecs: number, maxCalls: number) => void;
+  onApproveForTask: (durationSecs: number, budgets: LeaseBudgets) => void;
   onDeny: () => void;
   onSkip: () => void;
   onStopTask: () => void;
@@ -25,8 +27,10 @@ interface ApprovalActionsProps {
 
 /**
  * The five decisions every approval surface offers (#3193 §7). "Approve for
- * this task" expands an inline editor for the lease's requested duration and
- * call budget before granting, so the user reviews the limits they hand out.
+ * this task" expands an inline editor for the lease's requested duration, call
+ * budget, and optional monetary cap before granting, so the user reviews the
+ * limits they hand out. A blank spend cap leaves the lease with no monetary
+ * allowance, so a priced call still escalates rather than running unbounded.
  */
 export const ApprovalActions: Component<ApprovalActionsProps> = (props) => {
   const [showLeaseEditor, setShowLeaseEditor] = createSignal(false);
@@ -34,13 +38,17 @@ export const ApprovalActions: Component<ApprovalActionsProps> = (props) => {
     DEFAULT_DURATION_HOURS,
   );
   const [maxCalls, setMaxCalls] = createSignal(DEFAULT_MAX_CALLS);
+  // Whole currency units the lease may spend; blank ("") = no monetary allowance.
+  const [maxSpend, setMaxSpend] = createSignal("");
 
   const secondaryButton =
     "px-4 py-2.5 text-[0.9rem] font-medium rounded-md cursor-pointer transition-all duration-150 bg-transparent text-foreground border border-border hover:bg-surface-1 hover:border-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed";
 
   const grantLease = () => {
-    const calls = Math.max(1, Math.floor(maxCalls()));
-    props.onApproveForTask(durationHours() * 3600, calls);
+    props.onApproveForTask(
+      durationHours() * 3600,
+      leaseBudgetsFromInputs(maxCalls(), maxSpend()),
+    );
   };
 
   return (
@@ -79,6 +87,20 @@ export const ApprovalActions: Component<ApprovalActionsProps> = (props) => {
                 }
                 disabled={props.isProcessing}
               />
+            </label>
+            <label class="flex items-center gap-2 text-[0.85rem] text-muted-foreground">
+              Max spend
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="none"
+                class="bg-surface-1 border border-border rounded-md px-2 py-1.5 text-foreground w-24"
+                value={maxSpend()}
+                onInput={(event) => setMaxSpend(event.currentTarget.value)}
+                disabled={props.isProcessing}
+              />
+              <span class="text-[0.75rem]">USDC</span>
             </label>
             <button
               type="button"

--- a/src/components/approvals/ApprovalRequestCard.tsx
+++ b/src/components/approvals/ApprovalRequestCard.tsx
@@ -14,6 +14,7 @@ import { cancelOrchestration } from "@/services/orchestrator";
 import {
   type ContinuationView,
   grantCapabilityLease,
+  type LeaseBudgets,
   type LeasePredicates,
 } from "@/services/tool-authorization";
 import {
@@ -117,7 +118,7 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
 
   const handleApproveForTask = async (
     durationSecs: number,
-    maxCalls: number,
+    budgets: LeaseBudgets,
   ) => {
     const request = live();
     if (!request || isProcessing()) return;
@@ -129,7 +130,7 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
           `Task lease: ${leaseSummaryFor(props.view)}`,
           durationSecs,
           predicates,
-          { maxCalls },
+          budgets,
         );
       } catch (err) {
         console.error(
@@ -204,8 +205,8 @@ export const ApprovalRequestCard: Component<ApprovalRequestCardProps> = (
           approveOnceLabel="Approve once"
           leaseSummary={leaseSummaryFor(props.view)}
           onApproveOnce={() => void respond({ approved: true })}
-          onApproveForTask={(durationSecs, maxCalls) =>
-            void handleApproveForTask(durationSecs, maxCalls)
+          onApproveForTask={(durationSecs, budgets) =>
+            void handleApproveForTask(durationSecs, budgets)
           }
           onDeny={() => void respond({ approved: false })}
           onSkip={() => void respond({ approved: false, skipped: true })}

--- a/src/components/approvals/leaseBudgets.ts
+++ b/src/components/approvals/leaseBudgets.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Pure money-bounding conversion for the "Approve for this task" lease
+// ABOUTME: editor: editor inputs -> LeaseBudgets (call count + optional spend cap).
+
+import type { LeaseBudgets } from "@/services/tool-authorization";
+
+/** Micro-units per whole currency unit (USDC/SerenBucks are metered in micros). */
+export const MICROS_PER_UNIT = 1_000_000;
+
+/**
+ * Build the lease budgets from the editor inputs. A blank or non-positive spend
+ * cap leaves `maxSpendMicros` null (no monetary allowance — a priced call still
+ * escalates), and the asset is left unpinned so any charged asset counts against
+ * a set ceiling (a conservative fail-safe that escalates earlier, never
+ * mischarges).
+ */
+export function leaseBudgetsFromInputs(
+  maxCalls: number,
+  maxSpendInput: string,
+): LeaseBudgets {
+  const calls = Math.max(1, Math.floor(maxCalls));
+  const spend = Number.parseFloat(maxSpendInput);
+  const maxSpendMicros =
+    Number.isFinite(spend) && spend > 0
+      ? Math.round(spend * MICROS_PER_UNIT)
+      : null;
+  return { maxCalls: calls, maxSpendMicros, asset: null };
+}

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/services/publisher-oauth";
 import {
   grantCapabilityLease,
+  type LeaseBudgets,
   type LeasePredicates,
 } from "@/services/tool-authorization";
 import { conversationStore } from "@/stores/conversation.store";
@@ -337,7 +338,7 @@ export const GatewayToolApproval: Component = () => {
    */
   const handleApproveForTask = async (
     durationSecs: number,
-    maxCalls: number,
+    budgets: LeaseBudgets,
   ) => {
     const req = request();
     if (!req || isProcessing() || needsConnectionChoice()) return;
@@ -364,7 +365,7 @@ export const GatewayToolApproval: Component = () => {
         `Task lease: ${leaseSummary()}`,
         durationSecs,
         predicates,
-        { maxCalls },
+        budgets,
       );
     } catch (err) {
       console.error(

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -11,7 +11,10 @@ import {
 } from "solid-js";
 import { ApprovalActions } from "@/components/approvals/ApprovalActions";
 import { cancelOrchestration } from "@/services/orchestrator";
-import { grantCapabilityLease } from "@/services/tool-authorization";
+import {
+  grantCapabilityLease,
+  type LeaseBudgets,
+} from "@/services/tool-authorization";
 import { conversationStore } from "@/stores/conversation.store";
 
 interface ShellApprovalRequest {
@@ -137,7 +140,7 @@ export const ShellApproval: Component = () => {
    */
   const handleApproveForTask = async (
     durationSecs: number,
-    maxCalls: number,
+    budgets: LeaseBudgets,
   ) => {
     const req = request();
     const program = leaseProgram();
@@ -154,7 +157,7 @@ export const ShellApproval: Component = () => {
           `Task lease: "${program}" commands`,
           durationSecs,
           { commandRules: [{ program }] },
-          { maxCalls },
+          budgets,
         );
       } catch (err) {
         console.error(

--- a/tests/unit/lease-budgets-from-inputs.test.ts
+++ b/tests/unit/lease-budgets-from-inputs.test.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Guards the "Approve for this task" money-bounding conversion — a set
+// ABOUTME: spend cap becomes a micro ceiling; a blank cap leaves no monetary allowance.
+
+import { describe, expect, it } from "vitest";
+import { leaseBudgetsFromInputs } from "@/components/approvals/leaseBudgets";
+
+describe("leaseBudgetsFromInputs", () => {
+  it("threads a set spend cap through as unpinned micros", () => {
+    const budgets = leaseBudgetsFromInputs(100, "0.05");
+    expect(budgets.maxCalls).toBe(100);
+    expect(budgets.maxSpendMicros).toBe(50_000);
+    // Asset unpinned so any charged asset counts against the ceiling.
+    expect(budgets.asset).toBeNull();
+  });
+
+  it("leaves no monetary allowance when the spend cap is blank", () => {
+    const budgets = leaseBudgetsFromInputs(100, "");
+    expect(budgets.maxCalls).toBe(100);
+    expect(budgets.maxSpendMicros).toBeNull();
+  });
+
+  it("treats a zero or negative cap as no allowance", () => {
+    expect(leaseBudgetsFromInputs(50, "0").maxSpendMicros).toBeNull();
+    expect(leaseBudgetsFromInputs(50, "-1").maxSpendMicros).toBeNull();
+  });
+
+  it("floors the call count to at least one whole call", () => {
+    expect(leaseBudgetsFromInputs(0, "").maxCalls).toBe(1);
+    expect(leaseBudgetsFromInputs(3.9, "").maxCalls).toBe(3);
+  });
+
+  it("rounds fractional micros to the nearest integer", () => {
+    // 0.0000005 USDC * 1_000_000 = 0.5 micros -> rounds to 1.
+    expect(leaseBudgetsFromInputs(10, "0.0000005").maxSpendMicros).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds an optional **spend cap** to the "Approve for this task" lease editor (`ApprovalActions.tsx`), closing the one concrete §7 gap found in the #3193 epic-completion audit: the editor offered only duration + max-calls, so an interactively-granted task lease covering a **priced** publisher operation had no dollar bound — only a call-count bound — even though the lease model (`max_spend_micros`/`asset`) and slice-G metering (#3277) already support one.

## Behavior

- **Cap set** → lease granted with `maxSpendMicros = round(usdc * 1e6)`, `asset` left unpinned so any charged asset counts against the ceiling (a conservative fail-safe that escalates earlier, never mischarges).
- **Cap blank** → unchanged: no monetary allowance, so a priced call escalates rather than running unbounded.

The money-bounding conversion is a pure sibling module (`leaseBudgets.ts`) per the repo's component/logic split (matching `grouping.ts` / `composerToolbarClasses.ts`). `onApproveForTask` now hands back a `LeaseBudgets` object; all three consumers (`ApprovalRequestCard`, `ShellApproval`, `GatewayToolApproval`) thread it into `grantCapabilityLease`.

## Scope note

In the shipped reactive-per-block model the agent does not author a limit request, so "agent-requested limits" is N/A; the actionable §7 item was the missing **editable monetary limit**, which this delivers.

## Validation

- `vitest run tests/unit/lease-budgets-from-inputs.test.ts` — 5 passed (set cap → micros; blank/zero/negative → no allowance; call floor; micro rounding).
- `biome check` on all changed files — clean.
- `tsc --noEmit` — 0 errors.

Refs #3193. Closes #3327.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
