### PR TITLE
fix(security): wire derived coding bundle into shell approvals (#3331)

### DIFF
--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -10,10 +10,13 @@ import {
   Show,
 } from "solid-js";
 import { ApprovalActions } from "@/components/approvals/ApprovalActions";
+import { shellLeasePredicates } from "@/components/shell/shellLease";
 import { cancelOrchestration } from "@/services/orchestrator";
 import {
+  type CommandRule,
   grantCapabilityLease,
   type LeaseBudgets,
+  proposeCapabilityBundle,
 } from "@/services/tool-authorization";
 import { conversationStore } from "@/stores/conversation.store";
 
@@ -36,6 +39,24 @@ function commandProgram(command: string): string | null {
 export const ShellApproval: Component = () => {
   const [request, setRequest] = createSignal<ShellApprovalRequest | null>(null);
   const [isProcessing, setIsProcessing] = createSignal(false);
+  // The derived coding toolchain (cargo/pnpm/npm/node/git), owned by the host so
+  // the renderer never hard-codes it; empty until loaded / if the load fails.
+  const [toolchainRules, setToolchainRules] = createSignal<CommandRule[]>([]);
+  // Opt-in: extend a coding-command task lease to the whole toolchain. Default
+  // off — a single "Approve for this task" never silently broadens beyond the
+  // one blocked program.
+  const [coverToolchain, setCoverToolchain] = createSignal(false);
+
+  onMount(async () => {
+    // Load the host's coding toolchain once so the opt-in can offer it without
+    // the renderer defining which programs a coding lease covers.
+    try {
+      const bundle = await proposeCapabilityBundle({ profile: "coding" });
+      setToolchainRules(bundle.predicates.commandRules ?? []);
+    } catch (err) {
+      console.error("[ShellApproval] Failed to load coding toolchain:", err);
+    }
+  });
 
   onMount(async () => {
     const unlisten = await listen<ShellApprovalRequest>(
@@ -128,8 +149,25 @@ export const ShellApproval: Component = () => {
     return req ? commandProgram(req.command) : null;
   };
 
+  /** Whether the blocked program is part of the host's coding toolchain — i.e. the
+   * opt-in to extend the lease to the whole toolchain is meaningful. */
+  const isCodingToolchain = () => {
+    const program = leaseProgram();
+    return (
+      program !== null && toolchainRules().some((r) => r.program === program)
+    );
+  };
+
+  const toolchainNames = () =>
+    toolchainRules()
+      .map((r) => r.program)
+      .join(", ");
+
   const leaseSummary = () => {
     const program = leaseProgram();
+    if (coverToolchain() && isCodingToolchain()) {
+      return `coding toolchain commands (${toolchainNames()})`;
+    }
     return program ? `"${program}" commands` : "this command";
   };
 
@@ -154,9 +192,9 @@ export const ShellApproval: Component = () => {
       try {
         await grantCapabilityLease(
           conversationId,
-          `Task lease: "${program}" commands`,
+          `Task lease: ${leaseSummary()}`,
           durationSecs,
-          { commandRules: [{ program }] },
+          shellLeasePredicates(program, coverToolchain(), toolchainRules()),
           budgets,
         );
       } catch (err) {
@@ -203,6 +241,28 @@ export const ShellApproval: Component = () => {
                 <strong>Warning:</strong> This command will execute on your
                 machine. Review it carefully before approving.
               </div>
+
+              <Show when={isCodingToolchain()}>
+                <label class="mt-4 flex items-start gap-2 text-[0.85rem] text-muted-foreground cursor-pointer">
+                  <input
+                    type="checkbox"
+                    class="mt-0.5"
+                    checked={coverToolchain()}
+                    onChange={(event) =>
+                      setCoverToolchain(event.currentTarget.checked)
+                    }
+                    disabled={isProcessing()}
+                  />
+                  <span>
+                    When approving for this task, cover the whole coding
+                    toolchain ({toolchainNames()}) instead of just{" "}
+                    <span class="font-[var(--font-mono)]">
+                      {leaseProgram()}
+                    </span>
+                    , so a coding run does not re-prompt on each tool.
+                  </span>
+                </label>
+              </Show>
             </div>
 
             <ApprovalActions

--- a/src/components/shell/shellLease.ts
+++ b/src/components/shell/shellLease.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Pure predicate selection for a shell "Approve for this task" lease:
+// ABOUTME: single blocked program by default, or the full derived coding toolchain when opted in.
+
+import type {
+  CommandRule,
+  LeasePredicates,
+} from "@/services/tool-authorization";
+
+/**
+ * The command-rule predicates to grant when a user approves a shell command for
+ * the whole task. The default is the single blocked `program` — the conservative
+ * subset of intent, matching the gate's leading-program key. When the user opts
+ * in (`coverToolchain`) and the program is part of the derived coding toolchain
+ * (`toolchainRules`, sourced once from the host so the renderer never hard-codes
+ * it), the lease instead covers the whole toolchain so a coding task does not
+ * re-escalate on every distinct program. An off toggle, or a program outside the
+ * toolchain, always yields the single-program rule — the default is never
+ * silently broadened.
+ */
+export function shellLeasePredicates(
+  program: string,
+  coverToolchain: boolean,
+  toolchainRules: CommandRule[],
+): LeasePredicates {
+  const inToolchain = toolchainRules.some((rule) => rule.program === program);
+  if (coverToolchain && inToolchain) {
+    return { commandRules: toolchainRules };
+  }
+  return { commandRules: [{ program }] };
+}

--- a/src/services/tool-authorization.ts
+++ b/src/services/tool-authorization.ts
@@ -139,6 +139,32 @@ export interface ProposedBundle {
   budgets: LeaseBudgets;
 }
 
+/** Mirrors `BundleRequest` in `src-tauri/src/capability_lease.rs`. */
+export interface BundleRequest {
+  /** `"coding"` seeds the workspace toolchain; any other value seeds nothing. */
+  profile?: string;
+  extraCommands?: string[];
+  publisherOps?: PublisherRule[];
+  networkHosts?: string[];
+  exclusions?: LeaseExclusion[];
+  durationSecs?: number;
+  maxCalls?: number | null;
+  maxSpendMicros?: number | null;
+  asset?: string | null;
+}
+
+/**
+ * Derive a reviewable, editable capability proposal for a task profile — the
+ * host owns the toolchain definition (e.g. the coding programs), so the renderer
+ * never hard-codes it. Pure and side-effect-free: it grants nothing until a
+ * user approves the proposal via `grantCapabilityLease`.
+ */
+export async function proposeCapabilityBundle(
+  request: BundleRequest,
+): Promise<ProposedBundle> {
+  return invoke<ProposedBundle>("propose_capability_bundle", { request });
+}
+
 /** Mirrors `StandingPolicy` in `src-tauri/src/standing_policy.rs`. */
 export interface StandingPolicy {
   id: string;

--- a/tests/unit/shell-lease-predicates.test.ts
+++ b/tests/unit/shell-lease-predicates.test.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Guards the shell approve-for-task predicate selection: single blocked
+// ABOUTME: program by default, full toolchain only when explicitly opted in.
+
+import { describe, expect, it } from "vitest";
+import { shellLeasePredicates } from "@/components/shell/shellLease";
+
+const TOOLCHAIN = [
+  { program: "cargo" },
+  { program: "pnpm" },
+  { program: "npm" },
+  { program: "node" },
+  { program: "git" },
+];
+
+describe("shellLeasePredicates", () => {
+  it("grants only the blocked program when the toolchain opt-in is off", () => {
+    const predicates = shellLeasePredicates("cargo", false, TOOLCHAIN);
+    expect(predicates.commandRules).toEqual([{ program: "cargo" }]);
+  });
+
+  it("grants the whole toolchain when opted in for a toolchain program", () => {
+    const predicates = shellLeasePredicates("cargo", true, TOOLCHAIN);
+    expect(predicates.commandRules).toEqual(TOOLCHAIN);
+  });
+
+  it("never broadens beyond the single program for a non-toolchain command", () => {
+    const predicates = shellLeasePredicates("rm", true, TOOLCHAIN);
+    expect(predicates.commandRules).toEqual([{ program: "rm" }]);
+  });
+
+  it("falls back to the single program when the toolchain failed to load", () => {
+    const predicates = shellLeasePredicates("cargo", true, []);
+    expect(predicates.commandRules).toEqual([{ program: "cargo" }]);
+  });
+});


### PR DESCRIPTION
## What

Wires the previously **dead-wired** `derive_bundle` / `propose_capability_bundle` (§3) into the renderer, closing the epic-completion residual. `propose_capability_bundle` was implemented, registered, and unit-tested but had no caller, so the "review the derived task bundle" path never ran and the live shell "Approve for this task" granted a **single program per block** — a coding agent re-escalated once per distinct program (`cargo`, then `pnpm`, then `git`, …).

## Change

- `proposeCapabilityBundle` added to `src/services/tool-authorization.ts`.
- `ShellApproval` loads the host's coding toolchain once (`proposeCapabilityBundle({ profile: "coding" })`) and, when the blocked program is part of it, shows an **opt-in checkbox (default off)** to extend the task lease to the whole toolchain (`cargo`, `pnpm`, `npm`, `node`, `git`). The program list stays defined once in Rust.

## Security-default note (flagging explicitly)

The single-program grant remains the **default**. The toolchain lease is granted **only** when the user checks the box; the editor summary names exactly what is covered ("coding toolchain commands (cargo, pnpm, npm, node, git)"); and "Approve once" remains for single use. This deliberately does **not** silently broaden what a shell approval grants — I kept it opt-in precisely because the epic's thesis is tight authorization. If you'd prefer it default-on for coding agents, that's a one-line follow-up.

## Validation

- `vitest run tests/unit/shell-lease-predicates.test.ts` — **4 passed** (off; opted-in toolchain; non-toolchain command stays single; toolchain-load-failure falls back to single).
- `biome check` clean; `tsc --noEmit` — 0 errors.

Predicate selection is a pure helper (`shellLease.ts`) so the money/scope-bounding branch is testable without rendering the component (repo's component/logic split).

Refs #3193. Closes #3331.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
