### PR TITLE
test(security): gateway/MCP entrypoint dispatch refusal (#3333)

### DIFF
--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -112,8 +112,8 @@ fn publisher_dispatch_target(url: &Url) -> Option<(String, String)> {
 /// live host-minted handle for the exact publisher, tool, and body payload —
 /// the same rule the MCP transport enforces, so neither wire shape can be used
 /// to skip the authorization gate.
-fn enforce_publisher_dispatch(
-    app: &AppHandle,
+fn enforce_publisher_dispatch<R: tauri::Runtime>(
+    app: &AppHandle<R>,
     url: &Url,
     body: Option<&str>,
     auth_handle: Option<&str>,
@@ -463,5 +463,69 @@ mod tests {
         // so /auth/refresh does not loop into itself.
         let refresh = Url::parse("https://api.serendb.com/auth/refresh").unwrap();
         assert!(!should_attach_stored_auth(&refresh, &no_auth_headers, true));
+    }
+
+    fn mock_app_with_authorization() -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+        app.manage(crate::tool_authorization::ToolAuthorizationState::new(
+            std::path::PathBuf::from(":memory:"),
+        ));
+        app
+    }
+
+    /// #3193-F: the gateway HTTP bridge refuses a publisher tool dispatch unless a
+    /// live host-minted handle matches the exact publisher, tool, and body — the
+    /// same rule proven at the shared consume path, here driven through the bridge's
+    /// own enforcement entrypoint (the one `gateway_http_start` calls before any
+    /// network request leaves the process).
+    #[test]
+    fn publisher_dispatch_refuses_missing_forged_and_mismatched_handles() {
+        use crate::tool_authorization::{
+            ToolAuthorizationState, ToolRoute, binding_for_publisher_args,
+        };
+
+        let app = mock_app_with_authorization();
+        let url =
+            Url::parse("https://api.serendb.com/publishers/gmail/_mcp/tools/post_send").unwrap();
+        let body = r#"{"to":"a@example.com"}"#;
+        let args: serde_json::Value = serde_json::from_str(body).unwrap();
+        let mint = |tool: &str, args: &serde_json::Value| {
+            app.state::<ToolAuthorizationState>()
+                .mint_dispatch_handle_for_test(
+                    ToolRoute::Gateway,
+                    "gmail",
+                    tool,
+                    &binding_for_publisher_args(args),
+                )
+                .expect("test handle mints")
+        };
+
+        // A missing or forged handle refuses the dispatch.
+        assert!(enforce_publisher_dispatch(app.handle(), &url, Some(body), None).is_err());
+        assert!(
+            enforce_publisher_dispatch(app.handle(), &url, Some(body), Some("not-a-real-handle"))
+                .is_err()
+        );
+
+        // A handle minted for a different tool, or a different body, cannot be
+        // redeemed for this exact call.
+        let wrong_tool = mint("get_messages", &args);
+        assert!(
+            enforce_publisher_dispatch(app.handle(), &url, Some(body), Some(&wrong_tool)).is_err()
+        );
+        let wrong_body = mint("post_send", &serde_json::json!({"to":"someone-else@example.com"}));
+        assert!(
+            enforce_publisher_dispatch(app.handle(), &url, Some(body), Some(&wrong_body)).is_err()
+        );
+
+        // The exact matching handle redeems.
+        let good = mint("post_send", &args);
+        assert!(enforce_publisher_dispatch(app.handle(), &url, Some(body), Some(&good)).is_ok());
+
+        // A non-publisher Gateway path is app-level API traffic and needs no handle.
+        let api = Url::parse("https://api.serendb.com/projects").unwrap();
+        assert!(enforce_publisher_dispatch(app.handle(), &api, None, None).is_ok());
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1102,6 +1102,87 @@ mod dispatch_identity_tests {
 }
 
 #[cfg(test)]
+mod dispatch_enforcement_tests {
+    use super::*;
+    use crate::tool_authorization::{
+        ToolAuthorizationState, ToolRoute, binding_for_publisher_args,
+    };
+
+    fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+        app.manage(McpState::default());
+        app.manage(ToolAuthorizationState::new(std::path::PathBuf::from(
+            ":memory:",
+        )));
+        app
+    }
+
+    /// #3193-F: the stdio MCP transport redeems a dispatch handle before it ever
+    /// looks up the server slot, so a call that skipped the gate (no handle) or a
+    /// handle minted for a different tool is refused at the command entrypoint —
+    /// no child process is reached. Driven through `mcp_call_tool` itself so the
+    /// wrapper's enforcement is proven, not only the shared consume path.
+    #[tokio::test]
+    async fn mcp_call_tool_refuses_missing_forged_and_mismatched_handles() {
+        let app = mock_app();
+        let args = serde_json::json!({ "q": "hello" });
+
+        // No handle → refuse before any server lookup.
+        assert!(
+            mcp_call_tool(
+                app.state(),
+                app.state(),
+                "srv".into(),
+                "search".into(),
+                args.clone(),
+                None,
+            )
+            .await
+            .is_err()
+        );
+
+        // Forged handle → refuse.
+        assert!(
+            mcp_call_tool(
+                app.state(),
+                app.state(),
+                "srv".into(),
+                "search".into(),
+                args.clone(),
+                Some("not-a-real-handle".into()),
+            )
+            .await
+            .is_err()
+        );
+
+        // A handle minted for a different tool cannot be redeemed for this one.
+        let wrong_tool = app
+            .state::<ToolAuthorizationState>()
+            .mint_dispatch_handle_for_test(
+                ToolRoute::Mcp,
+                "srv",
+                "other_tool",
+                &binding_for_publisher_args(&args),
+            )
+            .expect("test handle mints");
+        assert!(
+            mcp_call_tool(
+                app.state(),
+                app.state(),
+                "srv".into(),
+                "search".into(),
+                args.clone(),
+                Some(wrong_tool),
+            )
+            .await
+            .is_err()
+        );
+    }
+}
+
+#[cfg(test)]
 #[cfg(unix)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds command-entrypoint refusal tests for the gateway HTTP and stdio MCP transports (slice F, #3276) — the two side-effecting wrappers whose handle enforcement previously rested on code-read verification (shell/skill already had entrypoint tests).

- **gateway_http**: `enforce_publisher_dispatch` made generic over the Tauri runtime so a mock app can drive it; asserts no-handle / forged / wrong-tool / wrong-body refuse and the exact matching handle redeems, against a real `ToolAuthorizationState` + real host-minted handles. This is the function `gateway_http_start` calls before any request leaves the process.
- **mcp**: drives `mcp_call_tool` (consumes the handle before `lookup_slot`, so no child is reached) with no-handle / forged / mismatched-tool and asserts refusal.

No mocks of the layer that can fail — real store, real handles.

**Scope note:** the frontend `escalate -> requireApproval` glue is intentionally not covered here — exercising it requires a mocked 402 + mocked reserve outcome, i.e. testing mocked behavior (which CLAUDE.md forbids). The real escalate decision is proven host-side against real SQLite (`over_budget_priced_call_escalates_without_charging`); the x402 charge parser has its own test.

`cargo test -- commands::gateway_http:: mcp::dispatch` — 10 passed, 0 failed.

Refs #3193. Closes #3333.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com