### PR TITLE
fix(security): remove dead ungated web/shell arms in chat worker (#3335)

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1389,7 +1389,7 @@ created if missing.",
         let Ok(arguments) = serde_json::to_string(&args) else {
             return ("Failed to serialize authorized file operation.".to_string(), true);
         };
-        Self::execute_tool_with_app(Some(app), name, &arguments).await
+        Self::execute_local_tool(name, &arguments).await
     }
 
     /// Track repeated identical parse-error tool calls within a single
@@ -1517,16 +1517,14 @@ created if missing.",
     /// Returns (result_content, is_error).
     #[cfg(test)]
     async fn execute_tool(name: &str, arguments: &str) -> (String, bool) {
-        Self::execute_tool_with_app(None, name, arguments).await
+        Self::execute_local_tool(name, arguments).await
     }
 
-    /// Execute a local tool with app context when secure storage is needed.
+    /// Execute a local file tool by name. Only the project-root-gated file tools
+    /// run in this loop; every side-effecting tool routes to the frontend where
+    /// the host gate mints and the transport enforces a dispatch handle (#3193-F).
     /// Returns (result_content, is_error).
-    async fn execute_tool_with_app(
-        app: Option<&tauri::AppHandle>,
-        name: &str,
-        arguments: &str,
-    ) -> (String, bool) {
+    async fn execute_local_tool(name: &str, arguments: &str) -> (String, bool) {
         let args: serde_json::Value = match serde_json::from_str(arguments) {
             Ok(v) => v,
             Err(e) => {
@@ -1611,66 +1609,11 @@ created if missing.",
                     Err(e) => (e, true),
                 }
             }
-            "seren_web_fetch" => {
-                let url = args["url"].as_str().unwrap_or("").to_string();
-                if url.is_empty() {
-                    return ("Missing required parameter: url".to_string(), true);
-                }
-                let timeout_ms = args["timeout_ms"].as_u64();
-                match crate::commands::web::fetch_web_content(url, timeout_ms).await {
-                    Ok(fetch_result) => (fetch_result.content, false),
-                    Err(e) => (e, true),
-                }
-            }
-            "execute_command" => {
-                let command = args["command"].as_str().unwrap_or("").to_string();
-                if command.is_empty() {
-                    return ("Missing required parameter: command".to_string(), true);
-                }
-                let timeout_secs = args["timeout_secs"].as_u64();
-                let inject_seren_credentials =
-                    args.get("inject_seren_credentials").and_then(|v| v.as_bool());
-                let command_result = if let Some(app) = app {
-                    crate::shell::execute_shell_command_for_tool(
-                        app,
-                        command,
-                        timeout_secs,
-                        inject_seren_credentials,
-                    )
-                    .await
-                } else {
-                    crate::shell::execute_shell_command_without_seren_credentials(
-                        command,
-                        timeout_secs,
-                    )
-                    .await
-                };
-                match command_result {
-                    Ok(cmd_result) => {
-                        let mut output = String::new();
-                        if !cmd_result.stdout.is_empty() {
-                            output.push_str(&cmd_result.stdout);
-                        }
-                        if !cmd_result.stderr.is_empty() {
-                            if !output.is_empty() {
-                                output.push('\n');
-                            }
-                            output.push_str("stderr: ");
-                            output.push_str(&cmd_result.stderr);
-                        }
-                        if cmd_result.timed_out {
-                            output = format!("Command timed out.\n{}", output);
-                        }
-                        if output.is_empty() {
-                            output = "(no output)".to_string();
-                        }
-                        let is_error =
-                            cmd_result.timed_out || cmd_result.exit_code.map_or(true, |c| c != 0);
-                        (output, is_error)
-                    }
-                    Err(e) => (e, true),
-                }
-            }
+            // `seren_web_fetch` (open-world egress) and `execute_command` are
+            // deliberately absent here: they are not `is_local_tool`, so the
+            // dispatcher routes them to the frontend where the host gate mints and
+            // the transport enforces a dispatch handle (#3193-F). Executing them in
+            // this loop would bypass that gate, so an unrecognized name fails closed.
             _ => (
                 format!("Tool '{}' is not available in chat mode", name),
                 true,
@@ -2103,7 +2046,7 @@ impl Worker for ChatModelWorker {
                                 Err(message) => (message.clone(), true),
                             }
                         } else if Self::is_local_tool(&tc.name) {
-                            Self::execute_tool_with_app(Some(app), &tc.name, &tc.arguments).await
+                            Self::execute_local_tool(&tc.name, &tc.arguments).await
                         } else {
                             // Route non-local tools (gateway__, mcp__)
                             // to the frontend for execution via the tool bridge.

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -234,26 +234,6 @@ pub async fn execute_shell_command_streaming<R: Runtime>(
     result
 }
 
-/// Execute an AI tool shell command with optional stored Seren auth injection.
-///
-/// `inject_seren_credentials = None` uses the same narrow auto-detect policy as
-/// the Tauri command so skill-local commands keep working without exposing the
-/// key to ordinary commands such as `ls`.
-pub async fn execute_shell_command_for_tool<R: Runtime>(
-    app: &AppHandle<R>,
-    command: String,
-    timeout_secs: Option<u64>,
-    inject_seren_credentials: Option<bool>,
-) -> Result<CommandResult, String> {
-    let api_key = if should_inject_seren_credentials(&command, inject_seren_credentials) {
-        read_stored_seren_api_key(app)?
-    } else {
-        None
-    };
-
-    execute_shell_command_inner(command, timeout_secs, api_key.as_deref(), None).await
-}
-
 pub async fn execute_shell_command_without_seren_credentials(
     command: String,
     timeout_secs: Option<u64>,


### PR DESCRIPTION
Removes the transport-free \`seren_web_fetch\` and \`execute_command\` arms from \`ChatModelWorker::execute_tool_with_app\` — a latent #3193-F hole. They ran the side effect without redeeming a dispatch handle, and were unreachable only because the dispatcher routes just \`is_local_tool\` (file) names here; adding either to \`is_local_tool\` would have made them an ungated data-egress / shell-exec path.

- Both arms removed -> an unrecognized name now fails closed ("not available in chat mode").
- This orphaned \`shell::execute_shell_command_for_tool\` (its only caller) and left the function's \`app\` param unused; removed both and renamed \`execute_tool_with_app\` -> \`execute_local_tool\` to match what it now does (local file tools only).
- \`fetch_web_content\` and \`execute_shell_command_without_seren_credentials\` stay (used elsewhere).

The existing \`is_local_tool\` regression tests already prove those names never reach this path; kept green.

\`cargo test chat_model_worker shell::\` — 73 passed, 0 failed; \`cargo check\` clean.

Refs #3193. Closes #3335.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com