### PR TITLE
fix(security): rate lease budget; defer data-egress (#3338)

### DIFF
--- a/src-tauri/src/capability_lease.rs
+++ b/src-tauri/src/capability_lease.rs
@@ -89,13 +89,44 @@ pub struct LeaseBudgets {
     pub spend_used_micros: u64,
     #[serde(default)]
     pub asset: Option<String>,
+    /// Rate limit: at most `max_calls_per_window` covered calls within each
+    /// rolling `window_secs` window. Both must be set for the limit to apply.
+    /// Bounds a runaway autonomous loop even under an approved lease, on top of
+    /// the total `max_calls` ceiling.
+    #[serde(default)]
+    pub max_calls_per_window: Option<u64>,
+    #[serde(default)]
+    pub window_secs: Option<i64>,
+    /// End instant (RFC3339 UTC) of the current window, or `None` before the
+    /// first call opens one. A call arriving after this instant opens a fresh
+    /// window, so an idle lease is never permanently rate-blocked.
+    #[serde(default)]
+    pub window_ends_at: Option<String>,
+    #[serde(default)]
+    pub calls_in_window: u64,
+    // Data-egress budget (max outbound bytes under this lease) is intentionally
+    // not implemented: no consumer authors a byte budget today, and enforcing it
+    // needs an `egress_bytes` measure threaded onto `OperationRequest`. Deferred
+    // to serenorg/seren-desktop#3337 until a consumer needs it (YAGNI).
 }
 
 impl LeaseBudgets {
-    /// Whether charging `cost_micros` for one more call stays within budget.
-    fn admits(&self, cost_micros: u64) -> bool {
+    /// Whether charging `cost_micros` for one more call at `now` stays within
+    /// budget. `now` is an RFC3339 UTC instant, compared lexicographically
+    /// against the rate window's end.
+    fn admits(&self, cost_micros: u64, now: &str) -> bool {
         if let Some(max) = self.max_calls
             && self.calls_used.saturating_add(1) > max
+        {
+            return false;
+        }
+        // Rate window: only enforce while the current window is still open. A
+        // window with no end (never opened) or one already closed does not block
+        // — the charge opens a fresh window for that call.
+        if let Some(max_per_window) = self.max_calls_per_window
+            && let Some(window_ends_at) = &self.window_ends_at
+            && now < window_ends_at.as_str()
+            && self.calls_in_window.saturating_add(1) > max_per_window
         {
             return false;
         }
@@ -364,7 +395,7 @@ pub fn evaluate_for_conversation(
 
     // First lease that both covers the call and has budget for it.
     for lease in &active {
-        if predicates_cover(lease, req) && lease.budgets.admits(req.cost_micros) {
+        if predicates_cover(lease, req) && lease.budgets.admits(req.cost_micros, now) {
             return LeaseOutcome::Allow(lease.id.clone());
         }
     }
@@ -538,6 +569,7 @@ pub fn derive_bundle(request: &BundleRequest) -> ProposedBundle {
         max_spend_micros: request.max_spend_micros,
         spend_used_micros: 0,
         asset: request.asset.clone(),
+        ..Default::default()
     };
 
     let label = if request.profile == "coding" {
@@ -925,11 +957,58 @@ mod tests {
             max_spend_micros: Some(10_000_000),
             spend_used_micros: 0,
             asset: Some("USDC".to_string()),
+            ..Default::default()
         };
-        assert!(!budgets.admits(1_000_000), "call budget is exhausted");
+        assert!(
+            !budgets.admits(1_000_000, "2026-07-25T00:00:00Z"),
+            "call budget is exhausted"
+        );
         assert!(
             budgets.admits_spend(1_000_000, "USDC"),
             "spend admission ignores the call budget",
+        );
+    }
+
+    #[test]
+    fn rate_window_admits_to_the_cap_then_blocks_until_it_closes() {
+        let now = "2026-07-25T00:00:00Z";
+        // A window of 3 that is still open at `now` and has seen 2 calls admits the
+        // 3rd but blocks the 4th.
+        let two_used = LeaseBudgets {
+            max_calls: Some(500),
+            max_calls_per_window: Some(3),
+            window_secs: Some(60),
+            window_ends_at: Some("2026-07-25T00:01:00Z".to_string()),
+            calls_in_window: 2,
+            ..Default::default()
+        };
+        assert!(two_used.admits(0, now), "3rd call in a window of 3 is admitted");
+
+        let saturated = LeaseBudgets {
+            calls_in_window: 3,
+            ..two_used.clone()
+        };
+        assert!(
+            !saturated.admits(0, now),
+            "4th call in a window of 3 is blocked"
+        );
+
+        // The same saturated window, but `now` is past its end → a fresh window
+        // opens, so an idle lease is never permanently rate-blocked.
+        assert!(
+            saturated.admits(0, "2026-07-25T00:02:00Z"),
+            "a call after the window closes is admitted"
+        );
+
+        // A per-window cap with no window ever opened does not block the first call.
+        let unopened = LeaseBudgets {
+            max_calls_per_window: Some(1),
+            window_secs: Some(60),
+            ..Default::default()
+        };
+        assert!(
+            unopened.admits(0, now),
+            "the first call opens the window rather than being blocked"
         );
     }
 

--- a/src-tauri/src/standing_policy.rs
+++ b/src-tauri/src/standing_policy.rs
@@ -61,6 +61,12 @@ fn fresh_budgets(budgets: &LeaseBudgets) -> LeaseBudgets {
         max_spend_micros: budgets.max_spend_micros,
         spend_used_micros: 0,
         asset: budgets.asset.clone(),
+        // The policy's rate limit carries over, with a fresh (unopened) window
+        // so each conversation gets the policy's full per-window allowance.
+        max_calls_per_window: budgets.max_calls_per_window,
+        window_secs: budgets.window_secs,
+        window_ends_at: None,
+        calls_in_window: 0,
     }
 }
 
@@ -112,6 +118,7 @@ mod tests {
                 max_spend_micros: Some(5_000_000),
                 spend_used_micros: 777,
                 asset: Some("USDC".to_string()),
+                ..Default::default()
             },
             created_at: "2026-07-24T00:00:00Z".to_string(),
             updated_at: "2026-07-24T00:00:00Z".to_string(),

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -987,6 +987,24 @@ impl ToolAuthorizationState {
                                 .spend_used_micros
                                 .saturating_add(request.cost_micros);
                         }
+                        // Rate window: increment the in-window count while the
+                        // window is open, or open a fresh one for this call once it
+                        // has closed (the admit check already allowed it).
+                        if let Some(window_secs) = lease.budgets.window_secs {
+                            let window_open = lease
+                                .budgets
+                                .window_ends_at
+                                .as_deref()
+                                .is_some_and(|end| now.as_str() < end);
+                            if window_open {
+                                lease.budgets.calls_in_window =
+                                    lease.budgets.calls_in_window.saturating_add(1);
+                            } else {
+                                lease.budgets.window_ends_at =
+                                    Some(timestamp_plus_seconds(conn, window_secs.max(1))?);
+                                lease.budgets.calls_in_window = 1;
+                            }
+                        }
                         write_lease(conn, &lease)?;
                         audit(
                             conn,
@@ -2627,6 +2645,64 @@ mod tests {
             .unwrap();
         assert_eq!(decision.decision, "prompt");
         assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+    }
+
+    /// §3 rate budget: a lease capped at N calls per rolling window runs N
+    /// silently, then escalates once while the window is still open — a runaway
+    /// loop is bounded even under an approved lease. Driven through the real gate
+    /// and store; the on-disk window counter reflects only the charged calls.
+    #[test]
+    fn rate_limited_lease_escalates_after_the_per_window_cap() {
+        let s = state();
+        s.grant_lease(
+            "conv-a",
+            "rate-limited",
+            4 * 3600,
+            command_rules(&["cargo"]),
+            LeaseBudgets {
+                max_calls: Some(500),
+                max_calls_per_window: Some(3),
+                window_secs: Some(3600),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        for i in 0..3 {
+            let decision = s
+                .authorize(
+                    ToolRoute::Shell,
+                    "seren",
+                    "execute_command",
+                    "conv-a",
+                    &cmd_ctx("cargo build"),
+                    None,
+                )
+                .unwrap();
+            assert_eq!(
+                decision.decision, "allow",
+                "call {i} within the per-window cap runs silently"
+            );
+        }
+
+        // The 4th call in the same window exceeds the rate cap → one escalation.
+        let decision = s
+            .authorize(
+                ToolRoute::Shell,
+                "seren",
+                "execute_command",
+                "conv-a",
+                &cmd_ctx("cargo build"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(decision.decision, "prompt");
+        assert_eq!(decision.prompt_kind.as_deref(), Some("one-shot"));
+
+        // Only the 3 admitted calls are charged; the escalated one is not.
+        let updated = s.list_leases("conv-a").unwrap().into_iter().next().unwrap();
+        assert_eq!(updated.budgets.calls_in_window, 3);
+        assert_eq!(updated.budgets.calls_used, 3);
     }
 
     /// A shell command outside the lease's command rules is not covered and

--- a/src/services/tool-authorization.ts
+++ b/src/services/tool-authorization.ts
@@ -39,6 +39,12 @@ export interface LeaseBudgets {
   maxSpendMicros?: number | null;
   spendUsedMicros?: number;
   asset?: string | null;
+  /** Rate limit: at most `maxCallsPerWindow` covered calls per rolling
+   * `windowSecs` window. Both must be set for the limit to apply. */
+  maxCallsPerWindow?: number | null;
+  windowSecs?: number | null;
+  windowEndsAt?: string | null;
+  callsInWindow?: number;
 }
 
 /** Mirrors `CapabilityLease` in `src-tauri/src/capability_lease.rs`. */


### PR DESCRIPTION
Adds the **rate** dimension to the §3 lease budget model (the last non-monetary/call-count budget), and formally **defers data-egress** to #3337 with a documented rationale — closing the final #3193 residual.

## Rate budget

\`LeaseBudgets\` gains \`max_calls_per_window\` + \`window_secs\` + \`window_ends_at\` + \`calls_in_window\`:

- \`admits(cost, now)\` enforces the per-window cap **only while the window is open**; a call after the window closes opens a fresh one, so an idle lease is never permanently rate-blocked.
- \`evaluate_and_charge_leases\` increments the in-window counter or opens a new window (\`timestamp_plus_seconds\`).
- **Standing policies** carry their rate limit into each materialized lease with a fresh window (\`fresh_budgets\`) — the owner-authoring path, so this is not dead enforcement.
- New fields are \`#[serde(default)]\` → existing persisted lease JSON deserializes unchanged (no migration).

Bounds a runaway autonomous loop even under an approved lease, on top of the total call-count ceiling.

## Data-egress: deferred → #3337

Documented in \`capability_lease.rs\`. No consumer authors a byte budget today, and enforcing it needs an \`egress_bytes\` measure threaded onto \`OperationRequest\` from \`authorize()\` — speculative until a consumer needs it (repo YAGNI rule). Tracked as its own ticket.

## Validation

- Pure \`admits\` window behavior (under cap allows, at cap blocks, after close a fresh window allows, unopened first call allows).
- Real-gate integration: 3 silent calls then the 4th escalates once; on-disk counters reflect only the 3 charged calls.
- \`cargo test tool_authorization capability_lease standing_policy authorization_audit\` — **119 passed, 0 failed**; biome + tsc clean.

Refs #3193. Closes #3338.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com