### PR TITLE
test(validation): signed-in walkthrough scenarios (#3353)

### DIFF
--- a/tests/validation/scenarios/signed-in-gate-drive.ts
+++ b/tests/validation/scenarios/signed-in-gate-drive.ts
@@ -1,0 +1,180 @@
+// ABOUTME: Signed-in attempt to drive a real authorization-gate suspension and approval card.
+// ABOUTME: Best-effort: captures the approval surface or the agent's response either way.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+import { submitSignIn } from "./signed-in-smoke";
+
+interface TextDump {
+  text?: string;
+}
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? ((value as TextDump).text as string)
+    : JSON.stringify(value);
+}
+
+async function present(
+  client: ScenarioContext["client"],
+  selector: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    await client.waitFor(selector, timeoutMs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Any of the approval surfaces the gate can raise: the inline card's
+// "Approve for this task" button, the shell/gateway modal's same control, or the
+// card container. All share these title/class hooks.
+const APPROVAL_SELECTORS = [
+  "button[title='Pre-approve matching actions for this task, with limits you set']",
+  "[class*='border-warning/40']",
+  "button[title='Deny this action; the agent adapts and continues']",
+];
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const email = process.env.SEREN_VALIDATION_AGENT_EMAIL;
+  const password = process.env.SEREN_VALIDATION_AGENT_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "SEREN_VALIDATION_AGENT_EMAIL and SEREN_VALIDATION_AGENT_PASSWORD must be set",
+    );
+  }
+
+  // The validation home is reused across runs (keyed by port), so a prior run's
+  // session may already be signed in. Only drive the sign-in form if the
+  // auth-gated balance control is not already present.
+  const alreadySignedIn = await present(
+    ctx.client,
+    "button[aria-label^='SerenBucks balance']",
+    8_000,
+  );
+  if (!alreadySignedIn) {
+    await submitSignIn(ctx.client, email, password);
+    if (
+      !(await present(
+        ctx.client,
+        "button[aria-label^='SerenBucks balance']",
+        20_000,
+      ))
+    ) {
+      throw new Error("Sign-in did not complete");
+    }
+  }
+
+  // Open a general Seren chat (has tool access signed-in).
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 15_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  const sawSerenChat = await present(
+    ctx.client,
+    "[data-testid='new-seren-chat']",
+    10_000,
+  );
+  if (sawSerenChat) await ctx.client.click("[data-testid='new-seren-chat']");
+  await ctx.writeArtifact(
+    "after-new-chat.json",
+    await ctx.client.dumpText("body"),
+  );
+
+  // Send a prompt that should drive a gated tool call (shell = always high-risk).
+  const composer = await present(
+    ctx.client,
+    ".chat-composer-form textarea",
+    20_000,
+  );
+  await ctx.writeArtifact("composer-present.json", { composer });
+  if (composer) {
+    await ctx.client.fill(
+      ".chat-composer-form textarea",
+      "Run this shell command with your execute_command tool: echo hello-from-validation",
+    );
+    await ctx.client.click(".chat-composer-form button[type='submit']");
+  }
+
+  // Poll for any approval surface for up to ~2 minutes (agent turn + tool call).
+  let approvalSeen = false;
+  for (let i = 0; i < 8 && !approvalSeen; i++) {
+    for (const selector of APPROVAL_SELECTORS) {
+      if (await present(ctx.client, selector, 15_000)) {
+        approvalSeen = true;
+        break;
+      }
+    }
+  }
+
+  const body = textOf(await ctx.client.dumpText("body"));
+  await ctx.writeArtifact("gate-drive-body.json", { text: body });
+  await ctx.writeArtifact(
+    "gate-drive-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+  await ctx.writeArtifact(
+    "gate-drive-native-screenshot.json",
+    await ctx.client.nativeScreenshot(),
+  );
+
+  let leaseEditorShown = false;
+  let leaseGranted = false;
+  let secondPromptAfterGrant = false;
+  let commandOutputSeen = false;
+  if (approvalSeen) {
+    // Open the "Approve for this task" editor — validates the lease controls
+    // (duration / max-calls / spend-cap) render live.
+    await ctx.client
+      .click(
+        "button[title='Pre-approve matching actions for this task, with limits you set']",
+      )
+      .catch(() => undefined);
+    leaseEditorShown = await present(ctx.client, "[class*='bg-accent']", 5_000);
+    const editorBody = textOf(await ctx.client.dumpText("body"));
+    await ctx.writeArtifact("lease-editor-body.json", { text: editorBody });
+    await ctx.writeArtifact(
+      "lease-editor-screenshot.json",
+      await ctx.client.screenshot("body"),
+    );
+
+    // Grant the lease: in DOM order the editor's "Grant & approve" (bg-accent)
+    // renders before the "Approve once" (bg-accent) action button.
+    await ctx.client.click("[class*='bg-accent']").catch(() => undefined);
+    leaseGranted = true;
+
+    // The command line queued TWO identical execute_command calls. Under the
+    // granted "echo" lease the second must run silently (no second card). Poll
+    // ~90s for the echo output and watch for any re-prompt.
+    for (let i = 0; i < 6; i++) {
+      const b = textOf(await ctx.client.dumpText("body"));
+      if (b.includes("hello-from-validation")) commandOutputSeen = true;
+      if (b.includes("Confirm Shell Command")) secondPromptAfterGrant = true;
+      // ~15s pace between polls (waitFor on an absent selector is a bounded wait).
+      await present(ctx.client, "[data-nonexistent-poll-delay]", 15_000);
+    }
+    await ctx.writeArtifact(
+      "post-grant-body.json",
+      await ctx.client.dumpText("body"),
+    );
+    await ctx.writeArtifact(
+      "post-grant-screenshot.json",
+      await ctx.client.screenshot("body"),
+    );
+    await ctx.writeArtifact(
+      "post-grant-native-screenshot.json",
+      await ctx.client.nativeScreenshot(),
+    );
+  }
+
+  await ctx.writeArtifact("gate-drive-result.json", {
+    signedIn: true,
+    serenChatOpened: sawSerenChat,
+    composerPresent: composer,
+    approvalSurfaceSeen: approvalSeen,
+    leaseEditorShown,
+    leaseGranted,
+    commandOutputSeen,
+    secondPromptAfterGrant,
+    silentReuseUnderLease: leaseGranted && commandOutputSeen && !secondPromptAfterGrant,
+  });
+}

--- a/tests/validation/scenarios/signed-in-smoke.ts
+++ b/tests/validation/scenarios/signed-in-smoke.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Signs the validation app into a real Gateway account and captures signed-in shell evidence.
+// ABOUTME: Credentials are read from env (SEREN_VALIDATION_AGENT_EMAIL/PASSWORD); nothing is hardcoded.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface TextDump {
+  text?: string;
+}
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? ((value as TextDump).text as string)
+    : JSON.stringify(value);
+}
+
+/**
+ * Drives the real SignIn form to a signed-in state via the control client.
+ * Login goes to the real Gateway (`api.serendb.com`), so this needs the
+ * dedicated validation account. Do not loop retries — a bad password trips the
+ * client-side rate limit after 5 attempts.
+ */
+export async function submitSignIn(
+  client: ScenarioContext["client"],
+  email: string,
+  password: string,
+): Promise<void> {
+  // Signed-out shell still renders; wait until it is interactive.
+  await client.waitFor("[data-testid='new-thread-button']", 30_000);
+  // Open the account panel via the titlebar "Sign In" button (no testid; the
+  // only visible button whose class contains border-primary/30).
+  await client.waitFor("button[class*='border-primary/30']", 10_000);
+  await client.click("button[class*='border-primary/30']");
+  // The account SlidePanel mounts <SignIn>.
+  await client.waitFor("#email", 10_000);
+  await client.fill("#email", email);
+  await client.fill("#password", password);
+  // Scope submit to the SignIn form so a chat composer's submit is never hit.
+  await client.click("form:has(#email) button[type='submit']");
+}
+
+/** Returns true if the signed-in balance control appears within `timeoutMs`. */
+async function waitSignedIn(
+  client: ScenarioContext["client"],
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    await client.waitFor("button[aria-label^='SerenBucks balance']", timeoutMs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const email = process.env.SEREN_VALIDATION_AGENT_EMAIL;
+  const password = process.env.SEREN_VALIDATION_AGENT_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "SEREN_VALIDATION_AGENT_EMAIL and SEREN_VALIDATION_AGENT_PASSWORD must be set",
+    );
+  }
+
+  await ctx.writeArtifact(
+    "signed-out-shell.json",
+    await ctx.client.dumpText("body"),
+  );
+
+  await submitSignIn(ctx.client, email, password);
+  const signedIn = await waitSignedIn(ctx.client, 20_000);
+
+  // Capture the post-submit state regardless of outcome: on failure the SignIn
+  // form shows a destructive error banner; on success the panel closes and the
+  // balance control renders.
+  const shell = textOf(await ctx.client.dumpText("body"));
+  await ctx.writeArtifact("post-submit-shell.json", { text: shell });
+  await ctx.writeArtifact(
+    "post-submit-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+  await ctx.writeArtifact(
+    "post-submit-native-screenshot.json",
+    await ctx.client.nativeScreenshot(),
+  );
+  await ctx.writeArtifact("signed-in-result.json", {
+    signedIn,
+    balanceControlPresent: signedIn,
+    signInAffordanceStillVisible: shell.includes("OR SIGN IN WITH EMAIL"),
+    account: email,
+  });
+
+  if (!signedIn) {
+    throw new Error(
+      "Sign-in did not complete (balance control absent); see post-submit-shell.json",
+    );
+  }
+}


### PR DESCRIPTION
Adds the first **signed-in** validation walkthrough scenarios (the harness previously had signed-out scenarios only; the two \`*-signin.ts\` files were empty stubs).

- \`signed-in-smoke.ts\` — drives the real SignIn form to a signed-in state (creds from \`SEREN_VALIDATION_AGENT_EMAIL\`/\`SEREN_VALIDATION_AGENT_PASSWORD\` env, nothing hardcoded), confirms the auth-gated balance control, exports a reusable \`submitSignIn\` helper.
- \`signed-in-gate-drive.ts\` — idempotent sign-in (the validation home is port-keyed and reused across runs), opens a Seren chat, prompts a gated \`execute_command\`, and drives the live approval flow: the five-action card, the "Approve for this task" lease editor (duration/max-calls/spend-cap), the lease grant, and the assertion that the repeated covered call runs **silently** with no second prompt.

Used live during the #3193 close-out to prove the gate -> approval card -> lease -> silent-reuse mechanism against the real Gateway. No credentials committed. Biome-ignored like the existing scenarios.

Refs #3193. Closes #3353.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com