### PR TITLE
fix(orchestrator): guard decomposed subtask completions (#3343)

### DIFF
--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -1162,6 +1162,15 @@ async fn execute_multi_task(
                                     .or_default()
                                     .push_str(text);
                             }
+                            // Settle any approval the host suspended for this
+                            // conversation and append the same disclosure notice
+                            // the single-task path adds before the subtask's
+                            // completion is persisted and forwarded. Without this a
+                            // decomposed subtask completes with an approval still
+                            // pending, leaving the thread stuck on "waiting for
+                            // approval" until the continuation's TTL or a reload.
+                            let worker_event =
+                                guard_completion(&app_for_events, &conv_id, worker_event);
                             if matches!(worker_event, WorkerEvent::Complete { .. }) {
                                 let message_id = format!("{}:{}", assistant_message_id_for_events, subtask_id);
                                 let streamed_content = streamed_by_subtask


### PR DESCRIPTION
Fixes #3343.

Completion-integrity settlement (#3325) ran on the single-task and RLM paths but not the decomposed multi-task path, so a subtask could forward `WorkerEvent::Complete` with an approval still suspended — the thread hung on "waiting for approval" until TTL/reload.

Routes the multi-task forwarding loop through `guard_completion`, mirroring the single-task path so a subtask completion settles any pending approval and carries the same disclosure notice.

### Verification
`cargo test --lib orchestrator::service::tests` → 18 passed (incl. the `guard_completion` settlement tests). The multi-task wiring mirrors the already-tested single-task rebind; a full decomposed-plan harness test is not added.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com