### PR TITLE
fix(approvals): task-lease predicates match the gate keys (#3344)

### DIFF
--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -318,7 +318,10 @@ export const GatewayToolApproval: Component = () => {
   /** For a web fetch, the lease predicate is the target host, not a publisher. */
   const webFetchHost = (): string | null => {
     const req = request();
-    if (req?.toolName !== "seren_web_fetch") return null;
+    // The gate authorizes web fetches under the tool name "web_fetch" (route
+    // "web"); matching "seren_web_fetch" here never fired, so the modal built a
+    // publisher lease that the gate's network-host rule could never cover.
+    if (req?.toolName !== "web_fetch") return null;
     const url = req.args.url;
     if (typeof url !== "string") return null;
     try {
@@ -344,10 +347,16 @@ export const GatewayToolApproval: Component = () => {
     if (!req || isProcessing() || needsConnectionChoice()) return;
 
     const host = webFetchHost();
+    // The gate resolves a lease's target from `args.connection_id` only. A
+    // model-originated call carries no connection_id at authorization time (the
+    // executor injects it afterwards), so pinning the lease to the selected
+    // connection produced a target the gate could never match — every later
+    // call re-prompted. Leave the target open when the call names no connection,
+    // yielding a publisher-scoped lease the gate does cover.
     const target =
       typeof req.args.connection_id === "string"
         ? req.args.connection_id
-        : (selectedConnection()?.id ?? undefined);
+        : undefined;
     const predicates: LeasePredicates = host
       ? { networkHosts: [host] }
       : {

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -23,6 +23,10 @@ import { conversationStore } from "@/stores/conversation.store";
 interface ShellApprovalRequest {
   approvalId: string;
   command: string;
+  // The command the gate authorized, when it differs from the displayed one:
+  // a skill script shows a `cwd> argv` preview but is gated on `argv.join(" ")`.
+  // The lease's program key must come from this, not the display string.
+  leaseCommand?: string;
   timeoutSecs: number;
   threadId?: string | null;
 }
@@ -146,7 +150,8 @@ export const ShellApproval: Component = () => {
 
   const leaseProgram = () => {
     const req = request();
-    return req ? commandProgram(req.command) : null;
+    if (!req) return null;
+    return commandProgram(req.leaseCommand ?? req.command);
   };
 
   /** Whether the blocked program is part of the host's coding toolchain — i.e. the

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -896,6 +896,7 @@ async function requestShellApproval(
   command: string,
   timeoutSecs: number,
   link?: ApprovalLink,
+  leaseCommand?: string,
 ): Promise<GatewayApprovalResult> {
   const approvalId = `shell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
@@ -907,6 +908,10 @@ async function requestShellApproval(
     await emit("shell-command-approval-request", {
       approvalId,
       command,
+      // When the displayed command is a preview, the gate authorized a
+      // different string; carry it so the modal's task-lease program key
+      // matches the gate's command-rule (see the skill-script call site).
+      leaseCommand: leaseCommand ?? command,
       timeoutSecs,
       threadId: link?.threadId ?? conversationStore.activeConversationId,
       continuationId: link?.continuationId,
@@ -1193,7 +1198,8 @@ export async function executeTool(
           args,
           conversationId,
           toolCall.id,
-          (link) => requestShellApproval(preview, timeoutSecs, link),
+          (link) =>
+            requestShellApproval(preview, timeoutSecs, link, argv.join(" ")),
         );
         if (!auth.approved) {
           return auth.toolResult;


### PR DESCRIPTION
Fixes #3344.

"Approve for this task" built lease predicates that never matched the host gate, so the flagship capability-lease silently re-prompted on the next call (and the web-fetch case pre-authorized unrelated seren-publisher ops).

- **Web fetch:** matched `toolName` `"seren_web_fetch"`, but the gate authorizes web fetches as `"web_fetch"` → now matches, building a `networkHosts` lease.
- **OAuth publisher:** lease `target` was pinned to the selected connection id, but the gate reads `target` from `args.connection_id` (absent on model calls) → leave target open for a publisher-scoped lease the gate covers.
- **Skill script:** program was derived from the `cwd> argv` display preview; carry the gate command (`argv.join(" ")`) so the program key matches `argv[0]`.

### Verification
`vitest` approval/lease suites → 36 passed; Biome clean on the 3 files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com