### PR TITLE
ci(release): gate the tag on Windows e2e before signing and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,55 @@ jobs:
         id: set_release_id
         run: echo "id=${{ steps.create_release.outputs.id }}" >> $GITHUB_OUTPUT
 
-  build:
+  # Build an UNSIGNED Windows installer purely to gate the release on the Windows
+  # on-box e2e BEFORE any signing budget is spent or anything is published. The
+  # signed `build` matrix depends on `windows-app-e2e`, which runs against this
+  # artifact, so a Windows regression fails the tag here — cheaply, with no
+  # SSL.com spend and nothing on R2 — instead of after the release is cut.
+  # The installer is unsigned; the e2e box accepts it because the harness passes
+  # `-AllowUnsignedBudgetBlockedArtifact` (WINDOWS_SIGNING_BLOCKED=true).
+  windows-e2e-preflight-build:
     needs: create-release
+    runs-on: windows-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure git for private dependencies
+        if: env.HAS_GH_PAT == 'true'
+        shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          prefix-key: v1-windows-e2e-preflight
+      - run: pnpm install --frozen-lockfile
+      # Same command CI uses for the Windows build; tauri.ci.json only disables
+      # updater artifacts. The embedded runtime is staged by tauri build's
+      # beforeBuild step, so the NSIS installer is a functional app.
+      - name: Build unsigned Windows installer for the e2e gate
+        run: pnpm tauri build --config src-tauri/tauri.ci.json
+      # Distinct name from the signed build's `Seren-Desktop-Windows-x64.exe`
+      # (uploaded later by `build` and shipped by `publish-release`), so the two
+      # never collide within one run.
+      - name: Upload unsigned Windows installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: Seren-Desktop-Windows-x64-unsigned.exe
+          path: src-tauri/target/release/bundle/nsis/*.exe
+
+  build:
+    needs: [create-release, windows-app-e2e]
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
     strategy:
@@ -1492,7 +1539,7 @@ jobs:
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
   windows-app-e2e:
-    needs: build
+    needs: [create-release, windows-e2e-preflight-build]
     runs-on: ubuntu-latest
     env:
       WINDOWS_E2E_INSTANCE_ID: ${{ secrets.WINDOWS_E2E_INSTANCE_ID }}
@@ -1513,10 +1560,15 @@ jobs:
       - name: Download signed Windows installer
         uses: actions/download-artifact@v8
         with:
-          name: Seren-Desktop-Windows-x64.exe
+          name: Seren-Desktop-Windows-x64-unsigned.exe
           path: windows-artifact
 
+      # The signed build now runs AFTER this gate, so its budget-state artifact
+      # does not exist yet. The preflight installer is always unsigned, so the
+      # stage step below treats a missing budget state as signing_blocked=true
+      # and the box accepts the unsigned artifact.
       - name: Download Windows signing budget state
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: windows-signing-budget-state
@@ -1689,10 +1741,13 @@ jobs:
           fi
           budget_state="windows-signing-budget-state/windows-signing-budget-state.json"
           if [ ! -f "$budget_state" ]; then
-            echo "::error::Windows signing budget state artifact is missing"
-            exit 1
+            # No signed build ran before this gate: the preflight installer is
+            # unsigned, so the box must accept an unsigned artifact.
+            echo "No signing budget state (pre-signing e2e gate); treating the installer as unsigned"
+            signing_blocked="true"
+          else
+            signing_blocked="$(jq -r 'if .blocked == true then "true" else "false" end' "$budget_state")"
           fi
-          signing_blocked="$(jq -r 'if .blocked == true then "true" else "false" end' "$budget_state")"
           payload="$RUNNER_TEMP/windows-e2e-payload.zip"
           # The box drives the installed app over CDP; it does not run the app
           # from source, so it needs only the test driver's two deps

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -49,16 +49,30 @@ function workflowJob(name: string): string {
 describe("Windows production e2e release gate", () => {
   it("blocks release publishing on the AWS Windows e2e job", () => {
     expect(releaseWorkflow).toContain("windows-app-e2e:");
-    expect(releaseWorkflow).toContain("needs: build");
     expect(releaseWorkflow).toContain("aws ssm send-command");
     expect(releaseWorkflow).toContain("aws ssm get-command-invocation");
     expect(releaseWorkflow).toContain("WINDOWS_E2E_INSTANCE_ID");
     expect(releaseWorkflow).toContain("WINDOWS_E2E_S3_BUCKET");
+    // The Windows e2e now runs BEFORE signing, against an unsigned preflight
+    // build, and the signed `build` matrix depends on it — so a Windows
+    // regression fails the tag before any signing spend or publish, not after.
+    expect(releaseWorkflow).toContain("windows-e2e-preflight-build:");
+    expect(releaseWorkflow).toMatch(
+      /windows-app-e2e:\s*\n\s*needs:\s*\[create-release, windows-e2e-preflight-build\]/,
+    );
+    expect(releaseWorkflow).toMatch(
+      /\n  build:\s*\n\s*needs:\s*\[create-release, windows-app-e2e\]/,
+    );
     expect(releaseWorkflow).toMatch(
       /publish-release:\s*\n\s*needs:\s*\[create-release, build, windows-app-e2e\]/,
     );
-    expect(workflowJob("windows-app-e2e")).not.toContain(
-      "continue-on-error: true",
+    // Only the pre-signing budget-state download may be best-effort (it does
+    // not exist before signing now). The SSM run itself must still fail the job
+    // — and therefore the release — on any error.
+    const job = workflowJob("windows-app-e2e");
+    expect((job.match(/continue-on-error: true/g) ?? []).length).toBe(1);
+    expect(job.indexOf("continue-on-error: true")).toBeLessThan(
+      job.indexOf("aws ssm send-command"),
     );
   });
 


### PR DESCRIPTION
Per Taariq: zero out the "Windows e2e fails after the tag" risk by running the on-box Windows e2e **first**, before any signing spend or publish.

### Problem
`windows-app-e2e` ran *after* the signed `build` and only gated `publish-release`. A Windows regression was therefore found **after** SSL.com signing budget was spent and a partial GitHub release existed.

### Change — new job graph
```
create-release
  → windows-e2e-preflight-build   (NEW: unsigned Windows installer, pnpm tauri build --config tauri.ci.json)
    → windows-app-e2e             (SSM on-box, now runs against the unsigned preflight installer)
      → build                     (signed 5-platform matrix — only runs if Windows e2e passed)
        → publish-release         (unchanged; still needs build + windows-app-e2e)
```
A Windows regression now fails the tag **cheaply**: no signing spend, nothing on R2, no partial release.

### Details / decisions
- The preflight installer is **unsigned**. `windows-app-e2e` treats a missing signing-budget-state as `signing_blocked=true`, so the box accepts it via `-AllowUnsignedBudgetBlockedArtifact` (the existing unsigned-artifact path).
- The preflight artifact is named `Seren-Desktop-Windows-x64-unsigned.exe` so it never collides with the signed `Seren-Desktop-Windows-x64.exe` that `build`/`publish-release` still produce and ship.
- `tauri build` stages the embedded runtime via its `beforeBuildCommand` (`prepare:tauri-build`), so the unsigned installer is a functional app for the e2e.
- Trade-off: the signed build now waits for the preflight build (~15m) + the on-box e2e before starting, and we do one extra unsigned Windows build. That is the cost of gating expensive work behind the e2e.

### ⚠️ Validation status
Per our constraint, the on-box SSM harness can only be validated by a real tag-driven run. YAML syntax + the job DAG are verified locally; the runtime behavior is **not** — the first tagged run validates it, and it fails cheaply if wrong. Please review the signing/budget interactions with your context before merging.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com