### PR TITLE
docs(release): curated release notes for v3.73.0

### DIFF
--- a/.github/release-notes/v3.73.0.md
+++ b/.github/release-notes/v3.73.0.md
@@ -1,0 +1,97 @@
+## What's New
+
+A security- and privacy-focused release: a new host-owned tool-authorization gate with capability leases and budgets, OS-native sandbox backends on all three platforms, a one-shot "erase everything" privacy flow with true cloud-side deletion, and migration of memory to the Seren Memory publisher service.
+
+## 🔐 Tool Authorization & Capability Leases
+
+Every agent tool call now passes through a non-bypassable, host-owned authorization gate in the Rust core — approvals can no longer be bypassed by a compromised or misbehaving worker process.
+
+- Host-owned Rust gate for tool authorization; dispatch requires host-issued authorization handles (#3267, #3284)
+- Capability leases with predicates and budgets — approve a whole task once, within limits (#3270)
+- Live monetary metering for lease budgets, with a spend cap in the approve-for-task lease editor (#3293, #3328)
+- Standing-policy auto-leases for unattended runs; concurrent auto-leases are honored before prompting (#3295, #3298)
+- Approval inbox with audit trail and lease revocation UI (#3275)
+- Approval timeouts are expiries, not durable denials; orphaned approval continuations expire on reload (#3273, #3290)
+- Suspended approval continuations with explicit task states; completion integrity enforced for pending approvals and blocked tasks (#3271, #3283, #3325)
+- Derived coding bundle wired into shell approvals; dead ungated web/shell arms removed from the chat worker (#3332, #3336)
+- Rate-lease budgets; data-egress budget deferred until a consumer needs it (#3339)
+- Fail-open approval allowlist closed; approvals classified by verb, not path patterns (#3216, #3251)
+- Authorization decisions proven to survive an on-disk reopen; 500-call coding task validated under one derived lease (#3268, #3303)
+- Native OS notifications when an approval is waiting in the background (#3299)
+
+## 🧱 OS Sandboxing
+
+Agent child processes now run inside OS-native sandboxes on every platform:
+
+- macOS Seatbelt backend (#3211)
+- Linux Landlock backend and launcher (#3214)
+- Windows restricted-token backend with valid token parameters and non-vacuous canaries (#3215, #3220)
+- Agent launch spec resolved in trusted code (#3239)
+- Settings now report the verified effective sandbox
+
+## 🔏 Privacy & Data Deletion
+
+- One-shot erase of all local conversation data, including recorded meetings (#3259)
+- "Clear all history" now true-deletes residue, cascades cloud-memory erasure, and VACUUMs the local database (#3313, #3311, #3321)
+- Conversation deletion cascades: linked meetings, seren-notes cloud notes, paired claude/codex transcripts, and CLI session transcripts (#3319, #3320, #3265)
+- Retained cloud-memory sources erased on delete; erase-all reports cloud-memory failures honestly instead of claiming success (#3305, #3309)
+- Source retention is now opt-in; synced chat content is hard-deleted (#3228, #3226)
+- Per-conversation Privileged Matter Mode
+- Honest egress controls and a Data Destinations panel (#3207)
+
+## 🧠 Memory
+
+- Memory now uses the Seren Memory publisher service
+- Recall and consolidation wired; MCP tool errors surfaced; request/bootstrap latency bounded (#3189, #3186, #3188)
+- Session scope kept on memories queued during cloud failures (#3236)
+- Remembered-detail provenance clarified (#3190)
+
+## 🔑 Credentials & Auth
+
+- Publisher credentials brokered outside agent processes (#3233)
+- Per-session publisher key leases with Rust-owned revocation (#3217)
+- Session leases revoked by record UUID (#3238)
+- A model flag can no longer inject the desktop key anywhere (#3241)
+- Restored user hydrated before memory sync (#3202)
+
+## 🤖 Agent & Chat
+
+- Host broadcasts authoritative task-execution state (#3304)
+- Full claude-code turn history persisted (#3254)
+- Tool bridge drained on reload so workers never hang (#3288)
+- ChatModelWorker web fetches gated via the frontend (#3286)
+- Immediate containment guards (#3209)
+- Recent history kept on tool rounds (#3177)
+- Native OS banners for CLI-update notifications and received wallet transfers (#3324, #3322)
+- Model catalog fetched via the seren-models publisher (#3297)
+- Managed Playwright state persisted; protocol version pinned
+
+## 📡 Happy (Mobile Remote)
+
+- Mobile sessions restored after restart; active sessions preserved across bridge restarts (#3222, #3218, #3210)
+- Remotely archived sessions terminated (#3229)
+- Reset pairing polls retried (#3232)
+- Mobile unpair confirmation fixed (#3224)
+
+## 🧪 Pre-Release Audit Fixes
+
+A full audit ran before this tag; the release-blocking findings were fixed:
+
+- **Privacy:** "Clear history" aborted on the `eval_signals` foreign key whenever a message carried a satisfaction signal, yet reported success and scrubbed the remote copies — now deletes the signal first, in one transaction, and only clears the thread on success (#3340)
+- **Linux sandbox:** the Landlock backend hard-required the full V7 access set, so bounded agents failed to start on any kernel below 6.10 (Ubuntu 22.04/24.04, Debian 12) — now hard-requires the universal floor and best-efforts newer rights (#3341)
+- **Windows sandbox:** bounded agents refused to start when a credential directory existed — now ships write-confinement on Windows (read-deny follow-up tracked) (#3342)
+- **Orchestrator:** decomposed multi-task plans could complete a subtask with an approval still pending, hanging the thread — now settled through the same completion-integrity guard as single-task runs (#3343)
+- **Capability leases:** "Approve for this task" built lease predicates that never matched the gate for web fetches, OAuth publishers, and skill scripts — now keyed to the gate's own capability (#3344)
+- Non-blocking findings (P2 hardening, erase/sync concurrency) are tracked as follow-up issues.
+
+## 🛠 Fixes & Internals
+
+- Keyed rendering crash repaired along with latent type errors (#3255)
+- Signing: every signer pass counted with nonce; audited bootstrap controls for the monthly ledger (#3206, #3204)
+- Skills catalog responses unwrapped; support flow uses session authentication
+- Models require a data-handling attestation
+- Agent store internals extracted into focused modules (compaction, bootstrap context, archive, metadata) (#3250)
+
+---
+
+Full changelog: https://github.com/serenorg/seren-desktop/compare/v3.72.0...v3.73.0


### PR DESCRIPTION
Adds `.github/release-notes/v3.73.0.md`, read verbatim by the release workflow as the What's New body. Covers the release themes + the pre-release audit fixes (#3340–#3344). Passes the curated release-notes contract test (starts with `## What's New`, no duplicated Installation/Note footer).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com