### PR TITLE
fix(agent): make grok binary resolution testable (#3352)

### DIFF
--- a/bin/browser-local/grok-binary.mjs
+++ b/bin/browser-local/grok-binary.mjs
@@ -19,6 +19,12 @@ export function resolveGrokBinary({
   arch = process.arch,
   home = os.homedir(),
   appData = process.env.APPDATA ?? "",
+  // Absolute install locations outside the caller's control, checked last.
+  // Injectable so a hermetic test can supply an empty list and assert the bare
+  // "grok" fallback without a real system grok on the host tainting the result.
+  systemPaths = platform === "win32"
+    ? []
+    : ["/usr/local/bin/grok", "/opt/homebrew/bin/grok"],
 } = {}) {
   const nodeDir = path.dirname(execPath);
   const executableName = platform === "win32" ? "grok.exe" : "grok";
@@ -64,8 +70,7 @@ export function resolveGrokBinary({
     path.join(home, ".grok", "bin", "grok"),
     ...(isSymlink(embeddedShim) ? [embeddedShim] : []),
     path.join(home, ".local", "bin", "grok"),
-    "/usr/local/bin/grok",
-    "/opt/homebrew/bin/grok",
+    ...systemPaths,
   ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) return candidate;

--- a/tests/unit/grok-agent.test.ts
+++ b/tests/unit/grok-agent.test.ts
@@ -105,6 +105,9 @@ describe("Grok native ACP agent (#3084)", () => {
           arch: "x64",
           home: join(root, "home"),
           appData: "",
+          // Empty so a real /opt/homebrew/bin/grok on the dev's host cannot
+          // taint the bare-command fallback assertion.
+          systemPaths: [],
         }),
       ).toBe("grok");
     } finally {


### PR DESCRIPTION
Fixes #3352.

`resolveGrokBinary` probed absolute `/usr/local/bin/grok` and `/opt/homebrew/bin/grok`, which a test cannot fake, so the bare-command fallback assertion failed on any host with a real system grok. Exposes the system-path list as an injectable option (default unchanged); the fallback test supplies `[]`.

Verification: `vitest tests/unit/grok-agent.test.ts` → 7 passed (was 1 failing locally).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com