### PR TITLE
fix(approvals): approval-UI robustness batch (#3351)

### DIFF
--- a/src/components/approvals/CapabilityLeasePanel.tsx
+++ b/src/components/approvals/CapabilityLeasePanel.tsx
@@ -100,14 +100,31 @@ export const CapabilityLeasePanel: Component<CapabilityLeasePanelProps> = (
   const [revision, setRevision] = createSignal(0);
   const [revokingId, setRevokingId] = createSignal<string | null>(null);
 
+  // Catch fetch failures here and return empty. An un-caught rejection puts the
+  // resource in an error state, and reading it in JSX then throws during render,
+  // escalating a panel-level data failure to the app-wide recovery boundary.
   const [leases] = createResource(
     () => [props.conversationId, revision()] as const,
-    async ([conversationId]) => listCapabilityLeases(conversationId),
+    async ([conversationId]) => {
+      try {
+        return await listCapabilityLeases(conversationId);
+      } catch (err) {
+        console.error("[CapabilityLeasePanel] Failed to load leases:", err);
+        return [];
+      }
+    },
   );
 
   const [audit] = createResource(
     () => [props.conversationId, revision()] as const,
-    async ([conversationId]) => listAuthorizationAudit(conversationId, 50),
+    async ([conversationId]) => {
+      try {
+        return await listAuthorizationAudit(conversationId, 50);
+      } catch (err) {
+        console.error("[CapabilityLeasePanel] Failed to load audit:", err);
+        return [];
+      }
+    },
   );
 
   const handleRevoke = async (lease: CapabilityLease) => {

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Approval dialog for Gateway publisher tool operations.
 // ABOUTME: Shows operation details and requires user confirmation before execution.
 
-import { emit, listen } from "@tauri-apps/api/event";
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   type Component,
   createEffect,
@@ -113,41 +113,60 @@ export const GatewayToolApproval: Component = () => {
     async ([approvalId]) => (approvalId ? listConnectedPublishers() : []),
   );
 
-  onMount(async () => {
-    const unlisten = await listen<ApprovalRequest>(
-      "gateway-tool-approval-request",
-      (event) => {
-        console.log(
-          "[GatewayToolApproval] Received approval request:",
-          event.payload,
-        );
-        // Snapshot provenance at the moment the request arrives
-        setProvenance(deriveProvenance(conversationStore.messages));
-        setSelectedConnectionId(null);
-        setRequest(event.payload);
-        setIsProcessing(false);
-      },
-    );
+  // Register cleanup synchronously so it keeps this component's reactive owner:
+  // an onCleanup added after an `await` is ownerless and never runs, so the
+  // Tauri listeners leaked and stacked on every remount. `disposed` also cancels
+  // listeners that resolve after the component has already unmounted.
+  onMount(() => {
+    let unlisten: UnlistenFn | undefined;
+    let unlistenResolved: UnlistenFn | undefined;
+    let disposed = false;
 
-    // The same request can be decided from another surface (the inline
-    // timeline card or the inbox). Dismiss this dialog when its request is
-    // settled elsewhere, so a stale prompt never lingers over a decided action.
-    const unlistenResolved = await listen<{ id: string }>(
-      "gateway-tool-approval-response",
-      (event) => {
-        const req = request();
-        if (req && event.payload.id === req.approvalId) {
-          setRequest(null);
-          setProvenance(null);
+    void (async () => {
+      unlisten = await listen<ApprovalRequest>(
+        "gateway-tool-approval-request",
+        (event) => {
+          console.log(
+            "[GatewayToolApproval] Received approval request:",
+            event.payload,
+          );
+          // Do not swap out a request already on screen — a concurrent tool
+          // round would otherwise replace it mid-review and a click could land
+          // on the wrong request. The newer request stays decidable via the
+          // inline timeline card / approval inbox.
+          if (request()) return;
+          // Snapshot provenance at the moment the request arrives
+          setProvenance(deriveProvenance(conversationStore.messages));
           setSelectedConnectionId(null);
+          setRequest(event.payload);
           setIsProcessing(false);
-        }
-      },
-    );
+        },
+      );
+      // The same request can be decided from another surface (the inline
+      // timeline card or the inbox). Dismiss this dialog when its request is
+      // settled elsewhere, so a stale prompt never lingers over a decided action.
+      unlistenResolved = await listen<{ id: string }>(
+        "gateway-tool-approval-response",
+        (event) => {
+          const req = request();
+          if (req && event.payload.id === req.approvalId) {
+            setRequest(null);
+            setProvenance(null);
+            setSelectedConnectionId(null);
+            setIsProcessing(false);
+          }
+        },
+      );
+      if (disposed) {
+        unlisten();
+        unlistenResolved();
+      }
+    })();
 
     onCleanup(() => {
-      unlisten();
-      unlistenResolved();
+      disposed = true;
+      unlisten?.();
+      unlistenResolved?.();
     });
   });
 

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Approval dialog for shell command execution.
 // ABOUTME: Shows the command and requires user confirmation before execution.
 
-import { emit, listen } from "@tauri-apps/api/event";
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   type Component,
   createSignal,
@@ -62,36 +62,54 @@ export const ShellApproval: Component = () => {
     }
   });
 
-  onMount(async () => {
-    const unlisten = await listen<ShellApprovalRequest>(
-      "shell-command-approval-request",
-      (event) => {
-        console.log(
-          "[ShellApproval] Received approval request:",
-          event.payload,
-        );
-        setRequest(event.payload);
-        setIsProcessing(false);
-      },
-    );
+  // Register cleanup synchronously so it keeps this component's reactive owner:
+  // an onCleanup added after an `await` is ownerless and never runs, so the
+  // Tauri listeners leaked and stacked on every remount. `disposed` also cancels
+  // listeners that resolve after the component has already unmounted.
+  onMount(() => {
+    let unlisten: UnlistenFn | undefined;
+    let unlistenResolved: UnlistenFn | undefined;
+    let disposed = false;
 
-    // The same request can be decided from another surface (the inline
-    // timeline card or the inbox). Dismiss this dialog when its request is
-    // settled elsewhere, so a stale prompt never lingers over a decided action.
-    const unlistenResolved = await listen<{ id: string }>(
-      "shell-command-approval-response",
-      (event) => {
-        const req = request();
-        if (req && event.payload.id === req.approvalId) {
-          setRequest(null);
+    void (async () => {
+      unlisten = await listen<ShellApprovalRequest>(
+        "shell-command-approval-request",
+        (event) => {
+          console.log(
+            "[ShellApproval] Received approval request:",
+            event.payload,
+          );
+          // Keep a request already on screen rather than letting a concurrent
+          // round swap it mid-review; the newer one stays decidable via the
+          // inline card / approval inbox.
+          if (request()) return;
+          setRequest(event.payload);
           setIsProcessing(false);
-        }
-      },
-    );
+        },
+      );
+      // The same request can be decided from another surface (the inline
+      // timeline card or the inbox). Dismiss this dialog when its request is
+      // settled elsewhere, so a stale prompt never lingers over a decided action.
+      unlistenResolved = await listen<{ id: string }>(
+        "shell-command-approval-response",
+        (event) => {
+          const req = request();
+          if (req && event.payload.id === req.approvalId) {
+            setRequest(null);
+            setIsProcessing(false);
+          }
+        },
+      );
+      if (disposed) {
+        unlisten();
+        unlistenResolved();
+      }
+    })();
 
     onCleanup(() => {
-      unlisten();
-      unlistenResolved();
+      disposed = true;
+      unlisten?.();
+      unlistenResolved?.();
     });
   });
 

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -566,6 +566,13 @@ async function requestGatewayApproval(
     const timeout = setTimeout(() => {
       console.log(`[Tool Executor] Approval timeout for ${approvalId}`);
       unlisten?.();
+      // Tell the UI the request expired so the modal dismisses itself instead
+      // of lingering over an action the executor has already abandoned.
+      void emit("gateway-tool-approval-response", {
+        id: approvalId,
+        approved: false,
+        expired: true,
+      });
       resolve({ approved: false, timedOut: true });
     }, GATEWAY_APPROVAL_TIMEOUT_MS);
 
@@ -929,6 +936,13 @@ async function requestShellApproval(
     const timeout = setTimeout(() => {
       console.log(`[Tool Executor] Shell approval timeout for ${approvalId}`);
       unlisten?.();
+      // Dismiss the shell approval dialog on expiry rather than leaving it open
+      // over an action the executor has already abandoned.
+      void emit("shell-command-approval-response", {
+        id: approvalId,
+        approved: false,
+        expired: true,
+      });
       resolve({ approved: false, timedOut: true });
     }, SHELL_APPROVAL_TIMEOUT_MS);
 

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -1210,11 +1210,21 @@ async function handleToolRequest(request: ToolExecutionRequest): Promise<void> {
     // Expected agent outcome (submitted back as an is_error result). Not reportable.
     console.warn("[orchestrator] Tool execution failed:", message);
 
-    await invoke("submit_tool_result", {
-      toolCallId: request.tool_call_id,
-      content: `Tool execution error: ${message}`,
-      isError: true,
-    });
+    // Guard the fallback submit: if it also rejects, an unhandled rejection
+    // would escape here while the worker keeps waiting on its result channel.
+    // Logging it at least surfaces the double failure instead of hiding it.
+    try {
+      await invoke("submit_tool_result", {
+        toolCallId: request.tool_call_id,
+        content: `Tool execution error: ${message}`,
+        isError: true,
+      });
+    } catch (submitError) {
+      console.error(
+        "[orchestrator] Failed to submit tool-error result; the worker may stall until Stop:",
+        submitError,
+      );
+    }
   } finally {
     activeToolRequests.delete(request.tool_call_id);
   }


### PR DESCRIPTION
Fixes #3351.

- **Ownerless onCleanup listener leak:** register the Tauri approval-listener cleanup synchronously (not after an `await`) in `GatewayToolApproval` and `ShellApproval`; the listeners no longer leak and stack on remount, with a `disposed` flag cancelling listeners that resolve after unmount.
- **Single-slot modal race:** do not swap a request already on screen for a concurrent one — a click could land on the wrong request; the newer one stays decidable via the inline card / inbox.
- **Silent timeout:** emit the approval-response event on the executor's 5-minute expiry (gateway + shell) so the modal dismisses instead of lingering.
- **Fallback hang:** guard the fallback `submit_tool_result` so a double IPC failure logs instead of escaping as an unhandled rejection.
- **createResource → ErrorBoundary:** catch `CapabilityLeasePanel` fetch failures so a panel-level error cannot escalate to the app-wide recovery boundary.

Verification: Biome clean (5 files); `vitest` approval/executor suites → 27 passed.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com