### PR TITLE
fix(privacy): erase/sync retention defects (#3345, #3348)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -349,17 +349,103 @@ fn cloud_memory_erase_report(
     }
 }
 
-/// Fire-and-forget the retained cloud-memory source erasure so an interactive
-/// conversation delete stays responsive. The local delete has already
-/// committed; this cleans up the remote copy in the background.
+/// Erase a set of cloud-memory source URIs, removing each from the durable
+/// retry queue only once the memory service confirms its erasure. A URI that
+/// fails (offline / unauthenticated) stays queued for the next drain.
+async fn erase_and_clear_pending(
+    app: &AppHandle,
+    source_uris: Vec<String>,
+) -> MemorySourceEraseCounts {
+    let mut counts = MemorySourceEraseCounts::default();
+    if source_uris.is_empty() {
+        return counts;
+    }
+    let client = reqwest::Client::new();
+    for uri in &source_uris {
+        match erase_memory_source(app, &client, uri).await {
+            Ok(outcome) => {
+                counts.sources_deleted += outcome.sources_deleted;
+                counts.memories_deleted += outcome.memories_deleted;
+                let uri_owned = uri.clone();
+                let _ = run_db(app.clone(), move |conn| {
+                    conn.execute(
+                        "DELETE FROM pending_memory_source_erase WHERE source_uri = ?1",
+                        params![uri_owned],
+                    )?;
+                    Ok(())
+                })
+                .await;
+            }
+            Err(err) => {
+                counts.failures += 1;
+                log::warn!("[Delete] Cloud-memory source erase failed for {uri}: {err}");
+            }
+        }
+    }
+    counts
+}
+
+/// Enqueue the retained cloud-memory sources for the deleted conversations into
+/// the durable retry queue, then fire-and-forget the erase so an interactive
+/// delete stays responsive. The local delete has already committed; enqueuing
+/// first means a delete made while offline or signed out is retried on the next
+/// sync instead of leaking the retained transcript forever (#3345).
 fn spawn_memory_source_erase_best_effort(app: &AppHandle, conversation_ids: Vec<String>) {
     if conversation_ids.is_empty() {
         return;
     }
+    let source_uris: Vec<String> = conversation_ids
+        .iter()
+        .map(|id| conversation_source_uri(id))
+        .collect();
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let _ = erase_memory_sources(&app, &conversation_ids).await;
+        let enqueue_uris = source_uris.clone();
+        let _ = run_db(app.clone(), move |conn| {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+            for uri in &enqueue_uris {
+                conn.execute(
+                    "INSERT OR IGNORE INTO pending_memory_source_erase (source_uri, enqueued_at)
+                     VALUES (?1, ?2)",
+                    params![uri, now],
+                )?;
+            }
+            Ok(())
+        })
+        .await;
+        let _ = erase_and_clear_pending(&app, source_uris).await;
     });
+}
+
+/// Retry every cloud-memory source erase still queued from an earlier delete
+/// that could not reach the memory service. Called after a successful history
+/// sync (i.e. once connectivity and auth are known good). Idempotent: erasing
+/// an already-removed source is a no-op that still clears the queue entry.
+pub(crate) async fn retry_pending_memory_erases(app: &AppHandle) {
+    let pending = match run_db(app.clone(), |conn| {
+        conn.prepare("SELECT source_uri FROM pending_memory_source_erase")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<String>>>()
+    })
+    .await
+    {
+        Ok(pending) => pending,
+        Err(err) => {
+            log::warn!("[Delete] Could not read pending cloud-memory erases: {err}");
+            return;
+        }
+    };
+    if pending.is_empty() {
+        return;
+    }
+    log::info!(
+        "[Delete] Retrying {} pending cloud-memory source erase(s)",
+        pending.len()
+    );
+    let _ = erase_and_clear_pending(app, pending).await;
 }
 
 /// Ids removed by the linked-meeting cascade: the meeting ids (to drop the
@@ -2644,6 +2730,12 @@ pub async fn erase_all_conversation_data(
         let meeting_note_ids = crate::commands::audio::collect_all_meeting_note_ids(conn)?;
         let meetings_removed = crate::commands::audio::clear_all_meetings(conn)?;
         delete_conversation_records(conn, &conversation_ids)?;
+        // Local-only metadata that outlives the conversations: archived virtual
+        // employee snapshots (names captured at delete time) and the provider
+        // session <-> conversation lifecycle links. Both hold identifying data
+        // and must not survive an "erase all" (#3348).
+        conn.execute("DELETE FROM archived_employees", [])?;
+        conn.execute("DELETE FROM happy_provider_session_lifecycle", [])?;
         vacuum_database(conn)?;
         Ok((conversation_ids, targets, meetings_removed, meeting_note_ids))
     })

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -966,6 +966,10 @@ pub async fn archive_conversation(app: AppHandle, id: String) -> Result<(), Stri
 
 #[tauri::command]
 pub async fn delete_conversation(app: AppHandle, id: String) -> Result<(), String> {
+    // Hold the history-sync lock so an in-flight pull cannot re-insert this
+    // conversation after we delete it locally (#3345).
+    let sync_lock = crate::services::history_sync::HistorySyncLock::handle(&app);
+    let _sync_guard = sync_lock.lock().await;
     let index_id = id.clone();
     let (transcript_targets, meetings) = run_db(app.clone(), move |conn| {
         let ids = vec![id];
@@ -2457,6 +2461,14 @@ pub(crate) fn clear_conversation_history_records(
         "DELETE FROM messages WHERE conversation_id = ?1",
         params![conversation_id],
     )?;
+    // The verbatim prompts the user typed live in `input_history`, not
+    // `messages`. Clearing a conversation's history must remove them too, or the
+    // raw prompts survive a "Clear history" (#3348), matching the delete and
+    // clear-all paths.
+    tx.execute(
+        "DELETE FROM input_history WHERE conversation_id = ?1",
+        params![conversation_id],
+    )?;
     tx.commit()?;
     Ok(())
 }
@@ -2538,12 +2550,23 @@ pub(crate) fn clear_all_history_records(conn: &Connection) -> rusqlite::Result<V
     conn.execute("DELETE FROM thread_skill_override_state", [])?;
     conn.execute("DELETE FROM message_events", [])?;
     conn.execute("DELETE FROM messages", [])?;
+    // Recorded meetings reference a conversation via `meetings
+    // .agent_conversation_id`, an enforced foreign key with no ON DELETE
+    // CASCADE. Clear them before the conversations or the delete aborts for any
+    // user who routed a meeting to an agent conversation (#3345), matching the
+    // erase-all path which clears meetings before the conversation delete.
+    crate::commands::audio::clear_all_meetings(conn)?;
     conn.execute("DELETE FROM conversations", [])?;
     Ok(conversation_ids)
 }
 
 #[tauri::command]
 pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
+    // Hold the history-sync lock across the local erase so an in-flight pull
+    // cannot re-insert the conversations/messages we are clearing (#3345).
+    // `run_history_sync_once` acquires the same lock.
+    let sync_lock = crate::services::history_sync::HistorySyncLock::handle(&app);
+    let _sync_guard = sync_lock.lock().await;
     let conversation_ids = run_db(app.clone(), |conn| {
         let ids = clear_all_history_records(conn)?;
         // Reclaim and zero the freed pages so no cleared content lingers in the
@@ -2594,6 +2617,10 @@ pub async fn erase_all_conversation_data(
     app: AppHandle,
     authorization_state: State<'_, crate::tool_authorization::ToolAuthorizationState>,
 ) -> Result<Vec<EraseTargetReport>, String> {
+    // Hold the history-sync lock across the erase so an in-flight pull cannot
+    // resurrect erased rows locally (#3345). run_history_sync_once holds it too.
+    let sync_lock = crate::services::history_sync::HistorySyncLock::handle(&app);
+    let _sync_guard = sync_lock.lock().await;
     let mut reports = Vec::new();
 
     // Local chat.db: capture each agent conversation's transcript identity
@@ -2627,6 +2654,9 @@ pub async fn erase_all_conversation_data(
     let mut erased_conversation_ids: Vec<String> = Vec::new();
     // Cloud-note ids captured before deletion, erased from seren-notes below.
     let mut meeting_note_ids: Vec<String> = Vec::new();
+    // When the chat.db step fails, no ids were captured, so the cloud erases are
+    // not genuinely attempted — they must not report a false green "0 erased".
+    let chat_failed = chat_result.is_err();
     let transcript_targets = match chat_result {
         Ok((conversation_ids, targets, meetings_removed, note_ids)) => {
             meeting_note_ids = note_ids;
@@ -2650,12 +2680,17 @@ pub async fn erase_all_conversation_data(
         }
         Err(err) => {
             reports.push(EraseTargetReport::new("local_chat_db", "failed", Some(err)));
-            // The meeting purge shares the chat.db transaction path, so a chat.db
-            // failure means it did not run either — report it honestly.
+            // clear_all_meetings commits per meeting before the conversation
+            // delete, so on a chat.db failure the meeting state is uncertain —
+            // some may already be gone. Report that honestly rather than
+            // asserting either outcome (#3348).
             reports.push(EraseTargetReport::new(
                 "meeting_recordings",
                 "failed",
-                Some("chat.db erase failed; meeting recordings were not removed".to_string()),
+                Some(
+                    "chat.db erase failed; some meeting recordings may have been removed before the failure"
+                        .to_string(),
+                ),
             ));
             Vec::new()
         }
@@ -2732,8 +2767,14 @@ pub async fn erase_all_conversation_data(
     // (offline / unauthenticated memory service) the target is `failed`, not a
     // false green `ok` that implies the retained cloud transcripts are gone.
     let memory_counts = erase_memory_sources(&app, &erased_conversation_ids).await;
-    let (memory_status, memory_detail) =
-        cloud_memory_erase_report(&memory_counts, erased_conversation_ids.len());
+    let (memory_status, memory_detail) = if chat_failed {
+        (
+            "failed",
+            "chat.db erase failed; retained cloud memory sources were not attempted".to_string(),
+        )
+    } else {
+        cloud_memory_erase_report(&memory_counts, erased_conversation_ids.len())
+    };
     reports.push(EraseTargetReport::new(
         "cloud_memories",
         memory_status,
@@ -2745,7 +2786,12 @@ pub async fn erase_all_conversation_data(
     let note_total = meeting_note_ids.len();
     let note_counts =
         crate::audio::seren_notes_publish::erase_meeting_notes(&app, &meeting_note_ids).await;
-    let (notes_status, notes_detail) = if note_counts.failed == 0 {
+    let (notes_status, notes_detail) = if chat_failed {
+        (
+            "failed",
+            "chat.db erase failed; cloud meeting notes were not attempted".to_string(),
+        )
+    } else if note_counts.failed == 0 {
         (
             "ok",
             format!("{} cloud meeting note(s) erased", note_counts.deleted),

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1374,6 +1374,19 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     setup_provider_runtime_schema(conn)?;
     setup_happy_provider_session_lifecycle_schema(conn)?;
 
+    // Durable queue for retained cloud-memory sources whose erase has not yet
+    // been confirmed. A conversation delete enqueues its source URI here and
+    // removes it once the memory service confirms the erase; a delete made while
+    // offline or signed out therefore retries on the next sync instead of
+    // leaking the retained transcript forever (#3345).
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS pending_memory_source_erase (
+            source_uri TEXT PRIMARY KEY NOT NULL,
+            enqueued_at INTEGER NOT NULL
+        )",
+        [],
+    )?;
+
     Ok(())
 }
 

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -199,7 +199,7 @@ pub async fn run_history_sync_once(
     let _guard = lock.lock().await;
     let sync_scope = history_sync_scope(&config);
     let excluded_conversation_ids = config.excluded_conversation_ids.clone();
-    with_remote_client(&app, &config, move |app, mut client| {
+    let result = with_remote_client(&app, &config, move |app, mut client| {
         ensure_remote_schema(&mut client)?;
 
         let backfilled = with_local_db(&app, |conn| {
@@ -228,7 +228,16 @@ pub async fn run_history_sync_once(
             conflicts,
         })
     })
-    .await
+    .await;
+
+    // A successful sync proves connectivity and auth, so drain any cloud-memory
+    // source erases queued by an earlier offline/signed-out delete (#3345). Only
+    // on success — a failed sync means the memory service is likely unreachable
+    // too, so the queue stays for the next attempt.
+    if result.is_ok() {
+        crate::commands::chat::retry_pending_memory_erases(&app).await;
+    }
+    result
 }
 
 pub async fn wipe_remote_history(
@@ -560,18 +569,18 @@ fn push_outbox(
         for item in batch {
             match push_outbox_item(app, client, &item, &excluded) {
                 Ok(PushItemOutcome::Pushed) => {
-                    clear_outbox_item(app, item.id)?;
+                    clear_outbox_item(app, &item)?;
                     mark_synced(app, &item.table_name, &item.row_id)?;
                     pushed += 1;
                     left_active_set += 1;
                 }
                 Ok(PushItemOutcome::Tombstoned) => {
-                    clear_outbox_item(app, item.id)?;
+                    clear_outbox_item(app, &item)?;
                     pushed += 1;
                     left_active_set += 1;
                 }
                 Ok(PushItemOutcome::Skipped) => {
-                    clear_outbox_item(app, item.id)?;
+                    clear_outbox_item(app, &item)?;
                     left_active_set += 1;
                 }
                 Ok(PushItemOutcome::Excluded) => {}
@@ -603,14 +612,18 @@ fn push_outbox_item(
     item: &OutboxItem,
     excluded_conversation_ids: &HashSet<String>,
 ) -> Result<PushItemOutcome, String> {
+    // A delete must always scrub whatever was previously synced, even for a
+    // conversation the user has since excluded from sync — exclusion suppresses
+    // uploads of new content, not the removal of content already on the remote
+    // (#3348). So push tombstones before the exclusion gate.
+    if item.op == "tombstone" {
+        push_tombstone(client, item)?;
+        return Ok(PushItemOutcome::Tombstoned);
+    }
     if let Some(conversation_id) = outbox_item_conversation_id(app, item)? {
         if excluded_conversation_ids.contains(&conversation_id) {
             return Ok(PushItemOutcome::Excluded);
         }
-    }
-    if item.op == "tombstone" {
-        push_tombstone(client, item)?;
-        return Ok(PushItemOutcome::Tombstoned);
     }
 
     let pushed_row = match item.table_name.as_str() {
@@ -749,9 +762,18 @@ fn read_outbox_batch(conn: &Connection) -> rusqlite::Result<Vec<OutboxItem>> {
     .collect()
 }
 
-fn clear_outbox_item(app: &AppHandle, id: i64) -> Result<(), String> {
+fn clear_outbox_item(app: &AppHandle, item: &OutboxItem) -> Result<(), String> {
     with_local_db(app, |conn| {
-        conn.execute("DELETE FROM sync_outbox WHERE id = ?1", params![id])?;
+        // Clear only the exact row-version we pushed. A delete that ran during
+        // the push flips this row to `op = tombstone` with a new `enqueued_at`
+        // (ON CONFLICT reuses the same id); an unconditional delete-by-id would
+        // then drop that fresh tombstone and the remote copy would survive the
+        // local delete. The `op`/`enqueued_at` guard leaves a flipped row in the
+        // outbox to be pushed on the next round (#3345).
+        conn.execute(
+            "DELETE FROM sync_outbox WHERE id = ?1 AND op = ?2 AND enqueued_at = ?3",
+            params![item.id, item.op, item.enqueued_at],
+        )?;
         Ok(())
     })
 }

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -46,7 +46,7 @@ pub struct HistorySyncConfig {
 pub struct HistorySyncLock(std::sync::Arc<tokio::sync::Mutex<()>>);
 
 impl HistorySyncLock {
-    fn handle(app: &AppHandle) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    pub(crate) fn handle(app: &AppHandle) -> std::sync::Arc<tokio::sync::Mutex<()>> {
         app.state::<HistorySyncLock>().0.clone()
     }
 }
@@ -1920,12 +1920,40 @@ fn apply_remote_meeting_speaker_assignment(conn: &Connection, row: PgRow) -> rus
 }
 
 fn delete_conversation_local(conn: &Connection, id: &str) -> rusqlite::Result<()> {
+    // Delete every child row that references this conversation (directly or via
+    // messages) before the conversation itself. The bundled SQLite enforces
+    // foreign keys, and PULL_ORDER applies `conversations` before `meetings`, so
+    // omitting any of these aborts the pull and wedges cross-device sync — the
+    // remote delete then never lands on this device (#3348).
+    conn.execute(
+        "DELETE FROM eval_signals
+         WHERE message_id IN (SELECT id FROM messages WHERE conversation_id = ?1)",
+        params![id],
+    )?;
     conn.execute(
         "DELETE FROM message_events WHERE conversation_id = ?1",
         params![id],
     )?;
     conn.execute(
         "DELETE FROM messages WHERE conversation_id = ?1",
+        params![id],
+    )?;
+    // meetings.agent_conversation_id references conversations(id) with no
+    // cascade; the meeting's own tombstone may not have been applied yet.
+    let meeting_ids = conn
+        .prepare("SELECT id FROM meetings WHERE agent_conversation_id = ?1")?
+        .query_map(params![id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for meeting_id in &meeting_ids {
+        delete_meeting_local(conn, meeting_id)?;
+    }
+    conn.execute(
+        "DELETE FROM plan_subtasks
+         WHERE plan_id IN (SELECT id FROM orchestration_plans WHERE conversation_id = ?1)",
+        params![id],
+    )?;
+    conn.execute(
+        "DELETE FROM orchestration_plans WHERE conversation_id = ?1",
         params![id],
     )?;
     conn.execute("DELETE FROM conversations WHERE id = ?1", params![id])?;

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -1084,6 +1084,12 @@ export async function deleteConversation(id: string): Promise<void> {
   if (!invoke) {
     throw new Error("Conversation operations require Tauri runtime");
   }
+  // Mark the conversation erased before the delete so a turn's memory capture
+  // still in flight cannot re-create a retained cloud source after the delete's
+  // erase runs (#3348). Dynamic import avoids a static cycle: privacy.store
+  // imports this module.
+  const { privacyStore } = await import("@/stores/privacy.store");
+  privacyStore.markConversationErased(id);
   await invoke("delete_conversation", { id });
 }
 

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -769,6 +769,14 @@ export async function processConversationMemory(
   ) {
     return null;
   }
+  // The conversation was deleted while this capture was in flight; retaining a
+  // source now would re-create cloud memory the delete just erased (#3348).
+  if (
+    input.conversationId &&
+    privacyStore.isConversationErased(input.conversationId)
+  ) {
+    return null;
+  }
   if (!isMemoryAvailable()) {
     return null;
   }

--- a/src/stores/privacy.store.ts
+++ b/src/stores/privacy.store.ts
@@ -117,6 +117,14 @@ function flagsFor(id: string): ConversationPrivacy {
   );
 }
 
+// Conversations whose data has been deleted this session. A turn's memory
+// capture is fired fire-and-forget at turn end and can still be in flight when
+// the user deletes the conversation; checking this at the capture's write point
+// stops a late capture from re-creating a retained cloud source the delete just
+// erased (#3348). Bounded so it cannot grow without limit.
+const ERASED_CONVERSATION_LIMIT = 512;
+const erasedConversationIds = new Set<string>();
+
 export const privacyStore = {
   getConversationPrivacy(id: string): ConversationPrivacy {
     return flagsFor(id);
@@ -124,6 +132,19 @@ export const privacyStore = {
 
   isMemoryExcluded(id: string | null | undefined): boolean {
     return id ? flagsFor(id).privileged || flagsFor(id).excludeMemory : false;
+  },
+
+  /** Record that a conversation was deleted so an in-flight memory capture for
+   * it does not re-create a retained source after the erase (#3348). */
+  markConversationErased(id: string): void {
+    if (erasedConversationIds.size >= ERASED_CONVERSATION_LIMIT) {
+      erasedConversationIds.clear();
+    }
+    erasedConversationIds.add(id);
+  },
+
+  isConversationErased(id: string | null | undefined): boolean {
+    return id ? erasedConversationIds.has(id) : false;
   },
 
   isHistorySyncExcluded(id: string | null | undefined): boolean {


### PR DESCRIPTION
Fixes #3345. Substantially addresses #3348.

### #3345 (P1) — all four defects
- **Erase-vs-pull resurrection:** `delete_conversation`, `clear_all_history`, and `erase_all` now hold the `HistorySyncLock` across the local erase, so an in-flight pull cannot re-insert erased rows.
- **clear-all meetings cascade:** `clear_all_history_records` clears meetings before conversations (the FK has no cascade), so the reset no longer aborts.
- **Outbox tombstone race:** `clear_outbox_item` clears only the exact row-version pushed (`id + op + enqueued_at`), so a delete that flips a row to a tombstone mid-push is not dropped — the remote copy is scrubbed.
- **Fire-and-forget cloud erase:** a new durable `pending_memory_source_erase` queue; a delete enqueues its source URI and removes it only on confirmed erase; a successful sync drains the queue. Offline/signed-out deletes retry instead of leaking forever.

### #3348 (P2) — addressed here
- Pull-side `delete_conversation_local` deletes eval_signals, linked meetings, and plan rows before the conversation (no more cross-device sync wedge).
- `clear-history` deletes `input_history`.
- erase-all reports cloud memory/notes honestly when chat.db fails (no false green "0 erased"); meeting-report wording is accurate about uncertain state.
- Excluded-conversation delete still scrubs the remote copy (tombstone pushed before the exclusion gate).
- erase-all clears `archived_employees` and `happy_provider_session_lifecycle`.
- In-flight memory capture is blocked for a conversation deleted mid-turn.

**Remaining #3348 residue (tracked, tiny):** `tool_authorization.db` VACUUM/secure_delete (will land with #3349, same file), CLI-transcript file deletion on *clear* (delete path already covers it), and `privacy.json` cleanup on erase-all.

### Verification
`cargo test --lib commands::chat` → 35 passed; `cargo test --lib services::history_sync` → 17 passed; Biome clean on the frontend files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com