### PR TITLE
fix(security): reject unenforceable rate caps; clamp lease budget (#3349, #3348)

### DIFF
--- a/src-tauri/src/capability_lease.rs
+++ b/src-tauri/src/capability_lease.rs
@@ -111,6 +111,21 @@ pub struct LeaseBudgets {
 }
 
 impl LeaseBudgets {
+    /// Reject a rate limit that can never fire. `max_calls_per_window` only
+    /// applies while a window is open, and a window is only opened when
+    /// `window_secs` is set — so a per-window cap with no window length (or a
+    /// window length with no cap) is silently unenforced. Require both or
+    /// neither at grant time rather than accepting the misconfiguration (#3349).
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_calls_per_window.is_some() != self.window_secs.is_some() {
+            return Err(
+                "a rate limit needs both max_calls_per_window and window_secs, or neither"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
     /// Whether charging `cost_micros` for one more call at `now` stays within
     /// budget. `now` is an RFC3339 UTC instant, compared lexicographically
     /// against the rate window's end.
@@ -593,6 +608,34 @@ mod tests {
     const NOW: &str = "2026-07-24T00:00:00Z";
     const LATER: &str = "2026-07-24T04:00:00Z";
     const PAST: &str = "2026-07-23T00:00:00Z";
+
+    #[test]
+    fn validate_rejects_a_rate_cap_that_can_never_fire() {
+        // A per-window cap with no window length (or vice versa) is silently
+        // unenforced, so grant-time validation must reject it.
+        let cap_without_window = LeaseBudgets {
+            max_calls_per_window: Some(5),
+            window_secs: None,
+            ..LeaseBudgets::default()
+        };
+        assert!(cap_without_window.validate().is_err());
+
+        let window_without_cap = LeaseBudgets {
+            max_calls_per_window: None,
+            window_secs: Some(60),
+            ..LeaseBudgets::default()
+        };
+        assert!(window_without_cap.validate().is_err());
+
+        let both = LeaseBudgets {
+            max_calls_per_window: Some(5),
+            window_secs: Some(60),
+            ..LeaseBudgets::default()
+        };
+        assert!(both.validate().is_ok());
+
+        assert!(LeaseBudgets::default().validate().is_ok());
+    }
 
     fn lease(predicates: LeasePredicates, budgets: LeaseBudgets) -> CapabilityLease {
         CapabilityLease {

--- a/src-tauri/src/commands/tool_authorization.rs
+++ b/src-tauri/src/commands/tool_authorization.rs
@@ -135,6 +135,7 @@ pub fn grant_capability_lease(
     predicates: LeasePredicates,
     budgets: LeaseBudgets,
 ) -> Result<CapabilityLease, String> {
+    budgets.validate()?;
     state.grant_lease(&conversation_id, &label, duration_secs, predicates, budgets)
 }
 
@@ -179,6 +180,7 @@ pub fn create_standing_policy(
     state: State<'_, ToolAuthorizationState>,
     input: StandingPolicyInput,
 ) -> Result<StandingPolicy, String> {
+    input.budgets.validate()?;
     state.create_standing_policy(input)
 }
 

--- a/src-tauri/src/tool_authorization.rs
+++ b/src-tauri/src/tool_authorization.rs
@@ -606,6 +606,11 @@ impl ToolAuthorizationState {
                 std::fs::create_dir_all(parent).ok();
             }
             let conn = Connection::open(&self.db_path).map_err(|e| e.to_string())?;
+            // Zero freed pages so wiped lease/audit/decision rows (tool names,
+            // conversation ids) do not linger in the file's free list after an
+            // erase-all wipe (#3348), matching the chat databases.
+            conn.execute_batch("PRAGMA secure_delete = ON;")
+                .map_err(|e| e.to_string())?;
             init_schema(&conn)?;
             *guard = Some(conn);
         }
@@ -1855,6 +1860,9 @@ impl ToolAuthorizationState {
             let reservations = conn
                 .execute("DELETE FROM spend_reservations", [])
                 .map_err(|e| e.to_string())?;
+            // Reclaim and zero the freed pages so no wiped authorization data
+            // survives in the file after an erase-all (#3348).
+            conn.execute_batch("VACUUM;").map_err(|e| e.to_string())?;
             Ok(decisions + leases + policies + continuations + audit_rows + handles + reservations)
         })
     }

--- a/src/components/approvals/leaseBudgets.ts
+++ b/src/components/approvals/leaseBudgets.ts
@@ -13,11 +13,19 @@ export const MICROS_PER_UNIT = 1_000_000;
  * a set ceiling (a conservative fail-safe that escalates earlier, never
  * mischarges).
  */
+/** Upper bound on a task lease's call budget. Also caps a non-finite input
+ * (e.g. `Number("1e999") === Infinity`), which would otherwise serialize to
+ * JSON null and become an unmetered (`max_calls: None`) lease in the gate. */
+export const MAX_LEASE_CALLS = 100_000;
+
 export function leaseBudgetsFromInputs(
   maxCalls: number,
   maxSpendInput: string,
 ): LeaseBudgets {
-  const calls = Math.max(1, Math.floor(maxCalls));
+  const requested = Number.isFinite(maxCalls)
+    ? Math.floor(maxCalls)
+    : MAX_LEASE_CALLS;
+  const calls = Math.min(MAX_LEASE_CALLS, Math.max(1, requested));
   const spend = Number.parseFloat(maxSpendInput);
   const maxSpendMicros =
     Number.isFinite(spend) && spend > 0

--- a/tests/unit/lease-budgets-from-inputs.test.ts
+++ b/tests/unit/lease-budgets-from-inputs.test.ts
@@ -2,7 +2,10 @@
 // ABOUTME: spend cap becomes a micro ceiling; a blank cap leaves no monetary allowance.
 
 import { describe, expect, it } from "vitest";
-import { leaseBudgetsFromInputs } from "@/components/approvals/leaseBudgets";
+import {
+  leaseBudgetsFromInputs,
+  MAX_LEASE_CALLS,
+} from "@/components/approvals/leaseBudgets";
 
 describe("leaseBudgetsFromInputs", () => {
   it("threads a set spend cap through as unpinned micros", () => {
@@ -32,5 +35,20 @@ describe("leaseBudgetsFromInputs", () => {
   it("rounds fractional micros to the nearest integer", () => {
     // 0.0000005 USDC * 1_000_000 = 0.5 micros -> rounds to 1.
     expect(leaseBudgetsFromInputs(10, "0.0000005").maxSpendMicros).toBe(1);
+  });
+
+  it("clamps a non-finite call count to a finite ceiling, never unmetered", () => {
+    // Number("1e999") === Infinity; Math.floor(Infinity) stays Infinity, which
+    // serializes to JSON null and would become an unmetered (max_calls: None)
+    // lease in the gate. Clamp it to the finite cap instead.
+    const budgets = leaseBudgetsFromInputs(Number("1e999"), "");
+    expect(Number.isFinite(budgets.maxCalls)).toBe(true);
+    expect(budgets.maxCalls).toBe(MAX_LEASE_CALLS);
+  });
+
+  it("caps an over-large call count to the ceiling", () => {
+    expect(leaseBudgetsFromInputs(MAX_LEASE_CALLS * 10, "").maxCalls).toBe(
+      MAX_LEASE_CALLS,
+    );
   });
 });


### PR DESCRIPTION
Addresses #3349 (2 of 4) and the #3348 tool-auth VACUUM item.

### Fixed
- **Rate-cap validation (#3349):** a `max_calls_per_window` with no `window_secs` never opens a window, so the cap is silently unenforced. `LeaseBudgets::validate()` now requires both or neither, called at `grant_capability_lease` and `create_standing_policy`. (Rust test added.)
- **Overflow → unmetered lease (#3349):** clamp the task-lease call budget to a finite ceiling so `Number("1e999") === Infinity` can no longer serialize to JSON `null` and become an unmetered (`max_calls: None`) lease. (Vitest added.)
- **tool-auth residue (#3348):** `tool_authorization.db` opens with `secure_delete` and `wipe()` VACUUMs, so wiped lease/audit/decision rows do not linger in free pages after erase-all.

### ⚠️ Not changed — payment-flow-sensitive (needs your call)
- **Uniform 3-use gateway handle (#3349):** the 3 uses cover the documented x402 signed-payment + SerenBucks dual-retry. Reducing it risks breaking a legitimate payment retry, so I did not change it blindly.
- **Spend metered only on the x402 path (#3349):** a directly-settled priced op (prepaid balance, no 402) is never metered — but the gateway success response carries **no charged cost**, so this cannot be metered client-side. It needs a Gateway-side change (return the cost on settle). 

So **#3349 should stay open** for those two until you decide the payment-flow approach.

### Verification
`cargo test --lib capability_lease` → 31 passed; `vitest lease-budgets-from-inputs` → 7 passed; Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com