### PR TITLE
fix(sandbox): deny writes to credential dirs in the workspace (#3347)

### DIFF
--- a/src-tauri/src/sandbox/landlock.rs
+++ b/src-tauri/src/sandbox/landlock.rs
@@ -64,6 +64,11 @@ mod linux {
             // No NetPort rules are added, so every handled TCP bind/connect is denied. AccessNet
             // arrives in ABI V4 (kernel 6.7); best-effort so an older kernel drops the network
             // handle rather than failing the whole launch, matching the filesystem handling above.
+            //
+            // Landlock only governs TCP: UDP (and other L4) is not restrictable, so a
+            // network-disabled bounded session on Linux can still send UDP (e.g. DNS-based
+            // exfiltration). This is a kernel limitation, unlike macOS Seatbelt's comprehensive
+            // `(deny network*)`. Documented so the "network disabled" promise is not overread (#3347).
             ruleset = ruleset
                 .set_compatibility(CompatLevel::BestEffort)
                 .handle_access(AccessNet::from_all(ABI::V4))
@@ -157,7 +162,11 @@ mod linux {
         env::var_os("PATH")
             .into_iter()
             .flat_map(|path| env::split_paths(&path).collect::<Vec<_>>())
-            .filter(|path| path.as_os_str().is_empty() || path.is_dir())
+            // Drop empty PATH components (a trailing ':' yields one). An empty
+            // path is not a real directory to grant, and it makes
+            // validate_deny_read's `starts_with` prefix-match every deny_read
+            // path, failing an otherwise-valid launch closed (#3347).
+            .filter(|path| !path.as_os_str().is_empty() && path.is_dir())
             .collect()
     }
 

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -50,8 +50,15 @@ pub fn seatbelt_profile(policy: &SandboxPolicy) -> Result<String, SandboxError> 
         profile.push("(deny network*)".to_string());
     }
 
+    // Deny both read and write on the credential directories. The workspace
+    // allow-write above would otherwise leave a deny_read path that sits inside
+    // the workspace root writable (e.g. ~/.config opened as the project) — a
+    // persistence vector even when reads are blocked. Last-match-wins in SBPL,
+    // so these denials override the earlier workspace allow for these subpaths
+    // (#3347). Matches Landlock's validate_deny_read invariant.
     for path in &policy.deny_read {
         profile.push(format!("(deny file-read* (subpath {}))", sbpl_path(path)));
+        profile.push(format!("(deny file-write* (subpath {}))", sbpl_path(path)));
     }
 
     Ok(profile.join("\n"))

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -360,6 +360,14 @@ mod platform {
         let base_token = HandleGuard::new(base_token);
         let logon_sid = logon_sid(base_token.get())?;
         let world_sid = world_sid()?;
+        // Restricting SID set for the write-restricted token. Note that keeping
+        // World (Everyone) here means a write to an object whose DACL grants
+        // Everyone write (world-writable temp/shared locations) is still
+        // permitted — write-confinement is to the workspace plus any
+        // Everyone-writable object, not the workspace alone. This matches the
+        // pinned Codex restricted-token design; tightening it (dropping World)
+        // needs on-box validation that the agent's own toolchain still runs and
+        // is tracked as sandbox hardening (#3347).
         let restricted = [
             SID_AND_ATTRIBUTES {
                 Sid: capability,

--- a/src-tauri/tests/sandbox_seatbelt.rs
+++ b/src-tauri/tests/sandbox_seatbelt.rs
@@ -105,6 +105,43 @@ fn sandbox_deny_read_canary_is_denied() {
     assert!(!String::from_utf8_lossy(&output.stdout).contains("do not read"));
 }
 
+// A credential directory that sits INSIDE the writable workspace root must not
+// be writable either: workspace-write allows writes to the workspace, so
+// without an explicit write-deny a deny_read path nested in the workspace (e.g.
+// the user opens ~ as the project) stays a persistence vector (#3347).
+#[test]
+fn sandbox_deny_read_path_inside_workspace_is_not_writable() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let creds = workspace.path().join("dot-ssh");
+    fs::create_dir_all(&creds).expect("creds dir");
+    let target = creds.join("authorized_keys");
+    let sandbox = policy(
+        SandboxMode::WorkspaceWrite,
+        workspace.path(),
+        &[creds.clone()],
+        true,
+    );
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!(
+            "if printf pwned > {} 2>/dev/null; then echo WROTE; else echo DENIED; fi",
+            shell_literal(&target)
+        ),
+    );
+
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("DENIED"),
+        "write to a deny_read dir inside the workspace must be denied: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        fs::read_to_string(&target).unwrap_or_default().is_empty(),
+        "the credential file must not have been written"
+    );
+}
+
 #[test]
 fn sandbox_grandchild_write_cannot_escape() {
     let workspace = tempdir().expect("workspace tempdir");


### PR DESCRIPTION
Fixes #3347.

- **macOS write-overlap (real fix):** Seatbelt now denies `file-write*` as well as `file-read*` on each `deny_read` path, so a credential dir nested inside a `workspace-write` root (user opens `~` as the project) is no longer a writable persistence vector. Last-match-wins in SBPL. New real sandboxed-child canary: `sandbox_deny_read_path_inside_workspace_is_not_writable`.
- **Landlock empty-PATH:** drop empty PATH components so a trailing `:` no longer makes `validate_deny_read` prefix-match everything and fail a valid launch closed.
- **Documented platform limits:** Landlock cannot restrict UDP on a network-disabled session (kernel limitation); the Windows restricted token keeps World as a restricting SID (Everyone-writable objects stay writable — tightening needs on-box validation).
- **Verified-status honesty:** the status struct already documents that it reports spec-buildability, not that a child is confined, and the detail text describes launch-time enforcement — no overstatement to change.

### Verification
`cargo test --test sandbox_seatbelt` → 7 passed (real sandboxed children). Landlock/Windows edits are `cfg`-gated and validate on the CI PR matrix.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com