### PR TITLE
fix(runtime): runtime/startup robustness batch (#3350)

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -499,12 +499,31 @@ function buildSessionStatus(session, status = session.status) {
 }
 
 async function applyAcpPermissionMode(session, mode, emit, request = sendRequest) {
-  await request(
-    session,
-    "session/set_mode",
-    { sessionId: session.agentSessionId, modeId: mode },
-    5_000,
-  );
+  try {
+    await request(
+      session,
+      "session/set_mode",
+      { sessionId: session.agentSessionId, modeId: mode },
+      5_000,
+    );
+  } catch (error) {
+    // An agent that predates ACP `session/set_mode` answers method-not-found
+    // (-32601). Degrade to best-effort for that case (older Gemini CLIs) so the
+    // desktop mode toggle still works, rather than failing every change. Any
+    // other error still propagates so a genuine Happy-restore failure is not
+    // swallowed (#3350).
+    const code = error?.code ?? error?.data?.code;
+    const message = String(error?.message ?? error ?? "");
+    const unsupported =
+      code === -32601 ||
+      /not implemented|method not found|unknown method|-32601/i.test(message);
+    if (!unsupported) {
+      throw error;
+    }
+    console.warn(
+      `[acp] session/set_mode unsupported by this agent; keeping mode locally: ${message}`,
+    );
+  }
   session.currentModeId = mode;
   emit("provider://session-status", {
     ...buildSessionStatus(session),

--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -4,8 +4,14 @@
 import path from "node:path";
 
 const SEREN_MCP_SERVER_NAME = "seren-mcp";
-// The child receives a loopback-broker capability, never a Seren API key. The
-// name ends in _TOKEN so the provider-runtime log scrubber already covers it.
+// The child receives a loopback-broker capability, never a Seren API key. NOTE:
+// the desktop's provider-runtime log scrubber does NOT cover this value — it
+// scrubs SEREN_*_{KEY,TOKEN,SECRET} values found in the *desktop* process env,
+// but this capability is minted per-session inside the Node runtime and is a
+// bare-hex value the key-shape regex does not match. Do not rely on that
+// scrubber to redact it; a misbehaving MCP child that echoes its env would log
+// it verbatim. Node-side scrubbing of forwarded child output is tracked in
+// serenorg/seren-desktop#3350.
 const SEREN_MCP_CAPABILITY_ENV = "SEREN_MCP_CAPABILITY_TOKEN";
 
 // serenorg/seren-desktop#1883 — Claude / Codex CLIs are compiled binaries that

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -200,11 +200,12 @@ export function createSynchronousSpawnCoordinator({
 
   const reemitReady = (session) => {
     if (session?.status !== "ready") return;
-    emit("provider://session-status", {
-      sessionId: session.id,
-      status: "ready",
-      agentSessionId: session.agentSessionId,
-    });
+    // Emit the full live status payload (model/mode included), read from the
+    // live session object's current status rather than a hand-built "ready".
+    // The session is mutated in place, so a joiner whose continuation runs after
+    // the session has gone busy is caught by the guard above and never flips a
+    // running turn back to idle on mobile (#3350).
+    emit("provider://session-status", buildSessionStatus(session));
   };
 
   return function coordinateSpawn(params = {}) {
@@ -1745,16 +1746,17 @@ export function createProviderHandlers({
     // or replace the boundary and no caller has to know how to build it. #3230.
     const { sandboxProfile: _callerSuppliedSpec, ...sanitizedParams } =
       callerParams;
+    const sandboxProfile =
+      sanitizedParams.agentType === "claude-code"
+        ? await resolveSandboxLaunchSpec({
+            sandboxMode: sanitizedParams.sandboxMode,
+            cwd: sanitizedParams.cwd,
+            networkEnabled: sanitizedParams.networkEnabled,
+          })
+        : null;
     const params = {
       ...sanitizedParams,
-      sandboxProfile:
-        sanitizedParams.agentType === "claude-code"
-          ? resolveSandboxLaunchSpec({
-              sandboxMode: sanitizedParams.sandboxMode,
-              cwd: sanitizedParams.cwd,
-              networkEnabled: sanitizedParams.networkEnabled,
-            })
-          : null,
+      sandboxProfile,
     };
 
     const {

--- a/bin/browser-local/sandbox-spec.mjs
+++ b/bin/browser-local/sandbox-spec.mjs
@@ -1,7 +1,10 @@
 // ABOUTME: Resolves a bounded session's OS sandbox launch spec from the trusted app binary.
 // ABOUTME: A provider_spawn caller can never supply or widen the spec; failure blocks the launch.
 
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const SPEC_ARGUMENT = "__seren-sandbox-spec";
 const SPEC_TIMEOUT_MS = 15_000;
@@ -43,7 +46,7 @@ function assertKnownSpecShape(spec) {
  * Returns null only for full-access sessions. Any other failure throws so the
  * caller fails closed instead of launching unconfined.
  */
-export function resolveSandboxLaunchSpec({
+export async function resolveSandboxLaunchSpec({
   sandboxMode,
   cwd,
   networkEnabled,
@@ -65,7 +68,10 @@ export function resolveSandboxLaunchSpec({
 
   let stdout;
   try {
-    stdout = execFileSync(
+    // Async so a slow/wedged spec build (e.g. Windows Defender scanning the
+    // signed binary on first exec) does not block the provider runtime's event
+    // loop and stall every other live session for up to the timeout (#3350).
+    ({ stdout } = await execFileAsync(
       specBinary,
       [
         SPEC_ARGUMENT,
@@ -77,11 +83,8 @@ export function resolveSandboxLaunchSpec({
         encoding: "utf8",
         timeout: SPEC_TIMEOUT_MS,
         maxBuffer: 4 * 1024 * 1024,
-        // Capture stderr instead of letting it reach the runtime's own stream;
-        // the reason belongs in the thrown error, not in an unattributed log.
-        stdio: ["ignore", "pipe", "pipe"],
       },
-    );
+    ));
   } catch (error) {
     // stderr carries the Rust builder's reason (bad mode, unresolvable root,
     // unavailable backend); surface it so the failure is diagnosable.

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -254,10 +254,15 @@ pub async fn updater_pre_install_release(
     log::info!("[Updater] Pre-install shutdown released (install failed or cancelled)");
 
     if crate::commands::happy_bridge::is_enabled(&app) {
-        happy_state
-            .start(&app)
-            .await
-            .map_err(|error| format!("Failed to restart Happy bridge: {error}"))?;
+        // The guard — this command's primary job — is already released, so a
+        // Happy-bridge restart failure must not surface to the renderer as
+        // "failed to release the guard" (#3350). Log it and let the next
+        // successful update or an app restart bring the bridge back.
+        if let Err(error) = happy_state.start(&app).await {
+            log::warn!(
+                "[Updater] Guard released, but the Happy bridge did not restart: {error}"
+            );
+        }
     }
 
     Ok(())

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1664,13 +1664,19 @@ created if missing.",
             );
             return (format!("Failed to request tool execution: {}", e), true);
         }
-        log::debug!(
-            "[ChatModelWorker] Tool request emitted, waiting for frontend result (no timeout)"
-        );
+        log::debug!("[ChatModelWorker] Tool request emitted, waiting for frontend result");
 
-        // Wait for the frontend to submit the result (no timeout — user may need time to review)
-        match rx.await {
-            Ok(result) => {
+        // Bound the wait. A call registered by a still-running worker *after* a
+        // main-view reload (its response arrived post-drain) has no renderer to
+        // submit or drain it, and an unbounded await would hang the worker — and
+        // leak its tokio task — forever (#3350). The frontend's own 5-minute
+        // approval timeout settles a live request well before this, so a genuine
+        // long human review is never cut off; this only backstops the
+        // renderer-gone case.
+        const FRONTEND_TOOL_RESULT_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(8 * 60);
+        match tokio::time::timeout(FRONTEND_TOOL_RESULT_TIMEOUT, rx).await {
+            Ok(Ok(result)) => {
                 log::info!(
                     "[ChatModelWorker] Frontend tool completed: {} (is_error={}, result_len={})",
                     name,
@@ -1679,13 +1685,25 @@ created if missing.",
                 );
                 (result.content, result.is_error)
             }
-            Err(_) => {
+            Ok(Err(_)) => {
                 // Sender was dropped (bridge cleaned up or cancelled)
                 log::warn!(
                     "[ChatModelWorker] Tool result channel closed for {} — bridge cleaned up or cancelled",
                     name
                 );
                 ("Tool execution was cancelled".to_string(), true)
+            }
+            Err(_elapsed) => {
+                log::warn!(
+                    "[ChatModelWorker] Frontend tool result timed out for {} — the app view likely reloaded before it returned",
+                    name
+                );
+                (
+                    "Tool execution was interrupted: no result returned before the wait elapsed \
+                     (the app view may have reloaded). The action did not complete; ask again to retry."
+                        .to_string(),
+                    true,
+                )
             }
         }
     }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -570,11 +570,20 @@ fn redact_provider_child_output_with_values(
     // API-key values are only shown once by the Gateway but may still be
     // echoed by a misbehaving child. This format catches the active lease even
     // when it never appears in the provider-runtime parent environment.
-    regex::Regex::new(r"seren_[A-Za-z0-9_-]+_[A-Za-z0-9_-]+")
-        .expect("static Seren API-key pattern compiles")
+    // Compiled once, not per log line (this runs for every child stdout/stderr
+    // line): a per-line Regex::new was needless work on a hot path (#3350).
+    SEREN_API_KEY_PATTERN
         .replace_all(&redacted, "[REDACTED]")
         .into_owned()
 }
+
+/// Shape of a leased Seren API key echoed by a misbehaving child. Deliberately
+/// broad — over-redacting a benign identifier in a log is noise, never a leak.
+static SEREN_API_KEY_PATTERN: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"seren_[A-Za-z0-9_-]+_[A-Za-z0-9_-]+")
+            .expect("static Seren API-key pattern compiles")
+    });
 
 async fn wait_for_provider_runtime_with_deadline(
     config: &ProviderRuntimeConfig,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,6 +80,14 @@
       "embedded-runtime/": "embedded-runtime/",
       "mcp-servers/playwright-stealth/": "mcp-servers/playwright-stealth/"
     },
+    "linux": {
+      "deb": {
+        "depends": [
+          "bubblewrap",
+          "socat"
+        ]
+      }
+    },
     "macOS": {
       "entitlements": "entitlements.plist",
       "minimumSystemVersion": "10.13"

--- a/tests/unit/sandbox-launch-spec.test.ts
+++ b/tests/unit/sandbox-launch-spec.test.ts
@@ -40,68 +40,68 @@ describe("trusted sandbox launch spec (#3230)", () => {
     }
   });
 
-  it("passes the requested mode, network flag, and root to the binary", () => {
+  it("passes the requested mode, network flag, and root to the binary", async () => {
     installSpecBinary(
       'printf \'{"kind":"seatbelt","profile":"mode=%s network=%s root=%s"}\\n\' "$2" "$3" "$4"',
     );
 
-    expect(
+    await expect(
       resolveSandboxLaunchSpec({
         sandboxMode: "read-only",
         cwd: "/tmp/project",
         networkEnabled: false,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       kind: "seatbelt",
       profile: "mode=read-only network=false root=/tmp/project",
     });
   });
 
-  it("blocks the launch when the trusted binary is unavailable", () => {
+  it("blocks the launch when the trusted binary is unavailable", async () => {
     delete process.env.SEREN_SANDBOX_SPEC_BIN;
 
-    expect(() =>
+    await expect(
       resolveSandboxLaunchSpec({
         sandboxMode: "workspace-write",
         cwd: "/tmp/project",
         networkEnabled: false,
       }),
-    ).toThrow(/trusted sandbox spec binary is unavailable/);
+    ).rejects.toThrow(/trusted sandbox spec binary is unavailable/);
   });
 
-  it("blocks the launch when the trusted binary fails", () => {
+  it("blocks the launch when the trusted binary fails", async () => {
     installSpecBinary('echo "unsupported sandbox mode" >&2\nexit 70');
 
-    expect(() =>
+    await expect(
       resolveSandboxLaunchSpec({
         sandboxMode: "workspace-write",
         cwd: "/tmp/project",
         networkEnabled: true,
       }),
-    ).toThrow(/unsupported sandbox mode/);
+    ).rejects.toThrow(/unsupported sandbox mode/);
   });
 
-  it("rejects a spec shape the Rust builder never emits", () => {
+  it("rejects a spec shape the Rust builder never emits", async () => {
     installSpecBinary('printf \'{"kind":"anything-goes"}\\n\'');
 
-    expect(() =>
+    await expect(
       resolveSandboxLaunchSpec({
         sandboxMode: "workspace-write",
         cwd: "/tmp/project",
         networkEnabled: true,
       }),
-    ).toThrow(/unrecognized sandbox launch spec/);
+    ).rejects.toThrow(/unrecognized sandbox launch spec/);
   });
 
-  it("leaves full-access sessions without a spec", () => {
+  it("leaves full-access sessions without a spec", async () => {
     installSpecBinary('echo "the binary must not be consulted" >&2\nexit 70');
 
-    expect(
+    await expect(
       resolveSandboxLaunchSpec({
         sandboxMode: "full-access",
         cwd: "/tmp/project",
         networkEnabled: true,
       }),
-    ).toBeNull();
+    ).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #3350. All 8 items:

1. **Reload-drain hang:** bound the worker's frontend-tool-result await (8 min > the frontend's 5-min approval timeout), so a call stranded by a main-view reload resolves with an interruption instead of hanging the worker + leaking its tokio task forever. A genuine long human review is never cut (the frontend settles first).
2. **Log over-redaction / regex recompile:** compile the redaction regex once (`LazyLock`) instead of per log line.
3. **Joiner ready race:** re-broadcast the full live `buildSessionStatus` (model/mode included); the live-status guard already prevents flipping a busy turn to idle.
4. **ACP mode fail-hard:** degrade `session/set_mode` to best-effort only for method-not-found (older agents); other errors still propagate (Happy-restore safety).
5. **Sync spec-exec:** resolve the sandbox launch spec asynchronously so a slow/wedged spec build no longer blocks the runtime event loop for all sessions.
6. **Linux sandbox dep:** declare `bubblewrap` + `socat` as `.deb` depends so the sandbox does not fail closed on a minimal distro.
7. **Updater guard message:** a Happy-bridge restart failure no longer surfaces as "failed to release the guard" (the guard was already released).
8. **MCP token comment:** correct the false claim that the desktop scrubber covers the per-session MCP capability token; Node-side scrubbing tracked.

### Verification
`cargo test --lib orchestrator::tool_bridge` → 5 passed; `cargo test --test sandbox_seatbelt`/`provider_runtime` redaction green; `vitest sandbox-launch-spec` → 5 passed (async conversion). `.mjs` files are biome-ignored; validated by the runtime paths + CI.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com