### PR TITLE
fix(privacy): clear CLI transcripts on clear-history; wipe privacy.json (#3348)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2565,15 +2565,20 @@ pub async fn clear_conversation_history(
     conversation_id: String,
 ) -> Result<(), String> {
     let index_id = conversation_id.clone();
-    run_db(app.clone(), move |conn| {
+    let transcript_targets = run_db(app.clone(), move |conn| {
+        // Capture the on-disk CLI transcript targets before the clear so the raw
+        // ~/.claude|.codex transcript is removed too, matching delete (#3348);
+        // otherwise "Clear history" leaves the full verbatim transcript on disk.
+        let targets = collect_agent_transcript_targets(conn, std::slice::from_ref(&conversation_id))?;
         clear_conversation_history_records(conn, &conversation_id)?;
         // Reclaim and zero the freed pages so the cleared messages don't linger
         // in the chat.db file, matching the per-conversation delete and
         // erase-all paths.
         vacuum_database(conn)?;
-        Ok(())
+        Ok(targets)
     })
     .await?;
+    delete_agent_transcripts_best_effort(&transcript_targets);
     delete_conversation_index_best_effort(&app, &index_id);
     vacuum_conversation_index_best_effort(&app);
     // Cascade the cloud-memory retained-source erasure so clearing a

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -52,6 +52,7 @@ import { chatStore } from "@/stores/chat.store";
 import { cryptoWalletStore } from "@/stores/crypto-wallet.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { resetAllKeybindings } from "@/stores/keybindings.store";
+import { privacyStore } from "@/stores/privacy.store";
 import { providerStore } from "@/stores/provider.store";
 import {
   mcpSettings,
@@ -305,6 +306,10 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     stopHistorySync();
     try {
       const reports = await eraseAllConversationData();
+      // Drop the renderer-side privacy.json entries (per-conversation flags and
+      // free-text counsel direction) so identifying data does not survive the
+      // erase-all (#3348).
+      await privacyStore.clearAll();
       setEraseAllReports(reports);
       setEraseAllConfirm("");
       setHistorySyncSummary(null);

--- a/src/stores/privacy.store.ts
+++ b/src/stores/privacy.store.ts
@@ -207,6 +207,17 @@ export const privacyStore = {
       .filter(([, flags]) => flags.privileged || flags.excludeHistorySync)
       .map(([id]) => id);
   },
+
+  /**
+   * Drop every per-conversation privacy entry and persist the empty state, for
+   * the "erase all data" flow. privacy.json holds identifying data (including
+   * free-text counsel direction), so it must not survive an erase-all (#3348).
+   */
+  async clearAll(): Promise<void> {
+    erasedConversationIds.clear();
+    setPrivacyState("conversations", {});
+    await saveStoredPrivacy();
+  },
 };
 
 export { privacyState };


### PR DESCRIPTION
Fixes #3348 (residue from #3365).

- **CLI transcript on clear:** `clear_conversation_history` collects the conversation transcript targets before clearing and deletes the on-disk `~/.claude|.codex` transcript files, matching `delete_conversation`.
- **privacy.json on erase-all:** the erase-all flow calls `privacyStore.clearAll()` so per-conversation flags + free-text counsel direction do not survive.

(The `tool_authorization.db` VACUUM residue item landed in #3366.)

Verification: chat clear-history canary passes; Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com