### PR TITLE
feat(validation): contextmenu, read-only state command, testids (#3355)

### DIFF
--- a/src-tauri/src/validation/control_server.rs
+++ b/src-tauri/src/validation/control_server.rs
@@ -101,6 +101,12 @@ struct ControlCommand {
     timeout_ms: Option<u64>,
     #[serde(default)]
     native: Option<bool>,
+    // readState: the read-only Tauri command to invoke and its arguments. The
+    // renderer enforces a read-only allowlist before invoking (#3355).
+    #[serde(default)]
+    invoke_name: Option<String>,
+    #[serde(default)]
+    invoke_args: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -121,6 +127,12 @@ struct IncomingCommand {
     timeout_ms: Option<u64>,
     #[serde(default)]
     native: Option<bool>,
+    // readState: the read-only Tauri command to invoke and its arguments. The
+    // renderer enforces a read-only allowlist before invoking (#3355).
+    #[serde(default)]
+    invoke_name: Option<String>,
+    #[serde(default)]
+    invoke_args: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -255,6 +267,8 @@ fn handle_request(
         key: incoming.key,
         timeout_ms: incoming.timeout_ms,
         native: incoming.native,
+        invoke_name: incoming.invoke_name,
+        invoke_args: incoming.invoke_args,
     };
     let (tx, rx) = mpsc::channel();
 
@@ -297,12 +311,19 @@ fn is_allowed_command(command: &str) -> bool {
         command,
         "navigate"
             | "click"
+            // Right-click a selector to open a context menu (conversation delete
+            // and other context-menu flows are otherwise undrivable). #3355.
+            | "contextmenu"
             | "fill"
             | "press"
             | "waitFor"
             | "dumpText"
             | "screenshot"
             | "setRootPath"
+            // Read a server-side outcome via a read-only allowlisted Tauri
+            // command (audit rows, lease charge, pending approvals). The
+            // renderer enforces the read-only allowlist. #3355.
+            | "readState"
     )
 }
 

--- a/src/components/approvals/ApprovalActions.tsx
+++ b/src/components/approvals/ApprovalActions.tsx
@@ -158,6 +158,7 @@ export const ApprovalActions: Component<ApprovalActionsProps> = (props) => {
           </button>
           <button
             type="button"
+            data-testid="approval-approve-once"
             class="px-5 py-2.5 text-[0.9rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-accent text-primary-foreground hover:bg-primary/85 hover:shadow-[var(--glow-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={() => props.onApproveOnce()}
             disabled={props.isProcessing || props.approveDisabled}

--- a/src/components/approvals/CapabilityLeasePanel.tsx
+++ b/src/components/approvals/CapabilityLeasePanel.tsx
@@ -184,6 +184,7 @@ export const CapabilityLeasePanel: Component<CapabilityLeasePanelProps> = (
                   <Show when={leaseIsActive(lease)}>
                     <button
                       type="button"
+                      data-testid="capability-lease-revoke"
                       class="ml-auto px-2.5 py-1 text-[0.78rem] font-medium rounded-md cursor-pointer bg-transparent text-destructive border border-destructive/40 hover:bg-destructive/10 disabled:opacity-50"
                       onClick={() => void handleRevoke(lease)}
                       disabled={revokingId() !== null}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -2485,6 +2485,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                   />
                   <button
                     type="button"
+                    data-testid="erase-all-data"
                     disabled={eraseAllBusy() || eraseAllConfirm() !== "ERASE"}
                     class="px-3 py-1.5 text-[0.8rem] rounded-md border border-destructive/60 bg-destructive/10 text-destructive hover:bg-destructive/15 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={handleEraseAllData}

--- a/src/services/validation-control.ts
+++ b/src/services/validation-control.ts
@@ -17,6 +17,8 @@ interface ValidationCommand {
   key?: string;
   timeoutMs?: number;
   native?: boolean;
+  invokeName?: string;
+  invokeArgs?: Record<string, unknown>;
 }
 
 interface ValidationReply {
@@ -105,6 +107,10 @@ async function handleCommand(command: ValidationCommand): Promise<unknown> {
     case "click":
       findElement(command.selector).click();
       return { clicked: command.selector };
+    case "contextmenu":
+      return contextmenu(command.selector);
+    case "readState":
+      return readState(command.invokeName, command.invokeArgs);
     case "fill":
       return fill(command.selector, command.value ?? "");
     case "press":
@@ -151,6 +157,43 @@ function fill(selector: string | undefined, value: string): { filled: string } {
   );
   element.dispatchEvent(new Event("change", { bubbles: true }));
   return { filled: selector ?? "" };
+}
+
+/** Read-only Tauri commands a validation scenario may invoke to assert a
+ * server-side outcome (audit rows written, lease charged, approvals pending).
+ * A small allowlist keeps the control channel read-only — no mutating or
+ * credential-bearing command is reachable. #3355. */
+const READ_STATE_ALLOWLIST = new Set([
+  "list_authorization_audit",
+  "list_capability_leases",
+  "list_pending_approvals",
+]);
+
+async function readState(
+  name: string | undefined,
+  args: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  if (!name) throw new Error("readState requires invokeName");
+  if (!READ_STATE_ALLOWLIST.has(name)) {
+    throw new Error(
+      `readState command is not on the read-only allowlist: ${name}`,
+    );
+  }
+  return invoke(name, args ?? {});
+}
+
+function contextmenu(selector: string | undefined): { contextmenu: string } {
+  const element = findElement(selector);
+  // Right button + a real contextmenu event, so SolidJS onContextMenu handlers
+  // (conversation delete, etc.) open exactly as they do for a user right-click.
+  element.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+    }),
+  );
+  return { contextmenu: selector ?? "" };
 }
 
 function press(key: string): { pressed: string } {


### PR DESCRIPTION
Fixes #3355. Unblocks the three deep signed-in E2E flows #3193 flagged as harness-limited.

1. **`contextmenu` command** — right-click a selector (button 2 + real `contextmenu` event) so `onContextMenu` flows (conversation delete) open as for a user right-click.
2. **`readState` command** — invoke a **read-only allowlisted** Tauri command (`list_authorization_audit`, `list_capability_leases`, `list_pending_approvals`) to assert server-side outcomes. Renderer enforces the allowlist; channel stays read-only. New `invokeName`/`invokeArgs` relay fields on both control-command structs.
3. **`data-testid`s** — `approval-approve-once`, `capability-lease-revoke`, `erase-all-data`.

Verification: `cargo test --lib validation` → 11 passed; Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com