### PR TITLE
docs(release): note the full audit resolution in v3.73.0 notes

### DIFF
--- a/.github/release-notes/v3.73.0.md
+++ b/.github/release-notes/v3.73.0.md
@@ -82,7 +82,13 @@ A full audit ran before this tag; the release-blocking findings were fixed:
 - **Windows sandbox:** bounded agents refused to start when a credential directory existed — now ships write-confinement on Windows (read-deny follow-up tracked) (#3342)
 - **Orchestrator:** decomposed multi-task plans could complete a subtask with an approval still pending, hanging the thread — now settled through the same completion-integrity guard as single-task runs (#3343)
 - **Capability leases:** "Approve for this task" built lease predicates that never matched the gate for web fetches, OAuth publishers, and skill scripts — now keyed to the gate's own capability (#3344)
-- Non-blocking findings (P2 hardening, erase/sync concurrency) are tracked as follow-up issues.
+- **Erase/sync retention:** every erase path now holds the history-sync lock (no resurrection mid-erase), the outbox tombstone race is closed, offline cloud-memory erases retry durably, cross-device delete tombstones no longer wedge on a foreign key, and clear-history removes verbatim prompts + CLI transcripts (#3345, #3348)
+- **Approval UI:** approval-listener leaks, a single-slot modal click-race, a silent post-timeout modal, an unguarded worker-stall path, and a panel error that could trip the app recovery boundary (#3351)
+- **Sandbox hardening:** credential dirs nested in a workspace are now write-denied on macOS, Landlock drops empty PATH components, and the UDP / Windows-World-SID limitations are documented (#3347)
+- **Runtime robustness:** a reload can no longer strand a worker forever, the child-log redaction regex is compiled once, the spec build no longer blocks the event loop, older ACP agents degrade gracefully, and the Linux `.deb` now depends on the sandbox packages (#3350)
+- **Leases:** unenforceable rate caps are rejected at grant, and an overflowing call budget can no longer become unmetered (#3349)
+- **Validation harness:** context-menu + read-only state-inspection commands and test ids to drive the deep signed-in E2E flows (#3355)
+- Two payment-flow metering edges are deferred to a Gateway-side follow-up.
 
 ## 🛠 Fixes & Internals
 


### PR DESCRIPTION
Updates `.github/release-notes/v3.73.0.md` so the published What's New reflects the complete pre-release audit close-out (erase/sync retention, approval-UI, sandbox hardening, runtime robustness, lease-metering, validation-harness — all landed after the notes were first written).

Curated contract test passes.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com