### PR TITLE
fix(windows-e2e): resolve app-installed codex; require codex creds

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -331,11 +331,16 @@ function Get-MissingAgentCredentialNames() {
   `$journeys = @(Get-ConfiguredAgentJourneys)
   `$requiresClaude = `$journeys -contains "claude-code" -or `$journeys -contains "claude-codex"
   `$requiresCodex = `$journeys -contains "codex" -or `$journeys -contains "claude-codex"
+  # A Bedrock-backed claude-code journey authenticates via the EC2 instance role
+  # (CLAUDE_CODE_USE_BEDROCK=1, set during secret hydration), so it needs no
+  # Claude login file. Codex has no Bedrock equivalent and still requires its
+  # archived credential file whenever the codex/claude-codex journeys run.
+  `$claudeViaBedrock = Convert-EnvFlag (Get-EnvValue "CLAUDE_CODE_USE_BEDROCK") `$false
   `$home = [Environment]::GetEnvironmentVariable("USERPROFILE")
   `$appData = [Environment]::GetEnvironmentVariable("APPDATA")
   `$missing = @()
 
-  if (`$requiresClaude) {
+  if (`$requiresClaude -and -not `$claudeViaBedrock) {
     `$claudePaths = @(
       (Join-Path `$home ".claude\.credentials.json"),
       (Join-Path `$home ".claude.json")
@@ -478,8 +483,13 @@ try {
     [Environment]::SetEnvironmentVariable("ANTHROPIC_MODEL", `$bedrockModel, "Process")
     [Environment]::SetEnvironmentVariable("ANTHROPIC_SMALL_FAST_MODEL", `$bedrockSmallModel, "Process")
     [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_MODEL", `$bedrockModel, "Process")
-    # Bedrock uses the AWS credential chain; no Claude login file is required.
-    [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0", "Process")
+    # Bedrock uses the AWS credential chain, so the claude-code journey needs no
+    # Claude login file — Get-MissingAgentCredentialNames skips the Claude check
+    # when CLAUDE_CODE_USE_BEDROCK is set. Codex has no Bedrock path, so we must
+    # NOT waive the overall credential requirement here: the codex/claude-codex
+    # journeys still require their archived .codex/auth.json, and blanket-forcing
+    # SEREN_E2E_AGENT_CREDENTIALS_REQUIRED=0 silently let the codex journey run
+    # uncertified across releases.
     # A brand-new profile's first claude-code run on the e2e host fetches the
     # autoupdater/telemetry/feature-gate catalog over the network at startup;
     # any of those stalling can wedge the stream-json initialize handshake on a
@@ -544,6 +554,17 @@ try {
     @{ Label = "Gemini"; Package = "@google/gemini-cli@latest"; Binary = "gemini.cmd" },
     @{ Label = "Grok"; Package = "@xai-official/grok@latest"; Binary = "grok.cmd" }
   )
+  # The installed app resolves agent CLIs from the real default npm global
+  # prefix (%APPDATA%\npm), NOT this portable toolchain Node's own dir, which is
+  # where a zip Node otherwise plants its globals. Pin the prefix to %APPDATA%\npm
+  # so the app's production resolver (resolveInstalledCodexBinary, candidate #1)
+  # finds them exactly as on a real MSI-Node user profile. Without this the box
+  # installed codex-cli 0.145.0 into the scratch Node dir, the app could not see
+  # it, and the codex journey died with "not installed in a verifiable location"
+  # while build+publish were correctly skipped (run 30159367572).
+  `$appDataNpmPrefix = Join-Path `$env:APPDATA "npm"
+  New-Item -ItemType Directory -Path `$appDataNpmPrefix -Force | Out-Null
+  `$env:npm_config_prefix = `$appDataNpmPrefix
   `$agentCliInstallArgs = @("install", "--global", "--no-audit", "--no-fund") + @(
     `$agentCliPackages | ForEach-Object { `$_.Package }
   )

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -348,6 +348,41 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("initialModelId");
   });
 
+  it("installs the agent CLIs where the app's production resolver looks (run 30159367572)", () => {
+    // The harness provisions a portable toolchain Node whose npm global prefix
+    // is the scratch Node dir, but the installed app resolves agent CLIs from
+    // %APPDATA%\npm (resolveInstalledCodexBinary candidate #1). Pin the install
+    // prefix to %APPDATA%\npm so the app can actually see the codex it installed;
+    // otherwise the codex journey dies with "not installed in a verifiable
+    // location" while the box demonstrably has the CLI.
+    expect(taskUserRunner).toContain("npm_config_prefix");
+    expect(taskUserRunner).toContain("appDataNpmPrefix");
+    expect(agentRegistry).toContain('path.join(appData, "npm", "codex.cmd")');
+  });
+
+  it("keeps codex credentials required under Bedrock — Bedrock waives only Claude (run 30159367572)", () => {
+    // Bedrock authenticates only the claude-code journey (AWS credential chain).
+    // The credential validator must skip the Claude login-file check when
+    // CLAUDE_CODE_USE_BEDROCK is set, but codex has no Bedrock path, so its
+    // archived .codex/auth.json stays required for the codex/claude-codex
+    // journeys. Regression guard: the Bedrock backend block must NOT blanket
+    // force SEREN_E2E_AGENT_CREDENTIALS_REQUIRED=0 (that silently let the codex
+    // journey run uncertified across releases).
+    expect(taskUserRunner).toContain("claudeViaBedrock");
+    expect(taskUserRunner).toContain("requiresClaude -and -not");
+    // Scope to the Bedrock backend block via anchors unique to it (the explicit
+    // -AllowMissingAgentCredentials escape hatch elsewhere legitimately still
+    // sets the flag to 0, so a whole-file assertion would be wrong).
+    const bedrockBlock = taskUserRunner.slice(
+      taskUserRunner.indexOf('"CLAUDE_CODE_USE_BEDROCK", "1"'),
+      taskUserRunner.indexOf("Configured Bedrock agent backend"),
+    );
+    expect(bedrockBlock.length).toBeGreaterThan(0);
+    expect(bedrockBlock).not.toContain(
+      'SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0"',
+    );
+  });
+
   it("allows unsigned release walkthroughs only for an explicit MAX_SIGNATURES block", () => {
     expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
     expect(runner).toContain("[switch]$AllowUnsignedBudgetBlockedArtifact");


### PR DESCRIPTION
## Root cause (release run 30159367572)

The reordered pipeline worked exactly as designed: `windows-app-e2e` failed, so `build` (signed) and `publish-release` were **SKIPPED** — zero signing spend, nothing published. The failure was **not** in the release/sandbox/reorder code: the unsigned app installed, launched, signed in to production as agentguy, and authenticated its provider runtime WebSocket. It died at codex CLI resolution:

> `Codex CLI is not installed in a verifiable location.`

Two harness gaps, both fixed here:

### 1. App can't resolve the codex the harness installed

The harness provisions its own **portable toolchain Node** (`node-v24.18.0-win-x64.zip`, prepended to PATH). A portable Windows Node's npm global prefix is its **own scratch dir**, so `npm install -g @openai/codex` planted `codex.cmd` there — and setup's `npm prefix --global` verify passed against it (`codex-cli 0.145.0`). But the **installed app** resolves agent CLIs through a fixed candidate list in `resolveInstalledCodexBinary()` whose first Windows candidate is `%APPDATA%\npm\codex.cmd` — never the scratch dir. So codex was present yet unresolvable.

**Fix:** pin `npm_config_prefix` to `%APPDATA%\npm` before the agent-CLI install, so the CLIs land exactly where the app's production resolver looks (matching a real MSI-Node user profile).

### 2. Bedrock silently waived codex credential validation

The Bedrock backend block hard-forced `SEREN_E2E_AGENT_CREDENTIALS_REQUIRED=0`. That's correct for the **claude-code** journey (Bedrock authenticates via the EC2 instance role, no login file) — but it also blanket-disabled **codex** credential validation, letting the codex/claude-codex journeys run uncertified across releases.

**Fix:** scope the relaxation to Claude only. `Get-MissingAgentCredentialNames` now skips the Claude login-file check when `CLAUDE_CODE_USE_BEDROCK` is set, while codex/claude-codex still require their archived `.codex/auth.json`.

## Blast radius

`release.yml` is **tag-only** (`push: tags: v*`) — there is no PR/dispatch Windows e2e — so the cred-policy change affects only release-tag runs, exactly the gate. No PR-CI impact.

## Tests

`windows-e2e-release-gate.test.ts` + `agent-resolver-paths.test.ts` pass (49). Two new regression guards lock in both fixes.

## Not sufficient alone — infra follow-up required

This makes the codex journey *resolvable and required*, but a green run also needs the **codex credential archive** provisioned on the box (`.codex/auth.json` via `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI`/`_B64`) and `SEREN_E2E_AGENT_CREDENTIALS_REQUIRED=1` in SSM. Tracked separately; the tag stays blocked until that lands.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
