### PR TITLE
fix(windows-e2e): avoid read-only $HOME in credential validator

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -336,14 +336,18 @@ function Get-MissingAgentCredentialNames() {
   # Claude login file. Codex has no Bedrock equivalent and still requires its
   # archived credential file whenever the codex/claude-codex journeys run.
   `$claudeViaBedrock = Convert-EnvFlag (Get-EnvValue "CLAUDE_CODE_USE_BEDROCK") `$false
-  `$home = [Environment]::GetEnvironmentVariable("USERPROFILE")
+  # NOT `$home: that is a read-only PowerShell automatic variable and assigning
+  # to it aborts the whole task ("Cannot overwrite variable HOME"). This path is
+  # only reached when credentials are required (previously the Bedrock backend
+  # forced them off, so the crash stayed latent until #3375 enabled validation).
+  `$profileHome = [Environment]::GetEnvironmentVariable("USERPROFILE")
   `$appData = [Environment]::GetEnvironmentVariable("APPDATA")
   `$missing = @()
 
   if (`$requiresClaude -and -not `$claudeViaBedrock) {
     `$claudePaths = @(
-      (Join-Path `$home ".claude\.credentials.json"),
-      (Join-Path `$home ".claude.json")
+      (Join-Path `$profileHome ".claude\.credentials.json"),
+      (Join-Path `$profileHome ".claude.json")
     )
     if (-not [string]::IsNullOrWhiteSpace(`$appData)) {
       `$claudePaths += @(
@@ -359,8 +363,8 @@ function Get-MissingAgentCredentialNames() {
   if (`$requiresCodex) {
     `$codexHasEnvKey = -not [string]::IsNullOrWhiteSpace((Get-EnvValue "OPENAI_API_KEY"))
     `$codexPaths = @(
-      (Join-Path `$home ".codex\auth.json"),
-      (Join-Path `$home ".codex\credentials.json")
+      (Join-Path `$profileHome ".codex\auth.json"),
+      (Join-Path `$profileHome ".codex\credentials.json")
     )
     if (-not [string]::IsNullOrWhiteSpace(`$appData)) {
       `$codexPaths += @(

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -383,6 +383,16 @@ describe("Windows production e2e release gate", () => {
     );
   });
 
+  it("does not assign the read-only $HOME automatic variable in the credential validator", () => {
+    // $HOME is a read-only PowerShell automatic variable; assigning it aborts
+    // the whole task ("Cannot overwrite variable HOME because it is read-only").
+    // The validator only runs when credentials are required, so this stayed
+    // latent until #3375 turned validation on and the first real release run
+    // crashed here. The profile root must be held in a normal variable.
+    expect(taskUserRunner).not.toMatch(/\$home\s*=/);
+    expect(taskUserRunner).toContain("$profileHome = [Environment]::GetEnvironmentVariable");
+  });
+
   it("allows unsigned release walkthroughs only for an explicit MAX_SIGNATURES block", () => {
     expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
     expect(runner).toContain("[switch]$AllowUnsignedBudgetBlockedArtifact");


### PR DESCRIPTION
## Latent PowerShell crash surfaced by the first real credential-validated run

Follow-up to #3375. The v3.73.0 release run (30164379654) got further than ever — my credential archive **downloaded and imported cleanly on the box** — then the task-user script crashed:

```
Imported agent credential archive into temporary user profile
::error::Cannot overwrite variable HOME because it is read-only or constant.
```

`Get-MissingAgentCredentialNames` assigned `$home = [Environment]::GetEnvironmentVariable("USERPROFILE")`, but `$HOME` is a **read-only PowerShell automatic variable** — assigning it aborts the whole task.

This was latent: the validator only runs when `SEREN_E2E_AGENT_CREDENTIALS_REQUIRED` is true, and before #3375 the Bedrock backend forced it to `0`, so the function never executed in a release. #3375 enabled codex credential validation, which ran this code for the first time and hit the crash — in the task-user PowerShell, before the app ever launched (so the codex-resolution fix wasn't even reached).

**Fix:** hold the profile root in `$profileHome`. Audited the whole script — `$home` was the only assignment to a read-only automatic variable.

## Why a unit test didn't catch it
The gate tests are content-based; they can't execute PowerShell, and local `pwsh` is broken in this env. Only a real run surfaces a runtime error like this — which is exactly the point of gating the release on the real Windows e2e. Added a content guard (`not.toMatch(/\$home\s*=/)`) so this specific mistake can't reappear.

Tests: `windows-e2e-release-gate.test.ts` — 34 pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
