### PR TITLE
fix(windows-e2e): retry cold-start TLS handshake in history sync (#3380)

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1293,6 +1293,11 @@ function isHistorySyncReadinessError(error) {
     "returned http 504",
     "server closed the connection",
     "could not connect",
+    // A history destination is provisioned on the spot; its branch-DB compute
+    // endpoint cold-starts and cannot complete TLS for a few seconds, surfacing
+    // "error performing TLS handshake". Same readiness class as the connection
+    // errors above, so retry it rather than failing the run (run 30165487150).
+    "tls handshake",
   ].some((marker) => message.includes(marker));
 }
 

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -393,6 +393,20 @@ describe("Windows production e2e release gate", () => {
     expect(taskUserRunner).toContain("$profileHome = [Environment]::GetEnvironmentVariable");
   });
 
+  it("retries a cold-start TLS handshake error from a freshly provisioned history destination", () => {
+    // A history destination is provisioned on the spot; its branch-DB compute
+    // endpoint cold-starts and throws "error performing TLS handshake" before it
+    // can complete TLS. That is the same readiness class as the connection
+    // errors already retried, so isHistorySyncReadinessError must match it or
+    // the run fails after the agent journey already passed (run 30165487150).
+    const readiness = probe.slice(
+      probe.indexOf("function isHistorySyncReadinessError"),
+      probe.indexOf("async function runHistorySync"),
+    );
+    expect(readiness).toContain("tls handshake");
+    expect(readiness).toContain("could not connect");
+  });
+
   it("allows unsigned release walkthroughs only for an explicit MAX_SIGNATURES block", () => {
     expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
     expect(runner).toContain("[switch]$AllowUnsignedBudgetBlockedArtifact");


### PR DESCRIPTION
Fixes #3380. After `all agent journeys verified`, the history-sync exercise failed the run on `error performing TLS handshake`. The destination is provisioned on the spot; its branch-DB compute endpoint cold-starts and cannot complete TLS for a few seconds. `isHistorySyncReadinessError` retries every sibling cold-start error but omitted the TLS-handshake variant. Adds `tls handshake` to the readiness markers (retry budget 90x2s=180s is ample; persistent failures still fail after retries). Guard added to windows-e2e-release-gate.test.ts (35 pass).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com