### PR TITLE
fix(sandbox): claude-code Windows GUI-DLL init crash (#3379)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -128,6 +128,7 @@ windows = { version = "0.62", features = [
     "Win32_System_Console",
     "Win32_System_JobObjects",
     "Win32_System_LibraryLoader",
+    "Win32_System_StationsAndDesktops",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",

--- a/src-tauri/src/sandbox/windows.rs
+++ b/src-tauri/src/sandbox/windows.rs
@@ -20,14 +20,21 @@ mod platform {
         SetEntriesInAclW, SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_UNKNOWN, TRUSTEE_W,
     };
     use windows::Win32::Security::{
-        ACL, AdjustTokenPrivileges, AllocateAndInitializeSid, CopySid, CreateRestrictedToken,
-        CreateWellKnownSid, DACL_SECURITY_INFORMATION, DISABLE_MAX_PRIVILEGE, FreeSid,
-        GetLengthSid, GetTokenInformation, LUA_TOKEN, LUID_AND_ATTRIBUTES, LookupPrivilegeValueW,
-        PSECURITY_DESCRIPTOR, PSID, SE_PRIVILEGE_ENABLED, SECURITY_NT_AUTHORITY,
-        SID_AND_ATTRIBUTES, SUB_CONTAINERS_AND_OBJECTS_INHERIT, SetTokenInformation,
-        TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_SESSIONID,
-        TOKEN_ASSIGN_PRIMARY, TOKEN_DEFAULT_DACL, TOKEN_DUPLICATE, TOKEN_GROUPS, TOKEN_PRIVILEGES,
-        TOKEN_QUERY, TokenDefaultDacl, TokenGroups, WRITE_RESTRICTED, WinWorldSid,
+        ACE_FLAGS, ACL, AdjustTokenPrivileges, AllocateAndInitializeSid, CONTAINER_INHERIT_ACE,
+        CopySid, CreateRestrictedToken, CreateWellKnownSid, DACL_SECURITY_INFORMATION,
+        DISABLE_MAX_PRIVILEGE, FreeSid, GetLengthSid, GetSecurityDescriptorDacl,
+        GetTokenInformation, GetUserObjectSecurity, InitializeSecurityDescriptor, LUA_TOKEN,
+        LUID_AND_ATTRIBUTES, LookupPrivilegeValueW, NO_PROPAGATE_INHERIT_ACE, OBJECT_INHERIT_ACE,
+        PSECURITY_DESCRIPTOR, PSID, SE_PRIVILEGE_ENABLED,
+        SECURITY_DESCRIPTOR, SECURITY_NT_AUTHORITY, SID_AND_ATTRIBUTES,
+        SUB_CONTAINERS_AND_OBJECTS_INHERIT, SetSecurityDescriptorDacl, SetTokenInformation,
+        SetUserObjectSecurity, TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ADJUST_PRIVILEGES,
+        TOKEN_ADJUST_SESSIONID, TOKEN_ASSIGN_PRIMARY, TOKEN_DEFAULT_DACL, TOKEN_DUPLICATE,
+        TOKEN_GROUPS, TOKEN_PRIVILEGES, TOKEN_QUERY, TokenDefaultDacl, TokenGroups,
+        WRITE_RESTRICTED, WinWorldSid,
+    };
+    use windows::Win32::System::StationsAndDesktops::{
+        GetProcessWindowStation, GetThreadDesktop,
     };
     use windows::Win32::Storage::FileSystem::{
         DELETE, FILE_DELETE_CHILD, FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
@@ -44,10 +51,10 @@ mod platform {
     use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
     use windows::Win32::System::Threading::{
         CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessAsUserW, GetCurrentProcess,
-        GetExitCodeProcess, INFINITE, OpenProcessToken, PROCESS_CREATION_FLAGS,
+        GetCurrentThreadId, GetExitCodeProcess, INFINITE, OpenProcessToken, PROCESS_CREATION_FLAGS,
         PROCESS_INFORMATION, ResumeThread, STARTF_USESTDHANDLES, STARTUPINFOW, WaitForSingleObject,
     };
-    use windows::core::{PCWSTR, PWSTR};
+    use windows::core::{BOOL, PCWSTR, PWSTR};
 
     use super::super::policy::{SandboxError, SandboxMode, SandboxPolicy};
 
@@ -142,6 +149,165 @@ mod platform {
         }
     }
 
+    // Restores a window-station / desktop object's DACL when dropped, mirroring
+    // AclSnapshot for file objects. Held for the confined child's lifetime.
+    struct UserObjectAcl {
+        handle: HANDLE,
+        original: Vec<u8>,
+    }
+
+    impl Drop for UserObjectAcl {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = SetUserObjectSecurity(
+                    self.handle,
+                    &DACL_SECURITY_INFORMATION,
+                    PSECURITY_DESCRIPTOR(self.original.as_ptr() as *mut c_void),
+                );
+            }
+        }
+    }
+
+    // Grant `sid` full access to a window-station or desktop USER object so a
+    // restricted-token child can connect to win32k and initialize user32/gdi32.
+    // A restricted token derived from an elevated token in a non-interactive
+    // service session otherwise cannot reach the interactive desktop, so the
+    // loader aborts the child with STATUS_DLL_INIT_FAILED (0xC0000142) before
+    // main. The original DACL is captured and restored on drop; `inheritable`
+    // adds child-object inheritance so a window-station grant reaches its
+    // desktops. #3379.
+    fn grant_user_object_access(
+        handle: HANDLE,
+        sid: PSID,
+        inheritable: bool,
+    ) -> Result<UserObjectAcl, SandboxError> {
+        let dacl_info: u32 = DACL_SECURITY_INFORMATION.0;
+        let mut needed = 0u32;
+        unsafe {
+            let _ = GetUserObjectSecurity(handle, &dacl_info, None, 0, &mut needed);
+        }
+        if needed == 0 {
+            return Err(SandboxError::Windows(
+                "GetUserObjectSecurity size query returned zero".to_string(),
+            ));
+        }
+        let mut sd_buffer = vec![0u8; needed as usize];
+        unsafe {
+            GetUserObjectSecurity(
+                handle,
+                &dacl_info,
+                Some(PSECURITY_DESCRIPTOR(sd_buffer.as_mut_ptr() as *mut c_void)),
+                needed,
+                &mut needed,
+            )
+            .map_err(|error| {
+                SandboxError::Windows(format!("GetUserObjectSecurity failed: {error}"))
+            })?;
+        }
+        let original = sd_buffer.clone();
+
+        let mut present = BOOL(0);
+        let mut old_dacl: *mut ACL = std::ptr::null_mut();
+        let mut defaulted = BOOL(0);
+        unsafe {
+            GetSecurityDescriptorDacl(
+                PSECURITY_DESCRIPTOR(sd_buffer.as_mut_ptr() as *mut c_void),
+                &mut present,
+                &mut old_dacl,
+                &mut defaulted,
+            )
+            .map_err(|error| {
+                SandboxError::Windows(format!("GetSecurityDescriptorDacl failed: {error}"))
+            })?;
+        }
+
+        let inheritance = if inheritable {
+            ACE_FLAGS(OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0 | NO_PROPAGATE_INHERIT_ACE.0)
+        } else {
+            ACE_FLAGS(0)
+        };
+        let explicit = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: GENERIC_ALL.0,
+            grfAccessMode: GRANT_ACCESS,
+            grfInheritance: inheritance,
+            Trustee: trustee(sid),
+        };
+        let mut new_dacl: *mut ACL = std::ptr::null_mut();
+        let acl_result = unsafe {
+            SetEntriesInAclW(
+                Some(std::slice::from_ref(&explicit)),
+                (present.as_bool() && !old_dacl.is_null()).then_some(old_dacl as *const ACL),
+                &mut new_dacl,
+            )
+        };
+        if acl_result.0 != 0 {
+            return Err(SandboxError::Windows(format!(
+                "SetEntriesInAclW for user object failed: {}",
+                acl_result.0
+            )));
+        }
+
+        let mut descriptor = SECURITY_DESCRIPTOR::default();
+        let descriptor_ptr = PSECURITY_DESCRIPTOR(&mut descriptor as *mut _ as *mut c_void);
+        let build = unsafe {
+            InitializeSecurityDescriptor(descriptor_ptr, 1).and_then(|_| {
+                SetSecurityDescriptorDacl(descriptor_ptr, true, Some(new_dacl as *const ACL), false)
+            })
+        };
+        if let Err(error) = build {
+            unsafe {
+                if !new_dacl.is_null() {
+                    let _ = LocalFree(Some(HLOCAL(new_dacl as *mut _)));
+                }
+            }
+            return Err(SandboxError::Windows(format!(
+                "building user-object security descriptor failed: {error}"
+            )));
+        }
+        let set_result =
+            unsafe { SetUserObjectSecurity(handle, &DACL_SECURITY_INFORMATION, descriptor_ptr) };
+        unsafe {
+            if !new_dacl.is_null() {
+                let _ = LocalFree(Some(HLOCAL(new_dacl as *mut _)));
+            }
+        }
+        set_result.map_err(|error| {
+            SandboxError::Windows(format!("SetUserObjectSecurity failed: {error}"))
+        })?;
+
+        Ok(UserObjectAcl { handle, original })
+    }
+
+    // Grant the confined token access to the interactive window station and
+    // desktop for the child's lifetime. Best-effort: on any failure the child is
+    // still launched (it may already have access on a non-elevated interactive
+    // session), and the grants restore their original DACLs on drop. #3379.
+    fn grant_gui_object_access() -> Vec<UserObjectAcl> {
+        let mut grants = Vec::new();
+        let mut base_token = HANDLE::default();
+        let logon = unsafe {
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut base_token).is_err() {
+                return grants;
+            }
+            let base = HandleGuard::new(base_token);
+            match logon_sid(base.get()) {
+                Ok(sid) => sid,
+                Err(_) => return grants,
+            }
+        };
+        if let Ok(winsta) = unsafe { GetProcessWindowStation() } {
+            if let Ok(grant) = grant_user_object_access(HANDLE(winsta.0), logon.as_psid(), true) {
+                grants.push(grant);
+            }
+        }
+        if let Ok(desktop) = unsafe { GetThreadDesktop(GetCurrentThreadId()) } {
+            if let Ok(grant) = grant_user_object_access(HANDLE(desktop.0), logon.as_psid(), false) {
+                grants.push(grant);
+            }
+        }
+        grants
+    }
+
     pub fn apply_and_spawn_contained(
         policy: &SandboxPolicy,
         command: &str,
@@ -166,6 +332,8 @@ mod platform {
         }
 
         let token = create_restricted_token(capability.as_psid())?;
+        // Kept alive until the child has fully run; DACLs restore on drop.
+        let _gui_object_acls = grant_gui_object_access();
         let job = create_job()?;
         let (application_name, mut command_line) = command_line(command, args)?;
         let application_wide = wide(&application_name);

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -320,6 +320,126 @@ fn sandbox_windows_gui_dll_child_starts() {
     );
 }
 
+/// Faithful repro of #3379: install the real claude-code CLI and run it through
+/// the restricted-token sandbox. node.exe alone runs fine sandboxed, so the
+/// STATUS_DLL_INIT_FAILED (0xC0000142) crash is specific to claude-code's own
+/// startup module graph (bundled JS + native addons). This exercises that graph.
+#[test]
+fn sandbox_windows_claude_cli_starts() {
+    const STATUS_DLL_INIT_FAILED: i32 = -1_073_741_502; // 0xC0000142 as i32
+    let Some(npm) = find_on_path("npm.cmd").or_else(|| find_on_path("npm.exe")) else {
+        eprintln!("npm not on PATH; skipping claude sandbox canary");
+        return;
+    };
+
+    let prefix = tempfile::tempdir().expect("claude install prefix");
+    let install = Command::new(&npm)
+        .args([
+            "install",
+            "-g",
+            "--no-fund",
+            "--no-audit",
+            "@anthropic-ai/claude-code@latest",
+        ])
+        .env("npm_config_prefix", prefix.path())
+        .output()
+        .expect("npm install runs");
+    if !install.status.success() {
+        eprintln!(
+            "npm install of claude-code failed (network?); skipping. stderr={}",
+            String::from_utf8_lossy(&install.stderr)
+        );
+        return;
+    }
+    let claude_cmd = prefix.path().join("claude.cmd");
+    assert!(
+        claude_cmd.is_file(),
+        "claude.cmd not installed at {}",
+        claude_cmd.display()
+    );
+
+    // Baseline: the CLI starts fine OUTSIDE the sandbox on this runner.
+    let direct = Command::new(&claude_cmd)
+        .arg("--version")
+        .output()
+        .expect("claude --version runs");
+    assert!(
+        direct.status.success(),
+        "claude --version failed unsandboxed (bad install, not a sandbox issue): status={:?} stdout={} stderr={}",
+        direct.status,
+        String::from_utf8_lossy(&direct.stdout),
+        String::from_utf8_lossy(&direct.stderr),
+    );
+
+    // Through the restricted-token sandbox: this is where the release e2e died.
+    let (_root, workspace) = workspace_fixture();
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+    let sandboxed = sandbox_launcher_command(&policy, &workspace, &claude_cmd)
+        .arg("--version")
+        .output()
+        .expect("sandbox launcher starts");
+
+    assert_ne!(
+        sandboxed.status.code(),
+        Some(STATUS_DLL_INIT_FAILED),
+        "claude crashed with STATUS_DLL_INIT_FAILED (0xC0000142) under the restricted-token \
+         sandbox while starting fine unsandboxed (#3379). stdout={} stderr={}",
+        String::from_utf8_lossy(&sandboxed.stdout),
+        String::from_utf8_lossy(&sandboxed.stderr),
+    );
+    assert!(
+        sandboxed.status.success(),
+        "claude did not exit cleanly under the sandbox: status={:?} stdout={} stderr={}",
+        sandboxed.status,
+        String::from_utf8_lossy(&sandboxed.stdout),
+        String::from_utf8_lossy(&sandboxed.stderr),
+    );
+}
+
+/// The real spawn runs the agent through the app's EMBEDDED node (bundled as a
+/// tauri resource), not the stock node on PATH. If that specific build is the
+/// differentiator behind #3379, it crashes here while stock node passes.
+#[test]
+fn sandbox_windows_embedded_node_starts() {
+    const STATUS_DLL_INIT_FAILED: i32 = -1_073_741_502; // 0xC0000142 as i32
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("embedded-runtime");
+    let candidates = [
+        base.join("win32-x64").join("node").join("node.exe"),
+        base.join("win32-x64").join("node.exe"),
+    ];
+    let Some(embedded) = candidates.iter().find(|p| p.is_file()) else {
+        eprintln!(
+            "embedded node not staged under {}; skipping embedded-node canary",
+            base.display()
+        );
+        return;
+    };
+
+    let (_root, workspace) = workspace_fixture();
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+    let output = sandbox_launcher_command(&policy, &workspace, embedded)
+        .arg("-e")
+        .arg("process.exit(0)")
+        .output()
+        .expect("sandbox launcher starts");
+
+    assert_ne!(
+        output.status.code(),
+        Some(STATUS_DLL_INIT_FAILED),
+        "EMBEDDED node crashed with STATUS_DLL_INIT_FAILED (0xC0000142) under the sandbox \
+         while stock node did not (#3379). stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.status.success(),
+        "embedded node did not exit cleanly under the sandbox: status={:?} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 fn sandbox_windows_bad_arguments_exit_64() {
     let output = Command::new(env!("CARGO_BIN_EXE_Seren"))

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -320,17 +320,57 @@ fn sandbox_windows_gui_dll_child_starts() {
     );
 }
 
+fn embedded_node_dir() -> Option<PathBuf> {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("embedded-runtime");
+    for candidate in [
+        base.join("win32-x64").join("node"),
+        base.join("win32-x64"),
+    ] {
+        if candidate.join("node.exe").is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Run a sandboxed child to completion with a timeout. Returns the exit code, or
+/// None if it was still running at the deadline (loaded fine, blocked on stdin).
+fn run_sandboxed_to_completion(cmd: &mut Command, timeout_secs: u64) -> Option<i32> {
+    use std::process::Stdio;
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("sandbox launcher starts");
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("wait on sandboxed child") {
+            return status.code();
+        }
+        if start.elapsed() >= std::time::Duration::from_secs(timeout_secs) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+}
+
 /// Faithful repro of #3379: install the real claude-code CLI and run it through
-/// the restricted-token sandbox. node.exe alone runs fine sandboxed, so the
-/// STATUS_DLL_INIT_FAILED (0xC0000142) crash is specific to claude-code's own
-/// startup module graph (bundled JS + native addons). This exercises that graph.
+/// the restricted-token sandbox exactly as the provider runtime does — the full
+/// stream-json invocation, resolved through the app's EMBEDDED node. node.exe
+/// alone runs fine sandboxed, so this exercises claude-code's real startup
+/// module graph (bundled JS + native addons) under the confined token.
+///
+/// LOUD by design: a missing prerequisite panics rather than silently skipping,
+/// so a green result cannot hide a no-op (cargo hides passing-test output).
 #[test]
-fn sandbox_windows_claude_cli_starts() {
+fn sandbox_windows_claude_stream_json_starts() {
     const STATUS_DLL_INIT_FAILED: i32 = -1_073_741_502; // 0xC0000142 as i32
-    let Some(npm) = find_on_path("npm.cmd").or_else(|| find_on_path("npm.exe")) else {
-        eprintln!("npm not on PATH; skipping claude sandbox canary");
-        return;
-    };
+    let npm = find_on_path("npm.cmd")
+        .or_else(|| find_on_path("npm.exe"))
+        .expect("npm must be on PATH in Windows CI (node/pnpm build ran first)");
 
     let prefix = tempfile::tempdir().expect("claude install prefix");
     let install = Command::new(&npm)
@@ -344,13 +384,12 @@ fn sandbox_windows_claude_cli_starts() {
         .env("npm_config_prefix", prefix.path())
         .output()
         .expect("npm install runs");
-    if !install.status.success() {
-        eprintln!(
-            "npm install of claude-code failed (network?); skipping. stderr={}",
-            String::from_utf8_lossy(&install.stderr)
-        );
-        return;
-    }
+    assert!(
+        install.status.success(),
+        "npm install of claude-code failed: status={:?} stderr={}",
+        install.status,
+        String::from_utf8_lossy(&install.stderr),
+    );
     let claude_cmd = prefix.path().join("claude.cmd");
     assert!(
         claude_cmd.is_file(),
@@ -358,41 +397,47 @@ fn sandbox_windows_claude_cli_starts() {
         claude_cmd.display()
     );
 
-    // Baseline: the CLI starts fine OUTSIDE the sandbox on this runner.
-    let direct = Command::new(&claude_cmd)
-        .arg("--version")
-        .output()
-        .expect("claude --version runs");
-    assert!(
-        direct.status.success(),
-        "claude --version failed unsandboxed (bad install, not a sandbox issue): status={:?} stdout={} stderr={}",
-        direct.status,
-        String::from_utf8_lossy(&direct.stdout),
-        String::from_utf8_lossy(&direct.stderr),
-    );
+    // Resolve claude's `node` through the app's embedded runtime, matching the
+    // real spawn's PATH. Fall back to the stock node already proven to work.
+    let mut child_path = String::new();
+    if let Some(dir) = embedded_node_dir() {
+        child_path.push_str(&dir.to_string_lossy());
+        child_path.push(';');
+    }
+    if let Some(existing) = env::var_os("PATH") {
+        child_path.push_str(&existing.to_string_lossy());
+    }
 
-    // Through the restricted-token sandbox: this is where the release e2e died.
+    // The exact stream-json flag set the provider runtime passes (buildClaudeArgs).
+    let claude_args = [
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--input-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--replay-user-messages",
+        "--permission-prompt-tool",
+        "stdio",
+        "--allow-dangerously-skip-permissions",
+        "--session-id",
+        "00000000-0000-4000-8000-000000000000",
+    ];
+
     let (_root, workspace) = workspace_fixture();
     let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
-    let sandboxed = sandbox_launcher_command(&policy, &workspace, &claude_cmd)
-        .arg("--version")
-        .output()
-        .expect("sandbox launcher starts");
+    let mut cmd = sandbox_launcher_command(&policy, &workspace, &claude_cmd);
+    cmd.args(claude_args).env("PATH", &child_path);
+
+    // stdin is closed, so a healthy claude reaches EOF and exits; a loader crash
+    // exits 0xC0000142 before reading stdin. Timeout guards against a clean block.
+    let code = run_sandboxed_to_completion(&mut cmd, 90);
 
     assert_ne!(
-        sandboxed.status.code(),
+        code,
         Some(STATUS_DLL_INIT_FAILED),
-        "claude crashed with STATUS_DLL_INIT_FAILED (0xC0000142) under the restricted-token \
-         sandbox while starting fine unsandboxed (#3379). stdout={} stderr={}",
-        String::from_utf8_lossy(&sandboxed.stdout),
-        String::from_utf8_lossy(&sandboxed.stderr),
-    );
-    assert!(
-        sandboxed.status.success(),
-        "claude did not exit cleanly under the sandbox: status={:?} stdout={} stderr={}",
-        sandboxed.status,
-        String::from_utf8_lossy(&sandboxed.stdout),
-        String::from_utf8_lossy(&sandboxed.stderr),
+        "claude stream-json crashed with STATUS_DLL_INIT_FAILED (0xC0000142) under the \
+         restricted-token sandbox (#3379); exit code reproduced the release-e2e crash",
     );
 }
 

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -273,6 +273,53 @@ fn sandbox_windows_batch_wrapper_preserves_quoted_paths_and_arguments() {
     );
 }
 
+fn find_on_path(exe: &str) -> Option<PathBuf> {
+    env::var_os("PATH").and_then(|paths| {
+        env::split_paths(&paths)
+            .map(|dir| dir.join(exe))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+/// A restricted-token child that loads the GUI-subsystem DLLs (user32/gdi32,
+/// whose DllMain connects to win32k/CSRSS) must still start. node.exe statically
+/// imports them, so it reproduces the STATUS_DLL_INIT_FAILED (0xC0000142) crash
+/// claude-code hit on the release e2e (#3379). The existing canaries only spawn
+/// cmd.exe (console-only), so this loader path was never exercised.
+#[test]
+fn sandbox_windows_gui_dll_child_starts() {
+    // 0xC0000142 == 3221225794 == -1073741502 as i32 (how ExitStatus reports it).
+    const STATUS_DLL_INIT_FAILED: i32 = -1_073_741_502;
+    let Some(node) = find_on_path("node.exe") else {
+        eprintln!("node.exe not on PATH; skipping GUI-DLL sandbox canary");
+        return;
+    };
+    let (_root, workspace) = workspace_fixture();
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+
+    let output = sandbox_launcher_command(&policy, &workspace, &node)
+        .arg("-e")
+        .arg("process.exit(0)")
+        .output()
+        .expect("sandbox launcher starts");
+
+    assert_ne!(
+        output.status.code(),
+        Some(STATUS_DLL_INIT_FAILED),
+        "node crashed with STATUS_DLL_INIT_FAILED (0xC0000142) under the restricted-token \
+         sandbox: GUI DLL init was denied. stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.status.success(),
+        "node did not exit cleanly under the sandbox: status={:?} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 fn sandbox_windows_bad_arguments_exit_64() {
     let output = Command::new(env!("CARGO_BIN_EXE_Seren"))


### PR DESCRIPTION
WIP, repro-first for #3379. First commit adds a canary spawning node.exe through the restricted-token sandbox to confirm the 0xC0000142 (STATUS_DLL_INIT_FAILED) crash reproduces on windows-latest CI; the fix follows once reproduction is confirmed. Do not merge until green.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com