### PR TITLE
fix(runtime): retry transient CLI --version spawn failure (#3383)

### DIFF
--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -196,15 +196,26 @@ export function classifyInstallChannel(resolvedPath, bareCommand) {
 export async function runInstalledVersion(resolvedPath, bareCommand) {
   if (resolvedPath === bareCommand) return null; // unresolved
   if (!existsSync(resolvedPath)) return null;
-  try {
-    const { stdout } = await execFileAsync(resolvedPath, ["--version"], {
-      timeout: VERSION_CMD_TIMEOUT_MS,
-      shell: process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd"),
-    });
-    return stdout.trim().match(SEMVER_EXTRACT_RE)?.[0] ?? null;
-  } catch {
-    return null;
+  // A single `--version` spawn can transiently fail on Windows — a loader
+  // hiccup / STATUS_DLL_INIT_FAILED in a constrained, elevated service session
+  // aborts the child before it prints anything. The path already resolved, so
+  // one failed spawn must not flake the whole "is this CLI installed" check
+  // into a false "not installed in a verifiable location". Retry a few times
+  // before concluding the binary is unusable; a real failure still fails. #3383.
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync(resolvedPath, ["--version"], {
+        timeout: VERSION_CMD_TIMEOUT_MS,
+        shell: process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd"),
+      });
+      return stdout.trim().match(SEMVER_EXTRACT_RE)?.[0] ?? null;
+    } catch {
+      if (attempt === maxAttempts) return null;
+      await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+    }
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
Fixes #3383. `runInstalledVersion` returned null on any transient `--version` spawn failure, which `ensureCodexCliViaUpdater` reports as "Codex CLI is not installed in a verifiable location" despite the binary resolving. Proven flaky by a controlled A/A re-run (run 30179755178: codex resolution failed then passed, zero changes). Retries the spawn up to 3x with backoff before concluding the CLI is unusable; de-flakes codex/claude/gemini/grok resolution. Real-run-validated (the elevated-service-session flake can't be unit-tested without mocking the forbidden layer). Existing cli-updater tests pass (45).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com