### PR TITLE
fix(runtime): recognize Anthropic API token as claude-code auth

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -263,6 +263,13 @@ function hasClaudeCredentials() {
   if (isClaudeBedrockConfigured()) {
     return true;
   }
+  // A direct or custom-endpoint API key authenticates the CLI too: a raw
+  // Anthropic key (ANTHROPIC_API_KEY) or an Anthropic-compatible proxy/gateway
+  // token (ANTHROPIC_AUTH_TOKEN, e.g. OpenRouter). Both are used directly by
+  // claude-code and need no login file. Empty strings do not count.
+  if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) {
+    return true;
+  }
   const home = os.homedir();
   const appData = process.env.APPDATA;
   return hasAnyCredentialPath([

--- a/tests/unit/provider-agent-auth-status.test.ts
+++ b/tests/unit/provider-agent-auth-status.test.ts
@@ -19,6 +19,16 @@ describe("provider agent authentication status", () => {
     expect(registrySource).toContain('path.join(os.homedir(), ".grok", "auth.json")');
   });
 
+  it("treats a direct or custom-endpoint API token as claude-code auth", () => {
+    // claude-code uses ANTHROPIC_API_KEY (direct) or ANTHROPIC_AUTH_TOKEN (an
+    // Anthropic-compatible proxy/gateway such as OpenRouter) with no login file.
+    // The auth-status check must recognize them or provider_check_agent_authenticated
+    // falsely reports claude-code unauthenticated and the journey aborts before spawn.
+    expect(registrySource).toContain(
+      "process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN",
+    );
+  });
+
   it("exposes a provider_check_agent_authenticated RPC", () => {
     expect(runtimeSource).toContain("provider_check_agent_authenticated");
     expect(providersSource).toContain("checkAgentAuthenticated({ agentType })");


### PR DESCRIPTION
`hasClaudeCredentials` only accepted Bedrock or a login file, so claude-code configured with `ANTHROPIC_API_KEY` (direct) or `ANTHROPIC_AUTH_TOKEN` (proxy/gateway like OpenRouter) was reported unauthenticated → `provider_check_agent_authenticated` returned false → journey aborted before spawn. Surfaced by the Windows e2e OpenRouter run 30206851309 (`returned false before prompt`); also a real-user gap for custom endpoints. Treats a non-empty token as authenticated (empty strings excluded). Auth-status test guard added (3 pass).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com