### PR TITLE
fix(runtime): forward Claude auth/model env to the spawned CLI

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -279,6 +279,21 @@ const CLAUDE_PARENT_ENV_ALLOWLIST = [
   "SEREN_DESKTOP",
   "SEREN_EMBEDDED_NODE_BIN",
   "SEREN_PLAYWRIGHT_MCP_COMMAND",
+  // Claude Code authenticates and picks its model from these when there is no
+  // login file. Without them on the allowlist the spawned CLI never sees its
+  // credentials and reports "Not logged in": a direct or gateway API key
+  // (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL, e.g.
+  // OpenRouter), Bedrock (CLAUDE_CODE_USE_BEDROCK + AWS_REGION), and the model
+  // ids the CLI selects when --model is not decisive.
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
 ];
 
 function buildClaudeSpawnEnv({

--- a/tests/unit/claude-spawn-env.test.ts
+++ b/tests/unit/claude-spawn-env.test.ts
@@ -43,4 +43,32 @@ describe("Claude spawn environment (#3194)", () => {
     expect(env[CANARY_ENV_NAME]).toBeUndefined();
     expect(Object.values(env)).not.toContain("canary-parent-secret");
   });
+
+  it("forwards Anthropic auth/model env so the CLI is not left 'Not logged in'", () => {
+    const keys = ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY"];
+    const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    process.env.ANTHROPIC_AUTH_TOKEN = "sk-or-test-token";
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.ANTHROPIC_API_KEY = ""; // must survive as an empty string
+    try {
+      const env = buildClaudeSpawnEnv({
+        childEnv: {},
+        extendedPath: "/runtime/bin",
+        cwd: "/workspace/project",
+        sandboxMode: "workspace-write",
+        sandboxProfile: null,
+        approvalPolicy: "on-request",
+        autoApproveReads: true,
+        networkEnabled: true,
+      });
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe("sk-or-test-token");
+      expect(env.ANTHROPIC_BASE_URL).toBe("https://openrouter.ai/api");
+      expect(env.ANTHROPIC_API_KEY).toBe("");
+    } finally {
+      for (const k of keys) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+    }
+  });
 });


### PR DESCRIPTION
Root cause of claude-code never authenticating in the Windows e2e. `CLAUDE_PARENT_ENV_ALLOWLIST` held only system vars, so the spawned claude-code got none of its auth/model env — every env-based method (API key, `ANTHROPIC_AUTH_TOKEN`+`ANTHROPIC_BASE_URL` for OpenRouter, Bedrock, model ids) was stripped; only a file login worked, so the CLI reported "Not logged in" (run 30208375244). Also a real-user gap. Adds the Anthropic + Bedrock auth/model vars; empty strings survive (`ANTHROPIC_API_KEY=""` required by OpenRouter). Functional test verifies forwarding while the canary stays blocked (2 pass).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com