### PR TITLE
fix(runtime): resolve agent CLIs under custom npm global prefixes

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -1,7 +1,7 @@
 // ABOUTME: Browser-local agent registry for install/login/availability behaviors.
 // ABOUTME: Keeps provider metadata and per-agent setup logic separate from session runtime handling.
 
-import { execFile, spawn } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
 import {
   accessSync,
   closeSync,
@@ -631,7 +631,7 @@ function resolveInstalledGeminiBinary() {
       }
     }
   }
-  return "gemini";
+  return resolveViaNpmGlobalPrefix("gemini.cmd", "gemini") ?? "gemini";
 }
 
 /**
@@ -704,7 +704,47 @@ export function resolveInstalledClaudeBinary() {
       }
     }
   }
-  return "claude";
+  return resolveViaNpmGlobalPrefix("claude.cmd", "claude") ?? "claude";
+}
+
+// The dynamic npm global prefix, queried once via the embedded npm. Covers
+// installs under a custom / version-manager prefix (nvm, fnm, volta, portable
+// Node, or an explicit `npm config set prefix`) that the static candidate lists
+// do not enumerate, so a CLI on a non-default prefix still resolves. #3377.
+let cachedNpmGlobalPrefix;
+function npmGlobalPrefixDir() {
+  if (cachedNpmGlobalPrefix !== undefined) return cachedNpmGlobalPrefix;
+  cachedNpmGlobalPrefix = null;
+  try {
+    const npmCliScript = resolveNpmCliScript();
+    const output = npmCliScript
+      ? execFileSync(process.execPath, [npmCliScript, "prefix", "-g"], {
+          timeout: 5000,
+          encoding: "utf8",
+        })
+      : execFileSync(
+          process.platform === "win32" ? "npm.cmd" : "npm",
+          ["prefix", "-g"],
+          { timeout: 5000, encoding: "utf8", shell: process.platform === "win32" },
+        );
+    const trimmed = output.trim();
+    if (trimmed) cachedNpmGlobalPrefix = trimmed;
+  } catch {
+    // No reachable npm / no global prefix; callers fall back to the bare command.
+  }
+  return cachedNpmGlobalPrefix;
+}
+
+// Resolve a CLI under the dynamic npm global prefix. On Windows a global bin
+// sits directly at <prefix>\<name>.cmd; on Unix at <prefix>/bin/<name>. #3377.
+function resolveViaNpmGlobalPrefix(windowsBin, unixBin) {
+  const prefix = npmGlobalPrefixDir();
+  if (!prefix) return null;
+  const candidate =
+    process.platform === "win32"
+      ? path.join(prefix, windowsBin)
+      : path.join(prefix, "bin", unixBin);
+  return existsSync(candidate) ? candidate : null;
 }
 
 /**
@@ -762,7 +802,7 @@ export function resolveInstalledCodexBinary() {
       }
     }
   }
-  return "codex";
+  return resolveViaNpmGlobalPrefix("codex.cmd", "codex") ?? "codex";
 }
 
 export function createBrowserLocalAgentRegistry({ emit }) {

--- a/tests/unit/agent-resolver-paths.test.ts
+++ b/tests/unit/agent-resolver-paths.test.ts
@@ -124,3 +124,19 @@ describe("#1665 — preference order preserved for Claude + Codex (regression gu
     expect(prefixIdx).toBeLessThan(usrLocalIdx);
   });
 });
+
+describe("#3377 — resolvers fall back to the dynamic npm global prefix", () => {
+  it.each([
+    "resolveInstalledCodexBinary",
+    "resolveInstalledClaudeBinary",
+    "resolveInstalledGeminiBinary",
+  ])(
+    "%s consults the dynamic prefix for custom / version-manager installs",
+    (name) => {
+      // Static candidate lists miss nvm/fnm/volta/portable-Node prefixes; the
+      // resolver must fall back to `npm prefix -g` before returning the bare
+      // command name.
+      expect(sliceFn(name)).toContain("resolveViaNpmGlobalPrefix");
+    },
+  );
+});


### PR DESCRIPTION
Closes #3377. The codex/claude/gemini resolvers only checked a fixed candidate list, missing CLIs under a custom/version-manager npm prefix (nvm, fnm, volta, portable Node). Adds a cached sync fallback via `npm prefix -g` (embedded npm) checking <prefix>\\<name>.cmd / <prefix>/bin/<name> before the bare command. Sync (no caller ripple); static fast paths run first. Tests: 22 pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com