### PR TITLE
fix(history-sync): validate Postgres TLS via rustls + webpki-roots

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2235,7 +2235,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2982,6 +2995,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -6401,18 +6420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres-native-tls"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
-dependencies = [
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7956,7 +7963,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "native-tls",
  "notify",
  "objc2",
  "objc2-core-foundation",
@@ -7965,13 +7971,13 @@ dependencies = [
  "objc2-screen-capture-kit",
  "portable-pty",
  "postgres",
- "postgres-native-tls",
  "rand 0.10.2",
  "rand_distr",
  "regex",
  "reqwest 0.13.4",
  "rmcp",
  "rusqlite",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "seren-secrets-crypto",
@@ -7998,6 +8004,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tiny_http",
  "tokio",
+ "tokio-postgres-rustls",
  "tokio-tungstenite 0.30.0",
  "tokio-util",
  "tree-sitter",
@@ -8010,6 +8017,7 @@ dependencies = [
  "uuid",
  "wacore",
  "wasapi",
+ "webpki-roots 1.0.5",
  "whatsapp-rust",
  "windows 0.62.2",
  "xcap",
@@ -9618,6 +9626,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9678,6 +9707,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2ad44aa0ae96db89c4742212ed41645b2f597311ff6e1945542a4d9fadc2fb"
+dependencies = [
+ "rustls 0.23.36",
+ "sha2 0.11.0",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.4",
+ "x509-cert",
 ]
 
 [[package]]
@@ -11956,6 +11999,18 @@ dependencies = [
  "curve25519-dalek 5.0.0",
  "rand_core 0.10.0",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,8 +63,9 @@ base64 = "0.22"
 libc = "0.2"
 reqwest = { version = "0.13", features = ["blocking", "json", "stream"] }
 postgres = { version = "0.19", features = ["with-serde_json-1"] }
-postgres-native-tls = "0.5"
-native-tls = "0.2"
+tokio-postgres-rustls = "0.14"
+rustls = "0.23"
+webpki-roots = "1"
 seren-secrets-crypto = { git = "https://github.com/serenorg/seren-secrets.git", tag = "v0.4.0" }
 rmcp = { version = "1.2", features = [
     "client",

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -376,14 +376,36 @@ fn connection_host(connection_string: &str) -> String {
     "<unknown>".to_string()
 }
 
+/// Build the Postgres TLS connector for history-sync.
+///
+/// Validates against the bundled Mozilla root set (`webpki-roots`) rather than
+/// the operating system trust store. On Windows, SChannel mis-builds Let's
+/// Encrypt's 2026 root hierarchy (ISRG Root YR): it AIA-chases into a longer,
+/// expired cross-signed path and rejects an otherwise-valid server certificate
+/// with CERT_E_EXPIRED, even when the box clock is correct and a valid short
+/// path to a trusted root exists. A bundled root set makes trust deterministic
+/// across every platform and process session and never wanders into the expired
+/// path. #3389.
+fn make_rustls_connector() -> Result<tokio_postgres_rustls::MakeRustlsConnect, String> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    // Pin the crypto provider explicitly: this workspace compiles both the
+    // aws-lc-rs and ring rustls backends, so no process-default provider is
+    // installed and `ClientConfig::builder()` would panic at runtime. #3389.
+    let provider = std::sync::Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|err| format!("rustls provider init failed: {err}"))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(tokio_postgres_rustls::MakeRustlsConnect::new(config))
+}
+
 fn connect_client(connection_string: &str) -> Result<PgClient, String> {
-    let tls = native_tls::TlsConnector::builder()
-        .build()
-        .map_err(|err| err.to_string())?;
-    let tls = postgres_native_tls::MakeTlsConnector::new(tls);
+    let tls = make_rustls_connector()?;
     let mut client = PgClient::connect(connection_string, tls).map_err(|err| {
-        // Surface the full error chain (native_tls/SChannel detail) and the
-        // host so a TLS/connect failure is diagnosable instead of a bare
+        // Surface the full error chain (rustls/webpki detail) and the host so a
+        // TLS/connect failure is diagnosable instead of a bare
         // "error performing TLS handshake". Credentials are never included. #3389.
         use std::fmt::Write as _;
         let mut detail = err.to_string();


### PR DESCRIPTION
## Root cause (#3389)

Windows `windows-app-e2e` history-sync fails persistently with `error performing TLS handshake`. The #3392 instrumentation resolved it to:

```
-> A required certificate is not within its validity period ... (os error -2146762495)
   [host=ep-rapid-ankaa-96e5867f-pooler.c-1.***.***.com]
```

`os error -2146762495` = `0x800B0101` = **`CERT_E_EXPIRED`**.

Diagnostics ruled out the obvious causes:
- **Box clock is correct** — `w32tm` offset vs Amazon Time Sync = **+9ms**; last sync healthy.
- **The server cert is valid** — the live chain is `leaf(*.us-east-2.aws.neon.tech) -> LE YR2 -> ISRG Root YR -> ISRG Root X1`, every cert within its validity window today.
- **The box trusts ISRG Root X1** (self-signed, valid to 2035) but **does not have ISRG Root YR** (LE's new 2026 root).

A valid short path exists (stop at the trusted ISRG Root X1), but **Windows SChannel AIA-chases into a longer, expired cross-signed path** and returns `CERT_E_EXPIRED`. Endpoints that chain to older roots (OpenRouter, AWS) are unaffected — so codex/claude-code journeys pass and only history-sync fails. This is a **real product bug**: it fails silently for any Windows user whose SChannel mis-chains LE's new roots, not just the e2e box.

## Fix

Validate history-sync's Postgres TLS against the **bundled Mozilla root set (`webpki-roots`) via rustls** instead of the OS trust store. rustls uses only the presented chain + bundled anchors — it builds the short valid path deterministically on every platform/session and never AIA-wanders into the expired cross-cert. The crypto provider is pinned explicitly (`aws_lc_rs`) because this workspace compiles both `aws-lc-rs` and `ring`, so no process-default provider is installed.

## Validation

- Unit tests pass (`connection_host_extracts_host_without_credentials`, `connect_client_runs_off_the_reactor_without_runtime_panic`).
- **Real-endpoint check (no mocks):** connecting the new stack to the live Neon endpoint, rustls **verifies the real 2026 LE chain and its validity dates** and proceeds *past* chain verification (to hostname matching) — the exact step SChannel failed with `CERT_E_EXPIRED`.
- **Authoritative validation is the Windows release e2e** against the real SerenDB endpoint + real connection string. The #3392 error instrumentation is preserved, so any residual issue is pinpointed in the log.

## Dependency delta

- **−** `postgres-native-tls`
- **+** `tokio-postgres-rustls` and its small pure-Rust subtree (`x509-cert` for SCRAM `tls-server-end-point` channel binding — a security plus — plus `der`/`tls_codec` helpers)
- `rustls`, `webpki-roots`, `aws-lc-sys` were already compiled in; **no new C/native toolchain**. `native-tls` remains (still pulled transitively by other crates).

Closes #3389.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
