### PR TITLE
revert(deps): monaco-editor 0.56 breaks production worker imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "happy": "1.2.0",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.7",
-    "monaco-editor": "^0.56.0",
+    "monaco-editor": "^0.55.1",
     "pdfjs-dist": "^6.1.200",
     "qrcode": "^1.5.4",
     "solid-js": "^1.9.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^18.0.7
         version: 18.0.7
       monaco-editor:
-        specifier: ^0.56.0
-        version: 0.56.0
+        specifier: ^0.55.1
+        version: 0.55.1
       pdfjs-dist:
         specifier: ^6.1.200
         version: 6.1.200
@@ -3208,8 +3208,8 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -4068,8 +4068,8 @@ packages:
       typescript:
         optional: true
 
-  monaco-editor@0.56.0:
-    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -9718,7 +9718,7 @@ snapshots:
 
   dijkstrajs@1.0.3: {}
 
-  dompurify@3.4.8:
+  dompurify@3.2.7:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10639,9 +10639,9 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  monaco-editor@0.56.0:
+  monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.2.7
       marked: 14.0.0
 
   ms@2.1.2: {}


### PR DESCRIPTION
Reverts #3402 (monaco 0.55.1 → 0.56.0). It broke the **production bundle** (`npx vite build`, the E2E CI job) and turned `main` red:

```
Rolldown failed to resolve import "monaco-editor/esm/vs/editor/editor.worker?worker"
  from src/lib/editor/monaco-config.ts
```

**Root cause:** monaco 0.56 added a restrictive `exports` map (`"./*": "./esm/vs/*.js"`) that redirects everything through `esm/vs/`, so the current `monaco-editor/esm/vs/...worker?worker` imports no longer resolve, and `editor.worker` was split into a new `editor.worker.start.js`. Adapting the worker imports is a deliberate migration, not a hotfix.

My earlier local `pnpm build` check passed because it ran before `pnpm add` had actually swapped node_modules to 0.56 — I verified against the wrong state. Reverting restores green (`npx vite build` → ✓ 2.70s with 0.55.1).

Follow-up: bump monaco with the worker-import migration + verification against `npx vite build`.