### PR TITLE
feat(deps): upgrade monaco-editor to 0.56 with worker-import migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "happy": "1.2.0",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.7",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.56.0",
     "pdfjs-dist": "^6.1.200",
     "qrcode": "^1.5.4",
     "solid-js": "^1.9.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^18.0.7
         version: 18.0.7
       monaco-editor:
-        specifier: ^0.55.1
-        version: 0.55.1
+        specifier: ^0.56.0
+        version: 0.56.0
       pdfjs-dist:
         specifier: ^6.1.200
         version: 6.1.200
@@ -3208,8 +3208,8 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -4068,8 +4068,8 @@ packages:
       typescript:
         optional: true
 
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -9718,7 +9718,7 @@ snapshots:
 
   dijkstrajs@1.0.3: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10639,9 +10639,9 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  monaco-editor@0.55.1:
+  monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.8
       marked: 14.0.0
 
   ms@2.1.2: {}

--- a/src/lib/editor/monaco-config.ts
+++ b/src/lib/editor/monaco-config.ts
@@ -1,9 +1,9 @@
 import * as monaco from "monaco-editor";
-import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
-import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
-import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
-import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
-import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import editorWorker from "monaco-editor/editor/editor.worker?worker";
+import cssWorker from "monaco-editor/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/language/html/html.worker?worker";
+import jsonWorker from "monaco-editor/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/language/typescript/ts.worker?worker";
 
 // Configure Monaco to use locally bundled workers (avoids CDN + CSP issues)
 self.MonacoEnvironment = {


### PR DESCRIPTION
Re-does the monaco 0.56 upgrade (reverted in #3415) **with** the worker-import migration, so the production bundle builds.

monaco 0.56 added `exports: { "./*": "./esm/vs/*.js" }`, redirecting all subpaths through `esm/vs/`. The five worker imports in `src/lib/editor/monaco-config.ts` therefore drop the `esm/vs/` prefix (e.g. `monaco-editor/editor/editor.worker?worker`).

**Verified against `npx vite build`** (the E2E production-bundle job that failed last time): `✓ built` with all five workers bundling, including `editor.worker`. Biome + typecheck clean.

Closes #3416.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com