### PR TITLE
docs(release): add v3.74.0 release notes

### DIFF
--- a/.github/release-notes/v3.74.0.md
+++ b/.github/release-notes/v3.74.0.md
@@ -1,0 +1,25 @@
+## What's New
+
+A polish-and-stability release: the privacy and sandbox controls are reworked into plain language you can act on, a duplicate-runtime crash on load is fixed, the editor moves to Monaco 0.56, and the dependency stack gets a security-oriented refresh.
+
+## 🔒 Clearer Privacy Controls
+
+- The data-destinations panel is now a plain-language **Privacy** control — no legal terminology, no permanently-green status, and restyled to match the rest of the app (#3409)
+- Starting a new chat now shows only the switches you can actually change — Privacy Mode plus the memory and history-sync exclusions — instead of a wall of read-only status you can't act on (#3413)
+
+## 🛡️ Actionable Sandbox Settings
+
+- The Settings → Agent sandbox panel now speaks plain language and offers a real action ("Confine to the project"), replacing the developer-only diagnostics grid (#3407)
+
+## 🐞 Stability
+
+- Fixed the "Workspace is recovering" crash on load. A transitive dependency was pulling in a second copy of the SolidJS runtime; the runtime is now pinned to a single version so reactive state stays consistent (#3411)
+
+## ✏️ Editor
+
+- Upgraded the Monaco code editor to 0.56, migrated to its new worker-loading layout (#3417)
+
+## 🔧 Dependencies
+
+- Rust: rustls, webpki-roots, serde_json, tree-sitter (#3400, #3396, #3394, #3397)
+- JavaScript: Biome, Playwright, @tanstack/solid-query, marked (#3399, #3395, #3401, #3404)


### PR DESCRIPTION
Curated `.github/release-notes/v3.74.0.md` for the v3.74.0 release cut. Used verbatim as the GitHub release "What's New" body; Installation/footer are auto-appended by the release workflow.

Scope: 15 commits since v3.73.0 — privacy-panel plain-language rework (#3409), inline actionable privacy switches (#3413), actionable sandbox settings (#3407), solid-js single-runtime crash fix (#3411), Monaco 0.56 (#3417), and 8 dependency bumps.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com