### PR TITLE
fix(privacy): allow attested Seren Private Models in Privacy Mode

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -104,6 +104,7 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
+import { serenPrivateModelsAttested } from "@/services/private-models";
 import { assertPrivilegedConversationProvider } from "@/services/providers";
 import { skills } from "@/services/skills";
 import { pendingForConversation } from "@/stores/approvals.store";
@@ -1187,7 +1188,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
         id,
         isPrivilegedConversation(),
         activeThreadProvider(),
-        { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+        {
+          lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl"),
+          serenPrivateModelsAttested: serenPrivateModelsAttested(),
+        },
       );
     } catch (error) {
       conversationStore.setError(
@@ -1301,7 +1305,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
         id,
         isPrivilegedConversation(),
         retryProvider,
-        { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+        {
+          lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl"),
+          serenPrivateModelsAttested: serenPrivateModelsAttested(),
+        },
       );
       const content = await sendMessageWithRetry(
         message.request.prompt,

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -23,7 +23,10 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
-import { privateModelsService } from "@/services/private-models";
+import {
+  privateModelsService,
+  serenPrivateModelsAttested,
+} from "@/services/private-models";
 import {
   evaluateChatSwitchGuard,
   type SwitchBlockedReason,
@@ -89,12 +92,15 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
     !isPrivilegedConversation() ||
     isConfidentialSafeProvider(providerId, {
       lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl"),
+      serenPrivateModelsAttested: serenPrivateModelsAttested(),
     });
-  const privilegedProviderMessage =
-    "Privacy Mode only permits LM Studio on a local loopback endpoint.";
+  const privilegedProviderMessage = () =>
+    serenPrivateModelsAttested()
+      ? "Privacy Mode permits a Seren Private Model or LM Studio on a local loopback endpoint."
+      : "Privacy Mode only permits LM Studio on a local loopback endpoint.";
   const rejectUnsafeProvider = (providerId: string): boolean => {
     if (isProviderAllowedForConversation(providerId)) return false;
-    conversationStore.setError(privilegedProviderMessage);
+    conversationStore.setError(privilegedProviderMessage());
     return true;
   };
   const activeConversation = (): PickerConversation | null => {
@@ -515,7 +521,7 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                     title={
                       isProviderAllowedForConversation(providerId)
                         ? PROVIDER_CONFIGS[providerId].name
-                        : privilegedProviderMessage
+                        : privilegedProviderMessage()
                     }
                   >
                     <ProviderIcon provider={providerId} size={14} />
@@ -564,7 +570,7 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
                       title={
                         isProviderAllowedForConversation(agent.type)
                           ? `Switch to ${agentDisplayName(agent.type)} — opens an external agent session for this thread`
-                          : privilegedProviderMessage
+                          : privilegedProviderMessage()
                       }
                     >
                       <ProviderIcon provider={agent.type} size={14} />

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -41,6 +41,7 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
+import { serenPrivateModelsAttested } from "@/services/private-models";
 import { assertPrivilegedConversationProvider } from "@/services/providers";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
@@ -212,7 +213,10 @@ export async function orchestrate(
       conversationId,
       isPrivilegedConversation,
       selectedProvider,
-      { lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl") },
+      {
+        lmStudioBaseUrl: settingsStore.get("lmStudioBaseUrl"),
+        serenPrivateModelsAttested: serenPrivateModelsAttested(),
+      },
     );
   } catch (error) {
     conversationStore.setError(

--- a/src/services/private-models.ts
+++ b/src/services/private-models.ts
@@ -1,8 +1,19 @@
 import { getPrivateModels } from "@/api/seren-private-models";
 import type { ProviderModel } from "@/lib/providers/types";
 import { authStore } from "@/stores/auth.store";
+import { hasNoTrainingNoRetentionAttestation } from "./organization-policy";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * True when the active org's private-chat policy carries a verified
+ * no-training/no-retention attestation, which is what makes Seren Private
+ * Models eligible in Privacy Mode. Fails closed when the policy or attestation
+ * is absent.
+ */
+export function serenPrivateModelsAttested(): boolean {
+  return hasNoTrainingNoRetentionAttestation(authStore.privateChatPolicy);
+}
 
 let cachedModels: ProviderModel[] | null = null;
 let cacheExpiresAt = 0;

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -36,18 +36,30 @@ export type UnlistenFn = () => void;
 /**
  * Explicit P0 allowlist for Privacy Mode. Unknown providers are
  * denied rather than inferred safe from a display name or marketing claim.
+ * Membership is necessary but not sufficient: each entry still passes a runtime
+ * check in `isConfidentialSafeProvider` (loopback for LM Studio, a verified
+ * no-training/no-retention attestation for Seren Private Models).
  */
 export const CONFIDENTIAL_SAFE_PROVIDERS = [
   // LM Studio is a local process only when its configured endpoint resolves to
   // loopback. The settings UI also permits remote URLs, so the runtime check in
   // `isConfidentialSafeProvider` is required in addition to this static entry.
   "lmstudio",
+  // Seren Private Models (Bedrock) are safe only when the organization's
+  // private-chat policy carries a verified no-training/no-retention attestation.
+  // The attestation, not the provider name, is the evidence.
+  "seren-private",
 ] as const;
 
 type ConfidentialSafeProvider = (typeof CONFIDENTIAL_SAFE_PROVIDERS)[number];
 
 export interface ConfidentialProviderOptions {
   lmStudioBaseUrl?: string | null;
+  /**
+   * True when the org's private-chat policy carries a verified
+   * no-training/no-retention attestation (see `hasNoTrainingNoRetentionAttestation`).
+   */
+  serenPrivateModelsAttested?: boolean;
 }
 
 function isLoopbackUrl(rawUrl: string): boolean {
@@ -62,9 +74,11 @@ function isLoopbackUrl(rawUrl: string): boolean {
 }
 
 /**
- * Returns true only for an explicitly reviewed provider in a configuration
- * that keeps inference on the user's device. This remains intentionally
- * static until a registry can provide verifiable retention and training terms.
+ * Returns true only for an explicitly reviewed provider whose configuration
+ * carries verifiable confidentiality terms: LM Studio keeping inference on the
+ * user's device (loopback), or Seren Private Models whose org policy attests
+ * no-training/no-retention. Safety is proven by the runtime check, never
+ * inferred from the provider name.
  */
 export function isConfidentialSafeProvider(
   providerId: string | null | undefined,
@@ -81,6 +95,9 @@ export function isConfidentialSafeProvider(
   if (providerId === "lmstudio") {
     return isLoopbackUrl(options.lmStudioBaseUrl ?? "http://localhost:1234");
   }
+  if (providerId === "seren-private") {
+    return options.serenPrivateModelsAttested === true;
+  }
   return false;
 }
 
@@ -92,8 +109,11 @@ export function assertPrivilegedConversationProvider(
   options: ConfidentialProviderOptions = {},
 ): void {
   if (!privileged || isConfidentialSafeProvider(providerId, options)) return;
+  const alternative = options.serenPrivateModelsAttested
+    ? "Choose a Seren Private Model or a local LM Studio endpoint instead."
+    : "Choose a local LM Studio endpoint instead.";
   throw new Error(
-    `Privacy Mode blocks ${providerId ?? "this provider"} for conversation ${conversationId}. Choose a local LM Studio endpoint instead.`,
+    `Privacy Mode blocks ${providerId ?? "this provider"} for conversation ${conversationId}. ${alternative}`,
   );
 }
 

--- a/tests/unit/privileged-provider-gate.test.ts
+++ b/tests/unit/privileged-provider-gate.test.ts
@@ -30,7 +30,7 @@ import {
 
 describe("Privileged Matter provider gate", () => {
   it("denies non-allowlisted providers and permits only loopback LM Studio", () => {
-    expect(CONFIDENTIAL_SAFE_PROVIDERS).toEqual(["lmstudio"]);
+    expect(CONFIDENTIAL_SAFE_PROVIDERS).toEqual(["lmstudio", "seren-private"]);
     expect(
       isConfidentialSafeProvider("lmstudio", {
         lmStudioBaseUrl: "http://localhost:1234",
@@ -49,6 +49,33 @@ describe("Privileged Matter provider gate", () => {
         lmStudioBaseUrl: "http://127.0.0.1:1234",
       }),
     ).not.toThrow();
+  });
+
+  it("permits Seren Private Models only with a verified no-training/no-retention attestation", () => {
+    // Allowed only when the org policy attests no-training/no-retention.
+    expect(
+      isConfidentialSafeProvider("seren-private", {
+        serenPrivateModelsAttested: true,
+      }),
+    ).toBe(true);
+    // Fails closed when the attestation is absent or unverified.
+    expect(isConfidentialSafeProvider("seren-private", {})).toBe(false);
+    expect(
+      isConfidentialSafeProvider("seren-private", {
+        serenPrivateModelsAttested: false,
+      }),
+    ).toBe(false);
+    // The gate lets an attested private model through and blocks it otherwise.
+    expect(() =>
+      assertPrivilegedConversationProvider("p1", true, "seren-private", {
+        serenPrivateModelsAttested: true,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertPrivilegedConversationProvider("p1", true, "seren-private", {
+        serenPrivateModelsAttested: false,
+      }),
+    ).toThrow("Privacy Mode blocks seren-private");
   });
 
   it("uses the same static allowlist in selector and send paths", () => {


### PR DESCRIPTION
## What

Privacy Mode blocked every non-local provider and forced LM Studio, leaving users without a local model no path to work. Seren Private Models (Bedrock) exist precisely for privileged conversations, but the gate (`CONFIDENTIAL_SAFE_PROVIDERS = ["lmstudio"]`) never treated them as confidential-safe.

## Fix

- `seren-private` is now confidential-safe **only when** the org's private-chat policy carries a verified no-training/no-retention attestation (`hasNoTrainingNoRetentionAttestation`), failing closed otherwise. Safety is proven by the attestation, not inferred from the provider name.
- Threaded `serenPrivateModelsAttested()` through the chat gate call sites (orchestrator send, ChatContent send/retry) and the model picker; agent gate sites are untouched (they carry `agentType`, never `seren-private`).
- Error/picker copy is now attestation-aware.

## Tests

Unit coverage in `privileged-provider-gate.test.ts`: attested `seren-private` is allowed; unattested/absent fails closed; gate throws otherwise.

## Networked path (verified)

`POST /publishers/seren-private-models/chat/completions` — the `seren-private-models` publisher is live and returns models.

## Dependency

Full end-to-end unblock also needs the Gateway to populate the attestation for the Bedrock publisher — serenorg/seren-core#231. This client change honors the attestation once present, and fails closed until then.

Closes #3419

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com