### PR TITLE
fix(privacy): remove counsel-direction input; always-on in stamp

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -652,7 +652,6 @@ pub struct Conversation {
     pub employee_id: Option<String>,
     #[serde(default)]
     pub privileged: bool,
-    pub counsel_direction: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -671,7 +670,6 @@ pub struct AgentConversation {
     pub is_archived: bool,
     #[serde(default)]
     pub privileged: bool,
-    pub counsel_direction: Option<String>,
 }
 
 /// Exact desktop record required to restore a provider process for a persisted
@@ -737,7 +735,6 @@ pub struct UnifiedConversationRow {
     // the durable SQLite value is hydrated immediately after the read.
     #[serde(default)]
     pub privileged: bool,
-    pub counsel_direction: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -783,7 +780,6 @@ pub async fn create_conversation(
         is_archived: false,
         employee_id: employee_id.clone(),
         privileged: false,
-        counsel_direction: None,
     };
 
     run_db(app, move |conn| {
@@ -852,7 +848,7 @@ pub async fn list_conversations(
                        c.employee_id, c.agent_type, c.agent_session_id,
                        c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
                        c.agent_metadata, c.project_id, c.privileged,
-                       c.counsel_direction, psr.provider AS runtime_provider,
+                       psr.provider AS runtime_provider,
                        {case} AS derived_kind
                 FROM conversations c
                 LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
@@ -867,7 +863,7 @@ pub async fn list_conversations(
                         ELSE agent_type END AS agent_type,
                    agent_session_id, agent_cwd, agent_model_id,
                    agent_permission_mode, agent_metadata, project_id,
-                   privileged, counsel_direction
+                   privileged
             FROM derived
             WHERE is_archived = 0
               AND (?1 IS NULL OR derived_kind = ?1)
@@ -903,7 +899,6 @@ pub async fn list_conversations(
                     agent_metadata: row.get(14)?,
                     project_id: row.get(15)?,
                     privileged: row.get::<_, i32>(16)? != 0,
-                    counsel_direction: row.get(17)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -925,7 +920,7 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                          THEN COALESCE(c.selected_provider, psr.provider)
                          ELSE c.selected_provider END AS selected_provider,
                     c.project_root, c.is_archived, c.employee_id,
-                    c.privileged, c.counsel_direction
+                    c.privileged
              FROM conversations c
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
              WHERE c.id = ?1
@@ -946,7 +941,6 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                     is_archived: row.get::<_, i32>(6)? != 0,
                     employee_id: row.get(7)?,
                     privileged: row.get::<_, i32>(8)? != 0,
-                    counsel_direction: row.get(9)?,
                 })
             })
             .optional()?;
@@ -1000,20 +994,14 @@ pub async fn set_conversation_privileged(
     app: AppHandle,
     id: String,
     privileged: bool,
-    counsel_direction: Option<String>,
 ) -> Result<(), String> {
     let index_id = id.clone();
-    let normalized_direction = counsel_direction
-        .as_deref()
-        .map(str::trim)
-        .filter(|direction| !direction.is_empty())
-        .map(str::to_string);
     run_db(app.clone(), move |conn| {
         let changed = conn.execute(
             "UPDATE conversations
-             SET privileged = ?1, counsel_direction = ?2
-             WHERE id = ?3",
-            params![i32::from(privileged), normalized_direction, id],
+             SET privileged = ?1
+             WHERE id = ?2",
+            params![i32::from(privileged), id],
         )?;
         if changed == 0 {
             return Err(rusqlite::Error::QueryReturnedNoRows);
@@ -1176,7 +1164,6 @@ pub(crate) async fn create_agent_conversation_record(
         project_root: normalized_project_root.clone(),
         is_archived: false,
         privileged: false,
-        counsel_direction: None,
     };
 
     let persisted_convo = convo.clone();
@@ -1933,7 +1920,7 @@ pub async fn get_agent_conversation(
                     c.agent_session_id,
                     c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
                     c.agent_metadata, c.project_id, c.project_root, c.is_archived,
-                    c.privileged, c.counsel_direction
+                    c.privileged
              FROM conversations c
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
              WHERE c.id = ?1
@@ -1958,7 +1945,6 @@ pub async fn get_agent_conversation(
                     project_root: row.get(10)?,
                     is_archived: row.get::<_, i32>(11)? != 0,
                     privileged: row.get::<_, i32>(12)? != 0,
-                    counsel_direction: row.get(13)?,
                 })
             })
             .optional()?;
@@ -4310,7 +4296,6 @@ mod tests {
             project_root: None,
             is_archived: false,
             privileged: false,
-            counsel_direction: None,
         };
         assert!(upsert_agent_conversation_in_db(&conn, &late).unwrap());
 
@@ -4451,7 +4436,6 @@ mod tests {
             project_root: Some("/synthetic/project".to_string()),
             is_archived: false,
             privileged: false,
-            counsel_direction: None,
         };
 
         assert!(!upsert_agent_conversation_in_db(&conn, &conversation).unwrap());

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -37,7 +37,7 @@ pub struct PersistedMessage {
 /// Matter conversation. Keeping this at the database persistence chokepoint
 /// covers renderer, agent-runtime, and orchestrator writes alike.
 pub const PRIVILEGED_MATTER_STAMP: &str =
-    "Privileged & Confidential — Prepared in Anticipation of Litigation";
+    "Privileged & Confidential. Prepared at the Direction of Counsel.";
 
 pub const WAL_AUTOCHECKPOINT_PAGES: u32 = 200;
 const WAL_CHECKPOINT_INTERVAL_SECS: u64 = 10;
@@ -283,12 +283,12 @@ fn stamp_privileged_message_metadata(
 ) -> Result<Option<String>> {
     let privileged = conn
         .query_row(
-            "SELECT privileged, counsel_direction FROM conversations WHERE id = ?1",
+            "SELECT privileged FROM conversations WHERE id = ?1",
             rusqlite::params![conversation_id],
-            |row| Ok((row.get::<_, i32>(0)? != 0, row.get::<_, Option<String>>(1)?)),
+            |row| Ok(row.get::<_, i32>(0)? != 0),
         )
         .optional()?;
-    let Some((true, counsel_direction)) = privileged else {
+    let Some(true) = privileged else {
         return Ok(metadata.clone());
     };
 
@@ -315,16 +315,6 @@ fn stamp_privileged_message_metadata(
         "privileged_matter_stamp".to_string(),
         serde_json::Value::String(PRIVILEGED_MATTER_STAMP.to_string()),
     );
-    if let Some(direction) = counsel_direction
-        .as_deref()
-        .map(str::trim)
-        .filter(|direction| !direction.is_empty())
-    {
-        object.insert(
-            "counsel_direction".to_string(),
-            serde_json::Value::String(direction.to_string()),
-        );
-    }
     serde_json::to_string(&serde_json::Value::Object(object))
         .map(Some)
         .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))
@@ -752,8 +742,7 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             project_id TEXT,
             project_root TEXT,
             employee_id TEXT,
-            privileged INTEGER NOT NULL DEFAULT 0,
-            counsel_direction TEXT
+            privileged INTEGER NOT NULL DEFAULT 0
         )",
         [],
     )?;
@@ -1078,16 +1067,6 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     if !has_privileged {
         conn.execute(
             "ALTER TABLE conversations ADD COLUMN privileged INTEGER NOT NULL DEFAULT 0",
-            [],
-        )?;
-    }
-
-    let has_counsel_direction: bool = conn
-        .prepare("SELECT counsel_direction FROM conversations LIMIT 1")
-        .is_ok();
-    if !has_counsel_direction {
-        conn.execute(
-            "ALTER TABLE conversations ADD COLUMN counsel_direction TEXT",
             [],
         )?;
     }
@@ -1669,8 +1648,8 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         setup_schema(&conn).unwrap();
         conn.execute(
-            "INSERT INTO conversations (id, title, created_at, privileged, counsel_direction)
-             VALUES ('privileged', 'Matter', 1000, 1, 'Counsel-directed review')",
+            "INSERT INTO conversations (id, title, created_at, privileged)
+             VALUES ('privileged', 'Matter', 1000, 1)",
             [],
         )
         .unwrap();
@@ -1703,7 +1682,6 @@ mod tests {
                 metadata["privileged_matter_stamp"],
                 PRIVILEGED_MATTER_STAMP
             );
-            assert_eq!(metadata["counsel_direction"], "Counsel-directed review");
             assert_eq!(metadata["origin"], "orchestrator");
         }
     }
@@ -1735,7 +1713,7 @@ mod tests {
 
         conn.execute(
             "UPDATE conversations
-             SET privileged = 1, counsel_direction = 'Counsel-directed review'
+             SET privileged = 1
              WHERE id = 'retroactive'",
             [],
         )
@@ -1754,7 +1732,6 @@ mod tests {
             metadata["privileged_matter_stamp"],
             PRIVILEGED_MATTER_STAMP
         );
-        assert_eq!(metadata["counsel_direction"], "Counsel-directed review");
         assert_eq!(metadata["origin"], "before-toggle");
     }
 
@@ -2742,21 +2719,21 @@ mod tests {
         setup_schema(&conn).unwrap();
 
         conn.execute(
-            "INSERT INTO conversations (id, title, created_at, privileged, counsel_direction)
-             VALUES ('p1', 'Privileged', 1000, 1, 'Counsel-directed review')",
+            "INSERT INTO conversations (id, title, created_at, privileged)
+             VALUES ('p1', 'Privileged', 1000, 1)",
             [],
         )
         .unwrap();
-        let values: (i64, Option<String>) = conn
+        let privileged: i64 = conn
             .query_row(
-                "SELECT privileged, counsel_direction FROM conversations WHERE id = 'p1'",
+                "SELECT privileged FROM conversations WHERE id = 'p1'",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(values, (1, Some("Counsel-directed review".to_string())));
+        assert_eq!(privileged, 1);
 
-        // Re-running setup remains idempotent once both columns exist.
+        // Re-running setup remains idempotent once the column exists.
         setup_schema(&conn).unwrap();
     }
 

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -257,12 +257,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
   const isPrivilegedConversation = () =>
     privacyStore.isPrivileged(activeAgentThread()?.id);
-  const counselDirection = () => {
-    const id = activeAgentThread()?.id;
-    return id
-      ? privacyStore.getConversationPrivacy(id).counselDirection
-      : undefined;
-  };
   const assertPrivilegedThreadProvider = () => {
     const thread = activeAgentThread();
     if (!thread) return;
@@ -816,7 +810,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           formatChatHistoryMarkdown(messages, {
             header: "# Agent Chat History",
           }),
-          counselDirection(),
         )
       : formatChatHistoryMarkdown(messages, {
           header: "# Agent Chat History",
@@ -1737,7 +1730,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           aria-label="Privacy Mode enabled"
         >
           <p class="m-0 text-xs font-semibold tracking-wide">
-            {formatPrivilegedMatterStamp(counselDirection())}
+            {formatPrivilegedMatterStamp()}
           </p>
           <p class="m-0 mt-1 text-[11px] leading-relaxed text-amber-100/75">
             Memory, history sync, cloud Notes export, local search indexing, and

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -244,12 +244,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       )?.privileged === true
     );
   };
-  const counselDirection = () => {
-    const id = conversationId();
-    return id
-      ? privacyStore.getConversationPrivacy(id).counselDirection
-      : undefined;
-  };
   const clearRecordedSession = () => {
     releaseRecordedSessionArtifacts?.();
     releaseRecordedSessionArtifacts = undefined;
@@ -1379,10 +1373,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     }
 
     const markdown = isPrivilegedConversation()
-      ? prependPrivilegedMatterStamp(
-          formatChatHistoryMarkdown(messages),
-          counselDirection(),
-        )
+      ? prependPrivilegedMatterStamp(formatChatHistoryMarkdown(messages))
       : formatChatHistoryMarkdown(messages);
 
     try {
@@ -1602,7 +1593,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
             aria-label="Privacy Mode enabled"
           >
             <p class="m-0 text-xs font-semibold tracking-wide">
-              {formatPrivilegedMatterStamp(counselDirection())}
+              {formatPrivilegedMatterStamp()}
             </p>
             <p class="m-0 mt-1 text-[11px] leading-relaxed text-amber-100/75">
               Memory, history sync, cloud Notes export, local search indexing,

--- a/src/components/chat/DataDestinationsPanel.tsx
+++ b/src/components/chat/DataDestinationsPanel.tsx
@@ -129,14 +129,6 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
     privacyStore.setConversationPrivacy(id, { privileged: checked });
   };
 
-  const updateCounselDirection = (value: string) => {
-    const id = props.conversationId;
-    if (!id) return;
-    privacyStore.setConversationPrivacy(id, {
-      counselDirection: value.trim() || undefined,
-    });
-  };
-
   // In controls mode there is nothing actionable to show without a
   // conversation to scope the switches to.
   if (props.variant === "controls" && !props.conversationId) {
@@ -235,27 +227,6 @@ export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
                   </span>
                 </span>
               </label>
-              <Show when={privacyStore.isPrivileged(props.conversationId)}>
-                <label class="mt-2 block">
-                  <span class="block text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    Reason (optional)
-                  </span>
-                  <input
-                    type="text"
-                    class="mt-1 w-full rounded border border-border-strong bg-surface-2 px-2.5 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:border-primary"
-                    value={
-                      privacyStore.getConversationPrivacy(
-                        props.conversationId ?? "",
-                      ).counselDirection ?? ""
-                    }
-                    placeholder="e.g. Confidential review"
-                    onChange={(event) =>
-                      updateCounselDirection(event.currentTarget.value)
-                    }
-                    aria-label="Reason this conversation is private"
-                  />
-                </label>
-              </Show>
             </div>
             <label class="flex cursor-pointer items-start gap-2 rounded-lg border border-border px-3 py-2 transition-colors hover:border-border-hover">
               <input

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -306,9 +306,8 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     stopHistorySync();
     try {
       const reports = await eraseAllConversationData();
-      // Drop the renderer-side privacy.json entries (per-conversation flags and
-      // free-text counsel direction) so identifying data does not survive the
-      // erase-all (#3348).
+      // Drop the renderer-side privacy.json entries (per-conversation privacy
+      // flags) so they do not survive the erase-all (#3348).
       await privacyStore.clearAll();
       setEraseAllReports(reports);
       setEraseAllConfirm("");

--- a/src/lib/privileged-matter.ts
+++ b/src/lib/privileged-matter.ts
@@ -2,21 +2,13 @@
 // ABOUTME: Keeps the user-visible stamp identical across chat, agent, and export surfaces.
 
 export const PRIVILEGED_MATTER_STAMP =
-  "Privileged & Confidential — Prepared in Anticipation of Litigation";
+  "Privileged & Confidential. Prepared at the Direction of Counsel.";
 
-export function formatPrivilegedMatterStamp(
-  counselDirection?: string | null,
-): string {
-  const direction = counselDirection?.trim();
-  return direction
-    ? `${PRIVILEGED_MATTER_STAMP}\nCounsel direction: ${direction}`
-    : PRIVILEGED_MATTER_STAMP;
+export function formatPrivilegedMatterStamp(): string {
+  return PRIVILEGED_MATTER_STAMP;
 }
 
 /** Prefix allowed local exports so the work-product designation travels with them. */
-export function prependPrivilegedMatterStamp(
-  content: string,
-  counselDirection?: string | null,
-): string {
-  return `${formatPrivilegedMatterStamp(counselDirection)}\n\n---\n\n${content}`;
+export function prependPrivilegedMatterStamp(content: string): string {
+  return `${PRIVILEGED_MATTER_STAMP}\n\n---\n\n${content}`;
 }

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -676,7 +676,6 @@ export interface Conversation {
   is_archived: boolean;
   employee_id: string | null;
   privileged: boolean;
-  counsel_direction: string | null;
 }
 
 /**
@@ -702,7 +701,6 @@ export interface AgentConversation {
   project_root: string | null;
   is_archived: boolean;
   privileged: boolean;
-  counsel_direction: string | null;
 }
 
 /**
@@ -729,7 +727,6 @@ export interface UnifiedConversationRow {
   agent_metadata: string | null;
   project_id: string | null;
   privileged: boolean;
-  counsel_direction: string | null;
 }
 
 /**
@@ -839,7 +836,6 @@ export async function updateConversation(
 export async function setConversationPrivileged(
   id: string,
   privileged: boolean,
-  counselDirection?: string | null,
 ): Promise<void> {
   const invoke = await getInvoke();
   if (!invoke) {
@@ -848,7 +844,6 @@ export async function setConversationPrivileged(
   await invoke("set_conversation_privileged", {
     id,
     privileged,
-    counselDirection: counselDirection ?? null,
   });
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1686,7 +1686,6 @@ function unifiedRowToAgent(row: UnifiedConversationRow): DbAgentConversation {
     project_root: row.project_root,
     is_archived: row.is_archived,
     privileged: row.privileged,
-    counsel_direction: row.counsel_direction,
   };
 }
 
@@ -2883,7 +2882,6 @@ export const agentStore = {
         privacyStore.hydrateConversationPrivilege(
           conversation.id,
           conversation.privileged,
-          conversation.counsel_direction,
         );
       }
       setState(
@@ -2915,11 +2913,7 @@ export const agentStore = {
    */
   upsertAgentConversationFromDb(row: DbAgentConversation) {
     if (happyArchiveFence.isArchived(row.id)) return;
-    privacyStore.hydrateConversationPrivilege(
-      row.id,
-      row.privileged,
-      row.counsel_direction,
-    );
+    privacyStore.hydrateConversationPrivilege(row.id, row.privileged);
     setState("recentAgentConversations", (rows) => {
       const without = rows.filter((r) => r.id !== row.id);
       return [row, ...without];
@@ -2948,7 +2942,6 @@ export const agentStore = {
         privacyStore.hydrateConversationPrivilege(
           conversation.id,
           conversation.privileged,
-          conversation.counsel_direction,
         );
       }
 
@@ -4042,11 +4035,7 @@ export const agentStore = {
         // Non-fatal — the runtime is the source of truth for the live session.
       }
       if (convo?.privileged) {
-        privacyStore.hydrateConversationPrivilege(
-          convo.id,
-          true,
-          convo.counsel_direction,
-        );
+        privacyStore.hydrateConversationPrivilege(convo.id, true);
         try {
           providerService.assertPrivilegedConversationProvider(
             conversationId,
@@ -4289,11 +4278,7 @@ export const agentStore = {
       setState("error", "Agent conversation not found");
       return null;
     }
-    privacyStore.hydrateConversationPrivilege(
-      convo.id,
-      convo.privileged,
-      convo.counsel_direction,
-    );
+    privacyStore.hydrateConversationPrivilege(convo.id, convo.privileged);
     const agentType: AgentType =
       convo.agent_type === "codex" ||
       convo.agent_type === "claude-code" ||

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -99,7 +99,6 @@ export interface Conversation {
   selectedProvider: ProviderId | AgentType | null;
   isArchived: boolean;
   privileged?: boolean;
-  counselDirection?: string | null;
   compactedSummary?: CompactedSummary;
   /** Reasoning effort level: "minimal" | "low" | "medium" | "high" | "xhigh". */
   reasoningEffort?: string;
@@ -158,7 +157,6 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     selectedProvider: (row.selected_provider as ProviderId | AgentType) ?? null,
     isArchived: row.is_archived,
     privileged: row.privileged,
-    counselDirection: row.counsel_direction,
   };
 }
 

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -34,7 +34,6 @@ export interface Conversation {
   isArchived: boolean;
   employeeId: string | null;
   privileged?: boolean;
-  counselDirection?: string | null;
 }
 
 interface ConversationState {
@@ -102,7 +101,6 @@ function dbToConversation(db: DbConversation): Conversation {
     isArchived: db.is_archived,
     employeeId: db.employee_id ?? null,
     privileged: db.privileged,
-    counselDirection: db.counsel_direction,
   };
 }
 
@@ -117,7 +115,6 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     isArchived: row.is_archived,
     employeeId: row.employee_id,
     privileged: row.privileged,
-    counselDirection: row.counsel_direction,
   };
 }
 
@@ -675,7 +672,6 @@ export const conversationStore = {
         privacyStore.hydrateConversationPrivilege(
           conversation.id,
           conversation.privileged === true,
-          conversation.counselDirection,
         );
       }
 

--- a/src/stores/privacy.store.ts
+++ b/src/stores/privacy.store.ts
@@ -13,8 +13,6 @@ export interface ConversationPrivacy {
   excludeHistorySync: boolean;
   /** Privileged conversations deny memory, history sync, notes export, and unsafe providers. */
   privileged: boolean;
-  /** Optional direction supplied by counsel and mirrored into the local chat DB. */
-  counselDirection?: string;
 }
 
 interface PrivacyState {
@@ -48,11 +46,6 @@ function normalizeConversations(
       excludeMemory: candidate.excludeMemory === true,
       excludeHistorySync: candidate.excludeHistorySync === true,
       privileged: candidate.privileged === true,
-      counselDirection:
-        typeof candidate.counselDirection === "string" &&
-        candidate.counselDirection.trim().length > 0
-          ? candidate.counselDirection.trim()
-          : undefined,
     };
   }
   return normalized;
@@ -162,18 +155,12 @@ export const privacyStore = {
    * A stale or unavailable privacy.json must never make a persisted privileged
    * conversation eligible for egress after an app restart.
    */
-  hydrateConversationPrivilege(
-    id: string,
-    privileged: boolean,
-    counselDirection?: string | null,
-  ): void {
+  hydrateConversationPrivilege(id: string, privileged: boolean): void {
     if (!id || !privileged) return;
     const current = flagsFor(id);
     setPrivacyState("conversations", id, {
       ...current,
       privileged: true,
-      counselDirection:
-        counselDirection?.trim() || current.counselDirection || undefined,
     });
   },
 
@@ -188,12 +175,8 @@ export const privacyStore = {
     };
     setPrivacyState("conversations", id, next);
     void saveStoredPrivacy();
-    if ("privileged" in updates || "counselDirection" in updates) {
-      void setConversationPrivileged(
-        id,
-        next.privileged,
-        next.counselDirection ?? null,
-      ).catch((error) => {
+    if ("privileged" in updates) {
+      void setConversationPrivileged(id, next.privileged).catch((error) => {
         console.warn(
           "[Privacy] Failed to persist Privacy Mode to the chat DB:",
           error,
@@ -210,8 +193,8 @@ export const privacyStore = {
 
   /**
    * Drop every per-conversation privacy entry and persist the empty state, for
-   * the "erase all data" flow. privacy.json holds identifying data (including
-   * free-text counsel direction), so it must not survive an erase-all (#3348).
+   * the "erase all data" flow. privacy.json maps conversation IDs to their
+   * privacy flags, so it must not survive an erase-all (#3348).
    */
   async clearAll(): Promise<void> {
     erasedConversationIds.clear();

--- a/tests/unit/privileged-matter-mode.test.ts
+++ b/tests/unit/privileged-matter-mode.test.ts
@@ -49,7 +49,6 @@ describe("Privileged Matter Mode", () => {
       excludeMemory: false,
       excludeHistorySync: false,
       privileged: true,
-      counselDirection: "Counsel-directed analysis",
     });
   });
 
@@ -62,11 +61,7 @@ describe("Privileged Matter Mode", () => {
 
   it("honors the durable database privilege flag before privacy settings reload", () => {
     const restoredConversationId = "privileged-matter-restored-test";
-    privacyStore.hydrateConversationPrivilege(
-      restoredConversationId,
-      true,
-      "Counsel-directed analysis",
-    );
+    privacyStore.hydrateConversationPrivilege(restoredConversationId, true);
 
     expect(privacyStore.isPrivileged(restoredConversationId)).toBe(true);
     expect(privacyStore.isMemoryExcluded(restoredConversationId)).toBe(true);


### PR DESCRIPTION
## What

The COUNSEL DIRECTION (later relabeled "Reason") free-text input in Privileged Matter Mode was unactionable UI — no explanation, and its only effect was appending a line to the work-product export stamp. Counsel direction is inherent to Privileged Matter Mode, so it needs neither an input nor a flag.

## Change

- Remove the input and **all** `counsel_direction` plumbing: UI (DataDestinationsPanel), stores (privacy/conversation/chat/agent), tauri-bridge, Rust structs + SQL (chat.rs), and the DB column + add-column migration (database.rs).
- Bake the designation into the single fixed stamp on both frontend and Rust:
  `Privileged & Confidential. Prepared at the Direction of Counsel.`
- The existing DB column is left **dormant** — no data-dropping migration; new schema omits it, existing rows keep a harmless unused column.
- Updated 2 tests and 2 stale comments.

## Validation

- `cargo check` ✅, `cargo test` **1198 passed / 0 failed** ✅
- frontend `tsc` clean, Biome ✅, `vite build` ✅
- privacy/privileged unit tests 6/6 ✅

Privileged Matter Mode and its blocking behavior are unchanged. No PII.

Closes #3421

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com