### PR TITLE
docs(release): note attested private models + counsel removal in v3.74.0

### DIFF
--- a/.github/release-notes/v3.74.0.md
+++ b/.github/release-notes/v3.74.0.md
@@ -1,11 +1,13 @@
 ## What's New
 
-A polish-and-stability release: the privacy and sandbox controls are reworked into plain language you can act on, a duplicate-runtime crash on load is fixed, the editor moves to Monaco 0.56, and the dependency stack gets a security-oriented refresh.
+A polish-and-stability release: the privacy and sandbox controls are reworked into plain language you can act on, Privacy Mode gains a hosted private-model path, a duplicate-runtime crash on load is fixed, the editor moves to Monaco 0.56, and the dependency stack gets a security-oriented refresh.
 
 ## 🔒 Clearer Privacy Controls
 
 - The data-destinations panel is now a plain-language **Privacy** control — no legal terminology, no permanently-green status, and restyled to match the rest of the app (#3409)
 - Starting a new chat now shows only the switches you can actually change — Privacy Mode plus the memory and history-sync exclusions — instead of a wall of read-only status you can't act on (#3413)
+- Privacy Mode now permits **Seren Private Models** (AWS Bedrock) when your organization's policy carries a verified no-training/no-retention attestation, so you're no longer forced to a local LM Studio endpoint (#3420)
+- Removed the confusing counsel-direction input from Privileged Matter Mode — the counsel-directed designation is now applied automatically to every privileged conversation (#3422)
 
 ## 🛡️ Actionable Sandbox Settings
 


### PR DESCRIPTION
Adds the two new privacy fixes (Seren Private Models in Privacy Mode #3420, counsel-direction removal #3422) to the v3.74.0 release notes before cutting the tag.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com