### PR TITLE
fix(mcp): lazy-load playwright browser modules off init path

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -1,13 +1,22 @@
 // ABOUTME: Unit tests for multi-browser selection, detection, and configuration.
 // ABOUTME: Validates parseBrowserType, isChromiumBased, resolveBrowserName, and listInstalledBrowsers.
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { InstalledBrowser } from "../browser.js";
 import {
   addPageInitPatchIfEnabled,
   applyStealthPluginIfEnabled,
   CONNECT_CDP_URL_ENV,
   createSafeStealthPlugin,
+  ensureBrowserModules,
   detectDefaultBrowser,
   getConfiguredCdpUrl,
   getConfiguredStorageStatePath,
@@ -45,6 +54,12 @@ const TEST_INSTALLED_BROWSERS: InstalledBrowser[] = [
     stealthSupported: false,
   },
 ];
+
+// playwright-extra + the stealth plugin now load lazily on first browser
+// launch, so tests that exercise the stealth helpers must load them first.
+beforeAll(async () => {
+  await ensureBrowserModules();
+});
 
 const CONTROLLED_ENV_KEYS = [
   "SEREN_PLAYWRIGHT_HEADLESS",

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -3,8 +3,32 @@
 
 import { existsSync } from "node:fs";
 import type { Browser, BrowserContext, BrowserType, Page } from "playwright";
-import { chromium, firefox, webkit } from "playwright-extra";
-import StealthPlugin from "puppeteer-extra-plugin-stealth";
+import type StealthPluginFactory from "puppeteer-extra-plugin-stealth";
+
+// playwright-extra and the stealth plugin are heavy to import. Loading them at
+// module scope ran during the MCP `initialize` handshake, and on a cold or
+// loaded machine that cold import pushed the handshake past its timeout and
+// failed agent startup. They are only needed once a browser actually launches,
+// so they load lazily off the initialize critical path (#3405).
+let chromium: typeof import("playwright-extra").chromium;
+let firefox: typeof import("playwright-extra").firefox;
+let webkit: typeof import("playwright-extra").webkit;
+let StealthPlugin: typeof StealthPluginFactory;
+let browserModulesPromise: Promise<void> | null = null;
+
+/** Import playwright-extra + the stealth plugin once, on first browser launch. */
+export async function ensureBrowserModules(): Promise<void> {
+  if (!browserModulesPromise) {
+    browserModulesPromise = (async () => {
+      const playwrightExtra = await import("playwright-extra");
+      chromium = playwrightExtra.chromium;
+      firefox = playwrightExtra.firefox;
+      webkit = playwrightExtra.webkit;
+      StealthPlugin = (await import("puppeteer-extra-plugin-stealth")).default;
+    })();
+  }
+  return browserModulesPromise;
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -650,6 +674,7 @@ export async function addPageInitPatchIfEnabled(
 
 export async function getBrowser(): Promise<Browser> {
   if (!browser) {
+    await ensureBrowserModules();
     const startupMode = resolveBrowserStartupMode();
 
     if (startupMode.mode === "cdp") {


### PR DESCRIPTION
## What

Partial hardening for #3405. The playwright-stealth MCP imported `playwright-extra` + `puppeteer-extra-plugin-stealth` at **module scope**, so that heavy cold import ran during the MCP `initialize` handshake. On a cold/loaded machine (e.g. a fresh Windows e2e box under load) that pushed the handshake past its 15s timeout and failed the agent journey.

## Change

- `browser.ts`: the heavy modules load lazily via `ensureBrowserModules()`, awaited at the top of `getBrowser()` (first browser launch) instead of at import. `getLauncher`/`createSafeStealthPlugin` read the loaded refs.
- `browser.test.ts`: `beforeAll` pre-loads the modules for the stealth-helper tests.

## Proof (local)

- `browser.js` module load: **~140ms warm → ~1ms** (heavy import deferred). Cold-box savings are much larger.
- Heavy load moves to first browser use (`ensureBrowserModules()`, ~120ms, cached after).
- tsc clean; **74/74 MCP tests pass**.

## Honest scope

This removes the **module-load** contributor from the init critical path — a real hardening. It is **not** a complete fix for every init-timeout: on a degraded box, concurrent cli-updater network hangs and the tight 15s timeout also contribute, and the true fix (don't gate provider-session initialize on optional MCP init at all) is deeper. The full slow-network failure only validates on the real release gate. Correcting #3405 to reflect the accurate root cause (the MCP uses **system** browsers and never downloads one — my original 'fetches browser assets' claim was wrong).

Refs #3405

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com