### PR TITLE
fix(happy): summarize file-read output on Happy Mobile (#3425)

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -11,6 +11,7 @@ import nacl from "tweetnacl";
 import {
   composeApprovalNotification,
   createAssistantMessageCoalescer,
+  createFileReadSummarizer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "./translate.mjs";
@@ -689,6 +690,7 @@ export function createHappyLayer({
   const liveSessions = new Set();
   const turnCorrelator = createTurnCorrelator();
   const assistantMessageCoalescer = createAssistantMessageCoalescer();
+  const fileReadSummarizer = createFileReadSummarizer();
 
   const sessionSummaries = new Map();
   const sessionSummaryRevisions = new Map();
@@ -2075,7 +2077,8 @@ export function createHappyLayer({
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     const correlatedEvent = turnCorrelator.correlate(event);
     for (const publishableEvent of assistantMessageCoalescer.consume(correlatedEvent)) {
-      for (const message of translateNeutralEvent(publishableEvent, { provider })) {
+      const summarizedEvent = fileReadSummarizer.annotate(publishableEvent);
+      for (const message of translateNeutralEvent(summarizedEvent, { provider })) {
         if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
         if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
       }
@@ -2650,6 +2653,7 @@ export function createHappyLayer({
       await promptQueue.close();
       turnCorrelator.close();
       assistantMessageCoalescer.close();
+      fileReadSummarizer.close();
       cancelPairing();
       await pairingAuthorizationPromise;
       // A remote spawn may already own a persisted relay row while provider

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -11,6 +11,12 @@ const TOOL_ERROR_MAX_CHARS = 6_000;
 const FILE_DIFF_MAX_CHARS = 2_000;
 const TOOL_INPUT_MAX_CHARS = 2_000;
 const MOBILE_TRUNCATION_MARKER = "\n… [truncated for Happy Mobile]";
+// A file read streams the whole file body to the phone. Provider runtimes label
+// that read differently: claude-code emits the semantic kind `fileRead`, while
+// ACP surfaces the ToolKind `read`. Either one identifies a read whose result
+// body should be summarized rather than forwarded. lmstudio labels calls by
+// transport (`local`/`mcp`), so its reads fall back to the character cap below.
+const FILE_READ_TOOL_KINDS = new Set(["fileRead", "read"]);
 
 function stringValue(value, fallback = "") {
   return typeof value === "string" ? value : fallback;
@@ -222,6 +228,57 @@ export function createAssistantMessageCoalescer({ createMessageId = randomUUID }
     },
     close() {
       pending.clear();
+    },
+  };
+}
+
+/**
+ * A file `Read` streams its whole result to the phone, and an agent that reads
+ * many files buries the conversation. `tool-end` carries only the call id and
+ * body, while the read kind arrives on the earlier `tool-start`, so remember
+ * which calls are reads and replace a completed read's body with a line-count
+ * summary — the same elision `summarizeFileContent` already applies to diffs.
+ * Errors are never elided; a truncated failure is worse than useless.
+ *
+ * @param {{maxPending?: number}} options
+ */
+export function createFileReadSummarizer({ maxPending = 512 } = {}) {
+  const fileReadCallIds = new Set();
+
+  function annotate(event) {
+    if (!event || typeof event !== "object" || typeof event.kind !== "string") {
+      return event;
+    }
+    const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
+    const callId = stringValue(payload.toolCallId);
+    if (event.kind === "tool-start") {
+      if (callId && FILE_READ_TOOL_KINDS.has(stringValue(payload.kind))) {
+        // A read whose `tool-end` never arrives (e.g. a cancelled turn) would
+        // otherwise pin its call id forever; evict the oldest to bound growth.
+        if (fileReadCallIds.size >= maxPending) {
+          const oldest = fileReadCallIds.values().next().value;
+          if (oldest !== undefined) fileReadCallIds.delete(oldest);
+        }
+        fileReadCallIds.add(callId);
+      }
+      return event;
+    }
+    if (event.kind === "tool-end" && callId && fileReadCallIds.has(callId)) {
+      fileReadCallIds.delete(callId);
+      if (!payload.error && typeof payload.result === "string") {
+        return {
+          ...event,
+          payload: { ...payload, result: summarizeFileContent(payload.result) },
+        };
+      }
+    }
+    return event;
+  }
+
+  return {
+    annotate,
+    close() {
+      fileReadCallIds.clear();
     },
   };
 }

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   composeApprovalNotification,
   createAssistantMessageCoalescer,
+  createFileReadSummarizer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "../../bin/happy-bridge/translate.mjs";
@@ -132,6 +133,84 @@ describe("neutral-to-Happy session translation", () => {
       isError: true,
       output: "e".repeat(3_000),
     });
+  });
+
+  it("summarizes a completed file read body while keeping the read visible", () => {
+    const summarizer = createFileReadSummarizer();
+    const body = "line one\nline two\nline three";
+
+    // The read announces itself on tool-start (claude-code emits kind "fileRead").
+    const startEvent = summarizer.annotate({
+      kind: "tool-start",
+      sessionId: "session-1",
+      payload: {
+        toolCallId: "read-1",
+        kind: "fileRead",
+        title: "Read: /workspace/project/app.ts",
+        parameters: { file_path: "/workspace/project/app.ts" },
+      },
+    });
+    const [startMessage] = translateNeutralEvent(startEvent);
+    expect(startMessage.body).toMatchObject({ type: "tool-call", callId: "read-1" });
+
+    // tool-end carries only the body; it is replaced with a line-count summary.
+    const endEvent = summarizer.annotate({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "read-1", result: body },
+    });
+    const [endMessage] = translateNeutralEvent(endEvent);
+    expect(endMessage.body.output).toBe("[3 lines hidden on Happy Mobile]");
+    expect(endMessage.body.output).not.toContain("line two");
+  });
+
+  it("summarizes an ACP `read` result the same way", () => {
+    const summarizer = createFileReadSummarizer();
+    summarizer.annotate({
+      kind: "tool-start",
+      sessionId: "session-1",
+      payload: { toolCallId: "read-2", kind: "read" },
+    });
+    const endEvent = summarizer.annotate({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "read-2", result: "only one line" },
+    });
+    expect(translateNeutralEvent(endEvent)[0].body.output).toBe(
+      "[1 line hidden on Happy Mobile]",
+    );
+  });
+
+  it("leaves a failed read and a non-read result untouched", () => {
+    const summarizer = createFileReadSummarizer();
+    // A read that errored keeps its short, diagnostic failure text.
+    summarizer.annotate({
+      kind: "tool-start",
+      sessionId: "session-1",
+      payload: { toolCallId: "read-err", kind: "fileRead" },
+    });
+    const failed = summarizer.annotate({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "read-err", error: "ENOENT: no such file" },
+    });
+    expect(translateNeutralEvent(failed)[0].body).toMatchObject({
+      isError: true,
+      output: "ENOENT: no such file",
+    });
+
+    // A shell command's output is not a read and stays on the character-cap path.
+    summarizer.annotate({
+      kind: "tool-start",
+      sessionId: "session-1",
+      payload: { toolCallId: "run-1", kind: "shell" },
+    });
+    const command = summarizer.annotate({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "run-1", result: "build succeeded" },
+    });
+    expect(translateNeutralEvent(command)[0].body.output).toBe("build succeeded");
   });
 
   it("bounds tool input without flattening its shape", () => {


### PR DESCRIPTION
## What

On Happy Mobile, a file `Read` still floods the phone. #3118 capped tool output at 1,200 chars, but for a read that cap is 1,200 chars of the **file body**, so an agent that reads many files stacks those blocks until the conversation is unreadable on a small screen. The desktop keeps a full read behind a collapsible card; the phone has no such control.

This replaces a completed file read's body — on the phone only — with the same compact line-count summary #3118 already uses for diffs: `[N lines hidden on Happy Mobile]`. The read stays visible (the `tool-call` still shows *that* it ran and which file); only the bulk body is elided.

## How

`tool-end` carries only `toolCallId` + `result`; the read `kind` (`fileRead` for claude-code, `read` for ACP) rides on the earlier `tool-start`. A small `createFileReadSummarizer` correlator — mirroring the existing `createTurnCorrelator` / `createAssistantMessageCoalescer` — remembers which call ids are file reads and rewrites the matching `tool-end` result via `summarizeFileContent`. It is wired into the single `publishEvent` translate pipeline in `happy-layer.mjs` and disposed on shutdown.

- Errors are never elided (a truncated failure is worse than useless).
- Non-read output (e.g. Bash) is untouched and stays on the existing character-cap path.
- lmstudio labels calls by transport (`local`/`mcp`), not a read signal, so its reads fall back to the 1,200-char cap — no regression.

## Why it's mobile-only and safe

`translateNeutralEvent` has a single caller — `publishEvent` — which feeds only the relay client. The desktop renderer uses a separate path, so this cannot reduce desktop fidelity (same construction that made #3118 safe).

## Tests

Added focused regression coverage to `tests/unit/happy-bridge-translate-happy.test.ts`:
- a completed file read's body becomes `[N lines hidden on Happy Mobile]` while the `tool-call` stays visible;
- an ACP `read` result is summarized the same way;
- a failed read and a non-read (shell) result are left untouched.

Full Happy bridge unit suite: 16 files / 191 tests green.

Closes #3425
