### PR TITLE
fix(wallet): offer daily SerenBucks claim at agent launch (#3427)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -104,6 +104,7 @@ import { privacyStore } from "@/stores/privacy.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
+import { surfaceDailyClaimIfEligible } from "@/stores/wallet.store";
 import { workspaceStore } from "@/stores/workspace.store";
 import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { AgentEffortSelector } from "./AgentEffortSelector";
@@ -979,6 +980,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           agentStore.setTurnError(thread.id, "spawn_failed");
           return;
         }
+        // A fresh agent launch is a moment of engagement — surface the daily
+        // SerenBucks claim if the user still has one, so the reward is timely
+        // instead of stranded behind a once-a-day popup they may have dismissed.
+        // Cold-start only, so it fires once per launch and never per message.
+        void surfaceDailyClaimIfEligible();
       } catch (err) {
         console.error("[AgentChat] cold-start spawn threw:", err);
         // If the user cancelled, don't overwrite their cancel with an error.

--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -488,6 +488,29 @@ function dismissDailyClaim(): void {
 }
 
 /**
+ * Re-check daily claim eligibility and re-surface the popup when the user still
+ * has an unclaimed daily reward. Called when the user launches an agent so the
+ * reward is offered at the moment of engagement — even after an earlier dismiss
+ * or a session that crossed midnight UTC. A fresh eligibility fetch keeps the
+ * midnight boundary honest; on a transient failure the existing state is left
+ * untouched (mirroring the poll) so a launch is never blocked or falsely reset.
+ */
+async function surfaceDailyClaimIfEligible(): Promise<void> {
+  try {
+    const eligibility = await fetchDailyEligibility();
+    setWalletState("dailyClaim", eligibility);
+    if (eligibility.can_claim) {
+      setWalletState("dailyClaimDismissed", false);
+    }
+  } catch (err) {
+    console.error(
+      "[Wallet Store] Failed to refresh daily claim on agent launch:",
+      err,
+    );
+  }
+}
+
+/**
  * Start periodic re-checking of daily claim eligibility.
  * Surfaces the claim popup for long-running sessions that span midnight UTC.
  */
@@ -615,6 +638,7 @@ export {
   startDailyClaimPolling,
   stopAutoRefresh,
   stopDailyClaimPolling,
+  surfaceDailyClaimIfEligible,
   updateBalanceFromError,
   walletState,
 };

--- a/tests/unit/daily-claim-agent-launch.test.ts
+++ b/tests/unit/daily-claim-agent-launch.test.ts
@@ -1,0 +1,93 @@
+// ABOUTME: Verifies the daily SerenBucks claim popup re-surfaces on agent launch.
+// ABOUTME: Protects the un-dismiss-when-still-claimable gate and its error safety.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dailyClaimMocks = vi.hoisted(() => ({
+  fetchDailyEligibility: vi.fn(),
+  claimDailyCredits: vi.fn(),
+}));
+
+vi.mock("@/services/dailyClaim", () => ({
+  fetchDailyEligibility: dailyClaimMocks.fetchDailyEligibility,
+  claimDailyCredits: dailyClaimMocks.claimDailyCredits,
+}));
+
+vi.mock("@/services/notifications", () => ({
+  postNotification: vi.fn(),
+}));
+
+vi.mock("@/services/wallet", () => ({
+  fetchBalance: vi.fn(),
+  markWalletNotificationRead: vi.fn(),
+}));
+
+import {
+  dismissDailyClaim,
+  resetWalletState,
+  surfaceDailyClaimIfEligible,
+  walletState,
+} from "@/stores/wallet.store";
+
+// Fresh objects per call — Solid's store proxies wrap values in place, so a
+// shared reference reused across setState calls/tests leaks reactive state.
+function eligibility(canClaim: boolean) {
+  return {
+    can_claim: canClaim,
+    claims_remaining_this_month: canClaim ? 5 : 4,
+    reason: canClaim ? null : "Already claimed today",
+    resets_in_seconds: 3600,
+  };
+}
+
+describe("daily claim on agent launch", () => {
+  beforeEach(() => {
+    dailyClaimMocks.fetchDailyEligibility.mockReset();
+    resetWalletState();
+  });
+
+  afterEach(() => {
+    resetWalletState();
+  });
+
+  it("re-surfaces a dismissed but still-claimable reward when an agent launches", async () => {
+    dailyClaimMocks.fetchDailyEligibility.mockResolvedValue(eligibility(true));
+    dismissDailyClaim();
+    expect(walletState.dailyClaimDismissed).toBe(true);
+
+    await surfaceDailyClaimIfEligible();
+
+    // The popup gate (can_claim && !dismissed) is satisfied again.
+    expect(walletState.dailyClaim?.can_claim).toBe(true);
+    expect(walletState.dailyClaimDismissed).toBe(false);
+  });
+
+  it("does not re-surface once the reward is already claimed", async () => {
+    dailyClaimMocks.fetchDailyEligibility.mockResolvedValue(eligibility(false));
+    dismissDailyClaim();
+
+    await surfaceDailyClaimIfEligible();
+
+    // can_claim is false, so the popup stays hidden regardless of the flag,
+    // and we do not spuriously clear the dismiss flag.
+    expect(walletState.dailyClaim?.can_claim).toBe(false);
+    expect(walletState.dailyClaimDismissed).toBe(true);
+  });
+
+  it("leaves existing eligibility untouched on a transient fetch failure", async () => {
+    // Simulate a known-eligible-but-dismissed state, then fail the refresh.
+    dailyClaimMocks.fetchDailyEligibility.mockResolvedValueOnce(eligibility(true));
+    await surfaceDailyClaimIfEligible();
+    dismissDailyClaim();
+
+    dailyClaimMocks.fetchDailyEligibility.mockRejectedValueOnce(
+      new Error("network down"),
+    );
+    await surfaceDailyClaimIfEligible();
+
+    // State is preserved (not nulled, not blocked): the launch is never gated
+    // on eligibility, and we do not un-dismiss on an unconfirmed reward.
+    expect(walletState.dailyClaim?.can_claim).toBe(true);
+    expect(walletState.dailyClaimDismissed).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

The daily SerenBucks claim popup only surfaced on login and via a 30-minute background re-poll (#1133). Once a user dismissed it — or simply missed it — it stayed hidden for the rest of the day even though the free claim was still available. The reward was disconnected from the moment the user actually sits down to work, so people didn't realize they had SerenBucks to claim.

This surfaces the claim at the **agent-launch** moment: when the user launches an agent on a day they haven't yet claimed, the popup reappears. Once claimed (`can_claim = false`) it stays hidden.

## How

- New wallet-store action `surfaceDailyClaimIfEligible()` — re-checks eligibility (`GET /wallet/daily/eligibility`) and clears the session `dailyClaimDismissed` flag when `can_claim` is true. The popup's own gate (`can_claim && !dismissed`) does the rest.
- Called fire-and-forget from the `AgentChat.tsx` `sendMessage` **cold-start** branch — the true "launch an agent" moment. It runs only when there is no live session and the user submits the first prompt, so it fires **once per launch, never per message** (dismiss still holds within a running session). `spawnSession` was deliberately not used because it also fires background warm-standby/predictive spawns.
- On a transient eligibility-fetch failure the existing state is left untouched (mirroring the 30-minute poll), so a launch is never blocked and an unconfirmed reward is never falsely surfaced.

## Networked path

No new or changed endpoint. Trace: `AgentChat` cold-start → `surfaceDailyClaimIfEligible` → `fetchDailyEligibility` (`src/services/dailyClaim.ts`) → generated `check_daily_eligibility` → `GET /wallet/daily/eligibility` on `https://api.serendb.com` (bearer auth). Both this and `POST /wallet/daily/claim` (`claim_daily`) are verified present in `openapi/openapi.json` and are already in production use by the popup.

## Tests

New `tests/unit/daily-claim-agent-launch.test.ts` (3 tests, following the existing wallet-store unit convention that stubs the `@/services` boundary):
- a dismissed-but-still-claimable reward re-surfaces on launch (the regression);
- an already-claimed reward does not re-surface and the dismiss flag isn't spuriously cleared;
- a transient fetch failure leaves eligibility and dismiss state untouched.

Existing wallet-store suites remain green (17 tests); `tsc --noEmit` clean for the changed files.

Closes #3427
