### PR TITLE
fix(happy): emit real ACP tool kind so read summarization works (#3454)

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -282,7 +282,9 @@ function emitToolCallUpdate(emit, session, update) {
     sessionId: session.id,
     toolCallId,
     title: update.title ?? update.name ?? "Tool call",
-    kind: update.name ?? "tool",
+    // ACP puts the tool category on `kind` (ToolKind: read/edit/execute/…);
+    // tool_call updates carry no `name` field on the wire.
+    kind: update.kind ?? "tool",
     status,
     parameters: update,
   });
@@ -1069,5 +1071,6 @@ export function createAcpRuntime({
 
 export {
   applyAcpPermissionMode as _applyAcpPermissionMode,
+  emitToolCallUpdate as _emitAcpToolCallUpdate,
   sendRequest as _sendAcpRequest,
 };

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -11,6 +11,10 @@ import {
   createTurnCorrelator,
   translateNeutralEvent,
 } from "../../bin/happy-bridge/translate.mjs";
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { translateProviderEvent } from "../../bin/happy-bridge/provider-source.mjs";
+// @ts-expect-error — the browser-local runtime is plain ESM without declarations.
+import { _emitAcpToolCallUpdate } from "../../bin/browser-local/acp-runtime.mjs";
 
 const payload = {
   text: "assistant text",
@@ -164,19 +168,38 @@ describe("neutral-to-Happy session translation", () => {
     expect(endMessage.body.output).not.toContain("line two");
   });
 
-  it("summarizes an ACP `read` result the same way", () => {
+  it("summarizes an ACP `read` result emitted by the real runtime pipeline", () => {
+    // The ACP wire carries the tool category on `kind` and has no `name`
+    // field, so a hand-built payload can pass while the runtime emits
+    // something else (#3454). Drive the fixture through the runtime's own
+    // emitter and the provider event mapping instead.
     const summarizer = createFileReadSummarizer();
-    summarizer.annotate({
-      kind: "tool-start",
-      sessionId: "session-1",
-      payload: { toolCallId: "read-2", kind: "read" },
+    const session = { id: "session-1" };
+    const neutralEvents: Array<Record<string, unknown>> = [];
+    const emit = (method: string, params: Record<string, unknown>) => {
+      const event = translateProviderEvent(method, params);
+      if (event) neutralEvents.push(summarizer.annotate(event));
+    };
+
+    _emitAcpToolCallUpdate(emit, session, {
+      sessionUpdate: "tool_call",
+      toolCallId: "read-2",
+      title: "Read app.ts",
+      kind: "read",
+      status: "pending",
     });
-    const endEvent = summarizer.annotate({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "read-2", result: "only one line" },
+    _emitAcpToolCallUpdate(emit, session, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "read-2",
+      status: "completed",
+      content: [{ type: "text", text: "only one line" }],
     });
-    expect(translateNeutralEvent(endEvent)[0].body.output).toBe(
+
+    const toolStart = neutralEvents.find((event) => event.kind === "tool-start");
+    expect(toolStart).toMatchObject({ payload: { kind: "read" } });
+    const toolEnd = neutralEvents.find((event) => event.kind === "tool-end");
+    expect(toolEnd).toBeDefined();
+    expect(translateNeutralEvent(toolEnd)[0].body.output).toBe(
       "[1 line hidden on Happy Mobile]",
     );
   });


### PR DESCRIPTION
## Problem

PR #3426 (closing #3425) added file-read summarization for Happy Mobile, keyed on `payload.kind` matching `FILE_READ_TOOL_KINDS = new Set(["fileRead", "read"])` in `bin/happy-bridge/translate.mjs`. For ACP-routed agents (Gemini, Grok) the feature was inert: `emitToolCallUpdate` in `bin/browser-local/acp-runtime.mjs` emitted `kind: update.name ?? "tool"`, but the ACP wire format has no `name` field on `tool_call`/`tool_call_update` session updates — the tool category arrives on `update.kind` (ACP `ToolKind`: `read`, `edit`, `execute`, ...). Verified against ACP agent implementations, which build the update as `ToolCall::new(id, title)` + `.kind(ToolKind::...)` with no `.name(...)` setter. So every ACP tool event reached the bridge as `kind: "tool"`, the `"read"` set member was dead code, and file reads kept streaming up to 1,200 chars per read to the phone.

The unit test "summarizes an ACP `read` result the same way" passed anyway because it hand-built `payload: { kind: "read" }` — a shape production never produces.

## Fix

- `bin/browser-local/acp-runtime.mjs`: emit `kind: update.kind ?? "tool"` (one line, plus a comment documenting the wire field). Also exports `emitToolCallUpdate as _emitAcpToolCallUpdate`, following the existing underscore test-seam pattern (`_applyAcpPermissionMode`, `_sendAcpRequest`).
- `tests/unit/happy-bridge-translate-happy.test.ts`: the ACP case now drives the fixture through the real production pipeline — `_emitAcpToolCallUpdate` (runtime emitter) → `translateProviderEvent` (provider event mapping) → `createFileReadSummarizer` → `translateNeutralEvent` — so the test locks the actual runtime/bridge contract. Confirmed the rewritten test fails against the old `update.name` line and passes with the fix.

## Validation

- `pnpm vitest run tests/unit/happy-bridge-translate-happy.test.ts` — 27/27 passed.
- All 16 unit test files touching `acp-runtime.mjs` and the happy bridge — 148/148 passed.
- `pnpm check` — no diagnostics in changed files (Biome does not cover `bin/` or `tests/`; the 48 warnings reported are pre-existing in `src/`).
- Staged copy under `src-tauri/embedded-runtime/provider-runtime/` is generated, not tracked in git — nothing to mirror.

Fixes #3454

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
