### PR TITLE
fix(runtime): handle stdin write errors so one dead CLI cannot crash the provider runtime (#3432)

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -567,6 +567,22 @@ function attachProcessListeners(emit, sessions, session) {
     console.error(`${logPrefix} process error: ${error.message}`);
   });
 
+  // Stdin write-error guard (#3432): when the agent dies while a write is in
+  // flight — the window between process death and the `close` event — the
+  // write fails with EPIPE, delivered as an `error` event on the stdin
+  // stream (emitted even when the write supplied a callback, as sendRequest
+  // does). Without a listener the event rethrows as an uncaughtException,
+  // killing the entire shared provider-runtime helper and every live agent
+  // session with it. Log and hard-kill this child so `close` — the single
+  // cleanup path — fails just this session; killChildTree is a no-op when
+  // the child is already dead.
+  session.process.stdin.on("error", (error) => {
+    console.error(
+      `${logPrefix} stdin write failed: ${error?.message ?? String(error)}`,
+    );
+    killChildTree(session.process);
+  });
+
   session.process.on("close", () => {
     const wasTracked = sessions.delete(session.id);
     if (!wasTracked) return;

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2613,6 +2613,22 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
     }
   });
 
+  // Stdin write-error guard (#3432): when the CLI dies while a write is in
+  // flight — the window between process death and the `exit` event, during
+  // which the session still looks live — the write fails with EPIPE,
+  // delivered as an `error` event on the stdin stream (emitted even when the
+  // write supplied a callback). Without a listener the event rethrows as an
+  // uncaughtException, killing the entire shared provider-runtime helper and
+  // every live agent session with it. Log and hard-kill this child so the
+  // exit handler below — the single cleanup path — fails just this session;
+  // killChildTree is a no-op when the child is already dead.
+  session.process.stdin.on("error", (error) => {
+    console.warn(
+      `${logPrefix} stdin write failed: ${error?.message ?? String(error)}`,
+    );
+    killChildTree(session.process);
+  });
+
   // Register an exit promise so spawnSession can wait for full cleanup
   // before reusing the same session ID.
   let resolveExit;

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1604,6 +1604,22 @@ function attachProcessListeners(
     });
   });
 
+  // Stdin write-error guard (#3432): when the Codex process dies while a
+  // write is in flight — the window between process death and the `exit`
+  // event — the write fails with EPIPE, delivered as an `error` event on the
+  // stdin stream. Without a listener the event rethrows as an
+  // uncaughtException, killing the entire shared provider-runtime helper and
+  // every live agent session with it. Log and hard-kill this child so the
+  // exit handler below — the cleanup path for a child that had started —
+  // fails just this session; killChildTree is a no-op when the child is
+  // already dead.
+  session.process.stdin.on("error", (err) => {
+    console.warn(
+      `${logPrefix} stdin write failed: ${err?.message ?? String(err)}`,
+    );
+    killChildTree(session.process);
+  });
+
   session.process.on("exit", () => {
     const wasTracked = sessions.delete(session.id);
     void session.serenMcpProxy?.close();

--- a/tests/unit/provider-resume-and-acceptance-contract.test.ts
+++ b/tests/unit/provider-resume-and-acceptance-contract.test.ts
@@ -31,7 +31,9 @@ function createCodexProcessHarness() {
     stderr,
     pid: 42,
     kill: vi.fn(),
-    stdin: {
+    // Real child stdin is a Socket (an EventEmitter); the runtime attaches an
+    // `error` listener to it at spawn (#3432), so the fake must support .on().
+    stdin: Object.assign(new EventEmitter(), {
       write: vi.fn((line: string) => {
         const request = JSON.parse(line.trim());
         if (request.id == null) return true;
@@ -49,7 +51,7 @@ function createCodexProcessHarness() {
         });
         return true;
       }),
-    },
+    }),
   });
 
   return {

--- a/tests/unit/stdin-epipe-guard.test.ts
+++ b/tests/unit/stdin-epipe-guard.test.ts
@@ -1,0 +1,188 @@
+// ABOUTME: Regression tests for #3432 — an EPIPE `error` event on an agent
+// ABOUTME: child's stdin must fail only that session, never crash the shared
+// ABOUTME: provider-runtime helper hosting every live agent session.
+
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+// @ts-expect-error — provider runtime files are plain ESM without generated declarations.
+import { createAcpRuntime } from "../../bin/browser-local/acp-runtime.mjs";
+// @ts-expect-error — provider runtime files are plain ESM without generated declarations.
+import { createProviderHandlers } from "../../bin/browser-local/providers.mjs";
+
+/**
+ * Fake agent child speaking newline-delimited JSON-RPC over stdio. stdin is an
+ * EventEmitter (like the real Socket) so the runtime's stdin `error` listener
+ * can be attached and the EPIPE crash mechanism reproduced faithfully: an
+ * `error` event on an EventEmitter with no listener throws — in production,
+ * an uncaughtException that kills the whole helper process.
+ */
+function createJsonRpcChildHarness(respond: (method: string) => unknown) {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn((line: string) => {
+      const request = JSON.parse(line.trim());
+      if (request.id == null) return true;
+      queueMicrotask(() => {
+        stdout.write(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: respond(request.method),
+          })}\n`,
+        );
+      });
+      return true;
+    }),
+  });
+  const processHandle = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    // pid stays undefined so killChildTree never reaches its win32 taskkill
+    // branch — a fake pid must not be able to target a real OS process.
+    pid: undefined,
+    kill: vi.fn(),
+    stdin,
+  });
+  return { processHandle, stdin };
+}
+
+function epipeError() {
+  return Object.assign(new Error("write EPIPE"), {
+    code: "EPIPE",
+    syscall: "write",
+  });
+}
+
+describe("#3432 — Codex stdin EPIPE fails one session, not the helper", () => {
+  it("attaches a stdin error listener at spawn and escalates to a kill", async () => {
+    const emit = vi.fn();
+    const harness = createJsonRpcChildHarness((method) => {
+      if (method === "model/list") return { data: [] };
+      if (method === "thread/start") return { thread: { id: "native-codex" } };
+      return {};
+    });
+    const handlers = createProviderHandlers({
+      emit,
+      spawnCodex: vi.fn(() => harness.processHandle),
+    });
+    await handlers.spawnSession({
+      localSessionId: "local-codex",
+      agentType: "codex",
+      cwd: "/project",
+    });
+
+    expect(harness.stdin.listenerCount("error")).toBeGreaterThan(0);
+    expect(() => harness.stdin.emit("error", epipeError())).not.toThrow();
+
+    // The guard hard-kills the child so the exit handler — the existing
+    // cleanup path for a child that had started — fails just this session.
+    expect(harness.processHandle.kill).toHaveBeenCalled();
+    harness.processHandle.emit("exit", null, "SIGTERM");
+
+    await expect(handlers.listSessions()).resolves.toEqual([]);
+    expect(emit).toHaveBeenCalledWith(
+      "provider://session-status",
+      expect.objectContaining({
+        sessionId: "local-codex",
+        status: "terminated",
+      }),
+    );
+  });
+});
+
+describe("#3432 — ACP stdin EPIPE fails one session, not the helper", () => {
+  it("attaches a stdin error listener at spawn and escalates to a kill", async () => {
+    const emit = vi.fn();
+    const harness = createJsonRpcChildHarness((method) => {
+      if (method === "initialize") {
+        return { agentInfo: { version: "0.0.0" }, agentCapabilities: {} };
+      }
+      if (method === "session/new") return { sessionId: "native-acp" };
+      return {};
+    });
+    const runtime = createAcpRuntime({
+      emit,
+      adapter: {
+        agentType: "synthetic-acp",
+        agentName: "Synthetic ACP",
+        defaultModeId: "default",
+        defaultModelId: "synthetic-model",
+        availableModels: [{ modelId: "synthetic-model", name: "Synthetic" }],
+        buildModes: (session: { currentModeId?: string }) => ({
+          currentModeId: session?.currentModeId ?? "default",
+          availableModes: [{ modeId: "default", name: "Default" }],
+        }),
+        resolveInitialMode: () => "default",
+        isAuthError: () => false,
+        stoppedBeforeRequestMessage:
+          "Synthetic ACP stopped before request completed.",
+        processExitedWhilePromptMessage:
+          "Synthetic ACP exited while prompt was active.",
+        spawnProcess: () => harness.processHandle,
+      },
+    });
+    await runtime.spawnSession({ localSessionId: "local-acp", cwd: "/project" });
+
+    expect(harness.stdin.listenerCount("error")).toBeGreaterThan(0);
+    expect(() => harness.stdin.emit("error", epipeError())).not.toThrow();
+
+    // The guard hard-kills the child so `close` — the single cleanup path —
+    // fails just this session.
+    expect(harness.processHandle.kill).toHaveBeenCalled();
+    harness.processHandle.emit("close");
+
+    await expect(runtime.listSessions()).resolves.toEqual([]);
+    expect(emit).toHaveBeenCalledWith(
+      "provider://session-status",
+      expect.objectContaining({
+        sessionId: "local-acp",
+        status: "terminated",
+      }),
+    );
+  });
+});
+
+describe("#3432 — Claude runtime stdin guard (source-level)", () => {
+  // Claude spawnSession resolves a real CLI binary and runs the stream-json
+  // handshake, so it cannot be driven with an injected fake child the way the
+  // Codex and ACP runtimes can. The behavioral EPIPE path is exercised above
+  // through the runtimes sharing the same attach-at-spawn pattern; this guard
+  // pins the Claude wiring in source.
+  const source = readFileSync(
+    resolve("bin/browser-local/claude-runtime.mjs"),
+    "utf-8",
+  );
+
+  function extractAttachProcessListenersBody(): string {
+    const start = source.indexOf("function attachProcessListeners(");
+    if (start < 0) return "";
+    const after = source.indexOf("\nfunction ", start + 1);
+    return after < 0 ? source.slice(start) : source.slice(start, after);
+  }
+
+  it("attachProcessListeners installs a stdin error listener that kills the child", () => {
+    const body = extractAttachProcessListenersBody();
+    expect(body, "attachProcessListeners body must be non-empty").not.toBe("");
+
+    const stdinIdx = body.indexOf('session.process.stdin.on("error"');
+    expect(
+      stdinIdx,
+      "attachProcessListeners must attach a stdin error listener (#3432).",
+    ).toBeGreaterThan(-1);
+
+    const killIdx = body.indexOf("killChildTree", stdinIdx);
+    expect(
+      killIdx,
+      "the stdin error listener must escalate to killChildTree so the exit handler fails the session.",
+    ).toBeGreaterThan(stdinIdx);
+
+    expect(
+      body.indexOf('session.process.on("exit"'),
+      "the exit handler — the single cleanup path — must still exist.",
+    ).toBeGreaterThan(-1);
+  });
+});


### PR DESCRIPTION
## Problem

Found in the v3.75.0 pre-release audit. Every provider runtime wrote to agent-child stdin with **no `error` listener on the stdin stream**, and the shared provider-runtime helper has no `uncaughtException` handler. If a CLI child dies concurrently with a write — the window between process death and Node dispatching the `exit` event, during which `sessions.get()` still returns the session — the write fails with EPIPE, delivered as an `error` event on the stdin socket. Node emits the stream `error` even when the write supplied a callback. The unhandled event rethrows as an uncaughtException and the whole helper exits, killing **every** live agent session (Claude Code, Codex, Gemini, Grok, LM Studio, paired) at once.

Realistic trigger: Stop (`cancelPrompt` → `interrupt` control write) or a permission auto-response written just as the CLI crashes/OOMs mid-turn.

Exposed sites (all six stdin writes across the three runtimes):

- `bin/browser-local/claude-runtime.mjs` — `writeMessage`, `writeMessageAccepted`
- `bin/browser-local/acp-runtime.mjs` — `sendRequest`, `writeMessage`
- `bin/browser-local/providers.mjs` — `sendRequest`, `writeMessage`

## Fix

Attach a per-session stdin `error` guard at spawn, in each runtime's `attachProcessListeners`: log via the file's log prefix, then `killChildTree(session.process)` so the **existing** `exit`/`close` handler — the single cleanup path — rejects in-flight work, emits `provider://error` / `terminated`, and deletes just that session. `killChildTree` is a no-op on an already-dead child, so the dominant race case reduces to the normal process-exit cleanup. This mirrors the two sibling crash-class fixes already in-tree: the ChildProcess `error` guard (`providers.mjs`, #1735) and the orphaned promise-rejection fix (`acp-runtime.mjs`, #1486), plus the cancel escalation precedent (#2301/#2306).

The staged copy under `src-tauri/embedded-runtime/provider-runtime/` is gitignored and regenerated at build time from `bin/browser-local/` by `scripts/build-provider-runtime.ts`, so no mirror edit is needed.

## Verification

- `pnpm vitest run tests/unit/stdin-epipe-guard.test.ts` — new regression tests, 3 passed:
  - **Codex and ACP, behavioral**: drives `createProviderHandlers` / `createAcpRuntime` through a real `spawnSession` against a fake JSON-RPC child whose stdin is an EventEmitter (like the real Socket), then emits `error` (EPIPE) on stdin. Asserts the emit does not throw (the exact crash mechanism — an unlistened EventEmitter `error` throws), the child is killed, and after exit/close the session is terminated and delisted. **Revert-check**: with the three runtime fixes stashed, all 3 tests fail; with the fix, all pass.
  - **Claude, source-level**: Claude's `spawnSession` resolves a real CLI binary and runs the stream-json handshake, so it cannot be driven with an injected fake child. The guard is pinned by a source assertion on `attachProcessListeners` (house style, cf. `cancel-guaranteed-stop.test.ts`). Being honest: the Claude path shares the identical attach-at-spawn pattern exercised behaviorally for Codex/ACP, but its own EPIPE path is not executed by a test.
- `pnpm test` — full unit suite: 387 files passed, 3 skipped (2792 tests passed, 15 skipped). Includes `provider-resume-and-acceptance-contract.test.ts`, whose shared fake-child harness now models stdin as an EventEmitter.
- `pnpm test:runtime-smoke` — real browser-local provider runtime boots end-to-end: "Local provider runtime smoke passed."
- `pnpm check` — exit 0 (Biome's `includes` scope excludes `bin/` and `tests/`; the 48 pre-existing warnings in `src/` are untouched).

Note: the commit subject was shortened from the planned wording to satisfy the repo's 72-char commit-msg hook.

Fixes #3432

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
