### PR TITLE
fix(claude-setup): emit valid settings.json on all platforms (#3431)

### DIFF
--- a/src-tauri/src/claude_setup.rs
+++ b/src-tauri/src/claude_setup.rs
@@ -5,6 +5,11 @@ use log::info;
 use std::fs;
 use std::path::Path;
 
+/// PATH separator Claude Code expects on this platform.
+fn path_separator() -> char {
+    if cfg!(target_os = "windows") { ';' } else { ':' }
+}
+
 /// Build the PATH written into `~/.claude/settings.json`.
 ///
 /// Claude Code's `env.PATH` **replaces** PATH for everything it spawns, so
@@ -31,6 +36,62 @@ fn claude_code_path(node_dir: Option<&Path>, cargo_bin: &Path) -> String {
         ]);
         entries.join(":")
     }
+}
+
+/// Serialize a settings document, escaping PATH backslashes correctly (#3431).
+fn render_settings(settings: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(settings).expect("a JSON value always serializes")
+}
+
+/// Serialize the settings document for a fresh `~/.claude/settings.json`.
+fn initial_settings(claude_path: &str) -> String {
+    render_settings(&serde_json::json!({ "env": { "PATH": claude_path } }))
+}
+
+/// Outcome of adding env.PATH to an existing settings document.
+enum SettingsPatch {
+    Updated(String),
+    HasEnvSection,
+    Invalid,
+}
+
+/// Add env.PATH to an existing settings document, keeping every other key.
+fn patch_existing_settings(content: &str, claude_path: &str) -> SettingsPatch {
+    let Ok(serde_json::Value::Object(mut settings)) =
+        serde_json::from_str::<serde_json::Value>(content)
+    else {
+        return SettingsPatch::Invalid;
+    };
+    if settings.contains_key("env") {
+        return SettingsPatch::HasEnvSection;
+    }
+    settings.insert(
+        "env".to_string(),
+        serde_json::json!({ "PATH": claude_path }),
+    );
+    SettingsPatch::Updated(render_settings(&serde_json::Value::Object(settings)))
+}
+
+/// True when env.PATH in `content` already lists `entry` as one of its
+/// `separator`-delimited components.
+fn env_path_lists_entry(content: &str, entry: &Path, separator: char) -> bool {
+    let Ok(settings) = serde_json::from_str::<serde_json::Value>(content) else {
+        return false;
+    };
+    let Some(path) = settings
+        .get("env")
+        .and_then(|env| env.get("PATH"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return false;
+    };
+    let entry = entry.to_string_lossy();
+    path.split(separator).any(|component| component == entry)
+}
+
+/// True when the settings content already routes Claude Code through cargo.
+fn cargo_bin_already_configured(content: &str, cargo_bin: &Path) -> bool {
+    env_path_lists_entry(content, cargo_bin, path_separator())
 }
 
 /// Configure Claude Code environment if both cargo and Claude Code are installed.
@@ -65,7 +126,7 @@ pub fn configure_claude_code_environment(node_dir: Option<&Path>) {
     // Check if already configured
     if claude_settings.exists() {
         if let Ok(content) = fs::read_to_string(&claude_settings) {
-            if content.contains(".cargo/bin") {
+            if cargo_bin_already_configured(&content, &cargo_bin) {
                 info!("[Claude Setup] Cargo already in Claude Code PATH");
                 return;
             }
@@ -77,16 +138,7 @@ pub fn configure_claude_code_environment(node_dir: Option<&Path>) {
 
     if !claude_settings.exists() {
         // Create new settings file
-        let settings = format!(
-            r#"{{
-  "env": {{
-    "PATH": "{}"
-  }}
-}}"#,
-            claude_path
-        );
-
-        if let Err(e) = fs::write(&claude_settings, settings) {
+        if let Err(e) = fs::write(&claude_settings, initial_settings(&claude_path)) {
             info!("[Claude Setup] Failed to create settings: {}", e);
             return;
         }
@@ -109,31 +161,21 @@ pub fn configure_claude_code_environment(node_dir: Option<&Path>) {
             }
         };
 
-        // Check if already has env section
-        if content.contains("\"env\"") {
-            info!("[Claude Setup] Settings already has env section, manual config needed");
-            return;
+        match patch_existing_settings(&content, &claude_path) {
+            SettingsPatch::Updated(patched) => {
+                if let Err(e) = fs::write(&claude_settings, patched) {
+                    info!("[Claude Setup] Failed to update settings: {}", e);
+                    return;
+                }
+                info!("[Claude Setup] Updated Claude Code settings with cargo in PATH");
+            }
+            SettingsPatch::HasEnvSection => {
+                info!("[Claude Setup] Settings already has env section, manual config needed");
+            }
+            SettingsPatch::Invalid => {
+                info!("[Claude Setup] Settings file is not valid JSON, manual config needed");
+            }
         }
-
-        // Insert env section after opening brace
-        let new_content = content.replacen(
-            "{",
-            &format!(
-                r#"{{
-  "env": {{
-    "PATH": "{}"
-  }},"#,
-                claude_path
-            ),
-            1,
-        );
-
-        if let Err(e) = fs::write(&claude_settings, new_content) {
-            info!("[Claude Setup] Failed to update settings: {}", e);
-            return;
-        }
-
-        info!("[Claude Setup] Updated Claude Code settings with cargo in PATH");
     }
 }
 
@@ -173,10 +215,6 @@ mod tests {
         }
     }
 
-    fn path_separator() -> char {
-        if cfg!(target_os = "windows") { ';' } else { ':' }
-    }
-
     /// Claude Code replaces PATH with whatever this writes, so a Windows
     /// separator mistake costs the user every entry — `C:\...` splits at the
     /// drive letter, and /usr/bin does not exist there to fall back on.
@@ -208,5 +246,97 @@ mod tests {
         let path = claude_code_path(None, &cargo_bin);
 
         assert_eq!(path, "/Users/dev/.cargo/bin:/usr/local/bin:/usr/bin:/bin");
+    }
+
+    /// A realistic Windows PATH for #3431: `\U`, `\e`, and `\.` are invalid
+    /// JSON escapes (a strict parser rejects the whole file), while `\r` and
+    /// `\n` are valid ones that silently rewrite the value if left unescaped.
+    fn windows_style_claude_path() -> &'static str {
+        r"C:\Program Files\Seren\resources\embedded-runtime\node;C:\Users\nick\.cargo\bin"
+    }
+
+    /// Regression guard for #3431 (create-new path). The emitted settings
+    /// file must be strict JSON even when PATH contains backslashes, and the
+    /// PATH value must survive byte-for-byte.
+    #[test]
+    fn initial_settings_round_trip_a_windows_path_through_json() {
+        let claude_path = windows_style_claude_path();
+
+        let written = initial_settings(claude_path);
+
+        let parsed: serde_json::Value = serde_json::from_str(&written)
+            .unwrap_or_else(|e| panic!("settings.json must be strict JSON ({e}), got: {written}"));
+        assert_eq!(parsed["env"]["PATH"].as_str(), Some(claude_path));
+    }
+
+    /// Regression guard for #3431 (update-existing path). Patching must stay
+    /// strict JSON, round-trip the Windows PATH, and keep every other key.
+    #[test]
+    fn patched_settings_round_trip_a_windows_path_and_keep_other_keys() {
+        let claude_path = windows_style_claude_path();
+        let existing = r#"{ "model": "opus", "permissions": { "allow": ["Bash"] } }"#;
+
+        let SettingsPatch::Updated(written) = patch_existing_settings(existing, claude_path) else {
+            panic!("expected the settings document to be updated");
+        };
+
+        let parsed: serde_json::Value = serde_json::from_str(&written)
+            .unwrap_or_else(|e| panic!("settings.json must be strict JSON ({e}), got: {written}"));
+        assert_eq!(parsed["env"]["PATH"].as_str(), Some(claude_path));
+        assert_eq!(parsed["model"].as_str(), Some("opus"));
+        assert_eq!(parsed["permissions"]["allow"][0].as_str(), Some("Bash"));
+    }
+
+    /// An existing env section stays untouched — same contract as before.
+    #[test]
+    fn patching_leaves_an_existing_env_section_alone() {
+        let existing = r#"{ "env": { "PATH": "/custom" } }"#;
+
+        assert!(matches!(
+            patch_existing_settings(existing, "/x"),
+            SettingsPatch::HasEnvSection
+        ));
+    }
+
+    /// A file that is not a JSON object cannot be patched safely; refuse
+    /// instead of writing more garbage into a user-owned config.
+    #[test]
+    fn patching_refuses_content_that_is_not_a_json_object() {
+        assert!(matches!(
+            patch_existing_settings("not json at all", "/x"),
+            SettingsPatch::Invalid
+        ));
+    }
+
+    /// #3431: the idempotence probe must match the value Windows actually
+    /// writes (backslashes, `;` separator), not just the Unix spelling.
+    #[test]
+    fn probe_finds_a_windows_written_cargo_bin_entry() {
+        let cargo_bin = Path::new(r"C:\Users\nick\.cargo\bin");
+        let content = serde_json::json!({
+            "env": { "PATH": windows_style_claude_path() }
+        })
+        .to_string();
+
+        assert!(env_path_lists_entry(&content, cargo_bin, ';'));
+    }
+
+    /// The probe must only trust env.PATH — a stray ".cargo/bin" elsewhere in
+    /// the file (say a permissions rule) is not a configured PATH.
+    #[test]
+    fn probe_ignores_cargo_bin_mentions_outside_env_path() {
+        let cargo_bin = PathBuf::from("/Users/dev/.cargo/bin");
+        let content = r#"{ "permissions": { "allow": ["Bash(/Users/dev/.cargo/bin/cargo:*)"] } }"#;
+
+        assert!(!cargo_bin_already_configured(content, &cargo_bin));
+    }
+
+    /// What this module writes, its own probe must recognize on re-launch.
+    #[test]
+    fn probe_finds_cargo_bin_in_env_path_written_by_this_module() {
+        let cargo_bin = PathBuf::from("/Users/dev/.cargo/bin");
+        let content = initial_settings(&claude_code_path(None, &cargo_bin));
+
+        assert!(cargo_bin_already_configured(&content, &cargo_bin));
     }
 }


### PR DESCRIPTION
Fixes #3431

## Problem

`src-tauri/src/claude_setup.rs` built the user's global `~/.claude/settings.json` by interpolating the PATH string raw into a JSON template via `format!`. On Windows the PATH contains backslashes:

- `\U`, `\.`, `\e` are invalid JSON escapes — strict parsers reject the whole settings file, so every setting in it is lost.
- `\n`, `\r`, `\t`, `\b`, `\f` are valid escapes that silently rewrite the PATH value (`C:\Users\nick\...` gains a literal newline).

The idempotence probe (`content.contains(".cargo/bin")`) used a forward slash, so it never matched the Windows-written value and the corruption re-ran on every launch. It also matched any `.cargo/bin` mention anywhere in the file, not just `env.PATH`. This silently defeated the #3148 embedded-node-first PATH fix on Windows.

## Fix

- Build the settings document with `serde_json` on both write paths (`initial_settings` for create-new, `patch_existing_settings` for update-existing), so PATH backslashes are escaped correctly on every platform.
- The update path parses the existing file and inserts `env` while preserving every other key. Content that is not a JSON object is left untouched (logged as manual config needed) instead of being string-patched further; the pre-existing backup is still taken first.
- The idempotence probe (`cargo_bin_already_configured`) now parses the JSON and checks whether `env.PATH` lists the cargo bin directory as a component using the platform separator (`;` on Windows, `:` elsewhere).
- PATH composition and ordering are unchanged — the embedded node dir still leads (#3148), separators stay platform-appropriate.

## Tests (TDD)

Five regression tests were added first and confirmed failing against the previous implementation (JSON parse error `invalid escape at line 3 column 17` on both write paths; probe misses on Windows values and false-positives outside `env.PATH`), then the fix was applied:

- `initial_settings_round_trip_a_windows_path_through_json`
- `patched_settings_round_trip_a_windows_path_and_keep_other_keys`
- `patching_refuses_content_that_is_not_a_json_object`
- `probe_finds_a_windows_written_cargo_bin_entry`
- `probe_ignores_cargo_bin_mentions_outside_env_path`

Plus behavior guards: `patching_leaves_an_existing_env_section_alone`, `probe_finds_cargo_bin_in_env_path_written_by_this_module`, and the three pre-existing #3148 PATH-composition tests, all green.

```
cargo test --manifest-path src-tauri/Cargo.toml --lib claude_setup
test result: ok. 10 passed; 0 failed
cargo check --manifest-path src-tauri/Cargo.toml
Finished `dev` profile
```

Note: a Windows machine already carrying a corrupt settings.json from the old code is not auto-repaired — the module now refuses to touch unparseable files and logs manual config needed (a `settings.json.backup` from the old update path may exist to restore from).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
