### PR TITLE
fix(orchestrator): bound cancel and publisher stream awaits so Stop cannot hang (#3433)

### DIFF
--- a/src-tauri/src/orchestrator/mcp_publisher_worker.rs
+++ b/src-tauri/src/orchestrator/mcp_publisher_worker.rs
@@ -24,6 +24,11 @@ pub struct McpPublisherWorker {
 
 /// Connect timeout for the HTTP client (seconds).
 const CONNECT_TIMEOUT_SECS: u64 = 30;
+/// Maximum time to wait between chunks from the SSE stream before giving up.
+/// Applied per-chunk (not as a total request timeout) so long-running publisher
+/// streams are not killed at a fixed wall-clock deadline, while a half-open
+/// connection that stops yielding data fails instead of spinning forever.
+const READ_TIMEOUT_SECS: u64 = 600;
 
 impl McpPublisherWorker {
     pub fn new() -> Self {
@@ -182,10 +187,19 @@ impl McpPublisherWorker {
         let mut accumulated_cost: f64 = 0.0;
         let mut got_complete = false;
 
-        while let Some(chunk_result) = stream.next().await {
+        loop {
             if *self.cancelled.lock().await {
                 return Ok(());
             }
+
+            let next_chunk =
+                tokio::time::timeout(Duration::from_secs(READ_TIMEOUT_SECS), stream.next())
+                    .await
+                    .map_err(|_| "Timed out waiting for publisher stream data".to_string())?;
+
+            let Some(chunk_result) = next_chunk else {
+                break;
+            };
 
             let chunk = chunk_result.map_err(|e| format!("Stream read error: {}", e))?;
             let text = String::from_utf8_lossy(&chunk);

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -258,6 +258,29 @@ async fn sleep_or_cancel(
     }
 }
 
+/// Bound on how long Stop waits for a worker's `cancel()` before falling back
+/// to aborting its task. A wedged runtime can accept the cancel connection and
+/// never reply; without a bound `orchestrate()` never reaches session cleanup
+/// and the conversation stays "running" until app restart (see GH #3433).
+const WORKER_CANCEL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Await `worker.cancel()` for at most `timeout`.
+///
+/// Returns `true` if the cancel resolved in time, `false` on timeout. Callers
+/// proceed to abort the worker task either way — abort handles teardown — so a
+/// hung cancel can delay Stop by at most `timeout` (see GH #3433).
+async fn cancel_worker_or_timeout(worker: &dyn Worker, timeout: Duration) -> bool {
+    if tokio::time::timeout(timeout, worker.cancel()).await.is_err() {
+        log::warn!(
+            "[Orchestrator] Worker '{}' cancel did not resolve within {:?}; proceeding to abort",
+            worker.id(),
+            timeout
+        );
+        return false;
+    }
+    true
+}
+
 // =============================================================================
 // Model Fallback Chain
 // =============================================================================
@@ -756,7 +779,7 @@ async fn execute_single_task(
                 "[Orchestrator] Cancelling worker for conversation {}",
                 conversation_id
             );
-            let _ = worker_for_cancel.cancel().await;
+            cancel_worker_or_timeout(worker_for_cancel.as_ref(), WORKER_CANCEL_TIMEOUT).await;
             worker_handle.abort();
             break;
         }
@@ -1378,7 +1401,7 @@ async fn execute_multi_task(
             // If already cancelled, signal workers to stop and abort handles
             if *cancel_check.borrow() {
                 for w in &active_workers {
-                    let _ = w.cancel().await;
+                    cancel_worker_or_timeout(w.as_ref(), WORKER_CANCEL_TIMEOUT).await;
                 }
                 handle.abort();
                 continue;
@@ -1419,7 +1442,7 @@ async fn execute_multi_task(
             };
             if cancelled_during_await {
                 for w in &active_workers {
-                    let _ = w.cancel().await;
+                    cancel_worker_or_timeout(w.as_ref(), WORKER_CANCEL_TIMEOUT).await;
                 }
                 break;
             }
@@ -1938,6 +1961,70 @@ mod tests {
         let sessions = state.active_sessions.lock().await;
         assert!(sessions.contains_key("test-conv"));
         assert!(*sessions.get("test-conv").unwrap().borrow());
+    }
+
+    // =========================================================================
+    // Bounded worker cancel (GH #3433 regression tests)
+    // =========================================================================
+
+    /// Worker stub whose `cancel()` either resolves immediately or pends
+    /// forever, reproducing a wedged runtime that accepts the cancel
+    /// connection but never replies.
+    struct CancelProbeWorker {
+        hang_cancel: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl Worker for CancelProbeWorker {
+        fn id(&self) -> &str {
+            "cancel-probe"
+        }
+
+        async fn execute(
+            &self,
+            _conversation_id: &str,
+            _prompt: &str,
+            _conversation_context: &[serde_json::Value],
+            _routing: &RoutingDecision,
+            _skill_content: &str,
+            _app: &tauri::AppHandle,
+            _images: &[ImageAttachment],
+            _event_tx: mpsc::Sender<WorkerEvent>,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn cancel(&self) -> Result<(), String> {
+            if self.hang_cancel {
+                std::future::pending::<()>().await;
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn hung_worker_cancel_unblocks_stop_at_timeout() {
+        // Contract (GH #3433): a cancel() that never resolves must not block
+        // orchestrate() past the timeout — Stop proceeds to abort() and the
+        // session cleanup that follows, instead of leaving the conversation
+        // stuck "running" until app restart.
+        let worker = CancelProbeWorker { hang_cancel: true };
+        let t0 = std::time::Instant::now();
+        let resolved =
+            cancel_worker_or_timeout(&worker, std::time::Duration::from_millis(100)).await;
+        assert!(!resolved, "hung cancel must report timeout");
+        assert!(
+            t0.elapsed() < std::time::Duration::from_secs(5),
+            "hung cancel must unblock promptly, took {:?}",
+            t0.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn responsive_worker_cancel_resolves_within_timeout() {
+        let worker = CancelProbeWorker { hang_cancel: false };
+        let resolved = cancel_worker_or_timeout(&worker, WORKER_CANCEL_TIMEOUT).await;
+        assert!(resolved, "responsive cancel must resolve inside the bound");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Fixes two unbounded awaits that could leave a conversation stuck "running" until app restart, with further Stop clicks silently absorbed by the idempotent-cancel path.

### 1. Stop hung on `worker.cancel().await` (service.rs)

On Stop, the orchestrator awaited `worker.cancel()` **before** `worker_handle.abort()`. `ProviderRuntimeWorker::cancel` opens a fresh WebSocket and blocks in `wait_for_response` (`socket.next().await`) with no timeout — a wedged runtime that accepts the connection but never replies hangs `orchestrate()` forever, so session cleanup never runs.

All three `cancel()` call sites now go through a new `cancel_worker_or_timeout` helper bounded by `WORKER_CANCEL_TIMEOUT` (5s): the single-task Stop path, and both multi-task loops (the already-cancelled fast path and the cancel-arrived-during-handle-await path — the issue cited the first two sites; the third is the identical hazard a few lines below in the same function, so it is wrapped too). On timeout we log and proceed to `abort()`, which already handles teardown. The guaranteed-stop contract is preserved: the watch-channel signalling, `sleep_or_cancel`, and the idempotent-stop path are untouched — the helper only bounds how long Stop politely waits for the worker before the abort that was already going to happen.

### 2. Publisher stream spun forever on a half-open connection (mcp_publisher_worker.rs)

The reqwest client set only `connect_timeout`, and the SSE loop blocked in `stream.next().await` unbounded. The loop now applies a 600s per-chunk `tokio::time::timeout` (`READ_TIMEOUT_SECS`), mirroring `CloudAgentWorker`'s per-chunk approach and constant, and fails with `"Timed out waiting for publisher stream data"` — which the orchestrator surfaces as a worker error instead of an infinite spinner. Per-chunk (not whole-request) so long-running publisher streams are never cut off while data still flows.

## Tests

Two regression tests added in `service.rs` next to the existing #1581 cancellation suite, following its structure (real `tokio::time` behavior, no mocked timers):

- `hung_worker_cancel_unblocks_stop_at_timeout` — a worker whose `cancel()` pends forever (`std::future::pending`) must not block past the bound; asserts the helper returns promptly and reports the timeout.
- `responsive_worker_cancel_resolves_within_timeout` — a healthy cancel resolves inside the bound and reports success.

**Honest limitation:** no stalled-stream test for the publisher per-chunk timeout. Standing one up for real would need either paused tokio time (the `test-util` feature is not enabled anywhere in the dependency graph, and `READ_TIMEOUT_SECS` is 600s so real time is infeasible) plus an `http` dev-dependency to build a `reqwest::Response` from a never-yielding body, or a real local server holding a half-open connection. Both require adding dev-dependencies/features, which this repo does not do without discussion. Rather than mock the failing layer, the change mirrors the already-shipped `CloudAgentWorker` pattern (which likewise has no stalled-stream test) and is covered by `cargo check` and the existing publisher-worker unit tests.

Ran:

- `set -o pipefail && cargo test --manifest-path src-tauri/Cargo.toml orchestrator` — 304 passed, 0 failed (includes both new tests)
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean

Note: the commit subject is shorter than originally planned because the repo pre-commit hook enforces a 72-char subject limit.

Fixes #3433

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
