### PR TITLE
fix(runtime): resolve provider-runtime.mjs and happy-bridge.mjs via resource_dir on Linux (#3434)

### DIFF
--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -205,7 +205,7 @@ impl HappyBridgeManager {
             .ensure_started(app)
             .await?;
         let node_binary = resolve_node_binary(app);
-        let bridge_entry = find_happy_bridge_mjs()?;
+        let bridge_entry = find_happy_bridge_mjs(app)?;
         let pairing_credential = self.load_pairing_credential(app)?;
         if let Some(directory) = happy_home_dir(app) {
             reconcile_session_key_store_reset(&directory, pairing_credential.is_some())?;
@@ -1081,28 +1081,58 @@ fn resolve_node_binary(app: &AppHandle) -> PathBuf {
     crate::embedded_runtime::system_node_fallback()
 }
 
-fn find_happy_bridge_mjs() -> Result<PathBuf, String> {
+/// Candidate locations for happy-bridge.mjs, in probe order.
+///
+/// The resource-dir candidates come first: Tauri's resource resolver is the
+/// only source that knows the Linux install layout (`exe_dir/../lib/<app>`
+/// for deb/rpm, `$APPDIR/usr/lib/<app>` for AppImage, `/usr/lib/<app>` for a
+/// system install — #3434). On macOS it resolves to `exe_dir/../Resources`,
+/// on Windows and in dev to `exe_dir` itself — directories the exe-relative
+/// candidates below already probe, so their behavior is unchanged. The
+/// exe-relative and dev candidates remain as fallback for when the resolver
+/// errors.
+fn happy_bridge_mjs_candidates(
+    exe_dir: &Path,
+    resource_dir: Option<&Path>,
+    platform: &str,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(8);
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(
+            resource_dir
+                .join("embedded-runtime")
+                .join(platform)
+                .join("provider-runtime/happy-bridge.mjs"),
+        );
+        candidates.push(resource_dir.join("embedded-runtime/provider-runtime/happy-bridge.mjs"));
+    }
+    candidates.extend([
+        exe_dir
+            .join("../Resources/embedded-runtime")
+            .join(platform)
+            .join("provider-runtime/happy-bridge.mjs"),
+        exe_dir.join("../Resources/embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        exe_dir
+            .join("embedded-runtime")
+            .join(platform)
+            .join("provider-runtime/happy-bridge.mjs"),
+        exe_dir.join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../bin/happy-bridge.mjs"),
+    ]);
+    candidates
+}
+
+fn find_happy_bridge_mjs(app: &AppHandle) -> Result<PathBuf, String> {
     let exe_dir = std::env::current_exe()
         .map_err(|err| format!("Failed to get current exe path: {err}"))?
         .parent()
         .ok_or_else(|| "Failed to get exe directory".to_string())?
         .to_path_buf();
     let platform = crate::embedded_runtime::platform_subdir();
-    let candidates = [
-        exe_dir
-            .join("../Resources/embedded-runtime")
-            .join(&platform)
-            .join("provider-runtime/happy-bridge.mjs"),
-        exe_dir.join("../Resources/embedded-runtime/provider-runtime/happy-bridge.mjs"),
-        exe_dir
-            .join("embedded-runtime")
-            .join(&platform)
-            .join("provider-runtime/happy-bridge.mjs"),
-        exe_dir.join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../bin/happy-bridge.mjs"),
-    ];
+    let resource_dir = app.path().resource_dir().ok();
+    let candidates = happy_bridge_mjs_candidates(&exe_dir, resource_dir.as_deref(), &platform);
     candidates
         .iter()
         .find(|candidate| candidate.exists())
@@ -1831,14 +1861,15 @@ mod tests {
         BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES,
         SESSION_KEY_STORE_FILENAME, SESSION_KEY_STORE_RESET_FILENAME,
         canonical_happy_restoration_root, canonical_path_for_wire, discovered_project_roots,
-        error_response, is_advertised_root, matching_identity_reset_result, next_restart_attempt,
-        notify_supervisor, parse_supervisor_line, read_bounded_line,
-        reconcile_session_key_store_reset, report_state, required_nullable_string, required_uuid,
-        reset_session_key_store_transaction, restart_allowed, restart_delay, should_rearm,
-        stage_session_key_store_reset,
+        error_response, happy_bridge_mjs_candidates, is_advertised_root,
+        matching_identity_reset_result, next_restart_attempt, notify_supervisor,
+        parse_supervisor_line, read_bounded_line, reconcile_session_key_store_reset, report_state,
+        required_nullable_string, required_uuid, reset_session_key_store_transaction,
+        restart_allowed, restart_delay, should_rearm, stage_session_key_store_reset,
     };
     use crate::commands::happy_bridge::{ADVERTISED_ROOTS_KEY, SETTINGS_STORE};
     use serde_json::Value;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::Ordering;
     use std::time::Duration;
     use tauri_plugin_store::StoreExt;
@@ -2578,6 +2609,57 @@ mod tests {
         assert!(
             result.is_err(),
             "a wedged bridge must fail the caller rather than block it forever"
+        );
+    }
+
+    /// #3434: installed Linux builds resolve resources to `../lib/<app>`,
+    /// `$APPDIR/usr/lib/<app>`, or `/usr/lib/<app>` — locations no
+    /// exe-relative candidate ever reaches, so the bridge could not start.
+    /// The resolver-backed candidates must be probed first (platform subdir
+    /// before flat layout), and every pre-existing exe-relative/dev
+    /// candidate must remain, in the same order, as the fallback tail.
+    #[test]
+    fn bridge_candidates_probe_resource_dir_before_exe_relative() {
+        let exe_dir = Path::new("/usr/bin");
+        let resource_dir = Path::new("/usr/lib/seren-desktop");
+        let candidates = happy_bridge_mjs_candidates(exe_dir, Some(resource_dir), "linux-x64");
+
+        assert_eq!(
+            candidates[0],
+            resource_dir
+                .join("embedded-runtime")
+                .join("linux-x64")
+                .join("provider-runtime/happy-bridge.mjs")
+        );
+        assert_eq!(
+            candidates[1],
+            resource_dir.join("embedded-runtime/provider-runtime/happy-bridge.mjs")
+        );
+        assert_eq!(
+            candidates[2..],
+            happy_bridge_mjs_candidates(exe_dir, None, "linux-x64")[..],
+            "exe-relative and dev candidates must be unchanged after the resolver pair"
+        );
+    }
+
+    /// A failed resolver must degrade to exactly the pre-#3434 candidate
+    /// list — macOS/Windows/dev discovery is untouched.
+    #[test]
+    fn bridge_candidates_without_resource_dir_keep_prior_probe_set() {
+        let exe_dir = Path::new("/Applications/Seren.app/Contents/MacOS");
+        let candidates = happy_bridge_mjs_candidates(exe_dir, None, "darwin-arm64");
+
+        assert_eq!(candidates.len(), 6);
+        assert_eq!(
+            candidates[0],
+            exe_dir
+                .join("../Resources/embedded-runtime")
+                .join("darwin-arm64")
+                .join("provider-runtime/happy-bridge.mjs")
+        );
+        assert_eq!(
+            candidates[5],
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../bin/happy-bridge.mjs")
         );
     }
 }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Starts the bundled runtime on localhost and returns connection config to the frontend.
 
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -131,7 +131,7 @@ impl ProviderRuntimeState {
         let host = "127.0.0.1".to_string();
         let mut config = startup_config_for_host(&host, preferred_config.as_ref())?;
         let node_bin = resolve_node_binary(app);
-        let runtime_entry = find_provider_runtime_mjs()?;
+        let runtime_entry = find_provider_runtime_mjs(app)?;
 
         // Spawn up to STARTUP_ATTEMPT_BUDGETS.len() attempts. #1568 shipped
         // with 2 attempts at 20s each; field evidence in #1587 showed cases
@@ -386,18 +386,41 @@ fn resolve_node_binary(app: &AppHandle) -> PathBuf {
     crate::embedded_runtime::system_node_fallback()
 }
 
-fn find_provider_runtime_mjs() -> Result<PathBuf, String> {
-    let exe_path = std::env::current_exe()
-        .map_err(|err| format!("Failed to get current exe path: {}", err))?;
-    let exe_dir = exe_path
-        .parent()
-        .ok_or_else(|| "Failed to get exe directory".to_string())?;
-    let platform_subdir = crate::embedded_runtime::platform_subdir();
-
-    let candidates = [
+/// Candidate locations for provider-runtime.mjs, in probe order.
+///
+/// The resource-dir candidates come first: Tauri's resource resolver is the
+/// only source that knows the Linux install layout (`exe_dir/../lib/<app>`
+/// for deb/rpm, `$APPDIR/usr/lib/<app>` for AppImage, `/usr/lib/<app>` for a
+/// system install — #3434). On macOS it resolves to `exe_dir/../Resources`,
+/// on Windows and in dev to `exe_dir` itself — directories the exe-relative
+/// candidates below already probe, so their behavior is unchanged. The
+/// exe-relative and dev candidates remain as fallback for when the resolver
+/// errors.
+fn provider_runtime_mjs_candidates(
+    exe_dir: &Path,
+    resource_dir: Option<&Path>,
+    platform_subdir: &str,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(7);
+    if let Some(resource_dir) = resource_dir {
+        candidates.push(
+            resource_dir
+                .join("embedded-runtime")
+                .join(platform_subdir)
+                .join("provider-runtime")
+                .join("provider-runtime.mjs"),
+        );
+        candidates.push(
+            resource_dir
+                .join("embedded-runtime")
+                .join("provider-runtime")
+                .join("provider-runtime.mjs"),
+        );
+    }
+    candidates.extend([
         exe_dir
             .join("../Resources/embedded-runtime")
-            .join(&platform_subdir)
+            .join(platform_subdir)
             .join("provider-runtime")
             .join("provider-runtime.mjs"),
         exe_dir
@@ -406,7 +429,7 @@ fn find_provider_runtime_mjs() -> Result<PathBuf, String> {
             .join("provider-runtime.mjs"),
         exe_dir
             .join("embedded-runtime")
-            .join(&platform_subdir)
+            .join(platform_subdir)
             .join("provider-runtime")
             .join("provider-runtime.mjs"),
         exe_dir
@@ -417,7 +440,21 @@ fn find_provider_runtime_mjs() -> Result<PathBuf, String> {
             .join("embedded-runtime")
             .join("provider-runtime")
             .join("provider-runtime.mjs"),
-    ];
+    ]);
+    candidates
+}
+
+fn find_provider_runtime_mjs(app: &AppHandle) -> Result<PathBuf, String> {
+    let exe_path = std::env::current_exe()
+        .map_err(|err| format!("Failed to get current exe path: {}", err))?;
+    let exe_dir = exe_path
+        .parent()
+        .ok_or_else(|| "Failed to get exe directory".to_string())?;
+    let platform_subdir = crate::embedded_runtime::platform_subdir();
+    let resource_dir = app.path().resource_dir().ok();
+
+    let candidates =
+        provider_runtime_mjs_candidates(exe_dir, resource_dir.as_deref(), &platform_subdir);
 
     for candidate in &candidates {
         if candidate.exists() {
@@ -1314,5 +1351,64 @@ mod tests {
                 "budgets should be non-decreasing: {prev:?} -> {next:?}"
             );
         }
+    }
+
+    /// #3434: installed Linux builds resolve resources to `../lib/<app>`,
+    /// `$APPDIR/usr/lib/<app>`, or `/usr/lib/<app>` — locations no
+    /// exe-relative candidate ever reaches, so agent mode could not start.
+    /// The resolver-backed candidates must be probed first (platform subdir
+    /// before flat layout), and every pre-existing exe-relative/dev
+    /// candidate must remain, in the same order, as the fallback tail.
+    #[test]
+    fn mjs_candidates_probe_resource_dir_before_exe_relative() {
+        let exe_dir = Path::new("/usr/bin");
+        let resource_dir = Path::new("/usr/lib/seren-desktop");
+        let candidates = provider_runtime_mjs_candidates(exe_dir, Some(resource_dir), "linux-x64");
+
+        assert_eq!(
+            candidates[0],
+            resource_dir
+                .join("embedded-runtime")
+                .join("linux-x64")
+                .join("provider-runtime")
+                .join("provider-runtime.mjs")
+        );
+        assert_eq!(
+            candidates[1],
+            resource_dir
+                .join("embedded-runtime")
+                .join("provider-runtime")
+                .join("provider-runtime.mjs")
+        );
+        assert_eq!(
+            candidates[2..],
+            provider_runtime_mjs_candidates(exe_dir, None, "linux-x64")[..],
+            "exe-relative and dev candidates must be unchanged after the resolver pair"
+        );
+    }
+
+    /// A failed resolver must degrade to exactly the pre-#3434 candidate
+    /// list — macOS/Windows/dev discovery is untouched.
+    #[test]
+    fn mjs_candidates_without_resource_dir_keep_prior_probe_set() {
+        let exe_dir = Path::new("/Applications/Seren.app/Contents/MacOS");
+        let candidates = provider_runtime_mjs_candidates(exe_dir, None, "darwin-arm64");
+
+        assert_eq!(candidates.len(), 5);
+        assert_eq!(
+            candidates[0],
+            exe_dir
+                .join("../Resources/embedded-runtime")
+                .join("darwin-arm64")
+                .join("provider-runtime")
+                .join("provider-runtime.mjs")
+        );
+        assert_eq!(
+            candidates[4],
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("embedded-runtime")
+                .join("provider-runtime")
+                .join("provider-runtime.mjs")
+        );
     }
 }


### PR DESCRIPTION
Refs #3434

## Problem

Installed Linux builds can never start desktop-native agent mode or the Happy bridge. `find_provider_runtime_mjs` (`src-tauri/src/provider_runtime.rs`) and `find_happy_bridge_mjs` (`src-tauri/src/happy_bridge.rs`) hand-roll exe-relative candidate paths that cover macOS (`exe_dir/../Resources/embedded-runtime/...`), Windows (`exe_dir/embedded-runtime/...`), and dev (compile-time `CARGO_MANIFEST_DIR`) — but none of them matches the Linux install layout. Per vendored `tauri-utils-2.9.3/src/platform.rs`, Linux resources resolve to `exe_dir/../lib/<app>` (deb/rpm), `$APPDIR/usr/lib/<app>` (AppImage), or `/usr/lib/<app>`. Every `ensure_started` attempt on Linux fails with `provider-runtime.mjs not found. Checked locations: ...`.

Node/git discovery already handles this correctly via Tauri's `resource_dir()` (`get_embedded_runtime_dir` in `src-tauri/src/embedded_runtime.rs`); only the `.mjs` entrypoint finders were left behind.

## Fix (strictly additive)

- Both finders now take the `AppHandle` (already in scope at both call sites) and prepend two `resource_dir()`-based candidates — `resource_dir/embedded-runtime/<platform-subdir>/provider-runtime/<entry>.mjs` and the flat-layout variant — mirroring `get_embedded_runtime_dir`.
- Resolver candidates go first because on macOS `resource_dir()` = `exe_dir/../Resources` and on Windows/dev it = `exe_dir` — the same directories the existing candidates already probe, so macOS/Windows/dev behavior is unchanged. Verified the dev case against the vendored resolver source (the cargo-output-directory check returns `exe_dir`) and against a real `target/debug/embedded-runtime` resource copy containing both `.mjs` files.
- All pre-existing exe-relative and `CARGO_MANIFEST_DIR` candidates are kept unchanged, in the same order, as the fallback for a failed resolver.
- The "Checked locations" / "not found in" error output is built from the same candidate list, so it now includes the resolver paths.
- Candidate construction is extracted into pure helpers (`provider_runtime_mjs_candidates`, `happy_bridge_mjs_candidates`) so ordering and the unchanged fallback tail are unit-testable without an `AppHandle`.

## Tests

- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `cargo test --manifest-path src-tauri/Cargo.toml provider_runtime` — 34 passed, 0 failed (includes new `mjs_candidates_probe_resource_dir_before_exe_relative` and `mjs_candidates_without_resource_dir_keep_prior_probe_set`).
- `cargo test --manifest-path src-tauri/Cargo.toml happy_bridge` — 40 passed, 0 failed (includes new `bridge_candidates_probe_resource_dir_before_exe_relative` and `bridge_candidates_without_resource_dir_keep_prior_probe_set`).

Note: the commit subject was shortened from the planned wording ("resolve provider-runtime.mjs and happy-bridge.mjs via resource_dir on Linux") to satisfy the repo's 72-char commit-subject cap (`scripts/check-commit-msg.sh`, #1778); the full wording is preserved in the commit body.

## Validation caveat (honest status)

This is code-level verification only. The failing layer is a real installed Linux build, which cannot be exercised from this macOS environment — the unit tests prove candidate construction, not the production outcome. Final validation requires running a real Linux .deb/AppImage artifact and confirming agent mode starts; that verification is tracked in #3434, which must NOT be closed on merge alone.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
