### PR TITLE
docs(release): add curated notes for v3.75.0

### DIFF
--- a/.github/release-notes/v3.75.0.md
+++ b/.github/release-notes/v3.75.0.md
@@ -1,0 +1,26 @@
+## What's New
+
+A reliability release driven by a full pre-release audit of the agent runtime: a crash that could take down every live agent session at once is guarded, Stop can no longer hang a conversation, agent mode is repaired on Linux installs, and Happy Mobile file-read summarization now works for every agent. Plus a daily SerenBucks claim offer when you launch an agent.
+
+## 🤖 Agent Runtime Reliability
+
+- A CLI process dying mid-write can no longer crash the shared provider runtime and take every live agent session down with it — the failure is now contained to the one session that died (#3456)
+- Stop is now guaranteed to stop: a wedged agent runtime or a stalled publisher stream can no longer hang a conversation in the "running" state until app restart (#3458)
+- Fixed agent mode on Linux installs — the embedded runtime entrypoints are now resolved through Tauri's resource directory, which the deb/rpm/AppImage layouts require; final on-device verification is tracked in #3434 (#3459)
+- The Claude Code PATH helper now writes strict, properly escaped JSON to `~/.claude/settings.json` on every platform — previously, Windows paths could corrupt the file or invalidate it entirely — and it refuses to modify a settings file it cannot parse (#3457)
+
+## 📱 Happy Mobile
+
+- Long file-read output is summarized on the phone instead of burying the conversation (#3426), and this now works for ACP-connected agents (Gemini, Grok) too — their tool events previously bypassed the summarizer (#3455)
+
+## 💰 Wallet
+
+- Launching an agent now offers your daily SerenBucks claim if it is still unclaimed that day (#3428)
+
+## 🔒 Private Models
+
+- The organization policy surface now exposes the authority that recorded a data-handling attestation (`policy_administrator` or `provider_configuration`), groundwork for provider-configured attestations
+
+## 🐞 Stability
+
+- Playwright browser modules are loaded lazily, off the MCP init path — server startup no longer depends on browser system libraries being present (#3424)


### PR DESCRIPTION
Curated "What's New" notes for the v3.75.0 tag, consumed verbatim by the release workflow from `.github/release-notes/v3.75.0.md`.

Covers all nine commits since v3.74.0, grouped: agent runtime reliability (#3456, #3458, #3459, #3457), Happy Mobile read summarization (#3426 + #3455), the daily SerenBucks claim offer (#3428), the provider data-handling basis field, and the playwright lazy-load fix (#3424).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
