### PR TITLE
fix(wallet,mcp): gate claim probe on auth; guard lazy-load (#3451, #3452)

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/lazy_browser_modules.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/lazy_browser_modules.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Regression guard for #3452 — importing browser.js must not load the
+// ABOUTME: heavy playwright-extra/stealth modules until first browser use (#3424).
+
+import { createRequire } from "node:module";
+import { sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+/** True when a module under the given package directory is in Node's CJS cache. */
+function isPackageLoaded(packageName: string): boolean {
+  return Object.keys(require.cache ?? {}).some((modulePath) =>
+    modulePath.split(sep).includes(packageName),
+  );
+}
+
+describe("browser.ts lazy module contract (#3424)", () => {
+  it("defers playwright-extra + stealth plugin until ensureBrowserModules()", async () => {
+    // Both packages are CommonJS, so vitest hands them to Node's native
+    // loader and every load lands in require.cache. Vitest runs each test
+    // file in its own process, so this file observes a genuinely fresh
+    // registry — browser.test.ts's beforeAll(ensureBrowserModules) cannot
+    // pollute it. No test in THIS file may import browser.js at top level.
+    expect(isPackageLoaded("playwright-extra")).toBe(false);
+    expect(isPackageLoaded("puppeteer-extra-plugin-stealth")).toBe(false);
+
+    // The regression #3424 fixed: a top-level `import` of playwright-extra
+    // in browser.ts ran during the MCP `initialize` handshake window and
+    // stalled agent startup on cold machines (#3405). Importing the module
+    // must therefore leave both packages unloaded.
+    const browserModule = await import("../browser.js");
+
+    expect(isPackageLoaded("playwright-extra")).toBe(false);
+    expect(isPackageLoaded("puppeteer-extra-plugin-stealth")).toBe(false);
+
+    // First browser use loads them. This phase also proves the
+    // require.cache probe actually observes these packages, so the
+    // absence assertions above cannot pass vacuously.
+    await browserModule.ensureBrowserModules();
+
+    expect(isPackageLoaded("playwright-extra")).toBe(true);
+    expect(isPackageLoaded("puppeteer-extra-plugin-stealth")).toBe(true);
+  });
+});

--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -15,6 +15,7 @@ import {
   type ReceivedTransferNotificationSummary,
   type WalletBalance,
 } from "@/services/wallet";
+import { authStore } from "@/stores/auth.store";
 
 export type LatestReceivedTransfer = ReceivedTransferNotificationSummary;
 
@@ -68,7 +69,12 @@ const initialState: WalletState = {
   dailyClaimTimerId: null,
 };
 
-const [walletState, setWalletState] = createStore<WalletState>(initialState);
+// Copy so the store never adopts `initialState` as its backing target — Solid
+// wraps the passed object in place, and writing mutations through into
+// `initialState` turns the `setWalletState(initialState)` reset into a no-op.
+const [walletState, setWalletState] = createStore<WalletState>({
+  ...initialState,
+});
 
 // Refresh interval in milliseconds (60 seconds)
 const REFRESH_INTERVAL = 60_000;
@@ -494,8 +500,12 @@ function dismissDailyClaim(): void {
  * or a session that crossed midnight UTC. A fresh eligibility fetch keeps the
  * midnight boundary honest; on a transient failure the existing state is left
  * untouched (mirroring the poll) so a launch is never blocked or falsely reset.
+ * Signed-out sessions skip the fetch entirely — agents are launchable without
+ * a Seren account, and an unauthenticated eligibility call is a guaranteed 401
+ * that only feeds diagnostics noise (#3451).
  */
 async function surfaceDailyClaimIfEligible(): Promise<void> {
+  if (!authStore.isAuthenticated) return;
   try {
     const eligibility = await fetchDailyEligibility();
     setWalletState("dailyClaim", eligibility);

--- a/tests/unit/daily-claim-agent-launch.test.ts
+++ b/tests/unit/daily-claim-agent-launch.test.ts
@@ -8,9 +8,15 @@ const dailyClaimMocks = vi.hoisted(() => ({
   claimDailyCredits: vi.fn(),
 }));
 
+const mockAuthState = vi.hoisted(() => ({ isAuthenticated: true }));
+
 vi.mock("@/services/dailyClaim", () => ({
   fetchDailyEligibility: dailyClaimMocks.fetchDailyEligibility,
   claimDailyCredits: dailyClaimMocks.claimDailyCredits,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: mockAuthState,
 }));
 
 vi.mock("@/services/notifications", () => ({
@@ -43,6 +49,7 @@ function eligibility(canClaim: boolean) {
 describe("daily claim on agent launch", () => {
   beforeEach(() => {
     dailyClaimMocks.fetchDailyEligibility.mockReset();
+    mockAuthState.isAuthenticated = true;
     resetWalletState();
   });
 
@@ -88,6 +95,19 @@ describe("daily claim on agent launch", () => {
     // State is preserved (not nulled, not blocked): the launch is never gated
     // on eligibility, and we do not un-dismiss on an unconfirmed reward.
     expect(walletState.dailyClaim?.can_claim).toBe(true);
+    expect(walletState.dailyClaimDismissed).toBe(true);
+  });
+
+  it("skips the eligibility fetch entirely when signed out (#3451)", async () => {
+    mockAuthState.isAuthenticated = false;
+    dismissDailyClaim();
+
+    await surfaceDailyClaimIfEligible();
+
+    // No Gateway call — a signed-out probe is a guaranteed 401 that only
+    // produces console noise and captureHttpFailure diagnostics entries.
+    expect(dailyClaimMocks.fetchDailyEligibility).not.toHaveBeenCalled();
+    expect(walletState.dailyClaim).toBeNull();
     expect(walletState.dailyClaimDismissed).toBe(true);
   });
 });


### PR DESCRIPTION
Two P2 findings from the v3.75.0 pre-release audit, plus one real bug the new test uncovered.

## #3451 — daily claim probe fired for signed-out users

`surfaceDailyClaimIfEligible()` (called on every successful agent cold start, `AgentChat.tsx`) had no auth guard, unlike `checkDailyClaim`/`startDailyClaimPolling` which only run inside App.tsx's `isAuth` effect. Every signed-out launch made a guaranteed-401 Gateway call, logged a `console.error`, and fed a failure into support diagnostics via `captureHttpFailure`.

**Fix:** a one-line early return on `authStore.isAuthenticated` inside the store function.

**Why inside the store rather than at the AgentChat call site:** it covers every future caller, and it is the established pattern — `skills.store.ts:879`, `agent.store.ts:7303`, and auth.store's own `refreshPrivateChatPolicy` all self-guard on `authStore.isAuthenticated`, and chat.store/agent.store already statically import the auth store (no import cycle: auth.store never reaches wallet.store).

## #3452 — no regression guard for playwright-stealth lazy loading

#3424 moved the heavy `playwright-extra` / `puppeteer-extra-plugin-stealth` imports off the MCP `initialize` path, but the suite runs `beforeAll(ensureBrowserModules)`, so a re-introduced top-level import would keep every test green.

**Fix:** new `mcp-servers/playwright-stealth/src/__tests__/lazy_browser_modules.test.ts`. It dynamically imports `browser.js` in a fresh process, asserts neither package is present in Node's CJS module registry (`require.cache` via `createRequire`), then calls `ensureBrowserModules()` and asserts both ARE present.

**Why the runtime registry check over a static source assertion:** it observes the real load behavior, so it also catches indirect re-introductions (e.g. a new top-level import of a module that itself pulls `playwright-extra`), which a source-text scan of `browser.ts` would miss. It is reliable here because both packages are CommonJS — vitest externalizes them to Node's native loader, so loads always land in `require.cache` — and vitest's per-file process isolation keeps `browser.test.ts`'s `beforeAll` from polluting the registry. The post-`ensureBrowserModules()` "they ARE loaded" phase doubles as a self-check that the probe actually observes these packages, so the absence assertions can never pass vacuously. Verified honest: temporarily re-adding `import "playwright-extra"` to `browser.ts` makes the test fail at the post-import absence assertion.

## Uncovered along the way: `resetWalletState()` was a no-op

wallet.store passed `initialState` directly to `createStore`, and Solid adopts that object as the store's backing target — so every `setWalletState` mutation wrote through into `initialState` itself, and `resetWalletState()`'s `setWalletState(initialState)` was a self-merge that reset nothing. In production that means wallet state (balance, daily-claim eligibility) silently survived logout via `resetUserSessionState()`. The new signed-out test exposed the leak. Fixed by copying `initialState` at store creation, which makes the existing reset merge genuinely restore pristine values.

## Tests

- `pnpm vitest run tests/unit/daily-claim-agent-launch.test.ts` — 4 passed (new signed-out case: no wallet-status call, state untouched)
- Full desktop unit suite `pnpm test` — 2793 passed, 15 skipped
- `mcp-servers/playwright-stealth`: `pnpm test` — 75 passed (11 files, incl. the new guard); `tsc --noEmit` clean
- Negative check: re-introducing the top-level import makes the new guard test fail (then reverted)
- `pnpm check` — 48 warnings, identical to the pre-existing baseline on main; the touched `src` file is Biome-clean

Fixes #3451
Fixes #3452

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
