### PR TITLE
fix(build): linux npm shims; verify staged node version (#3449, #3450)

### DIFF
--- a/build/darwin/prepare-embedded-runtime.ts
+++ b/build/darwin/prepare-embedded-runtime.ts
@@ -7,9 +7,15 @@ import * as https from 'https';
 import { pipeline } from 'stream/promises';
 import { execSync } from 'child_process';
 import { pathToFileURL } from 'url';
+import {
+	clearStagedNodeVersion,
+	ensureRuntimeShims,
+	readStagedNodeVersion,
+	writeStagedNodeVersion
+} from '../runtime-staging';
 
 // Version configuration - update these for new releases
-const NODE_VERSION = '22.12.0';
+export const NODE_VERSION = '22.12.0';
 const GIT_VERSION = '2.47.1';
 
 // Node.js download URLs for macOS
@@ -25,12 +31,6 @@ const NODE_DOWNLOADS: Record<string, { url: string }> = {
 interface DownloadOptions {
 	arch: 'x64' | 'arm64';
 	outputDir: string;
-}
-
-/** Replace an extracted symlink with a regular wrapper without touching its target. */
-export function replaceRuntimeShim(wrapperPath: string, contents: string): void {
-	fs.rmSync(wrapperPath, { force: true });
-	fs.writeFileSync(wrapperPath, contents, { mode: 0o755 });
 }
 
 async function downloadFile(url: string, dest: string): Promise<void> {
@@ -69,40 +69,28 @@ async function extractTarGz(archivePath: string, destDir: string): Promise<void>
 	execSync(`tar -xzf "${archivePath}" -C "${destDir}"`, { stdio: 'inherit' });
 }
 
-/**
- * Replace the extracted bin/npm, bin/npx and bin/corepack symlinks with shell
- * wrappers.
- *
- * Tauri resolves symlinks into regular files when bundling the .app, which
- * breaks `require('../lib/cli.js')` because the path resolves relative to bin/
- * rather than lib/node_modules/npm/bin/ where the symlink target lives. A shell
- * wrapper computes its own directory at runtime and stays correct whether or
- * not Tauri has dereferenced it.
- */
-export function ensureRuntimeShims(nodeDir: string): void {
-	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
-	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
-	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npm'), npmWrapper);
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npx'), npxWrapper);
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper);
-	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
-}
-
 export async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	const { arch, outputDir } = options;
 	const nodeConfig = NODE_DOWNLOADS[arch];
 	const nodeDir = path.join(outputDir, 'node');
 
 	if (fs.existsSync(nodeDir)) {
-		console.log(`Node.js directory already exists at ${nodeDir}, skipping download...`);
-		// The download is skippable; the wrappers are not. A tree extracted
-		// before this step existed still holds the original symlinks, and Tauri
-		// dereferences those at bundle time (#3152).
-		ensureRuntimeShims(nodeDir);
-		return nodeDir;
+		const stagedVersion = readStagedNodeVersion(outputDir);
+		if (stagedVersion === NODE_VERSION) {
+			console.log(`Node.js ${NODE_VERSION} already staged at ${nodeDir}, skipping download...`);
+			// The download is skippable; the wrappers are not. A tree extracted
+			// before this step existed still holds the original symlinks, and Tauri
+			// dereferences those at bundle time (#3152).
+			ensureRuntimeShims(nodeDir);
+			return nodeDir;
+		}
+		// A cached tree of any other (or unrecorded) version must not ship while
+		// embedded-runtime.json claims NODE_VERSION (#3450).
+		console.log(`Staged Node.js at ${nodeDir} is ${stagedVersion ?? 'of unrecorded version'}, expected ${NODE_VERSION}; re-staging...`);
+		fs.rmSync(nodeDir, { recursive: true, force: true });
 	}
 
+	clearStagedNodeVersion(outputDir);
 	fs.mkdirSync(nodeDir, { recursive: true });
 
 	const tarPath = path.join(outputDir, `node-${arch}.tar.gz`);
@@ -128,6 +116,7 @@ export async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	fs.unlinkSync(tarPath);
 
 	ensureRuntimeShims(nodeDir);
+	writeStagedNodeVersion(outputDir, NODE_VERSION);
 
 	console.log(`Node.js prepared at ${nodeDir}`);
 	return nodeDir;

--- a/build/linux/prepare-embedded-runtime.ts
+++ b/build/linux/prepare-embedded-runtime.ts
@@ -6,9 +6,16 @@ import * as path from 'path';
 import * as https from 'https';
 import { pipeline } from 'stream/promises';
 import { execSync } from 'child_process';
+import { pathToFileURL } from 'url';
+import {
+	clearStagedNodeVersion,
+	ensureRuntimeShims,
+	readStagedNodeVersion,
+	writeStagedNodeVersion
+} from '../runtime-staging';
 
 // Version configuration - update these for new releases
-const NODE_VERSION = '22.12.0';
+export const NODE_VERSION = '22.12.0';
 const GIT_VERSION = '2.47.1';
 
 // Node.js download URLs for Linux
@@ -65,16 +72,28 @@ async function extractTarGz(archivePath: string, destDir: string): Promise<void>
 	execSync(`tar -xzf "${archivePath}" -C "${destDir}"`, { stdio: 'inherit' });
 }
 
-async function prepareNodejs(options: DownloadOptions): Promise<string> {
+export async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	const { arch, outputDir } = options;
 	const nodeConfig = NODE_DOWNLOADS[arch];
 	const nodeDir = path.join(outputDir, 'node');
 
 	if (fs.existsSync(nodeDir)) {
-		console.log(`Node.js directory already exists at ${nodeDir}, skipping...`);
-		return nodeDir;
+		const stagedVersion = readStagedNodeVersion(outputDir);
+		if (stagedVersion === NODE_VERSION) {
+			console.log(`Node.js ${NODE_VERSION} already staged at ${nodeDir}, skipping download...`);
+			// The download is skippable; the wrappers are not. A tree extracted
+			// before this step existed still holds the original symlinks, and the
+			// bundler dereferences those at bundle time (#3449, #3152).
+			ensureRuntimeShims(nodeDir);
+			return nodeDir;
+		}
+		// A cached tree of any other (or unrecorded) version must not ship while
+		// embedded-runtime.json claims NODE_VERSION (#3450).
+		console.log(`Staged Node.js at ${nodeDir} is ${stagedVersion ?? 'of unrecorded version'}, expected ${NODE_VERSION}; re-staging...`);
+		fs.rmSync(nodeDir, { recursive: true, force: true });
 	}
 
+	clearStagedNodeVersion(outputDir);
 	fs.mkdirSync(nodeDir, { recursive: true });
 
 	const tarPath = path.join(outputDir, `node-${arch}.tar.gz`);
@@ -98,6 +117,9 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	// Cleanup
 	fs.rmSync(tempDir, { recursive: true, force: true });
 	fs.unlinkSync(tarPath);
+
+	ensureRuntimeShims(nodeDir);
+	writeStagedNodeVersion(outputDir, NODE_VERSION);
 
 	console.log(`Node.js prepared at ${nodeDir}`);
 	return nodeDir;
@@ -166,13 +188,16 @@ export async function prepareEmbeddedRuntime(arch: 'x64' | 'arm64' | 'armhf', ou
 	return { nodeDir, gitDir };
 }
 
-// CLI entry point (ESM compatible)
-const arch = (process.argv[2] as 'x64' | 'arm64' | 'armhf') || 'x64';
-const outputDir = process.argv[3] || path.join(process.cwd(), 'src-tauri', 'embedded-runtime', `linux-${arch}`);
+// CLI entry point (ESM compatible). Keep imports side-effect free so the
+// symlink replacement contract can be exercised against a real temp tree.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const arch = (process.argv[2] as 'x64' | 'arm64' | 'armhf') || 'x64';
+	const outputDir = process.argv[3] || path.join(process.cwd(), 'src-tauri', 'embedded-runtime', `linux-${arch}`);
 
-prepareEmbeddedRuntime(arch, outputDir)
-	.then(() => process.exit(0))
-	.catch((err) => {
-		console.error('Failed to prepare embedded runtime:', err);
-		process.exit(1);
-	});
+	prepareEmbeddedRuntime(arch, outputDir)
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error('Failed to prepare embedded runtime:', err);
+			process.exit(1);
+		});
+}

--- a/build/runtime-staging.ts
+++ b/build/runtime-staging.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Shared helpers for staging the embedded Node runtime in the platform prepare scripts.
+// ABOUTME: Provides Tauri-safe npm/npx/corepack wrappers and the staged-Node version marker.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Replace an extracted symlink with a regular wrapper without touching its target. */
+export function replaceRuntimeShim(wrapperPath: string, contents: string): void {
+	fs.rmSync(wrapperPath, { force: true });
+	fs.writeFileSync(wrapperPath, contents, { mode: 0o755 });
+}
+
+/**
+ * Replace the extracted bin/npm, bin/npx and bin/corepack symlinks with shell
+ * wrappers.
+ *
+ * Tauri resolves symlinks into regular files when bundling, which breaks
+ * `require('../lib/cli.js')` because the path resolves relative to bin/
+ * rather than lib/node_modules/npm/bin/ where the symlink target lives. A shell
+ * wrapper computes its own directory at runtime and stays correct whether or
+ * not Tauri has dereferenced it. The darwin and linux Node tarballs share this
+ * symlink layout; Windows ships real npm.cmd/npx.cmd and needs no shims.
+ */
+export function ensureRuntimeShims(nodeDir: string): void {
+	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
+	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
+	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npm'), npmWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npx'), npxWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper);
+	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
+}
+
+/**
+ * The staged-Node version marker records which Node version was actually
+ * extracted into `<outputDir>/node`. The prepare scripts skip the download when
+ * that directory exists, and before this marker they had no way to tell a
+ * current tree from a stale one — after a NODE_VERSION bump a cached dev
+ * staging dir silently shipped the old binary while embedded-runtime.json
+ * claimed the new version (#3450).
+ *
+ * A marker file is used instead of running `<staged node> --version` because
+ * the staged binary is not always executable on the staging host (e.g. the
+ * linux runtime staged on macOS).
+ */
+function stagedNodeVersionPath(outputDir: string): string {
+	return path.join(outputDir, 'staged-node-version');
+}
+
+/** Read the recorded staged Node version, or null when no marker exists. */
+export function readStagedNodeVersion(outputDir: string): string | null {
+	try {
+		return fs.readFileSync(stagedNodeVersionPath(outputDir), 'utf8').trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Remove the marker before (re-)staging begins so an interrupted download or
+ * extraction can never leave a marker that matches a broken tree.
+ */
+export function clearStagedNodeVersion(outputDir: string): void {
+	fs.rmSync(stagedNodeVersionPath(outputDir), { force: true });
+}
+
+/** Record the staged Node version. Call only after staging fully succeeds. */
+export function writeStagedNodeVersion(outputDir: string, version: string): void {
+	fs.writeFileSync(stagedNodeVersionPath(outputDir), `${version}\n`);
+}

--- a/build/win32/prepare-embedded-runtime.ts
+++ b/build/win32/prepare-embedded-runtime.ts
@@ -6,6 +6,11 @@ import * as path from 'path';
 import * as https from 'https';
 import { pipeline } from 'stream/promises';
 import { execSync } from 'child_process';
+import {
+	clearStagedNodeVersion,
+	readStagedNodeVersion,
+	writeStagedNodeVersion
+} from '../runtime-staging';
 
 // Version configuration - update these for new releases
 const NODE_VERSION = '22.12.0';
@@ -90,10 +95,18 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	const nodeDir = path.join(outputDir, 'node');
 
 	if (fs.existsSync(nodeDir)) {
-		console.log(`Node.js directory already exists at ${nodeDir}, skipping...`);
-		return nodeDir;
+		const stagedVersion = readStagedNodeVersion(outputDir);
+		if (stagedVersion === NODE_VERSION) {
+			console.log(`Node.js ${NODE_VERSION} already staged at ${nodeDir}, skipping download...`);
+			return nodeDir;
+		}
+		// A cached tree of any other (or unrecorded) version must not ship while
+		// embedded-runtime.json claims NODE_VERSION (#3450).
+		console.log(`Staged Node.js at ${nodeDir} is ${stagedVersion ?? 'of unrecorded version'}, expected ${NODE_VERSION}; re-staging...`);
+		fs.rmSync(nodeDir, { recursive: true, force: true });
 	}
 
+	clearStagedNodeVersion(outputDir);
 	fs.mkdirSync(nodeDir, { recursive: true });
 
 	const zipPath = path.join(outputDir, `node-${arch}.zip`);
@@ -117,6 +130,8 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	// Cleanup
 	fs.rmSync(tempDir, { recursive: true, force: true });
 	fs.unlinkSync(zipPath);
+
+	writeStagedNodeVersion(outputDir, NODE_VERSION);
 
 	console.log(`Node.js prepared at ${nodeDir}`);
 	return nodeDir;

--- a/tests/unit/darwin-embedded-runtime.test.ts
+++ b/tests/unit/darwin-embedded-runtime.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Critical regression coverage for macOS embedded-runtime wrapper preparation (#3086).
+// ABOUTME: Critical regression coverage for embedded-runtime wrapper preparation (#3086).
 // ABOUTME: Proves replacing an extracted npm symlink never overwrites its JavaScript target.
 
 import {
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { replaceRuntimeShim } from "../../build/darwin/prepare-embedded-runtime";
+import { replaceRuntimeShim } from "../../build/runtime-staging";
 import { expect, it } from "vitest";
 
 it("replaces an npm symlink without corrupting its target", () => {

--- a/tests/unit/linux-embedded-runtime-warm-tree.test.ts
+++ b/tests/unit/linux-embedded-runtime-warm-tree.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Regression coverage for macOS embedded-runtime preparation on a warm tree (#3152).
+// ABOUTME: Regression coverage for Linux embedded-runtime preparation on a warm tree (#3449).
 // ABOUTME: Proves an incremental prepare still replaces the npm/npx/corepack symlinks.
 
 import {
@@ -12,24 +12,21 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { NODE_VERSION, prepareNodejs } from "../../build/darwin/prepare-embedded-runtime";
+import { NODE_VERSION, prepareNodejs } from "../../build/linux/prepare-embedded-runtime";
 import { writeStagedNodeVersion } from "../../build/runtime-staging";
 import { expect, it } from "vitest";
 
 /**
- * The download is skipped when `<outputDir>/node` already exists with a
- * matching staged-node-version marker, which is the state of every incremental
- * `pnpm prepare:runtime:darwin-*`. That early return used to skip the wrapper
- * replacement with it, leaving the original symlinks in place — and Tauri
- * dereferences symlinks when bundling the .app, which breaks
- * `require('../lib/cli.js')` for npm/npx/corepack.
- *
- * Exercising the real function against a real warm tree also proves the early
+ * The Linux Node tarball ships bin/npm, bin/npx and bin/corepack as the same
+ * relative symlinks as the darwin one, and the bundler dereferences symlinks
+ * the same way — but the Linux prepare script historically never replaced them
+ * with wrappers (#3449). Exercising the real function against a real warm tree
+ * proves both the wrapper replacement and that the version-matched early
  * return still short-circuits the network: the download would fail or hang
  * here, not silently pass.
  */
 it("replaces runtime symlinks on an already-prepared node tree", async () => {
-  const outputDir = mkdtempSync(join(tmpdir(), "seren-warm-runtime-"));
+  const outputDir = mkdtempSync(join(tmpdir(), "seren-linux-warm-runtime-"));
   try {
     const nodeDir = join(outputDir, "node");
     const binDir = join(nodeDir, "bin");
@@ -44,7 +41,7 @@ it("replaces runtime symlinks on an already-prepared node tree", async () => {
     // matches NODE_VERSION; anything else is re-staged (#3450).
     writeStagedNodeVersion(outputDir, NODE_VERSION);
 
-    const prepared = await prepareNodejs({ arch: "arm64", outputDir });
+    const prepared = await prepareNodejs({ arch: "x64", outputDir });
 
     expect(prepared).toBe(nodeDir);
     for (const wrapper of ["npm", "npx", "corepack"]) {


### PR DESCRIPTION
Fixes #3449
Fixes #3450

## What changed

**#3449 — Linux prepare script lacked the npm/npx/corepack wrapper shims.** The Linux Node tarball ships `bin/npm`, `bin/npx`, `bin/corepack` as the same relative symlinks as the darwin one, and the bundler dereferences them the same way, breaking the relative `require('../lib/cli.js')`. The `ensureRuntimeShims` logic is now extracted from the darwin script into a shared module, `build/runtime-staging.ts`, imported by both `build/darwin/prepare-embedded-runtime.ts` and `build/linux/prepare-embedded-runtime.ts` (no copy-paste; the build/ scripts previously shared nothing, so a small module next to them). The wrapper content is byte-identical to what darwin produced before (verified below with `diff`). Windows keeps no shims — it ships real `npm.cmd`/`npx.cmd`.

**#3450 — skip-if-exists could ship a stale Node while the manifest claims `NODE_VERSION`.** All three prepare scripts now record a `staged-node-version` marker file (next to `embedded-runtime.json`) after a successful stage, and the skip fast-path only triggers when the marker matches `NODE_VERSION`. Any other value — including no marker, the state of every existing dev cache — wipes `<out>/node` and re-downloads. The marker is cleared before staging begins so an interrupted download/extract can never leave a matching marker over a broken tree. A marker is used instead of executing `<staged node> --version` because the staged binary is not always runnable on the staging host (linux runtime staged on macOS; also avoids any `node.exe` path/exec special-casing on Windows).

The linux script's CLI entry also gained the same `import.meta.url` guard darwin already had, so the new regression test can import `prepareNodejs` without triggering a download.

## Files changed

- `build/runtime-staging.ts` (new) — shared `replaceRuntimeShim`, `ensureRuntimeShims`, and staged-node-version marker helpers
- `build/darwin/prepare-embedded-runtime.ts` — shim helpers moved to shared module; version-checked skip
- `build/linux/prepare-embedded-runtime.ts` — shims ported (#3449); version-checked skip; guarded CLI entry
- `build/win32/prepare-embedded-runtime.ts` — version-checked skip (no shims)
- `tests/unit/darwin-embedded-runtime.test.ts` — import moved to shared module
- `tests/unit/darwin-embedded-runtime-warm-tree.test.ts` — warm tree now stages a matching marker
- `tests/unit/linux-embedded-runtime-warm-tree.test.ts` (new) — linux warm-tree shim regression coverage

## Functional verification (real script runs, inside the worktree's gitignored `src-tauri/embedded-runtime/`)

### darwin: fresh stage

```
$ pnpm prepare:runtime:darwin-arm64
Preparing embedded runtime for macOS arm64...
Downloading https://nodejs.org/dist/v22.12.0/node-v22.12.0-darwin-arm64.tar.gz...
Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.
Node.js prepared at .../src-tauri/embedded-runtime/darwin-arm64/node
Embedded runtime prepared successfully.

$ cat darwin-arm64/staged-node-version
22.12.0
$ ./darwin-arm64/node/bin/node --version     # staged binary really is the claimed version
v22.12.0
$ ./darwin-arm64/node/bin/npm --version      # wrapper actually executes
10.9.0
```

### darwin: warm re-run with matching marker (fast-path skip preserved)

```
$ time pnpm prepare:runtime:darwin-arm64
Node.js 22.12.0 already staged at .../darwin-arm64/node, skipping download...
Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.
real    0m0.276s
```

### darwin: simulated NODE_VERSION bump (stale marker) — with a sentinel file to prove the tree is really wiped

```
$ echo "22.11.0" > darwin-arm64/staged-node-version
$ touch darwin-arm64/node/STALE-SENTINEL
$ pnpm prepare:runtime:darwin-arm64
Staged Node.js at .../darwin-arm64/node is 22.11.0, expected 22.12.0; re-staging...
Downloading https://nodejs.org/dist/v22.12.0/node-v22.12.0-darwin-arm64.tar.gz...
Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.

$ cat darwin-arm64/staged-node-version
22.12.0
$ ls darwin-arm64/node/STALE-SENTINEL
ls: ...: No such file or directory        # tree wiped and re-staged, not just marker rewritten
$ darwin-arm64/node/bin/node --version
v22.12.0
```

### darwin: markerless cache (state of every existing dev machine) re-stages once

```
$ rm darwin-arm64/staged-node-version
$ pnpm prepare:runtime:darwin-arm64
Staged Node.js at .../darwin-arm64/node is of unrecorded version, expected 22.12.0; re-staging...
Downloading https://nodejs.org/dist/v22.12.0/node-v22.12.0-darwin-arm64.tar.gz...
```

### linux: fresh stage on macOS (downloads/stages files only), shim assertions

```
$ pnpm prepare:runtime:linux-x64
Preparing embedded runtime for Linux x64...
Downloading https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.gz...
Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.

$ stat -f "%N: %HT" linux-x64/node/bin/npm linux-x64/node/bin/npx linux-x64/node/bin/corepack
linux-x64/node/bin/npm: Regular File          # not a symlink
linux-x64/node/bin/npx: Regular File
linux-x64/node/bin/corepack: Regular File

$ cat linux-x64/node/bin/npm
#!/bin/sh
exec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"

$ for f in npm npx corepack; do diff linux-x64/node/bin/$f darwin-arm64/node/bin/$f && echo "$f: identical"; done
npm: identical                                 # byte-identical to darwin's wrappers
npx: identical
corepack: identical

$ cat linux-x64/staged-node-version
22.12.0
```

### linux: warm skip and forced mismatch

```
$ time pnpm prepare:runtime:linux-x64
Node.js 22.12.0 already staged at .../linux-x64/node, skipping download...
Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.
real    0m0.398s

$ echo "22.11.0" > linux-x64/staged-node-version
$ pnpm prepare:runtime:linux-x64
Staged Node.js at .../linux-x64/node is 22.11.0, expected 22.12.0; re-staging...
Downloading https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.gz...
$ cat linux-x64/staged-node-version
22.12.0
```

### win32

The Windows script cannot execute on this macOS host (its extraction shells out to PowerShell), so its download path was not run here. It uses the identical shared marker helpers and the same skip/wipe branch exercised above on darwin and linux, never executes the staged binary (marker read only — no `node.exe` exec, no execute-bit handling), and type-checks clean:

```
$ pnpm exec tsc --noEmit --ignoreConfig --skipLibCheck --module esnext --moduleResolution bundler \
    --target es2022 --strict --types node build/win32/prepare-embedded-runtime.ts \
    build/darwin/prepare-embedded-runtime.ts build/linux/prepare-embedded-runtime.ts
TSC: all three prepare scripts + shared module type-check clean
```

The wipe-on-mismatch also covers the #3450 "Windows wrinkle": a stale `node/` no longer skips re-staging, so signing always operates on freshly staged binaries.

### Unit tests

```
$ pnpm vitest run tests/unit/darwin-embedded-runtime.test.ts \
    tests/unit/darwin-embedded-runtime-warm-tree.test.ts \
    tests/unit/linux-embedded-runtime-warm-tree.test.ts
 Test Files  3 passed (3)
      Tests  3 passed (3)
```

### Biome

`build/` and `tests/` are outside Biome's `files.includes` scope (`biome.json` includes only `**/src/**/*`, `.vscode`, `index.html`, `vite.config.ts`; `pnpm exec biome check build/runtime-staging.ts` reports "No files were processed"). `pnpm check` on the branch matches main exactly: 48 pre-existing warnings, 1 info — no new diagnostics.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
