### PR TITLE
fix(runtime): enforce claude baseline at spawn; exact read match

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -454,19 +454,42 @@ function emitCliActionRequired(
   return officialInstructionsUrl;
 }
 
-async function ensureCodexCliViaUpdater(emit) {
-  const baseline = CLI_MIN_VERSION_BASELINE["@openai/codex"];
-  let resolved = resolveInstalledCodexBinary();
-  const installed = await runInstalledVersion(resolved, "codex");
+/**
+ * Block spawn until the resolved CLI meets its CLI_MIN_VERSION_BASELINE,
+ * force-updating through the verified updater when it does not. Shared by
+ * the Codex (#2904) and Claude Code (#3443) spawn paths so both degrade
+ * identically: an at-or-above-baseline install returns immediately with no
+ * network access; a below-baseline install triggers a blocking verified
+ * update and fails closed — with an actionable retry/instructions handoff —
+ * when the update cannot be confirmed (offline, scan rejection, stale shim).
+ *
+ * `_runInstalledVersion` / `_backgroundUpdateCli` are test seams; production
+ * callers leave them undefined so the real probe and updater run. Mirrors
+ * the `_versionOverrides` / `_scannerOverrides` seams in cli-updater.mjs.
+ */
+async function ensureCliBaselineViaUpdater(
+  emit,
+  {
+    label,
+    bareCommand,
+    packageName,
+    resolveBinary,
+    _runInstalledVersion = runInstalledVersion,
+    _backgroundUpdateCli = backgroundUpdateCli,
+  },
+) {
+  const baseline = CLI_MIN_VERSION_BASELINE[packageName];
+  let resolved = resolveBinary();
+  const installed = await _runInstalledVersion(resolved, bareCommand);
   if (!installed) {
     const url = emitCliActionRequired(emit, {
-      label: "Codex",
-      bareCommand: "codex",
-      packageName: "@openai/codex",
+      label,
+      bareCommand,
+      packageName,
       reason: "installation_required",
     });
     throw new Error(
-      `Codex CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
+      `${label} CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
     );
   }
   if (!isBelowBaseline(installed, baseline)) {
@@ -475,14 +498,14 @@ async function ensureCodexCliViaUpdater(emit) {
 
   emit("provider://cli-install-progress", {
     stage: "installing",
-    message: `Updating Codex CLI to ${baseline} or newer...`,
+    message: `Updating ${label} CLI to ${baseline} or newer...`,
   });
 
-  const outcome = await backgroundUpdateCli({
-    label: "Codex",
-    bareCommand: "codex",
+  const outcome = await _backgroundUpdateCli({
+    label,
+    bareCommand,
     resolvedPath: resolved,
-    packageName: "@openai/codex",
+    packageName,
     npmCliScript: resolveNpmCliScript(),
     force: true,
     onUpdated: ({ label, from, to }) =>
@@ -493,53 +516,94 @@ async function ensureCodexCliViaUpdater(emit) {
       emit?.("provider://cli-update-action-required", event),
   });
 
-  resolved = resolveInstalledCodexBinary();
-  const updated = await runInstalledVersion(resolved, "codex");
+  resolved = resolveBinary();
+  const updated = await _runInstalledVersion(resolved, bareCommand);
   if (
     outcome.outcome !== "success" ||
     !updated ||
     isBelowBaseline(updated, baseline)
   ) {
     throw new Error(
-      `Codex CLI is still ${updated ?? "unknown"}; Seren requires ${baseline} ` +
-        `or newer. Update it from ${CLI_INSTALL_INSTRUCTIONS["@openai/codex"]}, ` +
+      `${label} CLI is still ${updated ?? "unknown"}; Seren requires ${baseline} ` +
+        `or newer. Update it from ${CLI_INSTALL_INSTRUCTIONS[packageName]}, ` +
         `then retry. (${outcome.outcome})`,
     );
   }
 
   emit("provider://cli-install-progress", {
     stage: "complete",
-    message: "Codex CLI updated successfully",
+    message: `${label} CLI updated successfully`,
   });
 
   return resolved;
+}
+
+async function ensureCodexCliViaUpdater(emit) {
+  return ensureCliBaselineViaUpdater(emit, {
+    label: "Codex",
+    bareCommand: "codex",
+    packageName: "@openai/codex",
+    resolveBinary: resolveInstalledCodexBinary,
+  });
 }
 
 async function ensureClaudeCodeCli(emit) {
   // Check well-known install paths first (bare `which`/`where` can find stale wrappers)
   const existing = resolveInstalledClaudeBinary();
   if (existing !== "claude") {
-    return existing;
+    // Known install location — enforce the shared version baseline before
+    // spawn, exactly like Codex (#3443). Without this gate, the first spawn
+    // after an app update hands a below-baseline CLI the default model id,
+    // which it hard-rejects; the background updater only heals it later.
+    return ensureCliBaselineViaUpdater(emit, {
+      label: "Claude Code",
+      bareCommand: "claude",
+      packageName: "@anthropic-ai/claude-code",
+      resolveBinary: resolveInstalledClaudeBinary,
+    });
   }
 
   // `which`/`where` may resolve to a path not covered by resolveInstalledClaudeBinary
   // (a custom user PATH location). Arch-check the resolved path so a wrong-arch
   // binary on PATH doesn't get spawned and fail with EBADARCH (#1862).
   if (await isCommandAvailable("claude")) {
+    let resolvedPath = "";
     try {
       const whichCommand = process.platform === "win32" ? "where" : "which";
-      const resolvedPath = (await execText(whichCommand, ["claude"]))
+      resolvedPath = (await execText(whichCommand, ["claude"]))
         .split(/\r?\n/)[0]
         .trim();
-      if (
-        resolvedPath &&
-        existsSync(resolvedPath) &&
-        binaryRunsOnHost(resolvedPath)
-      ) {
-        return "claude";
-      }
     } catch {
       // which/where failed — fall through to the manual install handoff.
+    }
+    if (
+      resolvedPath &&
+      existsSync(resolvedPath) &&
+      binaryRunsOnHost(resolvedPath)
+    ) {
+      // Custom PATH installs are outside every channel the updater manages
+      // (classifyInstallChannel calls them unresolved), so no auto-update
+      // is attempted. Still refuse to spawn a CLI that is determinately
+      // below the baseline: it would reject the default model id with a
+      // far less actionable error (#3443). An unprobeable version stays
+      // permissive so a working custom setup is not blocked.
+      const baseline = CLI_MIN_VERSION_BASELINE["@anthropic-ai/claude-code"];
+      const installed = await runInstalledVersion(resolvedPath, "claude");
+      if (isBelowBaseline(installed, baseline)) {
+        const url = emitCliActionRequired(emit, {
+          label: "Claude Code",
+          bareCommand: "claude",
+          packageName: "@anthropic-ai/claude-code",
+          from: installed,
+          to: baseline,
+          reason: "update_required",
+        });
+        throw new Error(
+          `Claude Code CLI is ${installed}; Seren requires ${baseline} or newer. ` +
+            `Update it from ${url}, then retry.`,
+        );
+      }
+      return "claude";
     }
   }
 
@@ -1264,3 +1328,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
 // ensureCli failure interpolate `undefined` in place of the install URL,
 // which is the unhelpful error #3154 was filed about.
 export { CLI_INSTALL_INSTRUCTIONS as _CLI_INSTALL_INSTRUCTIONS };
+// Exported for regression tests of the spawn-path baseline gate (#2904,
+// #3443). Production callers go through ensureCodexCliViaUpdater /
+// ensureClaudeCodeCli.
+export { ensureCliBaselineViaUpdater as _ensureCliBaselineViaUpdater };

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -965,12 +965,32 @@ function combinePrompt(prompt, context) {
   return [contextText, prompt].filter(Boolean).join("\n\n");
 }
 
+// Split a tool name into lowercase word segments on underscore/hyphen/other
+// separators and camelCase boundaries: "mcp__fs__read_text_file" →
+// ["mcp", "fs", "read", "text", "file"], "ReadFile" → ["read", "file"].
+function toolNameSegments(toolName) {
+  return String(toolName ?? "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+// All-lowercase concatenations have no boundary for toolNameSegments to
+// split, so known read-tool spellings are matched exactly (lowercased).
+const READ_TOOL_NAMES = new Set(["read", "readfile", "notebookread"]);
+
 function toolKindForName(toolName) {
   const lower = String(toolName ?? "").toLowerCase();
   if (lower.includes("bash") || lower.includes("shell") || lower.includes("exec")) {
     return "commandExecution";
   }
-  if (lower.includes("read")) {
+  // Known names or whole-segment match only. A bare substring test
+  // classified "append_to_spreadsheet" ("sp-read-sheet") and "thread_reply"
+  // as file reads, and since #3426 the fileRead kind replaces the tool's
+  // Happy Mobile output with an "[N lines hidden]" summary — hiding real
+  // output for tools that never read a file (#3453).
+  if (READ_TOOL_NAMES.has(lower) || toolNameSegments(toolName).includes("read")) {
     return "fileRead";
   }
   if (
@@ -3652,4 +3672,5 @@ export {
   countSerenMcpTools as _countSerenMcpTools,
   SEREN_MCP_TOOL_PREFIX as _SEREN_MCP_TOOL_PREFIX,
   applySerenMcpOAuthRouting as _applySerenMcpOAuthRouting,
+  toolKindForName as _toolKindForName,
 };

--- a/tests/unit/claude-cli-baseline-gate.test.ts
+++ b/tests/unit/claude-cli-baseline-gate.test.ts
@@ -1,0 +1,156 @@
+// ABOUTME: Guards for #3443 — claude-code spawn must enforce the shared CLI version baseline.
+// ABOUTME: Source wiring checks plus behavioral coverage of the gate's decision logic via its test seams.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/agent-registry.mjs",
+  import.meta.url,
+).href;
+const { _ensureCliBaselineViaUpdater: ensureCliBaselineViaUpdater } =
+  await import(/* @vite-ignore */ modulePath);
+
+const agentRegistrySource = readFileSync(
+  new URL("../../bin/browser-local/agent-registry.mjs", import.meta.url),
+  "utf8",
+);
+
+const CLAUDE_BASELINE_CONFIG = {
+  label: "Claude Code",
+  bareCommand: "claude",
+  packageName: "@anthropic-ai/claude-code",
+};
+
+type EmittedEvent = { name: string; payload: Record<string, unknown> };
+
+function makeEmit(events: EmittedEvent[]) {
+  return (name: string, payload: Record<string, unknown>) => {
+    events.push({ name, payload });
+  };
+}
+
+describe("#3443 claude-code spawn wiring enforces the baseline", () => {
+  it("ensureClaudeCodeCli routes resolved installs through the shared gate", () => {
+    const start = agentRegistrySource.indexOf(
+      "async function ensureClaudeCodeCli",
+    );
+    const end = agentRegistrySource.indexOf(
+      "function resolveInstalledGeminiBinary",
+    );
+    const helper = agentRegistrySource.slice(start, end);
+
+    expect(helper).toContain("ensureCliBaselineViaUpdater(emit");
+    expect(helper).toContain('packageName: "@anthropic-ai/claude-code"');
+    expect(helper).toContain("resolveBinary: resolveInstalledClaudeBinary");
+    // Custom PATH installs cannot be auto-updated, but a determinately
+    // below-baseline one must still be refused with an actionable error.
+    expect(helper).toContain("isBelowBaseline(installed, baseline)");
+  });
+});
+
+describe("#3443 shared baseline gate decision logic", () => {
+  it("returns the resolved path without any update attempt at or above baseline", async () => {
+    for (const version of ["2.1.197", "9.9.9"]) {
+      const events: EmittedEvent[] = [];
+      const updaterCalls: unknown[] = [];
+      const result = await ensureCliBaselineViaUpdater(makeEmit(events), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "/fake/bin/claude",
+        _runInstalledVersion: async () => version,
+        _backgroundUpdateCli: async (options: unknown) => {
+          updaterCalls.push(options);
+          return { outcome: "success" };
+        },
+      });
+
+      expect(result).toBe("/fake/bin/claude");
+      expect(updaterCalls).toHaveLength(0);
+      expect(events).toHaveLength(0);
+    }
+  });
+
+  it("stays permissive when the version has a pre-release suffix", async () => {
+    const events: EmittedEvent[] = [];
+    const result = await ensureCliBaselineViaUpdater(makeEmit(events), {
+      ...CLAUDE_BASELINE_CONFIG,
+      resolveBinary: () => "/fake/bin/claude",
+      _runInstalledVersion: async () => "2.2.0-beta.1",
+      _backgroundUpdateCli: async () => {
+        throw new Error("updater must not run");
+      },
+    });
+
+    expect(result).toBe("/fake/bin/claude");
+  });
+
+  it("force-updates a below-baseline CLI and returns the refreshed path", async () => {
+    const events: EmittedEvent[] = [];
+    const versions = ["2.1.100", "2.1.200"];
+    const updaterCalls: Array<Record<string, unknown>> = [];
+    const result = await ensureCliBaselineViaUpdater(makeEmit(events), {
+      ...CLAUDE_BASELINE_CONFIG,
+      resolveBinary: () => "/fake/bin/claude",
+      _runInstalledVersion: async () => versions.shift() ?? null,
+      _backgroundUpdateCli: async (options: Record<string, unknown>) => {
+        updaterCalls.push(options);
+        return { outcome: "success" };
+      },
+    });
+
+    expect(result).toBe("/fake/bin/claude");
+    expect(updaterCalls).toHaveLength(1);
+    expect(updaterCalls[0].force).toBe(true);
+    expect(updaterCalls[0].packageName).toBe("@anthropic-ai/claude-code");
+    const stages = events
+      .filter((event) => event.name === "provider://cli-install-progress")
+      .map((event) => event.payload.stage);
+    expect(stages).toEqual(["installing", "complete"]);
+  });
+
+  it("fails closed when the updater cannot confirm the baseline offline", async () => {
+    const events: EmittedEvent[] = [];
+    await expect(
+      ensureCliBaselineViaUpdater(makeEmit(events), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "/fake/bin/claude",
+        _runInstalledVersion: async () => "2.1.100",
+        _backgroundUpdateCli: async () => ({ outcome: "skipped:network" }),
+      }),
+    ).rejects.toThrow(/requires 2\.1\.197.*skipped:network/s);
+  });
+
+  it("fails closed when the update reports success but the binary is stale", async () => {
+    const events: EmittedEvent[] = [];
+    await expect(
+      ensureCliBaselineViaUpdater(makeEmit(events), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "/fake/bin/claude",
+        _runInstalledVersion: async () => "2.1.100",
+        _backgroundUpdateCli: async () => ({ outcome: "success" }),
+      }),
+    ).rejects.toThrow(/still 2\.1\.100; Seren requires 2\.1\.197/);
+  });
+
+  it("hands off with installation_required when no version can be probed", async () => {
+    const events: EmittedEvent[] = [];
+    const updaterCalls: unknown[] = [];
+    await expect(
+      ensureCliBaselineViaUpdater(makeEmit(events), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "claude",
+        _runInstalledVersion: async () => null,
+        _backgroundUpdateCli: async (options: unknown) => {
+          updaterCalls.push(options);
+          return { outcome: "success" };
+        },
+      }),
+    ).rejects.toThrow(/not installed in a verifiable location/);
+
+    expect(updaterCalls).toHaveLength(0);
+    const action = events.find(
+      (event) => event.name === "provider://cli-update-action-required",
+    );
+    expect(action?.payload.reason).toBe("installation_required");
+  });
+});

--- a/tests/unit/claude-tool-kind-classification.test.ts
+++ b/tests/unit/claude-tool-kind-classification.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Guards for #3453 — toolKindForName must not classify reads by bare substring.
+// ABOUTME: A false fileRead kind hides the tool's real output behind a Happy Mobile read summary.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const { _toolKindForName: toolKindForName } = await import(
+  /* @vite-ignore */ modulePath
+);
+
+describe("#3453 toolKindForName read classification", () => {
+  it("classifies real read tools as fileRead", () => {
+    expect(toolKindForName("Read")).toBe("fileRead");
+    expect(toolKindForName("read_file")).toBe("fileRead");
+    expect(toolKindForName("ReadFile")).toBe("fileRead");
+    expect(toolKindForName("readFile")).toBe("fileRead");
+    expect(toolKindForName("NotebookRead")).toBe("fileRead");
+    expect(toolKindForName("read-many-files")).toBe("fileRead");
+    expect(toolKindForName("mcp__fs__read_text_file")).toBe("fileRead");
+  });
+
+  it("does not classify names that merely contain 'read' inside a word", () => {
+    // "append_to_spreadsheet" ("sp-read-sheet") and "thread_reply"
+    // ("th-read") matched the old substring test; since #3426 the fileRead
+    // kind replaces their Happy Mobile output with "[N lines hidden]".
+    expect(toolKindForName("append_to_spreadsheet")).toBe(
+      "append_to_spreadsheet",
+    );
+    expect(toolKindForName("thread_reply")).toBe("thread_reply");
+    expect(toolKindForName("update_spreadsheet_cell")).toBe(
+      "update_spreadsheet_cell",
+    );
+  });
+
+  it("keeps the other kind classifications stable", () => {
+    expect(toolKindForName("Bash")).toBe("commandExecution");
+    expect(toolKindForName("Edit")).toBe("fileChange");
+    expect(toolKindForName("Write")).toBe("fileChange");
+    expect(toolKindForName("Grep")).toBe("search");
+    expect(toolKindForName("Glob")).toBe("search");
+    expect(toolKindForName("WebFetch")).toBe("webFetch");
+    expect(toolKindForName(undefined)).toBe("tool");
+  });
+});

--- a/tests/unit/codex-cli-upgrade-gate.test.ts
+++ b/tests/unit/codex-cli-upgrade-gate.test.ts
@@ -23,18 +23,32 @@ describe("#2904 Codex CLI upgrade gate", () => {
     expect(codexDefinition).not.toContain("return ensureGlobalNpmPackage({");
   });
 
-  it("the Codex updater uses the verified update path and fails closed", () => {
-    const helperStart = agentRegistrySource.indexOf(
+  it("the Codex updater delegates to the shared baseline gate", () => {
+    const wrapperStart = agentRegistrySource.indexOf(
       "async function ensureCodexCliViaUpdater",
     );
-    const helperEnd = agentRegistrySource.indexOf(
+    const wrapperEnd = agentRegistrySource.indexOf(
       "async function ensureClaudeCodeCli",
+    );
+    const wrapper = agentRegistrySource.slice(wrapperStart, wrapperEnd);
+
+    expect(wrapper).toContain("ensureCliBaselineViaUpdater(emit");
+    expect(wrapper).toContain('packageName: "@openai/codex"');
+    expect(wrapper).toContain("resolveBinary: resolveInstalledCodexBinary");
+  });
+
+  it("the shared baseline gate uses the verified update path and fails closed", () => {
+    const helperStart = agentRegistrySource.indexOf(
+      "async function ensureCliBaselineViaUpdater",
+    );
+    const helperEnd = agentRegistrySource.indexOf(
+      "async function ensureCodexCliViaUpdater",
     );
     const helper = agentRegistrySource.slice(helperStart, helperEnd);
 
     expect(helper).toContain("CLI_MIN_VERSION_BASELINE");
     expect(helper).toContain("isBelowBaseline");
-    expect(helper).toContain("backgroundUpdateCli");
+    expect(helper).toContain("_backgroundUpdateCli");
     expect(helper).toContain("force: true");
     expect(helper).toContain("provider://cli-update-action-required");
     expect(helper).toContain('outcome.outcome !== "success"');


### PR DESCRIPTION
Fixes #3443
Fixes #3453

Both bugs are from the v3.75.0 pre-release audit, both in the embedded runtime under `bin/browser-local/`.

## #3443 — claude-code CLI baseline not enforced on the spawn path

`ensureCodexCliViaUpdater` blocks spawn until the installed Codex meets `CLI_MIN_VERSION_BASELINE` (#2904), but `ensureClaudeCodeCli` only checked presence/arch — the claude-code baseline (2.1.197, #2810) was applied solely by the fire-and-forget background update at registry init. First spawn after an app update could hand a below-baseline CLI `claude-opus-4-8[1m]`, an id it hard-rejects.

**Change.** The Codex gate body is extracted into a shared `ensureCliBaselineViaUpdater` (no behavior change for Codex — same probe, same baseline comparison, same messages and events), and `ensureClaudeCodeCli` now routes resolved installs through it. Degradation semantics are identical to Codex by construction:

- At-or-above baseline: returns immediately; the only work is a local `--version` probe, no network access, so offline spawns with a healthy CLI are unaffected.
- Below baseline: blocking verified update (`force: true` through `backgroundUpdateCli` — TTL bypassed, scanner + integrity checks intact). If the update cannot be confirmed (offline `skipped:network`, scan rejection, still-stale binary), spawn fails closed with the actionable retry / official-instructions handoff — the same way Codex has since #2904.
- Custom PATH installs (the `which`-fallback branch Codex does not have): these sit outside every updater-managed channel, so no auto-update is attempted. A determinately below-baseline one is refused with an actionable error instead of the CLI's opaque model rejection; an unprobeable version stays permissive so a working custom setup is not blocked.

## #3453 — substring tool-name matching hides real output on Happy Mobile

`toolKindForName` classified any name containing "read" as `fileRead` (`"append_to_spreadsheet"` → "sp-READ-sheet", `"thread_reply"` → "th-READ"). Since #3426 the `fileRead` kind replaces the tool's Happy Mobile output with an "[N lines hidden]" summary, so false positives hide real output on the phone.

**Change.** Matching is now exact known names (`read`, `readfile`, `notebookread`, lowercased) plus whole-segment matching across underscore/hyphen/other separators and camelCase boundaries. `Read`, `read_file`, `ReadFile`, `NotebookRead`, `read-many-files`, and `mcp__fs__read_text_file` still classify as `fileRead`; `append_to_spreadsheet` and `thread_reply` no longer do. The only consumer of the kind value in this runtime is the `provider://tool-call` event (icons in the desktop UI, `FILE_READ_TOOL_KINDS` in `bin/happy-bridge/translate.mjs`); the other kind branches are untouched.

## Tests

- `tests/unit/claude-cli-baseline-gate.test.ts` (new): behavioral coverage of the shared gate's decision logic through its test seams — pass-through at/above baseline with zero updater calls, pre-release-suffix permissiveness, forced update success path, fail-closed on `skipped:network` (offline) and on stale-after-success, `installation_required` handoff when no version can be probed — plus source checks that `ensureClaudeCodeCli` routes through the gate.
- `tests/unit/claude-tool-kind-classification.test.ts` (new): `Read`/`read_file`/`ReadFile`/`NotebookRead`/`mcp__fs__read_text_file` → `fileRead`; `append_to_spreadsheet`/`thread_reply`/`update_spreadsheet_cell` → not; other kinds stable.
- `tests/unit/codex-cli-upgrade-gate.test.ts` (updated): the #2904 source guards now assert the shared-gate structure (Codex wrapper delegates; the gate keeps `force: true`, action-required events, and the fail-closed outcome check).

**What ran, honestly:**

- Targeted vitest files above plus every other test that reads the two changed modules: green. Full unit suite: 389 files passed, 3 skipped (pre-existing).
- `pnpm check`: exit 0. Note Biome's `files.includes` only covers `src/**` — `bin/` and `tests/` are outside its scope by project config, so it does not lint these files.
- `pnpm test:runtime-smoke`: passed. It boots both runtimes against the real registry and exercises registry init including the real cli-updater arms (`cli=@anthropic-ai/claude-code outcome=skipped:ttl` on this machine — a real check ran within the 24h TTL).
- Additionally ran the real gate directly (no seams) via node against this machine's installed CLIs: resolves `~/.local/bin/claude` and `/opt/homebrew/bin/codex`, both at/above baseline, passes them through with zero events.

**What is NOT covered:** no environment here has a genuinely below-baseline installed CLI, so the real blocking `npm install` upgrade during spawn was not executed end-to-end — that path is covered by the seam-based unit tests plus the fact that the underlying `backgroundUpdateCli(force: true)` machinery is unchanged and is the same code the shipped Codex gate (#2904) has been running in production. The smoke test does not call `ensureAgentCli`/spawn, so it verifies wiring and updater init, not the gate itself.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
