### PR TITLE
fix(privacy): accept provider_configuration attestation basis (#3435)

### DIFF
--- a/src/services/organization-policy.ts
+++ b/src/services/organization-policy.ts
@@ -66,7 +66,11 @@ export function hasNoTrainingNoRetentionAttestation(
     attestation.output_retention === "none_after_response" &&
     attestation.derived_data_retention === "none_after_response" &&
     attestation.terms === "no_training_no_retention" &&
-    attestation.basis === "policy_administrator" &&
+    // Both recording authorities (PrivateModelsDataHandlingAttestationBasis)
+    // are accepted: the substantive data-handling fields above carry the
+    // no-training/no-retention guarantee; basis only records who attested.
+    (attestation.basis === "policy_administrator" ||
+      attestation.basis === "provider_configuration") &&
     Boolean(attestation.attested_at)
   );
 }

--- a/tests/unit/organization-policy-attestation.test.ts
+++ b/tests/unit/organization-policy-attestation.test.ts
@@ -40,6 +40,48 @@ describe("hasNoTrainingNoRetentionAttestation", () => {
     expect(hasNoTrainingNoRetentionAttestation(policy(affirmative))).toBe(true);
   });
 
+  it("accepts a provider_configuration basis with all substantive fields valid", () => {
+    expect(
+      hasNoTrainingNoRetentionAttestation(
+        policy({
+          ...affirmative,
+          basis: "provider_configuration",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("denies a provider_configuration basis when a substantive field is wrong", () => {
+    expect(
+      hasNoTrainingNoRetentionAttestation(
+        policy({
+          ...affirmative,
+          basis: "provider_configuration",
+          training_use: "unknown",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("denies unknown and absent basis values", () => {
+    expect(
+      hasNoTrainingNoRetentionAttestation(
+        policy({
+          ...affirmative,
+          basis: "unrecognized_basis" as never,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasNoTrainingNoRetentionAttestation(
+        policy({
+          ...affirmative,
+          basis: undefined,
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("denies absent and unknown declarations", () => {
     expect(hasNoTrainingNoRetentionAttestation(undefined)).toBe(false);
     expect(


### PR DESCRIPTION
Fixes #3435

## What

`hasNoTrainingNoRetentionAttestation()` in `src/services/organization-policy.ts` required `attestation.basis === "policy_administrator"`, so the moment the Gateway records an org's no-training/no-retention attestation with the new `provider_configuration` basis (added in ae565846), Private Models would silently drop out of Privacy Mode for that org.

Per the project owner's decision on #3435 (option 1): the gate now accepts both `PrivateModelsDataHandlingAttestationBasis` values — `policy_administrator` and `provider_configuration`. Both recording authorities are trusted equally because the substantive data-handling fields (status, scope, training_use, prompt/output/derived retention, terms, attested_at) carry the guarantee; `basis` only records who attested. Every other check is unchanged, and any unknown or absent basis still fails closed.

## Tests

`tests/unit/organization-policy-attestation.test.ts` gains three cases:

- `provider_configuration` basis with all substantive fields valid → `true`
- `provider_configuration` basis with a wrong substantive field (`training_use` not prohibited) → `false`
- unknown / absent basis → `false`

`pnpm vitest run tests/unit/organization-policy-attestation.test.ts`: 6/6 passed. Biome check clean on the changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
