### PR TITLE
fix(runtime): surface runtime failure; keep WS token out of logs

### DIFF
--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -18,15 +18,19 @@ const RUNTIME_MODE = "desktop-native";
 
 function usage() {
   console.log(`
-Usage: seren-provider-runtime [--host <address>] [--port <number>] [--token <value>]
+Usage: seren-provider-runtime [--host <address>] [--port <number>]
 
 Starts the local provider runtime used by desktop-native and browser-local flows.
 
 Options:
   --host <address>   Bind address. Default: 127.0.0.1
   --port <number>    HTTP port. Default: 0 (choose any free port)
-  --token <value>    Required WebSocket auth token. Default: random
   --help, -h         Show this help message
+
+Environment:
+  SEREN_PROVIDER_RUNTIME_TOKEN   WebSocket auth token. Default: random.
+                                 Env-only so the token never appears in argv
+                                 (visible via ps to other local users, #3442).
 `);
 }
 
@@ -53,11 +57,6 @@ function parseArgs(argv) {
       i += 1;
       continue;
     }
-    if (arg === "--token") {
-      config.token = argv[i + 1] ?? "";
-      i += 1;
-      continue;
-    }
     if (arg === "--help" || arg === "-h") {
       usage();
       process.exit(0);
@@ -65,6 +64,10 @@ function parseArgs(argv) {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
+  // #3442: the token arrives via env, never argv. Drop it from process.env
+  // after reading so spawned agent CLIs do not inherit the WS credential.
+  config.token = process.env.SEREN_PROVIDER_RUNTIME_TOKEN ?? "";
+  delete process.env.SEREN_PROVIDER_RUNTIME_TOKEN;
   if (!config.token) {
     config.token = randomBytes(24).toString("hex");
   }
@@ -237,13 +240,15 @@ function startServer(config) {
   server.listen(config.port, config.host, () => {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : config.port;
+    // #3442: the auth token stays out of this line — the desktop app logs
+    // child stdout verbatim, and Rust learns port/token via its own config,
+    // not by parsing stdout.
     console.log(
       JSON.stringify({
         ok: true,
         mode: RUNTIME_MODE,
         host: config.host,
         port,
-        token: config.token,
       }),
     );
   });

--- a/scripts/e2e-local-provider-runtime.mjs
+++ b/scripts/e2e-local-provider-runtime.mjs
@@ -80,10 +80,10 @@ function isAuthRequiredError(message) {
   );
 }
 
-function startProcess(command, args, label) {
+function startProcess(command, args, label, extraEnv) {
   const child = spawn(command, args, {
     cwd: ROOT,
-    env: process.env,
+    env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -466,10 +466,10 @@ async function main() {
       HOST,
       "--port",
       String(PROVIDER_RUNTIME_PORT),
-      "--token",
-      PROVIDER_RUNTIME_TOKEN,
     ],
     "provider-runtime",
+    // #3442: the runtime accepts its WS auth token via env only, never argv.
+    { SEREN_PROVIDER_RUNTIME_TOKEN: PROVIDER_RUNTIME_TOKEN },
   );
 
   const cleanup = () => {

--- a/scripts/smoke-local-provider-runtime.mjs
+++ b/scripts/smoke-local-provider-runtime.mjs
@@ -26,10 +26,10 @@ async function fetchJson(url, attempts = 50) {
   throw lastError ?? new Error(`Timed out waiting for ${url}`);
 }
 
-function startProcess(command, args, label) {
+function startProcess(command, args, label, extraEnv) {
   const child = spawn(command, args, {
     cwd: ROOT,
-    env: process.env,
+    env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -203,10 +203,10 @@ async function main() {
       HOST,
       "--port",
       String(PROVIDER_RUNTIME_PORT),
-      "--token",
-      PROVIDER_RUNTIME_TOKEN,
     ],
     "provider-runtime",
+    // #3442: the runtime accepts its WS auth token via env only, never argv.
+    { SEREN_PROVIDER_RUNTIME_TOKEN: PROVIDER_RUNTIME_TOKEN },
   );
 
   const cleanup = () => {

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -159,7 +159,7 @@ impl ProviderRuntimeState {
                 deadline.as_secs(),
             );
 
-            pipe_child_output(&mut child);
+            pipe_child_output(&mut child, &config.token);
 
             match wait_for_provider_runtime_with_deadline(&config, &mut child, *deadline).await {
                 Ok(()) => {
@@ -490,11 +490,14 @@ fn spawn_node_process(
         .arg(host)
         .arg("--port")
         .arg(port.to_string())
-        .arg("--token")
-        .arg(token)
         .kill_on_drop(true)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+
+    // serenorg/seren-desktop#3442 — the WS auth token rides an env var, never
+    // argv: argv is readable via `ps` by every local user, which defeats the
+    // point of authenticating the localhost socket.
+    command.env("SEREN_PROVIDER_RUNTIME_TOKEN", token);
 
     #[cfg(windows)]
     {
@@ -539,15 +542,16 @@ fn spawn_node_process(
         .map_err(|err| format!("Failed to spawn provider runtime: {err}"))
 }
 
-fn pipe_child_output(child: &mut Child) {
+fn pipe_child_output(child: &mut Child, ws_token: &str) {
     if let Some(stdout) = child.stdout.take() {
+        let token = ws_token.to_string();
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stdout).lines();
             loop {
                 match lines.next_line().await {
                     Ok(Some(line)) => log::info!(
                         "[ProviderRuntime stdout] {}",
-                        redact_provider_child_output(&line)
+                        redact_provider_child_output(&line, &token)
                     ),
                     Ok(None) => break,
                     Err(err) => {
@@ -560,13 +564,14 @@ fn pipe_child_output(child: &mut Child) {
     }
 
     if let Some(stderr) = child.stderr.take() {
+        let token = ws_token.to_string();
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
             loop {
                 match lines.next_line().await {
                     Ok(Some(line)) => log::warn!(
                         "[ProviderRuntime stderr] {}",
-                        redact_provider_child_output(&line)
+                        redact_provider_child_output(&line, &token)
                     ),
                     Ok(None) => break,
                     Err(err) => {
@@ -582,9 +587,13 @@ fn pipe_child_output(child: &mut Child) {
 /// Child-process output reaches the desktop log verbatim unless it is scrubbed
 /// here. Resolve the current runtime environment at capture time so newly
 /// issued session leases and future Seren secret variables are covered too.
-fn redact_provider_child_output(line: &str) -> String {
+/// The WS auth token is scrubbed by value (#3442): it lives only in the child
+/// environment, so the parent-env scan below cannot see it, yet the runtime or
+/// one of its children could still echo it into a logged line.
+fn redact_provider_child_output(line: &str, ws_token: &str) -> String {
     let runtime_secret_values = std::env::vars()
-        .filter_map(|(name, value)| is_seren_secret_env_name(&name).then_some(value));
+        .filter_map(|(name, value)| is_seren_secret_env_name(&name).then_some(value))
+        .chain(std::iter::once(ws_token.to_string()));
     redact_provider_child_output_with_values(line, runtime_secret_values)
 }
 
@@ -1010,6 +1019,32 @@ mod tests {
         assert!(!redacted.contains("canary-session-secret"));
         assert!(!redacted.contains(&lease_shape));
         assert_eq!(redacted.matches("[REDACTED]").count(), 2);
+    }
+
+    /// #3442: the WS auth token is random hex, so the `seren_*` lease pattern
+    /// and the parent-env scan both miss it. It must be scrubbed by value
+    /// wherever it appears in a child output line.
+    #[test]
+    fn child_output_redacts_ws_auth_token_value() {
+        let token = "0f0e0d0c0b0a09080706050403020100aabbccdd";
+        let redacted = redact_provider_child_output(
+            &format!(r#"{{"ok":true,"host":"127.0.0.1","port":4317,"token":"{token}"}}"#),
+            token,
+        );
+        assert!(!redacted.contains(token));
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(redacted.contains("\"port\":4317"));
+    }
+
+    /// An empty secret value (e.g. an unset token) must not corrupt the line
+    /// with zero-width replacements.
+    #[test]
+    fn child_output_with_empty_secret_value_is_untouched() {
+        let line = "plain runtime chatter";
+        assert_eq!(
+            redact_provider_child_output_with_values(line, vec![String::new()]),
+            line
+        );
     }
 
     /// Regression guard for #3156.

--- a/src/lib/browser-local-runtime.ts
+++ b/src/lib/browser-local-runtime.ts
@@ -313,9 +313,11 @@ export function disconnectLocalProviderRuntime(): void {
 }
 
 /**
- * Listen for provider-runtime restarts from the Rust backend.
- * When the runtime crashes and restarts on a new port, the cached config
- * (host/port/token) is stale. Disconnect so the next call re-fetches config.
+ * Listen for provider-runtime restarts and terminal failures from the Rust
+ * backend. In both cases the cached config (host/port/token) is stale.
+ * Disconnect so the next call re-fetches config — after a terminal failure
+ * (#3441) that re-fetch invokes `provider_runtime_get_config`, which spawns a
+ * fresh runtime with a fresh budget, so the user's retry works first try.
  */
 export async function listenForRuntimeRestart(): Promise<void> {
   if (!isDesktopNativeRuntime()) return;
@@ -324,6 +326,12 @@ export async function listenForRuntimeRestart(): Promise<void> {
     await listen("provider-runtime://restarted", () => {
       console.info(
         "[local-provider-runtime] Runtime restarted, invalidating cached config",
+      );
+      disconnectLocalProviderRuntime();
+    });
+    await listen("provider-runtime://failed", () => {
+      console.info(
+        "[local-provider-runtime] Runtime failed, invalidating cached config",
       );
       disconnectLocalProviderRuntime();
     });

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -478,6 +478,10 @@ let providerRuntimeReadyListener: Promise<UnlistenFn> | null = null;
  *  initialize() calls don't stack listeners. #1631. */
 let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
 
+/** Set once we've subscribed to `provider-runtime://failed` so repeated
+ *  initialize() calls don't stack listeners. #3441. */
+let providerRuntimeFailedListener: Promise<UnlistenFn> | null = null;
+
 /** Set once we've subscribed to remote Happy archive notifications so the
  *  sidebar and serving pointers cannot outlive the archived DB row. */
 let agentConversationArchivedListener: Promise<UnlistenFn> | null = null;
@@ -536,6 +540,10 @@ function disposeAgentStoreSideChannelListeners(): void {
   const restartedListener = providerRuntimeRestartedListener;
   providerRuntimeRestartedListener = null;
   disposeTauriListener(restartedListener, "provider-runtime restarted");
+
+  const failedListener = providerRuntimeFailedListener;
+  providerRuntimeFailedListener = null;
+  disposeTauriListener(failedListener, "provider-runtime failed");
 
   const archivedListener = agentConversationArchivedListener;
   agentConversationArchivedListener = null;
@@ -694,6 +702,82 @@ function subscribeToProviderRuntimeRestarted(): void {
             );
           }
         })();
+      }
+    },
+  );
+}
+
+/** Terminal message for the inline error bubble when the provider runtime is
+ *  gone for good. Retry is genuinely actionable: a fresh send re-invokes
+ *  `ensure_started`, which gets a brand-new spawn budget. #3441. */
+export const PROVIDER_RUNTIME_FAILED_MESSAGE =
+  "The agent runtime crashed and could not be restarted. Retry to relaunch it, or restart Seren if this keeps happening.";
+
+/** Compute the store transition for `provider-runtime://failed`: every live
+ *  session belongs to the dead runtime process and must drop; every thread
+ *  with an in-flight turn flips to a terminal error so its stalled stream
+ *  surfaces a retry instead of hanging until an unrelated RPC fails. #3441. */
+export function planProviderRuntimeFailure(
+  sessions: Record<string, { conversationId: string }>,
+  threadStates: Record<string, { turnInFlight: boolean }>,
+): { droppedSessionIds: string[]; failedThreadIds: string[] } {
+  const droppedSessionIds = Object.keys(sessions);
+  const failedThreadIds = [
+    ...new Set(
+      Object.values(sessions)
+        .map((session) => session.conversationId)
+        .filter((threadId) => threadStates[threadId]?.turnInFlight === true),
+    ),
+  ];
+  return { droppedSessionIds, failedThreadIds };
+}
+
+/**
+ * Subscribe once to `provider-runtime://failed`. The Rust crash monitor emits
+ * this when the auto-restart budget is exhausted (or the final restart attempt
+ * failed) — the runtime is gone and no `restarted` event will follow (#2563).
+ * Without a listener the UI showed a stalled stream until some later RPC
+ * failed generically (#3441). Mirrors the `restarted` teardown, minus the
+ * silent re-dispatch: there is no live runtime to re-dispatch against, so
+ * in-flight turns surface the terminal error bubble with its retry link.
+ */
+function subscribeToProviderRuntimeFailed(): void {
+  if (providerRuntimeFailedListener) return;
+  providerRuntimeFailedListener = listen<{ attempts?: number; error?: string }>(
+    "provider-runtime://failed",
+    (event) => {
+      console.error(
+        "[AgentStore] provider-runtime://failed — restart budget exhausted:",
+        event.payload,
+      );
+      const { droppedSessionIds, failedThreadIds } = planProviderRuntimeFailure(
+        state.sessions,
+        state.threadStates,
+      );
+      // Flip the error before dropping sessions so the auto-report still
+      // captures model/provider/tool-call context from the live session.
+      for (const threadId of failedThreadIds) {
+        agentStore.setTurnError(
+          threadId,
+          "crash_ceiling",
+          PROVIDER_RUNTIME_FAILED_MESSAGE,
+        );
+      }
+      for (const id of droppedSessionIds) terminatedSessionIds.add(id);
+      setState(
+        produce((draft) => {
+          for (const id of droppedSessionIds) delete draft.sessions[id];
+        }),
+      );
+      setState("activeSessionId", null);
+      for (const id of droppedSessionIds) {
+        // The runtime died, so its children can no longer use these keys.
+        void revokeCredentialLease(id).catch((error) => {
+          console.warn(
+            "[AgentStore] Failed to revoke runtime-failure credential lease:",
+            error,
+          );
+        });
       }
     },
   );
@@ -2830,6 +2914,7 @@ export const agentStore = {
     // to applyAgents just overwrite availableAgents with the same data.
     subscribeToProviderRuntimeReady();
     subscribeToProviderRuntimeRestarted();
+    subscribeToProviderRuntimeFailed();
     subscribeToAgentConversationArchived();
     // Surface CLI-updater scan rejections per #1646. Default-on, runs once
     // at app init, idempotent (the runtime emits the event at most once

--- a/tests/unit/agent-provider-runtime-failed.test.ts
+++ b/tests/unit/agent-provider-runtime-failed.test.ts
@@ -1,0 +1,111 @@
+// ABOUTME: Coverage for #3441 — the provider-runtime://failed listener. The runtime
+// ABOUTME: is gone for good, so sessions drop and in-flight turns surface a retryable error.
+
+import { describe, expect, it } from "vitest";
+import {
+  PROVIDER_RUNTIME_FAILED_MESSAGE,
+  planProviderRuntimeFailure,
+} from "@/stores/agent.store";
+import { readSource } from "./source-text";
+
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+const browserLocalRuntimeSource = readSource("src/lib/browser-local-runtime.ts");
+
+describe("#3441 — planProviderRuntimeFailure store transition", () => {
+  it("drops every live session and fails only threads with an in-flight turn", () => {
+    const plan = planProviderRuntimeFailure(
+      {
+        "session-a": { conversationId: "thread-a" },
+        "session-b": { conversationId: "thread-b" },
+        "session-c": { conversationId: "thread-c" },
+      },
+      {
+        "thread-a": { turnInFlight: true },
+        "thread-b": { turnInFlight: false },
+        // thread-c has no thread state at all — cold thread, nothing pending.
+      },
+    );
+
+    expect(plan.droppedSessionIds.sort()).toEqual([
+      "session-a",
+      "session-b",
+      "session-c",
+    ]);
+    expect(plan.failedThreadIds).toEqual(["thread-a"]);
+  });
+
+  it("collapses serving+standby sessions of one thread into a single failure", () => {
+    const plan = planProviderRuntimeFailure(
+      {
+        serving: { conversationId: "thread-a" },
+        standby: { conversationId: "thread-a" },
+      },
+      { "thread-a": { turnInFlight: true } },
+    );
+
+    expect(plan.droppedSessionIds.sort()).toEqual(["serving", "standby"]);
+    expect(plan.failedThreadIds).toEqual(["thread-a"]);
+  });
+
+  it("produces an empty plan when no sessions are live", () => {
+    expect(planProviderRuntimeFailure({}, {})).toEqual({
+      droppedSessionIds: [],
+      failedThreadIds: [],
+    });
+  });
+
+  it("terminal message tells the user what happened and what to do", () => {
+    expect(PROVIDER_RUNTIME_FAILED_MESSAGE).toContain("could not be restarted");
+    expect(PROVIDER_RUNTIME_FAILED_MESSAGE).toContain("Retry");
+    expect(PROVIDER_RUNTIME_FAILED_MESSAGE).toContain("restart Seren");
+  });
+});
+
+describe("#3441 — provider-runtime://failed listener wiring", () => {
+  it("subscribe function exists and is wired from initialize()", () => {
+    expect(agentStoreSource).toContain(
+      "function subscribeToProviderRuntimeFailed(",
+    );
+    expect(agentStoreSource).toContain("subscribeToProviderRuntimeFailed()");
+  });
+
+  it("handler listens on the Rust event name", () => {
+    expect(agentStoreSource).toContain('"provider-runtime://failed"');
+  });
+
+  it("handler applies the plan: terminal error, session teardown, lease revoke", () => {
+    const idx = agentStoreSource.indexOf(
+      "function subscribeToProviderRuntimeFailed(",
+    );
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("planProviderRuntimeFailure(");
+    expect(body).toContain('"crash_ceiling"');
+    expect(body).toContain("PROVIDER_RUNTIME_FAILED_MESSAGE");
+    expect(body).toContain("terminatedSessionIds.add(id)");
+    expect(body).toContain("delete draft.sessions[id]");
+    expect(body).toContain('setState("activeSessionId", null)');
+    expect(body).toContain("revokeCredentialLease(id)");
+  });
+
+  it("listener is disposed alongside the other runtime side-channels", () => {
+    const disposeStart = agentStoreSource.indexOf(
+      "function disposeAgentStoreSideChannelListeners()",
+    );
+    expect(disposeStart).toBeGreaterThan(0);
+    const disposeBody = agentStoreSource.slice(disposeStart, disposeStart + 1200);
+    expect(disposeBody).toContain("providerRuntimeFailedListener = null;");
+    expect(disposeBody).toContain(
+      'disposeTauriListener(failedListener, "provider-runtime failed")',
+    );
+  });
+
+  it("browser-local runtime client invalidates its cached config on failure", () => {
+    const idx = browserLocalRuntimeSource.indexOf(
+      'listen("provider-runtime://failed"',
+    );
+    expect(idx).toBeGreaterThan(0);
+    const body = browserLocalRuntimeSource.slice(idx, idx + 400);
+    expect(body).toContain("disconnectLocalProviderRuntime()");
+  });
+});

--- a/tests/unit/session-state-reset.test.ts
+++ b/tests/unit/session-state-reset.test.ts
@@ -92,13 +92,16 @@ describe("resetUserSessionState", () => {
     expect(sideChannelDisposeIdx).toBeGreaterThan(0);
     const sideChannelDisposeBody = source.slice(
       sideChannelDisposeIdx,
-      sideChannelDisposeIdx + 900,
+      sideChannelDisposeIdx + 1200,
     );
     expect(sideChannelDisposeBody).toContain(
       "providerRuntimeReadyListener = null;",
     );
     expect(sideChannelDisposeBody).toContain(
       "providerRuntimeRestartedListener = null;",
+    );
+    expect(sideChannelDisposeBody).toContain(
+      "providerRuntimeFailedListener = null;",
     );
     expect(sideChannelDisposeBody).toContain("cliScanRejectedUnsub?.();");
     expect(sideChannelDisposeBody).toContain(


### PR DESCRIPTION
## Summary

Fixes #3441
Fixes #3442

Both found in the v3.75.0 pre-release audit.

### #3441 — `provider-runtime://failed` now has a frontend listener

The Rust crash monitor emits `provider-runtime://failed` when the 3-attempt restart budget is exhausted (or the final restart attempt fails), but nothing in `src/` listened — a crash-looped runtime left the UI showing a stalled stream until some later RPC failed generically.

- `src/stores/agent.store.ts` gains `subscribeToProviderRuntimeFailed()`, wired from `initialize()` and disposed with the other side-channel listeners, mirroring the `://ready` / `://restarted` subscriptions.
- On failure it routes through the existing terminal-error flow (no new UI surface): every live session is dropped (all IDs belong to the dead process), credential leases are revoked, and each thread with an in-flight turn gets `setTurnError(threadId, "crash_ceiling", ...)` — the existing inline error bubble with its Retry link. Retry is genuinely actionable: a fresh send re-invokes `ensure_started`, which gets a brand-new spawn budget.
- The transition logic is a pure exported helper, `planProviderRuntimeFailure()`, unit-tested directly.
- `src/lib/browser-local-runtime.ts` also invalidates its cached host/port/token config on `://failed` (exactly as it already did for `://restarted`), so the retry's fresh spawn re-fetches config instead of dialing the dead port.

### #3442 — WS auth token out of argv and out of the logs

The runtime printed `{ ok, mode, host, port, token }` to stdout on listen, which `pipe_child_output` logged verbatim into the desktop log users attach to support bundles; the token was also passed as `--token` argv, visible in `ps` to other local users.

Rust learns the port/token from its own config (it generates both and health-checks over HTTP — it never parses the stdout line), so the clean cutover is:

- `bin/provider-runtime.mjs` no longer accepts `--token` argv (unknown-argument error on sight); the token arrives via `SEREN_PROVIDER_RUNTIME_TOKEN`, is deleted from `process.env` after reading so spawned agent CLIs don't inherit it, and is omitted from the printed listen line.
- `src-tauri/src/provider_runtime.rs` spawns with `command.env("SEREN_PROVIDER_RUNTIME_TOKEN", token)` instead of `--token` argv.
- Defense-in-depth: `redact_provider_child_output` now also scrubs the token *by value* from every logged child stdout/stderr line — the token lives only in the child environment, so the existing parent-env scan could never see it, yet the runtime or one of its children could still echo it.
- `scripts/smoke-local-provider-runtime.mjs` and `scripts/e2e-local-provider-runtime.mjs` updated to the env contract (both sides ship together — no back-compat window).

## Testing

- `pnpm test` — 388 files / 2801 tests passed (includes new `tests/unit/agent-provider-runtime-failed.test.ts`; `session-state-reset.test.ts` source-window widened for the new dispose lines).
- `cargo test --manifest-path src-tauri/Cargo.toml provider_runtime` — 36 passed, including new `child_output_redacts_ws_auth_token_value` and `child_output_with_empty_secret_value_is_untouched`.
- `cargo check` — clean.
- `pnpm check` — exit 0 (remaining warnings are pre-existing in unrelated files); `tsc --noEmit` diagnostic count identical to main (219 pre-existing).
- `pnpm test:runtime-smoke` — passed against the real spawn handshake: runtime spawned with the env-var token, WS auth succeeded, RPC surface verified.
- Manual: worktree runtime prints `{"ok":true,"mode":"desktop-native","host":"127.0.0.1","port":4399}` (no token) and rejects stale `--token` argv with `Unknown argument: --token`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
