### PR TITLE
docs(release): cover the full audit fix set in v3.75.0 notes

### DIFF
--- a/.github/release-notes/v3.75.0.md
+++ b/.github/release-notes/v3.75.0.md
@@ -1,26 +1,39 @@
 ## What's New
 
-A reliability release driven by a full pre-release audit of the agent runtime: a crash that could take down every live agent session at once is guarded, Stop can no longer hang a conversation, agent mode is repaired on Linux installs, and Happy Mobile file-read summarization now works for every agent. Plus a daily SerenBucks claim offer when you launch an agent.
+A reliability release: a full pre-release audit of the agent runtime produced twenty-one fixes, every one shipped in this build. Highlights: a crash that could take down every live agent session at once is guarded, Stop is now guaranteed to stop — locally, for wedged runtimes, and for server-side cloud runs — agent mode is repaired on Linux installs, the local MCP transport is hardened end to end, and Happy Mobile file-read summarization now works for every agent. Plus a daily SerenBucks claim offer when you launch an agent.
 
 ## 🤖 Agent Runtime Reliability
 
-- A CLI process dying mid-write can no longer crash the shared provider runtime and take every live agent session down with it — the failure is now contained to the one session that died (#3456)
+- A CLI process dying mid-write can no longer crash the shared provider runtime and take every live agent session down with it — the failure is contained to the one session that died (#3456)
 - Stop is now guaranteed to stop: a wedged agent runtime or a stalled publisher stream can no longer hang a conversation in the "running" state until app restart (#3458)
-- Fixed agent mode on Linux installs — the embedded runtime entrypoints are now resolved through Tauri's resource directory, which the deb/rpm/AppImage layouts require; final on-device verification is tracked in #3434 (#3459)
-- The Claude Code PATH helper now writes strict, properly escaped JSON to `~/.claude/settings.json` on every platform — previously, Windows paths could corrupt the file or invalidate it entirely — and it refuses to modify a settings file it cannot parse (#3457)
+- Stopping a private-chat cloud agent now also cancels the run server-side, halting billing and cloud-side tool activity instead of letting the run finish invisibly (#3468)
+- Fixed agent mode on Linux installs — the embedded runtime entrypoints are now resolved through Tauri's resource directory, verified against the real deb install layout on Linux (#3459)
+- If the agent runtime crash-loops past its restart budget, the app now tells you — with a working Retry — instead of leaving the conversation silently stalled (#3469)
+- Headless one-shot generations (meeting notes, dictation) are now bounded by a real timeout that also cleans up the wedged process, instead of hanging forever (#3465)
+- Agent shell commands no longer inherit Electron-host variables that could hang the embedded Node when the app is launched from an IDE terminal (#3465)
+- The claude-code CLI version baseline is now enforced at spawn time, matching Codex, so the first launch after an app update can't hand an outdated CLI an unknown model (#3463)
+
+## 🔌 MCP
+
+- The local stdio MCP transport was hardened end to end (#3467): servers that log or emit notifications on stdout can no longer permanently desync tool results; every tool call is bounded by a timeout instead of hanging forever on a wedged server; and child processes are killed and reaped on every failure path — no more orphaned or zombie server processes
+- Playwright browser modules load lazily, off the MCP init path, with a regression guard so the fix can't silently unravel (#3424, #3461)
+
+## 🔒 Privacy & Security
+
+- Privacy Mode now recognizes no-training/no-retention attestations recorded from provider configuration, not just administrator declarations — the substantive data-handling checks are unchanged (#3464)
+- The Claude Code PATH helper now writes strict, properly escaped JSON to `~/.claude/settings.json` on every platform — previously, Windows paths could corrupt the file — and it refuses to modify a settings file it cannot parse (#3457)
+- The provider runtime's WebSocket auth token no longer appears in process arguments or the app log; it now travels via environment variable and is redacted from child output (#3469)
 
 ## 📱 Happy Mobile
 
-- Long file-read output is summarized on the phone instead of burying the conversation (#3426), and this now works for ACP-connected agents (Gemini, Grok) too — their tool events previously bypassed the summarizer (#3455)
+- Long file-read output is summarized on the phone instead of burying the conversation (#3426), this now works for ACP-connected agents (Gemini, Grok) too (#3455), and tools whose names merely contain "read" no longer have their real output hidden (#3463)
 
 ## 💰 Wallet
 
-- Launching an agent now offers your daily SerenBucks claim if it is still unclaimed that day (#3428)
+- Launching an agent now offers your daily SerenBucks claim if it is still unclaimed that day (#3428); the check no longer fires for signed-out sessions, and wallet state is fully reset on logout (#3461)
 
-## 🔒 Private Models
+## 🛠️ Under the Hood
 
-- The organization policy surface now exposes the authority that recorded a data-handling attestation (`policy_administrator` or `provider_configuration`), groundwork for provider-configured attestations
-
-## 🐞 Stability
-
-- Playwright browser modules are loaded lazily, off the MCP init path — server startup no longer depends on browser system libraries being present (#3424)
+- Sending a second message to a conversation with a response already in progress is now cleanly rejected instead of corrupting the session's stop controls; multi-agent plan failures clean up their workers and mark the plan failed (#3466)
+- The build scripts now stage npm/npx wrappers for Linux bundles and verify the staged Node version instead of trusting a cached copy (#3462)
+- The organization policy surface exposes the authority that recorded a data-handling attestation (`policy_administrator` or `provider_configuration`)


### PR DESCRIPTION
Updates the curated v3.75.0 notes to include the second wave of audit fixes (#3461-#3469) so the release body reflects everything shipping in the tag.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com