### PR TITLE
fix(runtime): spawn claude-code when the version probe fails (#3471)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -474,6 +474,7 @@ async function ensureCliBaselineViaUpdater(
     bareCommand,
     packageName,
     resolveBinary,
+    allowUnprobeableInstall = false,
     _runInstalledVersion = runInstalledVersion,
     _backgroundUpdateCli = backgroundUpdateCli,
   },
@@ -482,6 +483,19 @@ async function ensureCliBaselineViaUpdater(
   let resolved = resolveBinary();
   const installed = await _runInstalledVersion(resolved, bareCommand);
   if (!installed) {
+    if (allowUnprobeableInstall && resolved !== bareCommand) {
+      // A resolved install whose version probe fails is usable, not missing:
+      // on an IO-starved machine every `--version` spawn can time out
+      // (5s × 3 attempts), and failing closed here turns a slow disk into
+      // "not installed" for a healthy CLI — the v3.75.0 release gate hit
+      // exactly this (#3471). Spawn permissively; baseline enforcement
+      // resumes on the next probe that succeeds.
+      console.warn(
+        `[agent-registry] ${label} version probe failed at ${resolved}; ` +
+          `spawning without the baseline check`,
+      );
+      return resolved;
+    }
     const url = emitCliActionRequired(emit, {
       label,
       bareCommand,
@@ -560,6 +574,12 @@ async function ensureClaudeCodeCli(emit) {
       bareCommand: "claude",
       packageName: "@anthropic-ai/claude-code",
       resolveBinary: resolveInstalledClaudeBinary,
+      // Unlike Codex (a small native binary that answers --version
+      // instantly), this CLI is a large JS package whose cold start can
+      // outlive the probe timeout on a slow machine. An unprobeable version
+      // at a known install location spawns permissively (#3471), matching
+      // the custom-PATH branch below.
+      allowUnprobeableInstall: true,
     });
   }
 

--- a/tests/unit/claude-cli-baseline-gate.test.ts
+++ b/tests/unit/claude-cli-baseline-gate.test.ts
@@ -46,6 +46,10 @@ describe("#3443 claude-code spawn wiring enforces the baseline", () => {
     // Custom PATH installs cannot be auto-updated, but a determinately
     // below-baseline one must still be refused with an actionable error.
     expect(helper).toContain("isBelowBaseline(installed, baseline)");
+    // A large JS CLI can outlive the version-probe timeout on a slow
+    // machine; failing closed there turned a slow disk into "not
+    // installed" and broke the v3.75.0 release gate (#3471).
+    expect(helper).toContain("allowUnprobeableInstall: true");
   });
 });
 
@@ -152,5 +156,47 @@ describe("#3443 shared baseline gate decision logic", () => {
       (event) => event.name === "provider://cli-update-action-required",
     );
     expect(action?.payload.reason).toBe("installation_required");
+  });
+
+  it("spawns a resolved install permissively when the probe fails and the CLI opts in (#3471)", async () => {
+    const events: EmittedEvent[] = [];
+    const updaterCalls: unknown[] = [];
+    const result = await ensureCliBaselineViaUpdater(makeEmit(events), {
+      ...CLAUDE_BASELINE_CONFIG,
+      resolveBinary: () => "/fake/bin/claude",
+      allowUnprobeableInstall: true,
+      _runInstalledVersion: async () => null,
+      _backgroundUpdateCli: async (options: unknown) => {
+        updaterCalls.push(options);
+        return { outcome: "success" };
+      },
+    });
+
+    expect(result).toBe("/fake/bin/claude");
+    expect(updaterCalls).toHaveLength(0);
+    expect(events).toHaveLength(0);
+  });
+
+  it("still hands off an UNRESOLVED install even when the CLI opts in (#3471)", async () => {
+    await expect(
+      ensureCliBaselineViaUpdater(makeEmit([]), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "claude",
+        allowUnprobeableInstall: true,
+        _runInstalledVersion: async () => null,
+        _backgroundUpdateCli: async () => ({ outcome: "success" }),
+      }),
+    ).rejects.toThrow(/not installed in a verifiable location/);
+  });
+
+  it("keeps the strict handoff for CLIs that do not opt in — the Codex contract (#2904)", async () => {
+    await expect(
+      ensureCliBaselineViaUpdater(makeEmit([]), {
+        ...CLAUDE_BASELINE_CONFIG,
+        resolveBinary: () => "/fake/bin/codex",
+        _runInstalledVersion: async () => null,
+        _backgroundUpdateCli: async () => ({ outcome: "success" }),
+      }),
+    ).rejects.toThrow(/not installed in a verifiable location/);
   });
 });


### PR DESCRIPTION
Fixes #3471.

**What broke.** The v3.75.0 release run (30460661755) failed at windows-app-e2e: "Claude Code CLI is not installed in a verifiable location" for a healthy claude-code 2.1.220 the same box had verified minutes earlier. Root cause: #3463 routed claude-code through the shared baseline gate, which fails closed when `runInstalledVersion` returns null — and on that IO-starved box all three 5s `--version` spawns timed out (provider-runtime log in the run's S3 bundle shows `[cli-updater] cli=@anthropic-ai/claude-code outcome=skipped:network` in the same window; the NSIS install took 13 minutes). Pre-#3463, a known-location resolve returned the path unprobed and the spawn worked.

**The fix.** `ensureCliBaselineViaUpdater` gains an `allowUnprobeableInstall` opt-in: a RESOLVED install whose version cannot be probed spawns permissively with a warning instead of throwing. claude-code opts in (large JS CLI, slow cold start — the same principle its custom-PATH branch already documents); Codex does not opt in, keeping its shipped #2904 fail-closed contract byte-for-byte. An unresolved install still hands off with installation_required for both. Baseline enforcement is unchanged whenever the version IS readable.

**Tests.** Three new seam tests (permissive resolved-null for opted-in CLI; unresolved still fails closed even when opted in; non-opted-in keeps the strict contract) plus a source-wiring assertion that ensureClaudeCodeCli opts in. Full unit suite 2820 passed; Biome baseline unchanged; `pnpm test:runtime-smoke` passed against the real spawn handshake.

**Validation caveat, stated plainly.** The failing layer is the real Windows release harness; per the repo's no-mocks rule this fix is only fully validated by the next release run's windows-app-e2e leg (v3.75.1). The unit tests reproduce the decision logic, not the slow-box condition.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
