### PR TITLE
docs(release): move curated notes to v3.75.1 with the spawn-gate fix

### DIFF
--- a/.github/release-notes/v3.75.1.md
+++ b/.github/release-notes/v3.75.1.md
@@ -11,7 +11,7 @@ A reliability release: a full pre-release audit of the agent runtime produced tw
 - If the agent runtime crash-loops past its restart budget, the app now tells you — with a working Retry — instead of leaving the conversation silently stalled (#3469)
 - Headless one-shot generations (meeting notes, dictation) are now bounded by a real timeout that also cleans up the wedged process, instead of hanging forever (#3465)
 - Agent shell commands no longer inherit Electron-host variables that could hang the embedded Node when the app is launched from an IDE terminal (#3465)
-- The claude-code CLI version baseline is now enforced at spawn time, matching Codex, so the first launch after an app update can't hand an outdated CLI an unknown model (#3463)
+- The claude-code CLI version baseline is now enforced at spawn time, matching Codex, so the first launch after an app update can't hand an outdated CLI an unknown model (#3463) — and a healthy CLI whose version check times out on a slow machine still launches instead of being reported as "not installed" (#3472)
 
 ## 🔌 MCP
 


### PR DESCRIPTION
v3.75.0 died at the windows-app-e2e gate (#3471, fixed by #3472) and published no artifacts; its draft release was deleted by ID. These are the same curated notes retargeted at the v3.75.1 tag, with the spawn-gate fix added.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com