### PR TITLE
fix(agent): bound Codex compaction retry characters

### DIFF
--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -85,6 +85,29 @@ export type CompactAgentResult = {
   newSessionId?: string;
 };
 
+export const CODEX_TURN_INPUT_MAX_CHARS = 1_048_576;
+
+const COMPACTION_PREPEND_HEADER = "[Auto-compaction restored prior context]\n";
+const COMPACTION_PREPEND_SEPARATOR = "\n\n---\n\n";
+
+export function wrapAgentCompactionPrepend(
+  prepend: string,
+  prompt: string,
+): string {
+  return `${COMPACTION_PREPEND_HEADER}${prepend}${COMPACTION_PREPEND_SEPARATOR}${prompt}`;
+}
+
+export function maxAgentCompactionPrependChars(
+  agentType: string,
+  prompt: string,
+): number | undefined {
+  if (agentType !== "codex") return undefined;
+  return Math.max(
+    0,
+    CODEX_TURN_INPUT_MAX_CHARS - wrapAgentCompactionPrepend("", prompt).length,
+  );
+}
+
 export function prunableAgentMessage(m: AgentMessage): PrunableMessage {
   return {
     id: m.id,
@@ -131,6 +154,10 @@ export function applyPrunedAgentMessages(
 export function buildAgentCompactionPrepend(
   summary: string,
   toPreserve: AgentMessage[],
+  options: {
+    maxChars?: number;
+    omitTrailingUser?: boolean;
+  } = {},
 ): string {
   // Tool messages can be enormous file contents / JSON dumps; user and
   // assistant text keep the original ceiling used by the long-standing
@@ -138,6 +165,14 @@ export function buildAgentCompactionPrepend(
   const MAX_MSG_CHARS = 2000;
   const MAX_TOOL_CHARS = 500;
   const preservedContext = toPreserve
+    .filter(
+      (m, index) =>
+        !(
+          options.omitTrailingUser === true &&
+          index === toPreserve.length - 1 &&
+          m.type === "user"
+        ),
+    )
     .map((m) => {
       if (m.type === "user" || m.type === "assistant") {
         const content =
@@ -160,11 +195,39 @@ export function buildAgentCompactionPrepend(
       }
       return null;
     })
-    .filter((s): s is string => s !== null)
-    .join("\n\n");
-  return preservedContext
-    ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
-    : `Prior work summary:\n${summary}`;
+    .filter((s): s is string => s !== null);
+
+  const maxChars = options.maxChars ?? Number.POSITIVE_INFINITY;
+  const summaryBlock = `Prior work summary:\n${summary}`;
+  if (maxChars <= 0) return "";
+  if (summaryBlock.length > maxChars) {
+    const marker = "... [truncated]";
+    if (maxChars <= marker.length) return summaryBlock.slice(0, maxChars);
+    return `${summaryBlock.slice(0, maxChars - marker.length)}${marker}`;
+  }
+  if (preservedContext.length === 0) return summaryBlock;
+
+  const prefix = `${summaryBlock}\n\n<prior_messages>\n`;
+  const suffix = "\n</prior_messages>";
+  if (prefix.length + suffix.length > maxChars) return summaryBlock;
+
+  // An aggregate character cap is independent of the per-message caps above.
+  // Keep a contiguous suffix of the preserved tail so the newest work wins
+  // when Codex's turn/start character limit cannot hold every retained item.
+  const selected: string[] = [];
+  let selectedChars = prefix.length + suffix.length;
+  for (let index = preservedContext.length - 1; index >= 0; index--) {
+    const separatorChars = selected.length > 0 ? 2 : 0;
+    const nextChars =
+      selectedChars + separatorChars + preservedContext[index].length;
+    if (nextChars > maxChars) break;
+    selected.unshift(preservedContext[index]);
+    selectedChars = nextChars;
+  }
+
+  return selected.length > 0
+    ? `${prefix}${selected.join("\n\n")}${suffix}`
+    : summaryBlock;
 }
 
 /** Claude Code model IDs that ship a 1M-token context tier behind the

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -20,8 +20,10 @@ import {
   type CompactAgentResult,
   type CompactionOutcome,
   defaultContextWindowFor,
+  maxAgentCompactionPrependChars,
   PredictiveCompactMutex,
   prunableAgentMessage,
+  wrapAgentCompactionPrepend,
 } from "@/lib/agent/compaction";
 import {
   planHappyArchiveInvalidation,
@@ -334,7 +336,7 @@ function consumeCompactionPrepend(sessionId: string, prompt: string): string {
   const prepend = session?.pendingCompactionPrepend;
   if (!prepend) return prompt;
   setState("sessions", sessionId, "pendingCompactionPrepend", undefined);
-  return `[Auto-compaction restored prior context]\n${prepend}\n\n---\n\n${prompt}`;
+  return wrapAgentCompactionPrepend(prepend, prompt);
 }
 
 /**
@@ -5071,9 +5073,22 @@ export const agentStore = {
           const tailReliefSummary = relief.stillOverBudget
             ? "No older transcript prefix was available to summarize. Reducible tool payloads in the preserved tail were pruned, but the retained context may still be close to the model limit."
             : "No older transcript prefix was available to summarize. Reducible tool payloads in the preserved tail were pruned before retrying the failed request.";
+          const retryPrompt =
+            session.compactRetryAttempted === true
+              ? session.lastUserPrompt
+              : undefined;
+          const retryPrependMaxChars = retryPrompt
+            ? maxAgentCompactionPrependChars(agentType, retryPrompt)
+            : undefined;
           const prependText = buildAgentCompactionPrepend(
             `${tailReliefSummary}\n\nVERIFY-BEFORE-ACTING: Files, projects, and databases mentioned above may not exist on disk. Re-read the workspace, list .worktrees/, and resolve SerenDB projects/tables before acting on any claim.`,
             toPreserve,
+            retryPrependMaxChars !== undefined
+              ? {
+                  maxChars: retryPrependMaxChars,
+                  omitTrailingUser: true,
+                }
+              : undefined,
           );
 
           try {
@@ -5336,7 +5351,23 @@ export const agentStore = {
       // the transcript inside its assistant content instead of treating
       // the block as quoted context, bleeding the prepend into the chat
       // and starving the Thinking budget. #1941.
-      const prependText = buildAgentCompactionPrepend(summary, toPreserve);
+      const retryPrompt =
+        mode === "reactive" && session.compactRetryAttempted === true
+          ? session.lastUserPrompt
+          : undefined;
+      const retryPrependMaxChars = retryPrompt
+        ? maxAgentCompactionPrependChars(agentType, retryPrompt)
+        : undefined;
+      const prependText = buildAgentCompactionPrepend(
+        summary,
+        toPreserve,
+        retryPrependMaxChars !== undefined
+          ? {
+              maxChars: retryPrependMaxChars,
+              omitTrailingUser: true,
+            }
+          : undefined,
+      );
 
       // The synthetic-transcript builder interprets this as a count of REAL
       // user turns to keep from the parent JSONL (findCutIndex in

--- a/tests/unit/codex-compaction-character-limit.test.ts
+++ b/tests/unit/codex-compaction-character-limit.test.ts
@@ -1,0 +1,65 @@
+// ABOUTME: Regression coverage for #3475 — Codex reactive compaction retries
+// ABOUTME: must fit the App Server turn/start character limit after prepending context.
+
+import {
+  buildAgentCompactionPrepend,
+  CODEX_TURN_INPUT_MAX_CHARS,
+  maxAgentCompactionPrependChars,
+  wrapAgentCompactionPrepend,
+} from "@/lib/agent/compaction";
+import type { AgentMessage } from "@/stores/agent.store";
+import { describe, expect, it } from "vitest";
+
+function message(
+  id: string,
+  type: "user" | "assistant",
+  content: string,
+): AgentMessage {
+  return { id, type, content, timestamp: 0 };
+}
+
+describe("#3475 — Codex compaction retry character budget", () => {
+  it("keeps the final retry within turn/start's limit and retains newest context", () => {
+    const oldestMarker = "OLDEST_CONTEXT";
+    const newestMarker = "NEWEST_PRIOR_CONTEXT";
+    const activePrompt = `ACTIVE_FAILED_REQUEST_${"p".repeat(300_000)}`;
+    const preserved: AgentMessage[] = [
+      message("oldest", "assistant", `${oldestMarker}${"a".repeat(3_000)}`),
+    ];
+
+    for (let index = 0; index < 429; index++) {
+      preserved.push(
+        message(
+          `middle-${index}`,
+          index % 2 === 0 ? "user" : "assistant",
+          `middle-${index}-${"m".repeat(3_000)}`,
+        ),
+      );
+    }
+    preserved.push(
+      message("newest", "assistant", `${newestMarker}${"n".repeat(3_000)}`),
+      message("active", "user", activePrompt),
+    );
+
+    const maxChars = maxAgentCompactionPrependChars("codex", activePrompt);
+    expect(maxChars).toBeTypeOf("number");
+
+    const prepend = buildAgentCompactionPrepend("bounded summary", preserved, {
+      maxChars,
+      omitTrailingUser: true,
+    });
+    const retry = wrapAgentCompactionPrepend(prepend, activePrompt);
+
+    expect(retry.length).toBeLessThanOrEqual(CODEX_TURN_INPUT_MAX_CHARS);
+    expect(prepend).toContain(newestMarker);
+    expect(prepend).not.toContain(oldestMarker);
+    expect(prepend).not.toContain("ACTIVE_FAILED_REQUEST_");
+    expect(retry.match(/ACTIVE_FAILED_REQUEST_/g)).toHaveLength(1);
+  });
+
+  it("does not impose the Codex character ceiling on other agents", () => {
+    expect(
+      maxAgentCompactionPrependChars("claude-code", "prompt"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #3475

## Audit

The Codex reactive compaction path rebuilt a retry from a token-budgeted preserved tail, but the final `turn/start` text had no aggregate character ceiling. The logged failure shows a successful compaction followed by another App Server rejection at 1,048,576 characters.

Relevant prior fixes for token-tail selection, over-budget pruning, request accounting, and Codex respawn were reviewed before this change. This patch preserves those behaviors and adds only the missing transport-level bound.

## Fix

- centralize the exact compaction prepend envelope
- derive the remaining prepend budget from the active Codex prompt
- keep the newest contiguous preserved context within that budget
- omit the already re-dispatched active user request from the preserved tail
- leave non-Codex compaction behavior unchanged

## Critical coverage

- focused compaction regression suite: 38 tests passed
- full Vitest suite: 2,822 passed, 15 skipped
- isolated native macOS validation app: `app-ready` passed; native 1200×800 capture succeeded
- live browser-compiled module walkthrough: 432 preserved messages + 300,022-character request produced a 1,047,300-character retry; newest context retained, oldest omitted, request present once

A standalone TypeScript diagnostic still reports existing unrelated test/fixture declaration errors; none reference the changed source or test.

## Network path

No publisher slug or external HTTP API is added or changed. The affected local path is renderer compaction → Tauri `provider_prompt` → embedded provider runtime → local Codex App Server JSON-RPC `turn/start`.