### PR TITLE
fix(agent): stop recursive compaction on oversized retry

### DIFF
--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -55,6 +55,9 @@ export class PredictiveCompactMutex {
  * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
  *   the session was already too small to compact. Usually means a single
  *   message is gigantic — Chat fallback would not help.
+ * - `retry_still_too_long`: compaction succeeded, but the one allowed retry
+ *   was still rejected as prompt-too-long. The replacement session owns the
+ *   terminal error; recursively compacting or falling back to Chat is wrong.
  * - `cancelled`: a Stop / predictive-promotion teardown / other graceful
  *   cancel propagated up as "Task cancelled" while compaction or the
  *   retry was in flight. Not a defect — the error event handler's
@@ -67,6 +70,7 @@ export type CompactionOutcome =
   | "retried"
   | "succeeded"
   | "skipped_nothing_to_compact"
+  | "retry_still_too_long"
   | "cancelled"
   | "failed_catastrophic";
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -165,6 +165,9 @@ const AGGRESSIVE_RETRY_PRESERVE_COUNT = 2;
  */
 const AGGRESSIVE_RETRY_TAIL_RATIO = 0.15;
 
+const COMPACTION_RETRY_TOO_LONG_MESSAGE =
+  "This thread is too full for the model's context window after compaction. Start a new thread to continue.";
+
 /**
  * Primary and fallback models for the compaction summarizer. Both route through
  * the public "seren" provider. The fallback is tried when the primary errors,
@@ -5797,12 +5800,30 @@ export const agentStore = {
           `[AgentStore] Compaction complete, retrying prompt on session ${newSessionId}`,
         );
         setState("sessions", newSessionId, "lastUserPrompt", lastPrompt);
+        // This is the one allowed retry for the same user turn. The replacement
+        // is a fresh session, so carry the retry-generation marker across the
+        // respawn before dispatch; otherwise another prompt-too-long event can
+        // recursively compact and terminate this session while we await it.
+        // A normal user submit resets the marker in sendPrompt. #3477.
+        setState("sessions", newSessionId, "compactRetryAttempted", true);
         // compactAndRetry bypasses store.sendPrompt (the user's UI message
         // is already on screen from the first failed attempt). Apply the
         // post-compaction prepend ourselves so the model receives the
         // structured summary banner in front of the retry. #1829.
         const retryPrompt = consumeCompactionPrepend(newSessionId, lastPrompt);
-        await providerService.sendPrompt(newSessionId, retryPrompt);
+        try {
+          await providerService.sendPrompt(newSessionId, retryPrompt);
+        } catch (retryError) {
+          const retryMessage =
+            retryError instanceof Error
+              ? retryError.message
+              : String(retryError);
+          if (isPromptTooLongError(retryMessage)) {
+            this.failCompactionRetryTooLong(newSessionId);
+            return "retry_still_too_long";
+          }
+          throw retryError;
+        }
         return "retried";
       }
       console.info(
@@ -7708,6 +7729,19 @@ export const agentStore = {
           );
         } else if (
           isPromptTooLongError(String(event.data.error)) &&
+          state.sessions[sessionId]?.compactRetryAttempted === true
+        ) {
+          // The single post-compaction retry is itself still too large.
+          // Never recurse into compaction on the fresh replacement: doing so
+          // races teardown with compactAndRetry's in-flight dispatch. The
+          // direct dispatch catch calls the same idempotent helper in case the
+          // runtime rejects without emitting this structured event. #3477.
+          console.warn(
+            "[AgentStore] Post-compaction retry is still too long — ending the turn without recursive compaction or Chat fallback",
+          );
+          this.failCompactionRetryTooLong(sessionId);
+        } else if (
+          isPromptTooLongError(String(event.data.error)) &&
           !state.sessions[sessionId]?.promptTooLongHandled
         ) {
           // Context window full — try compaction + retry before falling back.
@@ -7760,6 +7794,13 @@ export const agentStore = {
                   "This thread is too full for the model's context window and there is nothing left to compact. Start a new thread to continue.";
                 this.addErrorMessage(sessionId, terminalMessage);
                 this.failTurnForSession(sessionId, terminalMessage);
+              } else if (outcome === "retry_still_too_long") {
+                // The active replacement session already surfaced the stable
+                // terminal message. Do not fall back through the terminated
+                // serving session or start another recovery. #3477.
+                console.info(
+                  "[AgentStore] Post-compaction retry remained too long — terminal error already handled on replacement session",
+                );
               }
               return outcome;
             },
@@ -8976,6 +9017,11 @@ export const agentStore = {
     }
     // Set session-specific error instead of global error
     setState("sessions", sessionId, "error", prefixedError);
+  },
+
+  failCompactionRetryTooLong(sessionId: string): void {
+    this.addErrorMessage(sessionId, COMPACTION_RETRY_TOO_LONG_MESSAGE);
+    this.failTurnForSession(sessionId, COMPACTION_RETRY_TOO_LONG_MESSAGE);
   },
 
   // ============================================================================

--- a/tests/unit/compact-retry-codex.test.ts
+++ b/tests/unit/compact-retry-codex.test.ts
@@ -162,3 +162,42 @@ describe("#1757 — kickPredictiveCompact consumes the new result shape", () => 
     );
   });
 });
+
+describe("#3477 — a post-compaction retry cannot recursively compact", () => {
+  it("marks the replacement as the same retry generation before dispatch", () => {
+    const body = functionBody("async compactAndRetry(");
+    const marker = body.indexOf(
+      'setState("sessions", newSessionId, "compactRetryAttempted", true)',
+    );
+    const dispatch = body.indexOf(
+      "providerService.sendPrompt(newSessionId, retryPrompt)",
+    );
+
+    expect(marker).toBeGreaterThan(0);
+    expect(dispatch).toBeGreaterThan(marker);
+    expect(body).toContain('return "retry_still_too_long"');
+  });
+
+  it("handles a repeated prompt-too-long event before the first-attempt branch", () => {
+    const retryGuard = agentStoreSource.indexOf(
+      "state.sessions[sessionId]?.compactRetryAttempted === true",
+    );
+    const firstAttemptGuard = agentStoreSource.indexOf(
+      "!state.sessions[sessionId]?.promptTooLongHandled",
+      retryGuard,
+    );
+
+    expect(retryGuard).toBeGreaterThan(0);
+    expect(firstAttemptGuard).toBeGreaterThan(retryGuard);
+  });
+
+  it("terminates the replacement turn without compaction or Chat fallback", () => {
+    const body = functionBody("failCompactionRetryTooLong(sessionId:");
+
+    expect(body).toContain("this.addErrorMessage(");
+    expect(body).toContain("this.failTurnForSession(");
+    expect(body).not.toContain("compactAgentConversation");
+    expect(body).not.toContain("acceptRateLimitFallback");
+    expect(compactionSource).toContain('"retry_still_too_long"');
+  });
+});


### PR DESCRIPTION
Closes #3477

## Audit
- Traced the structured prompt-too-long error from the agent runtime event handler through `compactAndRetry`, replacement-session respawn, and the direct resend.
- Confirmed the replacement resend is the same recovery generation; a second prompt-too-long event could previously enter compaction again and race teardown of the active replacement.
- Network path: renderer agent store -> Tauri `provider_prompt` -> embedded provider runtime -> Codex App Server JSON-RPC `turn/start`. No third-party publisher or external HTTP API participates in this recovery path.

## Fix
- Mark the fresh replacement before dispatching the single allowed resend.
- Handle a repeated prompt-too-long runtime event ahead of first-attempt recovery.
- Converge event and direct-dispatch failures on one idempotent terminal error path.
- Add an explicit `retry_still_too_long` result so the original recovery does not recurse or fall back through a terminated session.

## Critical coverage
- Protect replacement-marker ordering before dispatch.
- Protect retry-event guard ordering before ordinary first-failure recovery.
- Protect terminal handling from compaction and Chat fallback.

## Validation
- Focused frontend regression set: 33 passed.
- Full frontend suite: 2,825 passed, 15 skipped.
- Rust: 1,221 passed, 2 ignored; macOS sandbox suites and doctests passed.
- Repository lint: passed with existing warnings only.
- Native no-mock walkthrough: `app-ready` passed in a focused 1200x800 Tauri validation window; embedded provider runtime reported healthy.
- `tsc --noEmit` continues to report the repository's pre-existing unrelated declaration/fixture baseline; no diagnostic references the changed files.