### PR TITLE
Fix app-ready walkthrough shell readiness

### DIFF
--- a/tests/unit/validation-app-ready.test.ts
+++ b/tests/unit/validation-app-ready.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Protects the validation app-ready walkthrough from passing on the root loading fallback.
+// ABOUTME: Verifies shell readiness is required before walkthrough evidence is captured.
+
+import { describe, expect, it, vi } from "vitest";
+import type { ScenarioContext } from "../../scripts/validate-walkthrough";
+import runAppReady from "../validation/scenarios/app-ready";
+
+describe("validation app-ready scenario", () => {
+  it("waits for the mounted application shell before capturing evidence", async () => {
+    const calls: string[] = [];
+    const client = {
+      waitFor: vi.fn(async (selector: string) => {
+        calls.push(`waitFor:${selector}`);
+      }),
+      dumpText: vi.fn(async () => {
+        calls.push("dumpText");
+        return { text: "Sign In" };
+      }),
+      screenshot: vi.fn(async () => {
+        calls.push("screenshot");
+        return { rasterSuccess: true };
+      }),
+      nativeScreenshot: vi.fn(async () => {
+        calls.push("nativeScreenshot");
+        return { rasterSuccess: true };
+      }),
+    } as unknown as ScenarioContext["client"];
+    const writeArtifact = vi.fn(async () => undefined);
+
+    await runAppReady({
+      client,
+      artifactsDir: "/unused",
+      writeArtifact,
+    });
+
+    expect(client.waitFor).toHaveBeenCalledWith(
+      "[data-testid='thread-sidebar']",
+      30_000,
+    );
+    expect(calls).toEqual([
+      "waitFor:[data-testid='thread-sidebar']",
+      "dumpText",
+      "screenshot",
+      "nativeScreenshot",
+    ]);
+  });
+});

--- a/tests/validation/scenarios/app-ready.ts
+++ b/tests/validation/scenarios/app-ready.ts
@@ -4,7 +4,7 @@
 import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
 
 export default async function run(ctx: ScenarioContext): Promise<void> {
-  await ctx.client.waitFor("body", 30_000);
+  await ctx.client.waitFor("[data-testid='thread-sidebar']", 30_000);
   const text = await ctx.client.dumpText("body");
   await ctx.writeArtifact("ui-text.json", text);
 


### PR DESCRIPTION
## Summary

Closes #3479.

The `app-ready` validation scenario now waits for the existing visible application-shell marker before collecting evidence. This prevents the walkthrough from reporting success while the real Tauri window still contains only the root `Loading...` fallback.

One focused regression test protects the required ordering: shell wait first, then UI text and screenshot evidence.

## Audit

Reviewed before editing:

- `scripts/validate-walkthrough.ts` bridge-readiness polling
- `src/services/validation-control.ts` listener installation and frontend-ready signal
- `src/App.tsx` auth/bootstrap loading fallback
- `src/components/layout/ThreadSidebar.tsx` shell marker lifecycle
- `tests/validation/scenarios/app-ready.ts`
- Rust validation flag/control server paths
- validation launch documentation and label-gated workflow
- the introducing PR #2782 and later validation HOME repair #3203
- repository issues/PRs for duplicate reports

No duplicate issue was found.

## Network path

No third-party publisher or external API path is added or changed. The affected feature path remains validation-only and loopback-only: the harness polls local `GET /health` and submits typed commands to the local validation control server. Normal app bootstrap retains its existing Seren requests unchanged.

## Real walkthrough

Ran `pnpm validate:walkthrough app-ready` on macOS against the real validation-isolated Tauri app with no mocks.

- `result.json`: `ok: true`, scenario `app-ready`
- UI evidence advanced beyond the fallback and included `Sign In`, `Open Folder`, `Employees`, `No threads yet`, and the employee intake screen
- native window evidence: focused, 1200x800, `nativeAvailable: true`, `rasterSuccess: true`
- DOM raster retained its known explicit WebKit fallback (`rasterSuccess: false`); native evidence succeeded

Post-walkthrough classification:

- P0/P1/P2 regressions found: none
- Non-blocking: existing WKWebView DOM `foreignObject` raster limitation, already recorded explicitly by the harness

## Checks

- `pnpm vitest run tests/unit/validation-app-ready.test.ts`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `git diff --check`
- `pnpm validate:walkthrough app-ready`

Baseline note: repository-wide `pnpm exec tsc --noEmit` remains red on unrelated pre-existing test typing/declaration errors; the changed scenario and focused regression test pass under the project test/build checks.