### PR TITLE
fix(agent): select compaction models from live catalog

### DIFF
--- a/src/lib/compaction/summarizer-models.ts
+++ b/src/lib/compaction/summarizer-models.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Selects agent-compaction summarizer models from SerenModels discovery.
+// ABOUTME: Prevents compaction from posting retired model IDs absent from the live catalog.
+
+import type { ProviderModel } from "@/lib/providers/types";
+
+export interface CompactionSummarizerModels {
+  primaryModel: string;
+  fallbackModels: string[];
+}
+
+function isSonnet(model: ProviderModel): boolean {
+  return model.id.startsWith("anthropic/claude-sonnet-");
+}
+
+function isFastSummarizer(model: ProviderModel): boolean {
+  const searchable = `${model.id} ${model.name}`.toLowerCase();
+  return searchable.includes("flash") || searchable.includes("haiku");
+}
+
+/**
+ * Choose only model IDs advertised by the current SerenModels catalog.
+ *
+ * Preserve the established Sonnet-primary intent when available, then keep one
+ * fast catalog model as the fallback. If Sonnet is unavailable, promote the
+ * first fast model to primary. Returning null tells the caller to use the
+ * deterministic no-network fallback.
+ */
+export function resolveCompactionSummarizerModels(
+  models: ProviderModel[],
+): CompactionSummarizerModels | null {
+  const advertised = models.filter(
+    (model, index) =>
+      model.id.trim().length > 0 &&
+      models.findIndex((candidate) => candidate.id === model.id) === index,
+  );
+  const fastModels = advertised.filter(isFastSummarizer);
+  const primary = advertised.find(isSonnet) ?? fastModels[0];
+
+  if (!primary) return null;
+
+  const fallback = fastModels.find((model) => model.id !== primary.id);
+  return {
+    primaryModel: primary.id,
+    fallbackModels: fallback ? [fallback.id] : [],
+  };
+}

--- a/src/lib/compaction/summarizer-policy.ts
+++ b/src/lib/compaction/summarizer-policy.ts
@@ -5,10 +5,12 @@
 export type SummarizerAttempt = (model: string) => Promise<string>;
 
 export interface SummarizerPolicyInput {
-  /** Preferred summarizer model. */
-  primaryModel: string;
+  /** Preferred summarizer model, or null when live discovery found none. */
+  primaryModel: string | null;
   /** Models tried, in order, when the primary fails or returns garbage. */
   fallbackModels?: string[];
+  /** Diagnostic used when discovery cannot supply a primary model. */
+  noModelReason?: string;
   /** Invoke the summarizer with a model id. */
   attempt: SummarizerAttempt;
   /** Treat an error as an auth failure that a token refresh might fix. */
@@ -46,6 +48,7 @@ export async function runSummarizerWithPolicy(
   const {
     primaryModel,
     fallbackModels = [],
+    noModelReason,
     attempt,
     isAuthError = () => false,
     refreshAuth,
@@ -53,7 +56,7 @@ export async function runSummarizerWithPolicy(
     deterministicFallback,
   } = input;
 
-  let lastError = "unknown summarizer failure";
+  let lastError = noModelReason ?? "unknown summarizer failure";
 
   const tryModel = async (
     model: string,
@@ -70,32 +73,34 @@ export async function runSummarizerWithPolicy(
     }
   };
 
-  // Primary attempt.
-  let result = await tryModel(primaryModel);
-  if (result.ok) {
-    return {
-      status: "ok",
-      summary: result.summary,
-      model: primaryModel,
-      usedFallbackModel: false,
-    };
-  }
-  lastError = errMessage(result.err);
+  if (primaryModel) {
+    // Primary attempt.
+    let result = await tryModel(primaryModel);
+    if (result.ok) {
+      return {
+        status: "ok",
+        summary: result.summary,
+        model: primaryModel,
+        usedFallbackModel: false,
+      };
+    }
+    lastError = errMessage(result.err);
 
-  // Auth-refresh retry on the primary, once.
-  if (isAuthError(result.err) && refreshAuth) {
-    const refreshed = await refreshAuth();
-    if (refreshed) {
-      result = await tryModel(primaryModel);
-      if (result.ok) {
-        return {
-          status: "ok",
-          summary: result.summary,
-          model: primaryModel,
-          usedFallbackModel: false,
-        };
+    // Auth-refresh retry on the primary, once.
+    if (isAuthError(result.err) && refreshAuth) {
+      const refreshed = await refreshAuth();
+      if (refreshed) {
+        result = await tryModel(primaryModel);
+        if (result.ok) {
+          return {
+            status: "ok",
+            summary: result.summary,
+            model: primaryModel,
+            usedFallbackModel: false,
+          };
+        }
+        lastError = errMessage(result.err);
       }
-      lastError = errMessage(result.err);
     }
   }
 

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -17,6 +17,7 @@ import type {
   ProviderModel,
 } from "./types";
 
+export { fetchSerenModelCatalog } from "./seren";
 // Re-export types
 export * from "./types";
 

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -133,6 +133,39 @@ const DEFAULT_MODELS: ProviderModel[] = [
   },
 ];
 
+/**
+ * Fetch the authoritative SerenModels catalog without substituting local
+ * defaults. Callers that must only send advertised IDs can treat failures or
+ * an empty response as "no model" and use their own safe fallback.
+ */
+export async function fetchSerenModelCatalog(): Promise<ProviderModel[]> {
+  const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/models`;
+  const response = await appFetch(url, {
+    method: "GET",
+    headers: await getGatewayHeaders(url),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Seren model catalog failed: ${response.status}`);
+  }
+
+  const result = await response.json();
+  const data = unwrapPublisherBody<{
+    data?: Array<{ id: string; name?: string; context_length?: number }>;
+  }>(result) as {
+    data?: Array<{ id: string; name?: string; context_length?: number }>;
+  };
+  if (!Array.isArray(data.data) || data.data.length === 0) {
+    throw new Error("Seren model catalog returned no models");
+  }
+
+  return data.data.map((model) => ({
+    id: model.id,
+    name: model.name || model.id,
+    contextWindow: model.context_length || 128000,
+  }));
+}
+
 export async function getGatewayHeaders(
   url: string,
   includeJsonContentType = false,
@@ -446,34 +479,7 @@ export const serenProvider: ProviderAdapter = {
   async getModels(_apiKey: string): Promise<ProviderModel[]> {
     // Try to fetch from Seren's models endpoint
     try {
-      const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/models`;
-
-      const response = await appFetch(url, {
-        method: "GET",
-        headers: await getGatewayHeaders(url),
-      });
-
-      if (!response.ok) {
-        return DEFAULT_MODELS;
-      }
-
-      const result = await response.json();
-      const data = unwrapPublisherBody<{
-        data?: Array<{ id: string; name?: string; context_length?: number }>;
-      }>(result);
-      if (Array.isArray((data as { data?: unknown[] }).data)) {
-        return (
-          data as {
-            data: Array<{ id: string; name?: string; context_length?: number }>;
-          }
-        ).data.map((m) => ({
-          id: m.id,
-          name: m.name || m.id,
-          contextWindow: m.context_length || 128000,
-        }));
-      }
-
-      return DEFAULT_MODELS;
+      return await fetchSerenModelCatalog();
     } catch {
       return DEFAULT_MODELS;
     }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -79,6 +79,7 @@ import {
   pruneCompactedHistory,
   relieveOverBudgetTail,
 } from "@/lib/compaction/prune";
+import { resolveCompactionSummarizerModels } from "@/lib/compaction/summarizer-models";
 import {
   buildDeterministicFallbackSummary,
   compactionCooldown,
@@ -167,19 +168,6 @@ const AGGRESSIVE_RETRY_TAIL_RATIO = 0.15;
 
 const COMPACTION_RETRY_TOO_LONG_MESSAGE =
   "This thread is too full for the model's context window after compaction. Start a new thread to continue.";
-
-/**
- * Primary and fallback models for the compaction summarizer. Both route through
- * the public "seren" provider. The fallback is tried when the primary errors,
- * times out, or returns an invalid summary, before the deterministic local
- * fallback. #2106.
- */
-const SUMMARY_PRIMARY_MODEL = "anthropic/claude-sonnet-4";
-// Fast, cheap model recognized by the seren provider catalog — ideal for a
-// fallback summarizer. A model id outside the catalog/migration map would be
-// rejected by the gateway, dead-ending the fallback tier before the
-// deterministic local summary. #2111.
-const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"];
 
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
@@ -395,7 +383,11 @@ import {
   flushAgentThinkingMarkupRemainder,
 } from "@/lib/agent-thinking-markup";
 import { isLikelyAuthError } from "@/lib/auth-errors";
-import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
+import {
+  buildChatRequest,
+  fetchSerenModelCatalog,
+  sendProviderMessage,
+} from "@/lib/providers";
 import {
   isPromptTooLongError,
   isRateLimitError,
@@ -5260,9 +5252,23 @@ export const agentStore = {
       // model, then a deterministic local summary. Only aborts (no-drop) when
       // none of those can produce a summary — the serving session is left
       // intact and a cooldown backs auto-compact off the failing summarizer.
+      let summarizerDiscoveryReason =
+        "Seren model catalog did not advertise a suitable summarizer";
+      let summarizerModels: ReturnType<
+        typeof resolveCompactionSummarizerModels
+      > = null;
+      try {
+        const catalog = await fetchSerenModelCatalog();
+        summarizerModels = resolveCompactionSummarizerModels(catalog);
+      } catch (error) {
+        summarizerDiscoveryReason =
+          error instanceof Error ? error.message : String(error);
+      }
+
       const summaryOutcome = await runSummarizerWithPolicy({
-        primaryModel: SUMMARY_PRIMARY_MODEL,
-        fallbackModels: SUMMARY_FALLBACK_MODELS,
+        primaryModel: summarizerModels?.primaryModel ?? null,
+        fallbackModels: summarizerModels?.fallbackModels ?? [],
+        noModelReason: summarizerDiscoveryReason,
         attempt: (model) =>
           sendProviderMessage("seren", buildChatRequest(summaryPrompt, model)),
         isAuthError: (e) => {

--- a/tests/unit/compaction-summarizer-policy.test.ts
+++ b/tests/unit/compaction-summarizer-policy.test.ts
@@ -8,6 +8,7 @@ import {
   type FallbackTurn,
   runSummarizerWithPolicy,
 } from "@/lib/compaction/summarizer-policy";
+import { resolveCompactionSummarizerModels } from "@/lib/compaction/summarizer-models";
 
 describe("#2106 runSummarizerWithPolicy", () => {
   it("returns the primary summary on success", async () => {
@@ -83,6 +84,23 @@ describe("#2106 runSummarizerWithPolicy", () => {
     }
   });
 
+  it("does not attempt inference when discovery supplied no model", async () => {
+    const attempt = vi.fn(async () => "SHOULD NOT RUN");
+    const out = await runSummarizerWithPolicy({
+      primaryModel: null,
+      noModelReason: "live catalog unavailable",
+      attempt,
+      deterministicFallback: () => "LOCAL FALLBACK SUMMARY",
+    });
+
+    expect(attempt).not.toHaveBeenCalled();
+    expect(out).toEqual({
+      status: "fallback",
+      summary: "LOCAL FALLBACK SUMMARY",
+      reason: "live catalog unavailable",
+    });
+  });
+
   it("aborts (no-drop) when no model and no deterministic fallback can produce a summary", async () => {
     const out = await runSummarizerWithPolicy({
       primaryModel: "primary",
@@ -92,6 +110,45 @@ describe("#2106 runSummarizerWithPolicy", () => {
     });
     expect(out.status).toBe("aborted");
     if (out.status === "aborted") expect(out.reason).toContain("provider unavailable");
+  });
+});
+
+describe("#3481 catalog-aware compaction model selection", () => {
+  it("uses only current advertised IDs for primary and fallback", () => {
+    const selection = resolveCompactionSummarizerModels([
+      {
+        id: "anthropic/claude-sonnet-5",
+        name: "Anthropic Claude Sonnet 5",
+        contextWindow: 1_000_000,
+      },
+      {
+        id: "deepseek/deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        contextWindow: 1_048_576,
+      },
+      {
+        id: "google/gemini-3.6-flash",
+        name: "Google Gemini 3.6 Flash",
+        contextWindow: 1_048_576,
+      },
+    ]);
+
+    expect(selection).toEqual({
+      primaryModel: "anthropic/claude-sonnet-5",
+      fallbackModels: ["deepseek/deepseek-v4-flash"],
+    });
+  });
+
+  it("returns no candidate when the catalog has no suitable summarizer", () => {
+    expect(
+      resolveCompactionSummarizerModels([
+        {
+          id: "meta-llama/llama-3.3-70b-instruct",
+          name: "Meta Llama 3.3 70B Instruct",
+          contextWindow: 131_072,
+        },
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/tests/unit/compaction-summarizer-wiring.test.ts
+++ b/tests/unit/compaction-summarizer-wiring.test.ts
@@ -11,7 +11,13 @@ const agentStore = readFileSync(resolve("src/stores/agent.store.ts"), "utf-8");
 describe("#2106 agent compaction runs the resilient summarizer policy", () => {
   it("drives the summary through runSummarizerWithPolicy with a fallback model", () => {
     expect(agentStore).toContain("runSummarizerWithPolicy({");
-    expect(agentStore).toContain("fallbackModels: SUMMARY_FALLBACK_MODELS");
+    expect(agentStore).toContain("fetchSerenModelCatalog()");
+    expect(agentStore).toContain("resolveCompactionSummarizerModels(catalog)");
+    expect(agentStore).toContain(
+      "fallbackModels: summarizerModels?.fallbackModels ?? []",
+    );
+    expect(agentStore).not.toContain('"anthropic/claude-sonnet-4"');
+    expect(agentStore).not.toContain('"anthropic/claude-haiku-4.5"');
     expect(agentStore).toContain("deterministicFallback: () =>");
   });
 


### PR DESCRIPTION
Closes #3481

## Audit

- Traced reactive agent context handling through `agent.store.ts`, the resilient summarizer policy, and Seren provider routing.
- Reviewed the prior compaction safeguards in #2106/#2110 and #2111/#2112, plus the related context-limit work in #3475/#3476 and #3477/#3478.
- Confirmed the failure was a definitive P2: both hard-coded summarizer IDs had been retired, so every affected compaction reached the deterministic local tier after two model-not-found responses.

## Fix

- Fetch the authoritative SerenModels catalog before agent summarization without substituting local default IDs.
- Select a Sonnet primary and one fast fallback only from model IDs present in that response.
- Skip network inference entirely when discovery fails or supplies no suitable model, preserving the existing deterministic no-drop fallback.
- Preserve the existing provider model-list fallback for UI consumers that still need defaults.

## Network path verification

- Agent compaction → `GET /publishers/seren-models/models` → select only advertised IDs → `POST /publishers/seren-models/chat/completions`.
- Verified publisher slug `seren-models` and upstream metadata for `GET /models` and `POST /chat/completions` against the live publisher registry.
- The live catalog advertised `anthropic/claude-sonnet-5`; a real non-streaming completion using that exact ID returned HTTP 200.

## Validation

- `pnpm vitest run tests/unit/compaction-summarizer-policy.test.ts tests/unit/compaction-summarizer-wiring.test.ts` — 17 passed.
- `pnpm lint` — exit 0 (existing warnings only).
- `pnpm build` — passed.
- Changed-path TypeScript diagnostic filter — no diagnostics.
- Real macOS Tauri walkthrough, no mocks: submitted an oversized 3,000,000-character prompt, exercised the prompt-too-long compaction branch, observed signed-out catalog access use the deterministic fallback without a retired-model request, and completed with successful native and raster captures.

No PII or environment-specific identifiers are included in this PR.