### PR TITLE
test(compaction): remove obsolete fallback assertion

### DIFF
--- a/tests/unit/synthetic-userturn-count.test.ts
+++ b/tests/unit/synthetic-userturn-count.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Regression test for #2111 — synthetic-transcript user-turn count must
-// ABOUTME: align with the token-budgeted tail, and the fallback model must be in-catalog.
+// ABOUTME: Regression test for #2111 synthetic-transcript user-turn counting.
+// ABOUTME: Keeps the synthetic boundary aligned with the token-budgeted tail.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -15,14 +15,5 @@ describe("#2111 synthetic-transcript boundary matches the token-budgeted tail", 
       'toPreserve.filter((m) => m.type === "user").length',
     );
     expect(agentStore).not.toContain("Math.ceil(toPreserve.length / 2)");
-  });
-});
-
-describe("#2111 fallback summarizer model is in the seren catalog", () => {
-  it("uses a recognized fallback model id, not the unlisted claude-3-5-sonnet", () => {
-    expect(agentStore).toContain(
-      'SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"]',
-    );
-    expect(agentStore).not.toContain("anthropic/claude-3-5-sonnet");
   });
 });


### PR DESCRIPTION
Closes #3486

## Cause

#3485 correctly removed hard-coded compaction summarizer IDs and moved model choice behind live catalog discovery. The full frontend suite still had a #2111 static assertion requiring the deleted `SUMMARY_FALLBACK_MODELS` constant and retired Haiku ID, so `test-frontend` failed after the PR was merged.

## Fix

- Remove only the obsolete fallback-model describe block from `synthetic-userturn-count.test.ts`.
- Keep the original #2111 synthetic user-turn boundary regression intact.
- Leave catalog-aware model behavior to the focused resolver and wiring tests added in #3485, avoiding duplicated coverage.

## Validation

- `pnpm test` — 394 files passed, 2,830 tests passed; expected skips only.
- `pnpm lint` — exit 0 with existing warnings only.
- `pnpm build` — passed.
- `git diff --check` — passed.

## Network path

This follow-up is test-only and changes no product code, publisher slug, API method, or outbound path.

No PII or environment-specific identifiers are included.