### PR TITLE
fix(auth): authorize managed deployment lease updates

### DIFF
--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -18,15 +18,13 @@ const DEFAULT_ORG_API_KEYS_PATH: &str = "/organizations/default/api-keys";
 const LEASE_STORE: &str = "credential-leases.json";
 const LEASE_LEDGER_KEY: &str = "orphaned_leases";
 const LEASE_EXPIRY_DAYS: u8 = 1;
-// Core now publishes and enforces a per-publisher scope grammar
-// (`publisher:*`, `publisher:<slug>`, `publisher:<slug>:operation:<id>`; see
-// seren-core#222). The lease stays `publisher:*` because a general agent
-// session does not know its publisher set at spawn — the Seren MCP catalog is
-// dynamic — so narrowing needs a per-publisher capability minted at first use,
-// not a scope-string change. One residual on the wildcard is tracked in
-// seren-core#224: for a user key it still authorizes destructive
-// seren-passwords operations. See #3194.
-const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*"];
+// A general agent session cannot predict its publisher set at spawn because
+// the Seren MCP catalog is dynamic, so it retains the existing publisher
+// wildcard. Managed deployment mutations are a separate Core capability and
+// must be granted explicitly. Keep this at the narrow update operation needed
+// by managed update/rollback/reconciliation workflows; do not broaden it to
+// `managed-deployment:*`. See #3194 and #3489.
+const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*", "managed-deployment:update"];
 
 /// What the renderer and provider runtime are allowed to see. The real key is
 /// deliberately absent: only the loopback broker holds it, and the capability
@@ -496,8 +494,17 @@ fn select_startup_reaper_records(records: &[LeaseLedgerEntry]) -> Vec<LeaseLedge
 mod tests {
     use super::{
         ApiKeyCreated, CredentialLease, CredentialLeaseLedger, LeaseLedgerEntry,
-        select_startup_reaper_records,
+        VERIFIED_LEASE_SCOPES, select_startup_reaper_records,
     };
+
+    #[test]
+    fn credential_lease_requests_exact_managed_update_capability() {
+        assert_eq!(
+            VERIFIED_LEASE_SCOPES,
+            ["publisher:*", "managed-deployment:update"]
+        );
+        assert!(!VERIFIED_LEASE_SCOPES.contains(&"managed-deployment:*"));
+    }
 
     /// The renderer reads these exact names. A rename here silently leaves a
     /// session without Seren MCP, so pin the wire contract rather than trusting

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -288,7 +288,10 @@ export async function isLoggedIn(): Promise<boolean> {
 export { getToken };
 
 const DESKTOP_API_KEY_NAME = "Seren Desktop";
-const DESKTOP_API_KEY_SCOPES = ["publisher:*"] as const;
+const DESKTOP_API_KEY_SCOPES = [
+  "publisher:*",
+  "managed-deployment:update",
+] as const;
 
 export interface CreateApiKeyOptions {
   name?: string;

--- a/tests/unit/auth-create-apikey-status.test.ts
+++ b/tests/unit/auth-create-apikey-status.test.ts
@@ -62,7 +62,28 @@ describe("createApiKey HTTP status (#2497 Defect 1)", () => {
         name: "Seren Desktop",
         key_type: undefined,
         agent_identity_id: undefined,
-        scopes: ["publisher:*"],
+        scopes: ["publisher:*", "managed-deployment:update"],
+      },
+      throwOnError: false,
+    });
+  });
+
+  it("preserves an explicit caller-supplied scope set", async () => {
+    createDefaultOrgApiKeyMock.mockResolvedValueOnce({
+      data: { data: { api_key: "seren_live_scoped" } },
+      error: undefined,
+      response: { status: 201 },
+    });
+
+    await expect(
+      createApiKey({ scopes: ["publisher:github-api"] }),
+    ).resolves.toBe("seren_live_scoped");
+    expect(createDefaultOrgApiKeyMock).toHaveBeenCalledWith({
+      body: {
+        name: "Seren Desktop",
+        key_type: undefined,
+        agent_identity_id: undefined,
+        scopes: ["publisher:github-api"],
       },
       throwOnError: false,
     });


### PR DESCRIPTION
## Summary

- mint Desktop session leases with the existing `publisher:*` scope plus the narrow `managed-deployment:update` capability
- align the persistent Desktop fallback key with the same exact scopes
- preserve explicit caller-supplied scope overrides
- pin the least-privilege scope set in Rust and TypeScript tests

This fixes the rotating-lease behavior that caused production reconciliation previews to return `apply_authorized: false` even after the long-lived `seren-mcp` key was repaired.

Closes #3489
Related: serenorg/seren-core#240

## Validation

- `pnpm prepare:mcp-servers`
- `pnpm exec biome check src/services/auth.ts tests/unit/auth-create-apikey-status.test.ts`
- `pnpm exec vitest run tests/unit/auth-create-apikey-status.test.ts` (6 passed)
- `cargo test credential_lease_requests_exact_managed_update_capability --lib -- --nocapture` (1 passed)
- `git diff --check`

No managed-deployment wildcard was added.