### PR TITLE
Reset incompatible agent model on provider switch

### DIFF
--- a/src-tauri/src/commands/provider_runtime.rs
+++ b/src-tauri/src/commands/provider_runtime.rs
@@ -157,9 +157,12 @@ pub async fn switch_thread_provider(
             // `agent_model_id` and `agent_cwd` are mirrored on the agent
             // branch and cleared on the chat branch so the row's agent-*
             // columns are coherent with `kind` rather than leaving stale
-            // agent metadata on a now-chat row. `agent_cwd` lets the
-            // sidebar group the freshly-flipped agent row by the right
-            // project before the native spawn callback fires.
+            // agent metadata on a now-chat row. A null model keeps an
+            // override only when the provider itself is unchanged; a new
+            // native agent must choose from its own model namespace.
+            // `agent_cwd` lets the sidebar group the freshly-flipped agent
+            // row by the right project before the native spawn callback
+            // fires.
             // The `selected_model` mirror uses COALESCE so a switch that
             // does not name a new model keeps the conversation's current
             // model in the compatibility column; the runtime row itself
@@ -179,9 +182,12 @@ pub async fn switch_thread_provider(
                  SET kind = ?1,
                      agent_type = ?2,
                      agent_session_id = NULL,
-                     agent_model_id = CASE WHEN ?1 = 'agent'
-                         THEN COALESCE(?3, agent_model_id)
-                         ELSE NULL END,
+                     agent_model_id = CASE
+                         WHEN ?1 != 'agent' THEN NULL
+                         WHEN ?3 IS NOT NULL THEN ?3
+                         WHEN selected_provider = ?4 THEN agent_model_id
+                         ELSE NULL
+                     END,
                      agent_cwd = CASE WHEN ?1 = 'agent'
                          THEN COALESCE(?6, agent_cwd)
                          ELSE NULL END,
@@ -407,9 +413,12 @@ mod tests {
                  SET kind = ?1,
                      agent_type = ?2,
                      agent_session_id = NULL,
-                     agent_model_id = CASE WHEN ?1 = 'agent'
-                         THEN COALESCE(?3, agent_model_id)
-                         ELSE NULL END,
+                     agent_model_id = CASE
+                         WHEN ?1 != 'agent' THEN NULL
+                         WHEN ?3 IS NOT NULL THEN ?3
+                         WHEN selected_provider = ?4 THEN agent_model_id
+                         ELSE NULL
+                     END,
                      agent_cwd = CASE WHEN ?1 = 'agent'
                          THEN COALESCE(?6, agent_cwd)
                          ELSE NULL END,
@@ -1147,6 +1156,50 @@ mod tests {
         assert_eq!(agent_type, Some("codex".to_string()));
         assert_eq!(agent_session_id, None);
         assert_eq!(agent_model_id, Some("codex-mid".to_string()));
+    }
+
+    #[test]
+    fn agent_to_agent_type_change_without_model_clears_prior_agent_model() {
+        let conn = open();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, agent_type,
+                                        agent_session_id, agent_model_id,
+                                        selected_provider, selected_model)
+             VALUES ('t1', 'Thread', 1000, 'agent', 'claude-code',
+                     'claude-session', 'claude-fable-5[1m]',
+                     'claude-code', 'claude-fable-5[1m]')",
+            [],
+        )
+        .unwrap();
+
+        try_perform_switch(&conn, "t1", "codex", None, None, None, None, 2000).unwrap();
+
+        let (kind, agent_type, agent_session_id, agent_model_id, _, _) =
+            read_conv_compat(&conn, "t1");
+        assert_eq!(kind, "agent");
+        assert_eq!(agent_type, Some("codex".to_string()));
+        assert_eq!(agent_session_id, None);
+        assert_eq!(agent_model_id, None);
+    }
+
+    #[test]
+    fn same_agent_type_without_model_preserves_prior_agent_model() {
+        let conn = open();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, agent_type,
+                                        agent_session_id, agent_model_id,
+                                        selected_provider, selected_model)
+             VALUES ('t1', 'Thread', 1000, 'agent', 'codex',
+                     'codex-session', 'gpt-5.6-sol',
+                     'codex', 'gpt-5.6-sol')",
+            [],
+        )
+        .unwrap();
+
+        try_perform_switch(&conn, "t1", "codex", None, None, None, None, 2000).unwrap();
+
+        let (_, _, _, agent_model_id, _, _) = read_conv_compat(&conn, "t1");
+        assert_eq!(agent_model_id, Some("gpt-5.6-sol".to_string()));
     }
 
     #[test]

--- a/tests/unit/provider-bindings.test.ts
+++ b/tests/unit/provider-bindings.test.ts
@@ -829,7 +829,7 @@ describe("switchChatProvider", () => {
       agent_type: "claude-code",
       agent_session_id: null,
       agent_cwd: "/Users/dev/my-project",
-      agent_model_id: "gpt-5.1-codex",
+      agent_model_id: null,
       agent_permission_mode: null,
       agent_metadata: null,
       project_id: null,
@@ -848,6 +848,9 @@ describe("switchChatProvider", () => {
     );
     expect(agentStoreMock.upsertAgentConversationFromDb).toHaveBeenCalledTimes(
       1,
+    );
+    expect(agentStoreMock.upsertAgentConversationFromDb).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_model_id: null }),
     );
     expect(agentStoreMock.spawnSession).toHaveBeenCalledWith(
       "/Users/dev/my-project",


### PR DESCRIPTION
## Summary

Closes #3484.

When a thread switches between native agent providers without an explicit target model, the compatibility row now clears the prior provider's `agent_model_id`. The new runtime can then select a model from its own namespace. Explicit target models still win, and same-provider rebinding still preserves the existing model override.

The frontend handoff regression fixture now verifies that the cleared model is applied before spawning the replacement agent session.

## Root cause

The provider switch transaction previously used `COALESCE(target_model, agent_model_id)`. Agent-to-agent switches intentionally pass a null target model, so the prior agent provider's model ID survived the provider change and was restored into the replacement session. The model picker correctly showed the replacement provider's catalog but retained the incompatible sticky label.

## Audit

Reviewed before editing:

- agent provider and model picker UI paths
- provider binding service, frontend cache transition, agent spawn/resume lifecycle
- Tauri provider-runtime switch transaction and compatibility mirrors
- SQLite schema and focused provider-runtime tests
- user-facing provider-switch documentation
- introducing provider-switch history and prior model-persistence fixes
- live GitHub issues and pull requests for duplicate reports

No existing issue covered this defect.

## Network path

No third-party publisher or external API path is added or changed. The affected path is local: provider picker → `switchChatProvider` → Tauri IPC `switch_thread_provider` → SQLite transaction → local native-agent runtime restart. The later provider inference transport is unchanged, so there is no outbound publisher slug, HTTP method, or API path to update or verify for this fix.

## Real macOS walkthrough

Ran a two-stage, no-mock walkthrough in a fresh validation-isolated Tauri app identity using the installed native agent CLIs.

Setup and switch:

- created a real source-provider agent session
- explicitly selected `Opus 4.8 (1M context)`
- switched the existing thread to Codex through the UI
- immediate Codex model chip: `GPT-5.6-Sol`
- persisted conversation: `agent_type=codex`, `agent_model_id=NULL`
- persisted runtime: `provider=codex`, `model=NULL`, `status=active`
- native evidence: 1200×800, `nativeAvailable=true`, `rasterSuccess=true`

Restart and rehydrate:

- provider chip: `Codex`
- model chip: `GPT-5.6-Sol`
- selected dropdown row: `GPT-5.6-Sol` (`Latest frontier agentic coding model.`)
- persisted model overrides remained null after restart
- native evidence: 1200×800, `nativeAvailable=true`, `rasterSuccess=true`

Screenshots and local identifiers were retained locally rather than attached because the source evidence can contain workspace information.

Post-walkthrough classification:

- P0/P1/P2 regressions found: none
- Non-blocking: the first validation-only attempt used an overly specific portal selector; it was corrected in uncommitted walkthrough scaffolding and the clean setup/restart run passed
- Non-blocking: the isolated signed-out validation environment logged its existing system-node fallback and unavailable refresh-token warnings; neither affected the local provider switch

## Checks

- `pnpm test` — 2,826 passed, 15 skipped
- `pnpm vitest run tests/unit/provider-bindings.test.ts` — 27 passed
- `cargo test --manifest-path src-tauri/Cargo.toml commands::provider_runtime::tests --lib -j 1` — 21 passed
- `pnpm check` — passes with existing warnings
- `pnpm build`
- focused `rustfmt --check`
- `git diff --check`