### PR TITLE
fix(chat): hydrate Auto from the live SerenModels catalog

### DIFF
--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -43,6 +43,7 @@ import {
 } from "@/services/organization-policy";
 import { serenPrivateModelsAttested } from "@/services/private-models";
 import { assertPrivilegedConversationProvider } from "@/services/providers";
+import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
@@ -305,9 +306,31 @@ export async function orchestrate(
   // user switching providers on one thread cannot leak into orchestration
   // on another. Threads with no recorded selection fall back to the
   // user's globally-active default.
-  await skillsStore.ensureContextLoaded(fileTreeState.rootPath, conversationId);
   const threadProvider = selectedProvider as ProviderId;
   const threadModel = conv?.selectedModel ?? providerStore.activeModel;
+  const needsLiveSerenCatalog =
+    threadProvider === "seren" &&
+    threadModel === AUTO_MODEL_ID &&
+    allowsSerenPublicModels(authStore.privateChatPolicy);
+
+  if (needsLiveSerenCatalog) {
+    try {
+      const liveModels = await getLiveSerenModelCatalog();
+      providerStore.setProviderModels("seren", liveModels);
+    } catch (error) {
+      console.warn(
+        "[orchestrator] SerenModels catalog unavailable before Auto routing:",
+        error,
+      );
+      conversationStore.setError(
+        "Seren Models could not load its current model catalog. Please retry.",
+      );
+      conversationStore.setLoading(false, conversationId);
+      return;
+    }
+  }
+
+  await skillsStore.ensureContextLoaded(fileTreeState.rootPath, conversationId);
   const capabilities = buildCapabilities(
     conversationId,
     threadProvider,

--- a/src/services/seren-model-catalog.ts
+++ b/src/services/seren-model-catalog.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Short-lived cache for the authoritative SerenModels inference catalog.
+// ABOUTME: Prevents Auto chat from routing through retired hard-coded model IDs.
+
+import { fetchSerenModelCatalog } from "@/lib/providers/seren";
+import type { ProviderModel } from "@/lib/providers/types";
+
+export const SEREN_MODEL_CATALOG_TTL_MS = 5 * 60 * 1000;
+
+let cachedCatalog: ProviderModel[] | null = null;
+let catalogExpiresAt = 0;
+let catalogRequest: Promise<ProviderModel[]> | null = null;
+
+export async function getLiveSerenModelCatalog(
+  now = Date.now(),
+): Promise<ProviderModel[]> {
+  if (cachedCatalog && cachedCatalog.length > 0 && now < catalogExpiresAt) {
+    return cachedCatalog;
+  }
+
+  if (catalogRequest) {
+    return catalogRequest;
+  }
+
+  catalogRequest = fetchSerenModelCatalog()
+    .then((models) => {
+      if (models.length === 0) {
+        throw new Error("Seren model catalog returned no models");
+      }
+      cachedCatalog = models;
+      catalogExpiresAt = now + SEREN_MODEL_CATALOG_TTL_MS;
+      return models;
+    })
+    .finally(() => {
+      catalogRequest = null;
+    });
+
+  return catalogRequest;
+}
+
+export function clearLiveSerenModelCatalogCache(): void {
+  cachedCatalog = null;
+  catalogExpiresAt = 0;
+  catalogRequest = null;
+}

--- a/tests/unit/orchestrator-auto-model-catalog.test.ts
+++ b/tests/unit/orchestrator-auto-model-catalog.test.ts
@@ -1,0 +1,88 @@
+// ABOUTME: Regression coverage for live SerenModels discovery before Auto routing.
+// ABOUTME: Ensures retired local defaults cannot reach the Rust orchestrator.
+
+import { describe, expect, it, vi } from "vitest";
+import { readSource } from "./source-text";
+
+const fetchSerenModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/providers/seren", () => ({
+  fetchSerenModelCatalog,
+}));
+
+import {
+  clearLiveSerenModelCatalogCache,
+  getLiveSerenModelCatalog,
+  SEREN_MODEL_CATALOG_TTL_MS,
+} from "@/services/seren-model-catalog";
+
+const liveModels = [
+  {
+    id: "anthropic/claude-sonnet-5",
+    name: "Claude Sonnet 5",
+    contextWindow: 1_000_000,
+  },
+  {
+    id: "google/gemini-3.6-flash",
+    name: "Gemini 3.6 Flash",
+    contextWindow: 1_048_576,
+  },
+];
+
+describe("#3492 SerenModels Auto catalog", () => {
+  it("reuses a successful live catalog only within the short TTL", async () => {
+    clearLiveSerenModelCatalogCache();
+    fetchSerenModelCatalog.mockReset();
+    fetchSerenModelCatalog.mockResolvedValue(liveModels);
+
+    await expect(getLiveSerenModelCatalog(1_000)).resolves.toEqual(liveModels);
+    await expect(
+      getLiveSerenModelCatalog(1_000 + SEREN_MODEL_CATALOG_TTL_MS - 1),
+    ).resolves.toEqual(liveModels);
+    expect(fetchSerenModelCatalog).toHaveBeenCalledTimes(1);
+
+    await expect(
+      getLiveSerenModelCatalog(1_000 + SEREN_MODEL_CATALOG_TTL_MS),
+    ).resolves.toEqual(liveModels);
+    expect(fetchSerenModelCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache discovery failures or an empty catalog", async () => {
+    clearLiveSerenModelCatalogCache();
+    fetchSerenModelCatalog.mockReset();
+    fetchSerenModelCatalog
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce([]);
+
+    await expect(getLiveSerenModelCatalog(2_000)).rejects.toThrow(
+      "catalog unavailable",
+    );
+    await expect(getLiveSerenModelCatalog(2_001)).rejects.toThrow(
+      "returned no models",
+    );
+    expect(fetchSerenModelCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("hydrates Auto capabilities before routing and fails closed on discovery errors", () => {
+    const source = readSource("src/services/orchestrator.ts");
+    const loadCatalog = source.indexOf(
+      "const liveModels = await getLiveSerenModelCatalog();",
+    );
+    const updateStore = source.indexOf(
+      'providerStore.setProviderModels("seren", liveModels);',
+    );
+    const buildCapabilities = source.indexOf(
+      "const capabilities = buildCapabilities(",
+    );
+
+    expect(loadCatalog).toBeGreaterThan(0);
+    expect(updateStore).toBeGreaterThan(loadCatalog);
+    expect(buildCapabilities).toBeGreaterThan(updateStore);
+    expect(source).toContain(
+      "Seren Models could not load its current model catalog. Please retry.",
+    );
+    expect(source).toContain(
+      "conversationStore.setLoading(false, conversationId);",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- load the authoritative SerenModels catalog before public SerenModels `Auto` routing
- replace stale provider-store candidates before capabilities are sent to Rust
- cache successful discovery briefly and fail closed when discovery is unavailable
- leave explicit-model and private-model routing unchanged

Closes #3492.

## Audited network path

`Auto send -> frontend orchestrate -> GET /publishers/seren-models/models -> buildCapabilities -> Tauri orchestrate -> Rust router -> POST /publishers/seren-models/chat/completions`

The publisher slug, methods, paths, and current model IDs were verified against the live Seren publisher metadata. The live catalog contained none of the retired hard-coded IDs observed in #3492.

## Validation

- focused frontend regression set: 32 passed
- full frontend suite: 2,834 passed, 15 skipped
- `pnpm check`: passed
- production frontend build and committed-head manifest verification: passed
- Rust orchestrator tests: 56 passed
- `git diff --check`: passed
- real no-mock Tauri walkthrough: Auto hydrated the live seven-model catalog and routed only to live IDs; the original `404 model not found` did not recur

The walkthrough also exposed a separate P1 in the existing Rust embedded-SSE error path. It is tracked independently as #3493 under the required one-ticket/one-PR workflow. No local paths, credentials, account identifiers, conversation identifiers, or raw runtime logs are included here.

## Focused regression coverage

- successful live catalog reuse within the short TTL
- refresh after TTL expiry
- discovery failure/empty response is not cached
- catalog hydration and fail-closed behavior precede capability construction