### PR TITLE
fix(wallet): surface daily claim popup only on agent launch

### DIFF
--- a/src/components/wallet/DailyClaimPopup.tsx
+++ b/src/components/wallet/DailyClaimPopup.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Modal popup for claiming daily SerenBucks credits after login.
+// ABOUTME: Modal popup for claiming daily SerenBucks credits at agent launch.
 // ABOUTME: Shows eligibility, handles claim action, and supports dismissal.
 
 import { type Component, createSignal, Show } from "solid-js";
@@ -11,7 +11,7 @@ import {
 
 /**
  * Daily SerenBucks claim popup modal.
- * Appears after login when user is eligible to claim.
+ * Appears after an authenticated agent launch when the user is eligible.
  */
 export const DailyClaimPopup: Component = () => {
   const [claiming, setClaiming] = createSignal(false);

--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -42,7 +42,7 @@ interface WalletState {
   refreshTimerId: ReturnType<typeof setInterval> | null;
   /** Daily claim eligibility data */
   dailyClaim: DailyClaimEligibility | null;
-  /** Whether user dismissed the daily claim popup this session */
+  /** Whether the daily claim popup is suppressed until an agent launch */
   dailyClaimDismissed: boolean;
   /** Whether daily claim check is in progress */
   dailyClaimLoading: boolean;
@@ -64,7 +64,7 @@ const initialState: WalletState = {
   autoRefreshActive: false,
   refreshTimerId: null,
   dailyClaim: null,
-  dailyClaimDismissed: false,
+  dailyClaimDismissed: true,
   dailyClaimLoading: false,
   dailyClaimTimerId: null,
 };
@@ -449,7 +449,8 @@ function setTopUpInProgress(inProgress: boolean): void {
 
 /**
  * Check if the user is eligible to claim daily credits.
- * Called after login to determine if popup should show.
+ * Called after login to keep wallet eligibility current without surfacing a
+ * modal before the user launches an agent.
  */
 async function checkDailyClaim(): Promise<void> {
   setWalletState("dailyClaimLoading", true);
@@ -483,6 +484,9 @@ async function claimDaily(): Promise<DailyClaimResponse> {
     reason: "Already claimed today",
     resets_in_seconds: null,
   });
+  // A completed claim should stay quiet across the next UTC reset. The next
+  // intentional agent launch can clear this suppression if a claim is due.
+  setWalletState("dailyClaimDismissed", true);
   return result;
 }
 
@@ -522,20 +526,16 @@ async function surfaceDailyClaimIfEligible(): Promise<void> {
 
 /**
  * Start periodic re-checking of daily claim eligibility.
- * Surfaces the claim popup for long-running sessions that span midnight UTC.
+ * Keeps wallet data current for non-modal UI such as the Settings banner.
+ * Only an intentional agent launch may clear popup suppression.
  */
 function startDailyClaimPolling(): void {
   if (walletState.dailyClaimTimerId) return;
 
   const timerId = setInterval(async () => {
-    const wasPreviouslyEligible = walletState.dailyClaim?.can_claim ?? false;
     try {
       const eligibility = await fetchDailyEligibility();
       setWalletState("dailyClaim", eligibility);
-      // New eligibility appeared — reset dismiss so popup re-surfaces
-      if (!wasPreviouslyEligible && eligibility.can_claim) {
-        setWalletState("dailyClaimDismissed", false);
-      }
     } catch {
       // Silently ignore — don't clear existing state on transient errors
     }

--- a/tests/unit/daily-claim-agent-launch.test.ts
+++ b/tests/unit/daily-claim-agent-launch.test.ts
@@ -29,8 +29,10 @@ vi.mock("@/services/wallet", () => ({
 }));
 
 import {
+  claimDaily,
   dismissDailyClaim,
   resetWalletState,
+  startDailyClaimPolling,
   surfaceDailyClaimIfEligible,
   walletState,
 } from "@/stores/wallet.store";
@@ -49,12 +51,14 @@ function eligibility(canClaim: boolean) {
 describe("daily claim on agent launch", () => {
   beforeEach(() => {
     dailyClaimMocks.fetchDailyEligibility.mockReset();
+    dailyClaimMocks.claimDailyCredits.mockReset();
     mockAuthState.isAuthenticated = true;
     resetWalletState();
   });
 
   afterEach(() => {
     resetWalletState();
+    vi.useRealTimers();
   });
 
   it("re-surfaces a dismissed but still-claimable reward when an agent launches", async () => {
@@ -78,6 +82,40 @@ describe("daily claim on agent launch", () => {
     // can_claim is false, so the popup stays hidden regardless of the flag,
     // and we do not spuriously clear the dismiss flag.
     expect(walletState.dailyClaim?.can_claim).toBe(false);
+    expect(walletState.dailyClaimDismissed).toBe(true);
+  });
+
+  it("does not auto-surface the next reward during a background UTC-reset poll", async () => {
+    vi.useFakeTimers();
+    dailyClaimMocks.fetchDailyEligibility.mockResolvedValueOnce(
+      eligibility(true),
+    );
+    dailyClaimMocks.claimDailyCredits.mockResolvedValue({
+      success: true,
+      amount_atomic: 250_000,
+      amount_usd: "$0.25",
+      balance_atomic: 1_250_000,
+      balance_usd: "$1.25",
+      claims_remaining_this_month: 4,
+    });
+
+    // The user intentionally launches an agent and claims today's reward.
+    await surfaceDailyClaimIfEligible();
+    expect(walletState.dailyClaimDismissed).toBe(false);
+    await claimDaily();
+    expect(walletState.dailyClaim?.can_claim).toBe(false);
+    expect(walletState.dailyClaimDismissed).toBe(true);
+
+    // A later background poll discovers the next reward after the UTC reset.
+    dailyClaimMocks.fetchDailyEligibility.mockResolvedValueOnce(
+      eligibility(true),
+    );
+    startDailyClaimPolling();
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1_000);
+
+    // Eligibility stays current for Settings, but only an agent launch may
+    // clear suppression and satisfy the popup gate.
+    expect(walletState.dailyClaim?.can_claim).toBe(true);
     expect(walletState.dailyClaimDismissed).toBe(true);
   });
 


### PR DESCRIPTION
## What

Prevent the daily SerenBucks modal from opening automatically when a background eligibility poll discovers a new claim after the UTC reset. Eligibility still refreshes for non-modal Wallet UI, while an authenticated agent cold-start remains the only path that clears modal suppression.

Closes #3498

## Root cause

#3428 added the intended agent-launch trigger but retained #1133's older 30-minute poll behavior. That poll explicitly cleared `dailyClaimDismissed` on a `false -> true` eligibility transition, satisfying the popup gate in an idle app.

## Fix

- Start daily-claim modal suppression enabled so authenticated startup can refresh eligibility without opening a modal.
- Keep successful claims suppressed across the next UTC reset.
- Stop background polling from clearing suppression; it updates eligibility only.
- Preserve `surfaceDailyClaimIfEligible()` as the authenticated agent-launch path that clears suppression.
- Update popup documentation to match the engagement-triggered behavior.

## Critical regression coverage

Extended the existing focused wallet-store suite with the reported sequence:

1. an agent launch surfaces an eligible claim;
2. the user claims it;
3. a later 30-minute poll discovers the next reward;
4. eligibility updates, but modal suppression remains enabled.

## Validation

- `pnpm exec vitest run tests/unit/daily-claim-agent-launch.test.ts` — 5 passed
- `pnpm test -- tests/unit/daily-claim-agent-launch.test.ts` — full suite: 2,837 passed, 15 skipped
- `pnpm exec biome check src/stores/wallet.store.ts src/components/wallet/DailyClaimPopup.tsx tests/unit/daily-claim-agent-launch.test.ts` — passed
- `pnpm build` — passed
- Native macOS validation build — compiled and launched successfully

Repository-wide `tsc --noEmit` remains red on existing unrelated test-fixture and `.mjs` declaration errors; none reference the changed files.

## Networked path

No MCP publisher is involved and no endpoint changes. Existing direct Seren Core REST paths remain:

- Eligibility: `App auth effect / AgentChat cold-start -> fetchDailyEligibility -> GET https://api.serendb.com/wallet/daily/eligibility`
- Claim: `DailyClaimPopup -> claimDailyCredits -> POST https://api.serendb.com/wallet/daily/claim`

Both method/path pairs are present in the generated SDK and `openapi/openapi.json`.

## Privacy

The issue, commit, and PR contain repository-only evidence and no user account details, screenshots, or logs.