### PR TITLE
fix(agent): gate publisher primer on registered Seren MCP

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -8,6 +8,7 @@ import readline from "node:readline";
 import {
   buildProviderMcpConfig,
   resolveBrokeredSerenCredential,
+  SEREN_MCP_SERVER_NAME,
 } from "./mcp-config.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
@@ -74,6 +75,7 @@ function createAcpSessionRecord({
   currentModeId,
   currentModelId,
   logPrefix,
+  serenMcpConfigured = false,
   serenMcpProxy = null,
 }) {
   return {
@@ -99,6 +101,7 @@ function createAcpSessionRecord({
     currentModelId: currentModelId ?? adapter.defaultModelId,
     availableModels: adapter.availableModels,
     configOptions: [],
+    serenMcpConfigured,
     serenMcpProxy,
   };
 }
@@ -746,12 +749,16 @@ export function createAcpRuntime({
       // the user's configured MCP servers. The agent child is a separate
       // process and cannot see the Tauri-side MCP supervisor, so the
       // wiring must be passed explicitly on every session/new.
+      const acpMcpServers = mcpConfig.acpMcpServers(mcpCapabilities);
+      session.serenMcpConfigured = acpMcpServers.some(
+        (server) => server.name === SEREN_MCP_SERVER_NAME,
+      );
       const sessionResult = await sendRequest(
         session,
         "session/new",
         {
           cwd,
-          mcpServers: mcpConfig.acpMcpServers(mcpCapabilities),
+          mcpServers: acpMcpServers,
         },
         20_000,
       );
@@ -769,6 +776,7 @@ export function createAcpRuntime({
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        serenMcpConfigured: session.serenMcpConfigured,
         // OS PID of the agent child, so Rust can force-kill this one session
         // when the cooperative cancel/terminate RPCs are unreachable. #2313
         pid: session.process?.pid ?? null,
@@ -970,6 +978,7 @@ export function createAcpRuntime({
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      serenMcpConfigured: session.serenMcpConfigured,
       pid: session.process?.pid ?? null,
     }));
   }

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -12,6 +12,8 @@ import { fileURLToPath } from "node:url";
 import {
   buildProviderMcpConfig,
   resolveBrokeredSerenCredential,
+  SEREN_MCP_SERVER_NAME,
+  SEREN_MCP_TOOL_PREFIX,
 } from "./mcp-config.mjs";
 import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 import {
@@ -1264,9 +1266,6 @@ const INITIALIZE_MAX_ATTEMPTS = 2;
 // earliest point that count is fully resolved. We audit it there and recover in
 // place with the `mcp_reconnect` control request (single-server reconnect +
 // tools re-fetch, no process restart) before surfacing a degraded state. #2802
-const SEREN_MCP_SERVER_NAME = "seren-mcp";
-const SEREN_MCP_TOOL_PREFIX = `mcp__${SEREN_MCP_SERVER_NAME}__`;
-
 function applySerenMcpOAuthRouting(routing, toolName, toolInput) {
   if (toolName !== `${SEREN_MCP_TOOL_PREFIX}call_publisher`) {
     return { input: toolInput, denyMessage: null };
@@ -2838,7 +2837,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     // present (see createRemoteSerenServer). Mirror that check so the
     // post-spawn tool audit only runs for sessions that actually expect
     // gateway tools. #2802
-    const serenMcpConfigured = serenCredential != null;
+    let serenMcpConfigured = false;
     const claudeBin = resolveClaudeBinary();
     const extendedPath = buildExtendedPath();
     const effectiveEffort =
@@ -2873,6 +2872,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         mcpServers,
         serenMcpGatewayUrl: serenMcpProxy?.url,
       });
+      serenMcpConfigured = mcpConfig.serenMcpConfigured;
       policySettingsJson = JSON.stringify(
         buildClaudePolicySettings({
           cwd,
@@ -3170,6 +3170,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        serenMcpConfigured: session.serenMcpConfigured,
         // OS PID of the agent child, so Rust can force-kill this one session
         // when the cooperative cancel/terminate RPCs are unreachable. #2313
         pid: session.process?.pid ?? null,
@@ -3335,6 +3336,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      serenMcpConfigured: session.serenMcpConfigured,
       pid: session.process?.pid ?? null,
     }));
   }

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -1627,6 +1627,8 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
           capability: serenCredential?.capability,
           url: serenMcpProxy?.url,
         }),
+        serenMcpConfigured:
+          serenCredential != null && serenMcpProxy != null,
         serenMcpProxy,
         availableModelRecords,
         currentModelId: initialModel.modelId,
@@ -1668,6 +1670,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       createdAt: session.createdAt,
       agentSessionId: session.agentSessionId,
       timeoutSecs: session.timeoutSecs,
+      serenMcpConfigured: session.serenMcpConfigured,
       pid: null,
     };
   }
@@ -1719,6 +1722,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       currentModelId: session.currentModelId,
       currentModeId: session.currentModeId,
       pendingPermissions: listPendingPermissions(session),
+      serenMcpConfigured: session.serenMcpConfigured,
       pid: null,
     }));
   }

--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -2,8 +2,13 @@
 // ABOUTME: Normalizes Seren's MCP settings into provider-specific Claude/Codex formats.
 
 import path from "node:path";
+import { SEREN_MCP_SERVER_NAME } from "./seren-mcp-contract.mjs";
 
-const SEREN_MCP_SERVER_NAME = "seren-mcp";
+export {
+  SEREN_MCP_SERVER_NAME,
+  SEREN_MCP_TOOL_PREFIX,
+  serenMcpToolName,
+} from "./seren-mcp-contract.mjs";
 // The child receives a loopback-broker capability, never a Seren API key. NOTE:
 // the desktop's provider-runtime log scrubber does NOT cover this value — it
 // scrubs SEREN_*_{KEY,TOKEN,SECRET} values found in the *desktop* process env,
@@ -259,14 +264,20 @@ export function buildProviderMcpConfig({
   mcpServers,
   serenMcpGatewayUrl,
 } = {}) {
+  const remoteSerenServer = createRemoteSerenServer(
+    serenCapability,
+    serenMcpGatewayUrl,
+  );
   const normalizedServers = dedupeServers([
-    createRemoteSerenServer(serenCapability, serenMcpGatewayUrl),
+    remoteSerenServer,
     ...((Array.isArray(mcpServers) ? mcpServers : [])
       .map((server) => normalizeLocalServer(server))
       .filter(Boolean)),
   ].filter(Boolean));
 
   return {
+    serenMcpConfigured:
+      remoteSerenServer != null && normalizedServers.includes(remoteSerenServer),
     childEnv:
       trimToNull(serenCapability) == null
         ? {}

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -1094,6 +1094,7 @@ export function createPairedRuntime({ emit, inner }) {
       status: "initializing",
       createdAt: new Date().toISOString(),
       timeoutSecs: params.timeoutSecs ?? undefined,
+      serenMcpConfigured: false,
       state: "idle",
       activeRole: null,
       roles: {
@@ -1112,8 +1113,21 @@ export function createPairedRuntime({ emit, inner }) {
     pairedSessions.set(pairedId, paired);
 
     try {
-      await spawnRole(paired, "planner", params, params.paired);
-      await spawnRole(paired, "executor", params, params.paired);
+      const plannerInfo = await spawnRole(
+        paired,
+        "planner",
+        params,
+        params.paired,
+      );
+      const executorInfo = await spawnRole(
+        paired,
+        "executor",
+        params,
+        params.paired,
+      );
+      paired.serenMcpConfigured =
+        plannerInfo?.serenMcpConfigured === true &&
+        executorInfo?.serenMcpConfigured === true;
 
       paired.status = "ready";
       if (!resumeIds) {
@@ -1129,6 +1143,7 @@ export function createPairedRuntime({ emit, inner }) {
         createdAt: paired.createdAt,
         agentSessionId: compositeAgentSessionId(paired),
         timeoutSecs: paired.timeoutSecs,
+        serenMcpConfigured: paired.serenMcpConfigured,
         // Two child processes back this session; per-PID force-kill cannot
         // target both, so cancel/terminate are the supported stop paths.
         pid: null,
@@ -1518,6 +1533,7 @@ export function createPairedRuntime({ emit, inner }) {
       createdAt: paired.createdAt,
       agentSessionId: compositeAgentSessionId(paired),
       timeoutSecs: paired.timeoutSecs,
+      serenMcpConfigured: paired.serenMcpConfigured,
       pid: null,
     }));
   }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -574,6 +574,7 @@ function createCodexSessionRecord({
   sessionId,
   cwd,
   processHandle,
+  serenMcpConfigured = false,
   serenMcpProxy,
   timeoutSecs,
   currentModeId,
@@ -585,6 +586,7 @@ function createCodexSessionRecord({
     status: "initializing",
     createdAt: new Date().toISOString(),
     process: processHandle,
+    serenMcpConfigured,
     serenMcpProxy,
     output: readline.createInterface({ input: processHandle.stdout }),
     pendingRequests: new Map(),
@@ -1831,6 +1833,7 @@ export function createProviderHandlers({
     const resolvedSandbox = sandboxFromMode(sandboxMode, networkEnabled);
     const serenCredential = resolveBrokeredSerenCredential(params);
     let serenMcpProxy = null;
+    let serenMcpConfigured = false;
     let processHandle;
     try {
       if (serenCredential) {
@@ -1839,6 +1842,11 @@ export function createProviderHandlers({
           apiUrl: serenCredential.apiBaseUrl,
         });
       }
+      serenMcpConfigured = buildProviderMcpConfig({
+        serenCapability: serenCredential?.capability,
+        mcpServers,
+        serenMcpGatewayUrl: serenMcpProxy?.url,
+      }).serenMcpConfigured;
       processHandle = spawnCodex(cwd, {
         serenCapability: serenCredential?.capability,
         mcpServers,
@@ -1853,6 +1861,7 @@ export function createProviderHandlers({
       sessionId,
       cwd,
       processHandle,
+      serenMcpConfigured,
       serenMcpProxy,
       timeoutSecs,
       currentModeId: resolvedMode,
@@ -2039,6 +2048,7 @@ export function createProviderHandlers({
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        serenMcpConfigured: session.serenMcpConfigured,
         // OS PID of the agent child, so Rust can force-kill this one session
         // when the cooperative cancel/terminate RPCs are unreachable. #2313
         pid: session.process?.pid ?? null,
@@ -2345,6 +2355,7 @@ export function createProviderHandlers({
         currentModelId: session.currentModelId,
         currentModeId: session.currentModeId,
         pendingPermissions: listPendingPermissions(session),
+        serenMcpConfigured: session.serenMcpConfigured,
         pid: session.process?.pid ?? null,
       })),
       ...(await claudeRuntime.listSessions()),

--- a/bin/browser-local/seren-mcp-contract.mjs
+++ b/bin/browser-local/seren-mcp-contract.mjs
@@ -1,0 +1,9 @@
+// ABOUTME: Shared identity contract for the Seren MCP server and its registered tool names.
+// ABOUTME: Keeps provider configuration and renderer prompt guidance on one namespace source.
+
+export const SEREN_MCP_SERVER_NAME = "seren-mcp";
+export const SEREN_MCP_TOOL_PREFIX = `mcp__${SEREN_MCP_SERVER_NAME}__`;
+
+export function serenMcpToolName(toolName) {
+  return `${SEREN_MCP_TOOL_PREFIX}${toolName}`;
+}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -176,6 +176,8 @@ export interface AgentSessionInfo {
   currentModeId?: string | null;
   /** Pending approval dialogs that must be re-surfaced after UI re-attach. */
   pendingPermissions?: PermissionRequestEvent[];
+  /** True only when the Seren MCP server was registered for this live session. */
+  serenMcpConfigured?: boolean;
 }
 
 export interface AgentInfo {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -101,6 +101,8 @@ import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
+// @ts-expect-error — shared provider-runtime ESM has no generated declaration.
+import { serenMcpToolName } from "../../bin/browser-local/seren-mcp-contract.mjs";
 
 // Bootstrap-context helpers live in @/lib/agent/bootstrap-context.
 // Re-exported so existing importers keep the unchanged public surface.
@@ -196,8 +198,8 @@ export const PREDICTIVE_STRUCTURAL_FAILURE_RE =
   /issue with the selected model|model.*not exist|ENOENT|schema_drift|Parent JSONL transcript not found/i;
 
 /**
- * Instruction prepended to every agent session telling Claude Code / Codex
- * that the Seren MCP gateway exists and MUST be queried live before refusing
+ * Instruction prepended to agent sessions whose provider runtime confirms the
+ * Seren MCP gateway was registered. It MUST be queried live before refusing
  * any third-party service. Intentionally does NOT embed a snapshot of
  * publisher slugs — snapshots go stale at cold-start when the gateway's
  * discovery is still in-flight, and the agent then confidently refuses real
@@ -205,19 +207,28 @@ export const PREDICTIVE_STRUCTURAL_FAILURE_RE =
  */
 export const PUBLISHER_LIVE_QUERY_INSTRUCTION =
   "You have access to a Seren MCP gateway with callable publishers via " +
-  "your seren-mcp tools (list_agent_publishers, call_publisher). Before " +
+  `your registered tools (${serenMcpToolName("list_agent_publishers")}, ` +
+  `${serenMcpToolName("call_publisher")}). Before ` +
   "stating that any third-party service (Google Docs, Gmail, GitHub, " +
   "Slack, Notion, Linear, Figma, and many others) is unavailable, you " +
-  "MUST call list_agent_publishers with NO arguments to get the current " +
+  `MUST call ${serenMcpToolName("list_agent_publishers")} with NO arguments ` +
+  "to get the current " +
   "live publisher list — publishers are added frequently and any list " +
   "you may have seen is stale. After confirming a publisher exists, " +
   "filter that returned list client-side, then use the publisher's tool " +
-  "enumeration metadata and call_publisher to invoke it. A failed or empty " +
+  `enumeration metadata and ${serenMcpToolName("call_publisher")} to invoke ` +
+  "it. A failed or empty " +
   "parameterized discovery call is not evidence that a publisher is absent. " +
   "Authorization or allowlist rejection means the publisher exists but access " +
   "is blocked; report that actionable state instead of calling it unavailable. " +
   "This live-query rule " +
   "overrides any prior belief about what tools you have.";
+
+export function resolvePublisherLiveQueryInstruction(
+  serenMcpConfigured: boolean,
+): string | null {
+  return serenMcpConfigured ? PUBLISHER_LIVE_QUERY_INSTRUCTION : null;
+}
 
 /**
  * Defensive re-prime threshold. The primary re-prime trigger is a signature
@@ -4628,7 +4639,10 @@ export const agentStore = {
       );
     }
 
-    const currentSignature = `${PUBLISHER_LIVE_QUERY_INSTRUCTION}\n\n${skillsContent}`;
+    const publisherInstruction = resolvePublisherLiveQueryInstruction(
+      session.info.serenMcpConfigured === true,
+    );
+    const currentSignature = `${publisherInstruction ?? ""}\n\n${skillsContent}`;
     const messageCount = session.messages.length;
     const messagesSincePrimed =
       messageCount - (session.primedAtMessageCount ?? 0);
@@ -4674,7 +4688,7 @@ export const agentStore = {
         );
         const projectedFullPrimingTokens =
           estimatePromptContextTokens(promptForBudget, mergedContext) +
-          estimateTokens(PUBLISHER_LIVE_QUERY_INSTRUCTION) +
+          estimateTokens(publisherInstruction ?? "") +
           estimateTokens(skillsContent);
 
         if (projectedFullPrimingTokens > maxSafeInputTokens) {
@@ -4701,10 +4715,12 @@ export const agentStore = {
           ...mergedContext,
         ];
       }
-      mergedContext = [
-        { type: "text", text: PUBLISHER_LIVE_QUERY_INSTRUCTION },
-        ...mergedContext,
-      ];
+      if (publisherInstruction) {
+        mergedContext = [
+          { type: "text", text: publisherInstruction },
+          ...mergedContext,
+        ];
+      }
     }
 
     return {

--- a/tests/unit/agent-skills-priming.test.ts
+++ b/tests/unit/agent-skills-priming.test.ts
@@ -19,9 +19,18 @@ describe("agent skill context priming", () => {
     const body = methodBody("async buildPromptContext");
 
     expect(body).toContain("skillsStore.getThreadSkillsContent");
-    expect(body).toContain("PUBLISHER_LIVE_QUERY_INSTRUCTION");
+    expect(body).toContain("resolvePublisherLiveQueryInstruction");
+    expect(body).toContain("session.info.serenMcpConfigured === true");
+    expect(body).toContain("publisherInstruction");
     expect(body).toContain("const currentSignature");
     expect(body).toContain("primedContextSignature === currentSignature");
+  });
+
+  it("only injects publisher guidance for a session with registered Seren MCP", () => {
+    const body = methodBody("async buildPromptContext");
+
+    expect(body).toContain("if (publisherInstruction)");
+    expect(body).toContain('{ type: "text", text: publisherInstruction }');
   });
 
   it("re-primes after the defensive message threshold", () => {

--- a/tests/unit/credential-broker-child-env.test.ts
+++ b/tests/unit/credential-broker-child-env.test.ts
@@ -46,14 +46,16 @@ describe("brokered agent credentials (#3194)", () => {
   it("configures no Seren MCP server when the broker endpoints are absent", () => {
     // Without a broker there is no safe place for a credential, so the gateway
     // must simply be unavailable rather than fall back to a raw key.
-    const { childEnv, claudeMcpConfigJson } = buildProviderMcpConfig({
-      serenCapability: CAPABILITY,
-      serenMcpGatewayUrl: undefined,
-      mcpServers: [],
-    });
+    const { childEnv, claudeMcpConfigJson, serenMcpConfigured } =
+      buildProviderMcpConfig({
+        serenCapability: CAPABILITY,
+        serenMcpGatewayUrl: undefined,
+        mcpServers: [],
+      });
 
     expect(childEnv).toEqual({ SEREN_MCP_CAPABILITY_TOKEN: CAPABILITY });
     expect(claudeMcpConfigJson).toBeNull();
+    expect(serenMcpConfigured).toBe(false);
   });
 
   it("resolves a spawn credential only when every broker field is present", () => {

--- a/tests/unit/publisher-live-query-instruction.test.ts
+++ b/tests/unit/publisher-live-query-instruction.test.ts
@@ -2,7 +2,21 @@
 // ABOUTME: must force a live list_agent_publishers query, never embed a stale snapshot.
 
 import { describe, expect, it } from "vitest";
-import { PUBLISHER_LIVE_QUERY_INSTRUCTION } from "@/stores/agent.store";
+import {
+  PUBLISHER_LIVE_QUERY_INSTRUCTION,
+  resolvePublisherLiveQueryInstruction,
+} from "@/stores/agent.store";
+const modulePath = new URL(
+  "../../bin/browser-local/mcp-config.mjs",
+  import.meta.url,
+).href;
+const {
+  buildProviderMcpConfig,
+  serenMcpToolName,
+} = await import(/* @vite-ignore */ modulePath);
+
+const CAPABILITY = "test-capability";
+const MCP_URL = "http://127.0.0.1:51234/session/mcp";
 
 describe("#1622 — PUBLISHER_LIVE_QUERY_INSTRUCTION", () => {
   it("does not embed any publisher slug or comma-separated list", () => {
@@ -24,10 +38,23 @@ describe("#1622 — PUBLISHER_LIVE_QUERY_INSTRUCTION", () => {
     ).not.toMatch(slugListPattern);
   });
 
-  it("forces the agent to call list_agent_publishers live before refusing", () => {
+  it("names the registered list_agent_publishers tool before refusing", () => {
     const txt = PUBLISHER_LIVE_QUERY_INSTRUCTION;
-    // Must mention the tool name — that's how the agent knows what to call.
-    expect(txt).toContain("list_agent_publishers");
+    const { claudeMcpConfigJson, serenMcpConfigured } =
+      buildProviderMcpConfig({
+        serenCapability: CAPABILITY,
+        serenMcpGatewayUrl: MCP_URL,
+        mcpServers: [],
+      });
+    const registeredServer = Object.keys(
+      JSON.parse(claudeMcpConfigJson).mcpServers,
+    )[0];
+
+    expect(serenMcpConfigured).toBe(true);
+    expect(serenMcpToolName("list_agent_publishers")).toBe(
+      `mcp__${registeredServer}__list_agent_publishers`,
+    );
+    expect(txt).toContain(serenMcpToolName("list_agent_publishers"));
     // Must state the rule as a MUST, not a suggestion, and must call out
     // the staleness of any prior belief — without these the model has
     // discretion and will revert to "I don't have that tool" on low confidence.
@@ -35,8 +62,24 @@ describe("#1622 — PUBLISHER_LIVE_QUERY_INSTRUCTION", () => {
     expect(txt.toLowerCase()).toContain("stale");
   });
 
-  it("mentions call_publisher so the agent can invoke after discovery", () => {
-    expect(PUBLISHER_LIVE_QUERY_INSTRUCTION).toContain("call_publisher");
+  it("names the registered call_publisher tool after discovery", () => {
+    expect(PUBLISHER_LIVE_QUERY_INSTRUCTION).toContain(
+      serenMcpToolName("call_publisher"),
+    );
+  });
+
+  it("omits the instruction when the Seren MCP server was not registered", () => {
+    const { serenMcpConfigured } = buildProviderMcpConfig({
+      serenCapability: CAPABILITY,
+      serenMcpGatewayUrl: undefined,
+      mcpServers: [],
+    });
+
+    expect(serenMcpConfigured).toBe(false);
+    expect(resolvePublisherLiveQueryInstruction(serenMcpConfigured)).toBeNull();
+    expect(resolvePublisherLiveQueryInstruction(true)).toBe(
+      PUBLISHER_LIVE_QUERY_INSTRUCTION,
+    );
   });
 
   it("forbids parameterized discovery failures from becoming absence claims (#2910)", () => {


### PR DESCRIPTION
Closes #3500

## Summary

- derive the Seren MCP server namespace and fully qualified tool names from one shared runtime contract
- return whether the Seren MCP server was actually registered for each Claude, Codex, ACP, LM Studio, and paired session, including reattached sessions
- inject the publisher live-query primer only when that registration fact is true
- protect both the namespaced-tool and no-registration behaviors with focused regression coverage

## Network path audited

Agent UI send -> agent session spawn -> brokered Seren credential lease -> loopback OAuth proxy -> provider MCP config named `seren-mcp` -> `mcp__seren-mcp__list_agent_publishers` / `mcp__seren-mcp__call_publisher` -> live Seren gateway.

The publisher slug and endpoint metadata were verified against the live Seren publisher list. No other outbound path is changed.

## Validation

- `pnpm test` — 2,839 passed, 15 skipped
- `pnpm build`
- `pnpm test:runtime-smoke`
- `pnpm test:runtime-e2e` — live no-mock Codex paths passed
- focused issue coverage — 26 passed
- real isolated Tauri `app-ready` walkthrough
- real signed-out Tauri/Codex send walkthrough confirmed the provider transcript contains the user prompt and no publisher primer when Seren MCP is not registered
- JavaScript syntax, Biome, and diff checks

Functional walkthrough classification: no P0/P1/P2 regressions found. The host-only Claude sandbox refusal and expired local Seren validation session were classified as non-blocking environment constraints.