### PR TITLE
fix(agent): preserve conversation agent_type across re-spawn (#3502)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1211,7 +1211,14 @@ fn upsert_agent_conversation_in_db(
                 ?9
             )
              ON CONFLICT(id) DO UPDATE SET
-                agent_type = excluded.agent_type,
+                -- Preserve the row's persisted agent identity on re-spawn. A
+                -- spawn resolves its agent type from the global selected-agent
+                -- when a caller omits one, so overwriting here let an action on
+                -- one thread flip a backgrounded thread's agent (#3502). Only an
+                -- explicit provider switch (switch_thread_provider) may change
+                -- agent_type; keep the existing value, taking the incoming one
+                -- only when the row has none.
+                agent_type = COALESCE(conversations.agent_type, excluded.agent_type),
                 agent_session_id = COALESCE(excluded.agent_session_id, conversations.agent_session_id),
                 agent_cwd = COALESCE(conversations.agent_cwd, excluded.agent_cwd),
                 agent_metadata = COALESCE(excluded.agent_metadata, conversations.agent_metadata),
@@ -4452,6 +4459,51 @@ mod tests {
             .unwrap(),
             (1, Some("late-provider-session".to_string())),
         );
+    }
+
+    #[test]
+    fn re_spawn_upsert_preserves_existing_agent_type() {
+        // A backgrounded thread that re-spawns must keep its persisted agent
+        // identity. A spawn resolves agent_type from the global selected agent
+        // when a caller omits one, so an overwriting upsert let switching one
+        // thread's provider flip a different, backgrounded thread (#3502). Only
+        // an explicit provider switch may change a conversation's agent_type.
+        let conn = open();
+
+        let codex = AgentConversation {
+            id: "victim".to_string(),
+            title: "Codex thread".to_string(),
+            created_at: 1000,
+            agent_type: "codex".to_string(),
+            agent_session_id: Some("codex-session".to_string()),
+            agent_cwd: Some("/project".to_string()),
+            agent_model_id: None,
+            agent_permission_mode: None,
+            agent_metadata: None,
+            project_id: Some("/project".to_string()),
+            project_root: Some("/project".to_string()),
+            is_archived: false,
+            privileged: false,
+        };
+        assert!(!upsert_agent_conversation_in_db(&conn, &codex).unwrap());
+
+        // A re-spawn of the same conversation arrives with claude-code (resolved
+        // from the just-flipped global selected agent). The persisted identity
+        // must NOT change.
+        let respawn_as_claude = AgentConversation {
+            agent_type: "claude-code".to_string(),
+            ..codex.clone()
+        };
+        assert!(!upsert_agent_conversation_in_db(&conn, &respawn_as_claude).unwrap());
+
+        let agent_type: String = conn
+            .query_row(
+                "SELECT agent_type FROM conversations WHERE id = ?1",
+                params![codex.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(agent_type, "codex");
     }
 
     /// Mirror of the production `list_conversations` SQL so tests can


### PR DESCRIPTION
Closes #3502.

## Problem

Switching **one** agent thread's provider (e.g. forking a Codex thread and changing it to Claude) could silently flip a **different, backgrounded** agent thread's persisted `agent_type`. The victim thread kept its original provider's model + permission mode, so it became permanently broken — reopening it re-spawned the wrong runtime with an incompatible model/mode and spammed errors (`Unsupported Claude mode: auto`, `There's an issue with the selected model (...)`).

## Root cause

- The "selected agent" is a single global (`state.selectedAgentType`, `src/stores/agent.store.ts`), set whenever any agent thread is selected.
- On (re-)spawn, `spawnSession` resolves the agent type as `agentType ?? state.selectedAgentType` and persists it onto the conversation row via `createAgentConversation` → `upsert_agent_conversation_in_db`.
- That upsert did `ON CONFLICT(id) DO UPDATE SET agent_type = excluded.agent_type`, so a re-spawn of a backgrounded thread *after* the global was flipped rewrote its **persisted** identity. The overwrite was introduced incidentally with the create-or-update upsert (#581); it was never meant to change a conversation's agent on re-spawn.
- The explicit switch path (`switch_thread_provider`) is single-thread and resets the model on a provider change (#3484), so it is not the cause — which is why the victim thread kept its old-provider model/mode.

## Fix

Preserve the existing `agent_type` on conflict in `upsert_agent_conversation_in_db` (keep the row's value, fall back to the incoming one only when the row has none). A re-spawn can no longer change a conversation's persisted agent identity; only an explicit provider switch may. New conversations and forks (fresh ids) still set `agent_type` via `INSERT`.

## Tests

- New regression test `re_spawn_upsert_preserves_existing_agent_type`: create a `codex` conversation, re-upsert the same id with `claude-code`, assert the persisted `agent_type` stays `codex`. Runs against a real in-memory SQLite (no mocks).
- Verified no regression: full `commands::chat::tests` (36 passed) and `commands::provider_runtime::tests` (21 passed, incl. the switch-path model-reset tests).

## Notes / follow-ups (separate)

- `switch_thread_provider` resets `agent_model_id` on a provider change but not `agent_permission_mode`, so a *deliberate* Codex→Claude switch still leaves a stale permission mode. Tracking separately.
- This fix prevents new corruption; already-corrupted rows are not auto-healed — switching the affected thread's provider restores a coherent state.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
