### PR TITLE
fix(agent): surface publisher sign-in expiry (#3504)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3407,6 +3407,12 @@ export const agentStore = {
             apiBaseUrl: lease.apiBaseUrl,
           };
           credentialLeaseCreated = true;
+        } else {
+          // A signed-out spawn can still run the local provider, but it cannot
+          // receive publisher tools. Reuse the existing session-expired modal
+          // so this degraded mode is explicit and immediately actionable.
+          // #3504
+          requestSignInModal();
         }
         const enabledMcpServers = getEnabledMcpServers();
 
@@ -7587,11 +7593,19 @@ export const agentStore = {
         if (!degradedSession) {
           break;
         }
-        const degradedNotice =
-          "Seren publisher tools could not be loaded for this thread — the " +
-          "Seren gateway was reachable but its tool list stayed unavailable " +
-          "after several retries. Publisher actions may fail here; start a " +
-          "new thread to try again.";
+        const signedOut = !authStore.isAuthenticated;
+        if (signedOut) {
+          // Re-raise the existing modal even if it was previously dismissed.
+          // A new thread cannot restore publisher tools until auth is repaired.
+          requestSignInModal();
+        }
+        const degradedNotice = signedOut
+          ? "Seren publisher tools are off because your Seren session expired. " +
+            "Sign in to restore them."
+          : "Seren publisher tools could not be loaded for this thread — the " +
+            "Seren gateway was reachable but its tool list stayed unavailable " +
+            "after several retries. Publisher actions may fail here; start a " +
+            "new thread to try again.";
         const lastDegradedMessage = degradedSession.messages.at(-1);
         if (
           lastDegradedMessage?.type !== "error" ||
@@ -7618,7 +7632,9 @@ export const agentStore = {
         }
         void captureSupportError({
           kind: "agent.seren_mcp_tools_unavailable",
-          message: `seren-mcp registered 0 tools after reconnect recovery (server: ${event.data.serverName})`,
+          message: signedOut
+            ? `seren-mcp unavailable because the Desktop session is signed out (server: ${event.data.serverName})`
+            : `seren-mcp registered 0 tools after reconnect recovery (server: ${event.data.serverName})`,
           agentContext: {
             model: degradedSession.currentModelId,
             provider: degradedSession.info.agentType,

--- a/tests/unit/agent-credential-lease-wiring.test.ts
+++ b/tests/unit/agent-credential-lease-wiring.test.ts
@@ -26,7 +26,7 @@ function directTerminationContext(sessionExpression: string): string {
   return agentStoreSource.slice(Math.max(0, index - 1_200), index + 400);
 }
 
-describe("agent session credential leases (#3194)", () => {
+describe("agent session credential leases (#3194, #3504)", () => {
   it("creates a per-session lease instead of reading the persistent desktop key", () => {
     const spawnBody = bodyAfter("async spawnSession(");
     expect(spawnBody).toContain("await createCredentialLease(localSessionId)");
@@ -44,6 +44,24 @@ describe("agent session credential leases (#3194)", () => {
     // raw key used to occupy.
     expect(bodyAfter("async spawnSession(", 30_000)).toMatch(
       /agentSandboxMode,\s*\n\s*serenCredential,/,
+    );
+  });
+
+  it("surfaces sign-in instead of silently omitting publisher tools", () => {
+    const spawnBody = bodyAfter("async spawnSession(", 30_000);
+    const authGate = spawnBody.slice(
+      spawnBody.indexOf("if (authStore.isAuthenticated)"),
+      spawnBody.indexOf("const enabledMcpServers"),
+    );
+    expect(authGate).toContain("await createCredentialLease(localSessionId)");
+    expect(authGate).toContain("else {");
+    expect(authGate).toContain("requestSignInModal()");
+
+    const degradedBody = bodyAfter('case "mcpDegraded":', 5_000);
+    expect(degradedBody).toContain("!authStore.isAuthenticated");
+    expect(degradedBody).toContain("requestSignInModal()");
+    expect(degradedBody).toContain(
+      "Seren publisher tools are off because your Seren session expired.",
     );
   });
 

--- a/tests/validation/scenarios/agent-signed-out-publisher-tools.ts
+++ b/tests/validation/scenarios/agent-signed-out-publisher-tools.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Verifies a signed-out agent spawn visibly prompts for Seren auth.
+// ABOUTME: Runs against the isolated real Tauri app with no mocked services.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface DumpTextResult {
+  text?: string;
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.command({ command: "setRootPath", path: process.cwd() });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-codex-agent']", 10_000);
+  await ctx.client.click("[data-testid='new-codex-agent']");
+
+  const dialogSelector =
+    "[role='dialog'][aria-labelledby='session-expired-modal-title']";
+  await ctx.client.waitFor(dialogSelector, 60_000);
+  const dialog = (await ctx.client.dumpText(dialogSelector)) as DumpTextResult;
+  const text = dialog.text ?? "";
+  if (
+    !text.includes("Sign in to continue") ||
+    !text.includes("Your Seren session has expired")
+  ) {
+    throw new Error(`Unexpected signed-out publisher-tools prompt: ${text}`);
+  }
+
+  await ctx.writeArtifact("signed-out-modal-text.json", dialog);
+  await ctx.writeArtifact(
+    "signed-out-modal-screenshot.json",
+    await ctx.client.nativeScreenshot(),
+  );
+}


### PR DESCRIPTION
## Description

When an agent session spawns while the Seren Desktop session is signed out, surface the existing sign-in modal before continuing without publisher tools. The existing degraded-tool notice now branches on authentication state: expired sessions direct the user to sign in, while authenticated gateway failures retain the new-thread recovery advice.

This keeps signed-out local agents usable, preserves authenticated credential-lease creation, and introduces no new publisher route, request, or credential path.

## Related Issue

Fixes #3504

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests (if applicable)
- [x] I have updated documentation (not applicable; no public interface changed)
- [x] `pnpm test` passes
- [x] `pnpm check` passes
- [x] No secrets or credentials in code

## Verification

- Focused auth, lease-wiring, runtime-audit, sign-in, and provider tests: 28 passed
- Full unit suite: 2,840 passed, 15 skipped
- Production frontend build: passed
- Runtime smoke and runtime E2E: passed
- No-mock Tauri validation walkthrough: passed on the signed-out Codex spawn path
- Native validation-window capture: 1200×800, rasterized successfully
- `pnpm check`: passed (warning-only diagnostics are pre-existing and outside this diff)

## Screenshots

The walkthrough exercised the existing session-expired modal rather than introducing a new UI component. Validation captured the isolated `SerenDesktop (Validation)` window and asserted both the actionable expired-session copy and the sign-in form.
