### PR TITLE
fix(agent): renew Seren MCP leases in place

### DIFF
--- a/scripts/validate-walkthrough.ts
+++ b/scripts/validate-walkthrough.ts
@@ -52,6 +52,7 @@ interface ScenarioModule {
 export interface ScenarioContext {
   client: ControlClient;
   artifactsDir: string;
+  validationHome: string;
   writeArtifact(name: string, value: unknown): Promise<void>;
 }
 
@@ -126,6 +127,7 @@ async function main(): Promise<void> {
     await run({
       client,
       artifactsDir,
+      validationHome,
       writeArtifact: writeJson,
     });
 

--- a/src-tauri/src/commands/credential_lease.rs
+++ b/src-tauri/src/commands/credential_lease.rs
@@ -30,3 +30,19 @@ pub async fn credential_lease_revoke_all(
 ) -> Result<(), String> {
     state.revoke_all(&app).await
 }
+
+#[tauri::command]
+pub async fn credential_lease_suspend_all(
+    app: AppHandle,
+    state: State<'_, CredentialLeaseManager>,
+) -> Result<(), String> {
+    state.suspend_all(&app).await
+}
+
+#[tauri::command]
+pub async fn credential_lease_resume_all(
+    app: AppHandle,
+    state: State<'_, CredentialLeaseManager>,
+) -> Result<(), String> {
+    state.resume_leases(&app).await
+}

--- a/src-tauri/src/credential_broker.rs
+++ b/src-tauri/src/credential_broker.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -24,6 +25,7 @@ const API_UPSTREAM_PREFIX: &str = "publishers/";
 const MAX_REQUEST_BODY_BYTES: usize = 8 * 1024 * 1024;
 const MAX_CONCURRENT_REQUESTS: usize = 64;
 const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const LEASE_RECOVERY_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Request headers the broker relays upstream. `authorization`, `cookie`,
 /// `host`, and every `proxy-*` header are absent by construction: anything not
@@ -76,12 +78,23 @@ struct BrokerRoute {
     /// stale capability stops working even if revocation never ran.
     expires_at: Option<jiff::Timestamp>,
     revoked: Arc<AtomicBool>,
+    generation: u64,
+}
+
+/// A rejected upstream lease asks the async credential manager to rotate the
+/// key in place. The broker thread waits only long enough to retry the current
+/// request once; no secret crosses this channel. #3508
+pub(crate) struct BrokerRecoveryRequest {
+    pub session_id: String,
+    pub generation: u64,
+    pub completed: mpsc::Sender<bool>,
 }
 
 struct BrokerInner {
     /// Keyed by the unguessable path segment, so an unknown route is rejected
     /// before any comparison touches key material.
     routes: Mutex<HashMap<String, BrokerRoute>>,
+    recovery_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<BrokerRecoveryRequest>>>,
     port: u16,
     in_flight: AtomicUsize,
     client: reqwest::blocking::Client,
@@ -122,6 +135,7 @@ impl PublisherCredentialBroker {
 
         let inner = Arc::new(BrokerInner {
             routes: Mutex::new(HashMap::new()),
+            recovery_tx: Mutex::new(None),
             port,
             in_flight: AtomicUsize::new(0),
             client,
@@ -174,6 +188,7 @@ impl PublisherCredentialBroker {
                 api_key: api_key.to_string(),
                 expires_at: expires_at.parse::<jiff::Timestamp>().ok(),
                 revoked: Arc::new(AtomicBool::new(false)),
+                generation: 0,
             },
         );
         Ok(BrokeredEndpoints {
@@ -181,6 +196,93 @@ impl PublisherCredentialBroker {
             api_base_url: format!("http://127.0.0.1:{}/{route_id}/api/", self.inner.port),
             capability,
         })
+    }
+
+    /// Install the host-side recovery queue after the Tauri runtime exists.
+    /// Replacing the sender is harmless and makes test/app construction simple.
+    pub(crate) fn set_recovery_sender(
+        &self,
+        sender: tokio::sync::mpsc::UnboundedSender<BrokerRecoveryRequest>,
+    ) {
+        let Ok(mut recovery_tx) = self.inner.recovery_tx.lock() else {
+            log::warn!("[credential-broker] Recovery channel is poisoned");
+            return;
+        };
+        *recovery_tx = Some(sender);
+    }
+
+    /// Swap a renewed key into every route for one live session without
+    /// changing its URL or opaque capability. Existing request snapshots are
+    /// revoked before new requests get a fresh flag and key. #3508
+    pub(crate) fn rotate_session(
+        &self,
+        session_id: &str,
+        api_key: &str,
+        expires_at: &str,
+        expected_generation: u64,
+    ) -> Result<bool, String> {
+        let expires_at = expires_at
+            .parse::<jiff::Timestamp>()
+            .map_err(|error| format!("Credential lease expiry was invalid: {error}"))?;
+        let mut routes = self
+            .inner
+            .routes
+            .lock()
+            .map_err(|_| "Credential broker route table is poisoned".to_string())?;
+        let mut rotated = false;
+        for route in routes.values_mut() {
+            if route.session_id != session_id || route.generation != expected_generation {
+                continue;
+            }
+            route.revoked.store(true, Ordering::Release);
+            route.api_key = api_key.to_string();
+            route.expires_at = Some(expires_at);
+            route.revoked = Arc::new(AtomicBool::new(false));
+            route.generation = route.generation.saturating_add(1);
+            rotated = true;
+        }
+        Ok(rotated)
+    }
+
+    pub(crate) fn session_generation(&self, session_id: &str) -> Option<u64> {
+        self.inner.routes.lock().ok().and_then(|routes| {
+            routes
+                .values()
+                .find(|route| route.session_id == session_id)
+                .map(|route| route.generation)
+        })
+    }
+
+    #[cfg(feature = "validation")]
+    pub(crate) fn expire_all_for_validation(&self) -> Result<usize, String> {
+        let expired_at = "1970-01-01T00:00:00Z"
+            .parse::<jiff::Timestamp>()
+            .map_err(|error| format!("Validation expiry was invalid: {error}"))?;
+        let mut routes = self
+            .inner
+            .routes
+            .lock()
+            .map_err(|_| "Credential broker route table is poisoned".to_string())?;
+        for route in routes.values_mut() {
+            route.expires_at = Some(expired_at);
+        }
+        Ok(routes.len())
+    }
+
+    /// Logout drops key material and denies every route immediately, but keeps
+    /// the opaque route identity so a successful sign-in can restore a still-
+    /// running agent without replacing its MCP configuration. #3508
+    pub(crate) fn suspend_all(&self) {
+        let Ok(mut routes) = self.inner.routes.lock() else {
+            log::warn!("[credential-broker] Route table is poisoned; cannot suspend all");
+            return;
+        };
+        for route in routes.values_mut() {
+            route.revoked.store(true, Ordering::Release);
+            route.api_key.clear();
+            route.expires_at = None;
+            route.generation = route.generation.saturating_add(1);
+        }
     }
 
     /// Deny the session's capability. Requests already streaming stop at their
@@ -255,7 +357,7 @@ impl PublisherCredentialBroker {
             };
             routes.get(&target.route_id).cloned()
         };
-        let Some(route) = route else {
+        let Some(mut route) = route else {
             respond_error(request, 401, "capability_revoked");
             return;
         };
@@ -266,9 +368,23 @@ impl PublisherCredentialBroker {
             return;
         }
 
-        if lease_has_expired(route.expires_at, jiff::Timestamp::now()) {
-            respond_error(request, 401, "capability_expired");
+        if route.revoked.load(Ordering::Acquire) {
+            respond_error(request, 401, "capability_revoked");
             return;
+        }
+
+        if lease_has_expired(route.expires_at, jiff::Timestamp::now()) {
+            if self.recover_route(&route) {
+                if let Some(refreshed) = self.route_after_recovery(&target.route_id, &route) {
+                    route = refreshed;
+                } else {
+                    respond_error(request, 401, "capability_expired");
+                    return;
+                }
+            } else {
+                respond_error(request, 401, "capability_expired");
+                return;
+            }
         }
 
         let method = request.method().clone();
@@ -288,24 +404,8 @@ impl PublisherCredentialBroker {
             }
         };
 
-        let mut builder = self
-            .inner
-            .client
-            .request(upstream.method, &upstream.url)
-            // The one place a real credential is ever attached, against a URL
-            // built from constants rather than from anything the child sent.
-            .bearer_auth(&route.api_key)
-            // Node's fetch decodes transparently; ask for identity so relayed
-            // bytes always match the relayed content-type.
-            .header("accept-encoding", "identity");
-        for (name, value) in forwarded_request_headers(&request) {
-            builder = builder.header(name, value);
-        }
-        if !body.is_empty() {
-            builder = builder.body(body);
-        }
-
-        let response = match builder.send() {
+        let request_headers = forwarded_request_headers(&request);
+        let mut response = match self.send_upstream(&upstream, &route, &request_headers, &body) {
             Ok(response) => response,
             Err(error) => {
                 log::warn!(
@@ -316,6 +416,30 @@ impl PublisherCredentialBroker {
                 return;
             }
         };
+
+        // A remotely revoked/invalidated lease used to permanently disconnect
+        // every provider runtime. Ask the async manager for one in-place
+        // rotation, then replay this exact request once before the child ever
+        // sees the 401. Publisher-account re-auth challenges are not lease
+        // failures and retain their existing response. #3508
+        if gateway_lease_was_rejected(&response) && self.recover_route(&route) {
+            if let Some(refreshed) = self.route_after_recovery(&target.route_id, &route) {
+                match self.send_upstream(&upstream, &refreshed, &request_headers, &body) {
+                    Ok(retried) => {
+                        response = retried;
+                        route = refreshed;
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "[credential-broker] Upstream retry after lease recovery failed: {}",
+                            error.without_url()
+                        );
+                        respond_error(request, 502, "upstream_unreachable");
+                        return;
+                    }
+                }
+            }
+        }
 
         let status = StatusCode(response.status().as_u16());
         let headers = forwarded_response_headers(&response);
@@ -328,6 +452,74 @@ impl PublisherCredentialBroker {
                 revoked: Arc::clone(&route.revoked),
             },
         );
+    }
+
+    fn send_upstream(
+        &self,
+        upstream: &UpstreamRequest,
+        route: &BrokerRoute,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Result<reqwest::blocking::Response, reqwest::Error> {
+        let mut builder = self
+            .inner
+            .client
+            .request(upstream.method.clone(), &upstream.url)
+            // The one place a real credential is ever attached, against a URL
+            // built from constants rather than from anything the child sent.
+            .bearer_auth(&route.api_key)
+            // Node's fetch decodes transparently; ask for identity so relayed
+            // bytes always match the relayed content-type.
+            .header("accept-encoding", "identity");
+        for (name, value) in headers {
+            builder = builder.header(name, value);
+        }
+        if !body.is_empty() {
+            builder = builder.body(body.to_vec());
+        }
+        builder.send()
+    }
+
+    fn recover_route(&self, failed_route: &BrokerRoute) -> bool {
+        let sender = self
+            .inner
+            .recovery_tx
+            .lock()
+            .ok()
+            .and_then(|sender| sender.clone());
+        let Some(sender) = sender else {
+            return false;
+        };
+        let (completed, result) = mpsc::channel();
+        if sender
+            .send(BrokerRecoveryRequest {
+                session_id: failed_route.session_id.clone(),
+                generation: failed_route.generation,
+                completed,
+            })
+            .is_err()
+        {
+            return false;
+        }
+        result.recv_timeout(LEASE_RECOVERY_TIMEOUT).unwrap_or(false)
+    }
+
+    fn route_after_recovery(
+        &self,
+        route_id: &str,
+        failed_route: &BrokerRoute,
+    ) -> Option<BrokerRoute> {
+        self.inner.routes.lock().ok().and_then(|routes| {
+            routes.get(route_id).and_then(|route| {
+                (route.generation > failed_route.generation
+                    && !route.revoked.load(Ordering::Acquire)
+                    && constant_time_eq(
+                        route.capability.as_bytes(),
+                        failed_route.capability.as_bytes(),
+                    ))
+                .then(|| route.clone())
+            })
+        })
     }
 }
 
@@ -618,6 +810,11 @@ fn forwarded_response_headers(response: &reqwest::blocking::Response) -> Vec<Hea
         .collect()
 }
 
+fn gateway_lease_was_rejected(response: &reqwest::blocking::Response) -> bool {
+    response.status() == reqwest::StatusCode::UNAUTHORIZED
+        && !response.headers().contains_key("x-seren-reauth-required")
+}
+
 fn respond_error(request: Request, status: u16, reason: &str) {
     let body = format!(r#"{{"error":"{reason}"}}"#);
     let response = Response::from_string(body)
@@ -750,5 +947,96 @@ mod tests {
         assert!(constant_time_eq(b"abc", b"abc"));
         assert!(!constant_time_eq(b"abc", b"abd"));
         assert!(!constant_time_eq(b"abc", b"ab"));
+    }
+
+    #[test]
+    fn broker_rotates_a_suspended_session_without_changing_child_endpoints() {
+        let broker = PublisherCredentialBroker::start().expect("broker starts");
+        let endpoints = broker
+            .register("session-a", "old-secret", "2030-01-01T00:00:00Z")
+            .expect("route registers");
+        let route_id = endpoints
+            .mcp_url
+            .split('/')
+            .nth_back(1)
+            .expect("route id")
+            .to_string();
+        let before = broker
+            .inner
+            .routes
+            .lock()
+            .expect("routes lock")
+            .get(&route_id)
+            .expect("route exists")
+            .clone();
+
+        broker.suspend_all();
+        assert!(before.revoked.load(Ordering::Acquire));
+        {
+            let routes = broker.inner.routes.lock().expect("routes lock");
+            let suspended = routes.get(&route_id).expect("route stays reserved");
+            assert_eq!(suspended.capability, endpoints.capability);
+            assert!(suspended.api_key.is_empty());
+            assert!(suspended.revoked.load(Ordering::Acquire));
+        }
+
+        assert!(
+            !broker
+                .rotate_session(
+                    "session-a",
+                    "racing-secret",
+                    "2030-01-02T00:00:00Z",
+                    before.generation,
+                )
+                .expect("stale rotation is refused")
+        );
+
+        assert!(
+            broker
+                .rotate_session(
+                    "session-a",
+                    "renewed-secret",
+                    "2030-01-02T00:00:00Z",
+                    before.generation + 1,
+                )
+                .expect("route rotates")
+        );
+        let routes = broker.inner.routes.lock().expect("routes lock");
+        let renewed = routes.get(&route_id).expect("route remains");
+        assert_eq!(renewed.capability, endpoints.capability);
+        assert_eq!(renewed.api_key, "renewed-secret");
+        assert_eq!(renewed.generation, before.generation + 2);
+        assert!(!renewed.revoked.load(Ordering::Acquire));
+        // The old stream snapshot stays revoked after the new route is active.
+        assert!(before.revoked.load(Ordering::Acquire));
+        drop(routes);
+
+        let active_endpoints = broker
+            .register("session-b", "active-secret", "2030-01-01T00:00:00Z")
+            .expect("active route registers");
+        let active_route_id = active_endpoints
+            .mcp_url
+            .split('/')
+            .nth_back(1)
+            .expect("active route id");
+        let active_before = broker
+            .inner
+            .routes
+            .lock()
+            .expect("routes lock")
+            .get(active_route_id)
+            .expect("active route exists")
+            .clone();
+        assert!(
+            broker
+                .rotate_session(
+                    "session-b",
+                    "active-renewed-secret",
+                    "2030-01-02T00:00:00Z",
+                    active_before.generation,
+                )
+                .expect("active route rotates")
+        );
+        assert!(active_before.revoked.load(Ordering::Acquire));
     }
 }

--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -11,13 +11,15 @@ use tauri::AppHandle;
 use tauri_plugin_store::StoreExt;
 use tokio::sync::Mutex;
 
-use crate::credential_broker::PublisherCredentialBroker;
+use crate::credential_broker::{BrokerRecoveryRequest, PublisherCredentialBroker};
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 const DEFAULT_ORG_API_KEYS_PATH: &str = "/organizations/default/api-keys";
 const LEASE_STORE: &str = "credential-leases.json";
 const LEASE_LEDGER_KEY: &str = "orphaned_leases";
 const LEASE_EXPIRY_DAYS: u8 = 1;
+const LEASE_RENEWAL_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const LEASE_RENEWAL_WINDOW_SECONDS: i64 = 6 * 60 * 60;
 // A general agent session cannot predict its publisher set at spawn because
 // the Seren MCP catalog is dynamic, so it retains the existing publisher
 // wildcard. Managed deployment mutations are a separate Core capability and
@@ -46,6 +48,7 @@ struct ActiveLease {
     revoke_id: String,
     expires_at: String,
     endpoints: crate::credential_broker::BrokeredEndpoints,
+    suspended: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -93,16 +96,22 @@ pub struct CredentialLeaseManager {
     operation_lock: Arc<Mutex<()>>,
     startup_reaper_pending: Arc<AtomicBool>,
     broker: Option<PublisherCredentialBroker>,
+    recovery_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BrokerRecoveryRequest>>>>,
     client: reqwest::Client,
 }
 
 impl CredentialLeaseManager {
     pub fn new(broker: Option<PublisherCredentialBroker>) -> Self {
+        let (recovery_tx, recovery_rx) = tokio::sync::mpsc::unbounded_channel();
+        if let Some(broker) = broker.as_ref() {
+            broker.set_recovery_sender(recovery_tx);
+        }
         Self {
             active: Arc::new(Mutex::new(HashMap::new())),
             operation_lock: Arc::new(Mutex::new(())),
             startup_reaper_pending: Arc::new(AtomicBool::new(false)),
             broker,
+            recovery_rx: Arc::new(Mutex::new(Some(recovery_rx))),
             client: reqwest::Client::builder()
                 .timeout(Duration::from_secs(10))
                 .build()
@@ -147,14 +156,10 @@ impl CredentialLeaseManager {
         }
 
         if let Some(existing) = self.active.lock().await.get(&session_id).cloned() {
-            return Ok(CredentialLease {
-                session_id,
-                key_id: existing.key_id,
-                expires_at: existing.expires_at,
-                capability: existing.endpoints.capability,
-                mcp_url: existing.endpoints.mcp_url,
-                api_base_url: existing.endpoints.api_base_url,
-            });
+            if existing.suspended {
+                return self.renew_lease_locked(app, &session_id, None).await;
+            }
+            return Ok(credential_lease(&session_id, &existing));
         }
 
         let request_body = serde_json::json!({
@@ -189,7 +194,9 @@ impl CredentialLeaseManager {
         // treat its absence as a failed creation rather than issuing a lease
         // that only server-side expiry can end.
         if created.id.trim().is_empty() {
-            return Err("Credential lease creation response omitted its revocation id.".to_string());
+            return Err(
+                "Credential lease creation response omitted its revocation id.".to_string(),
+            );
         }
 
         let expires_at = created.expires_at.unwrap_or_default();
@@ -231,7 +238,9 @@ impl CredentialLeaseManager {
             Err(error) => {
                 let revoke_result = self.revoke_records_locked(app, vec![record]).await;
                 return Err(match revoke_result {
-                    Ok(()) => format!("Credential broker registration failed ({error}); key was revoked."),
+                    Ok(()) => {
+                        format!("Credential broker registration failed ({error}); key was revoked.")
+                    }
                     Err(revoke_error) => format!(
                         "Credential broker registration failed ({error}); key revocation was queued: {revoke_error}"
                     ),
@@ -246,6 +255,7 @@ impl CredentialLeaseManager {
                 revoke_id: created.id.clone(),
                 expires_at: expires_at.clone(),
                 endpoints: endpoints.clone(),
+                suspended: false,
             },
         );
 
@@ -257,6 +267,228 @@ impl CredentialLeaseManager {
             mcp_url: endpoints.mcp_url,
             api_base_url: endpoints.api_base_url,
         })
+    }
+
+    /// Keep live agent leases ahead of their server expiry and service broker
+    /// requests when a key is invalidated early. Both paths rotate the broker
+    /// route in place, so provider runtimes keep the same URL + capability.
+    pub async fn run_maintenance(&self, app: AppHandle) {
+        let Some(mut recovery_rx) = self.recovery_rx.lock().await.take() else {
+            log::warn!("[credential-lease] Maintenance worker already started");
+            return;
+        };
+        let mut interval = tokio::time::interval(LEASE_RENEWAL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    self.renew_due_leases(&app).await;
+                }
+                request = recovery_rx.recv() => {
+                    let Some(request) = request else {
+                        return;
+                    };
+                    let recovered = self
+                        .renew_lease(&app, &request.session_id, Some(request.generation))
+                        .await
+                        .is_ok();
+                    let _ = request.completed.send(recovered);
+                }
+            }
+        }
+    }
+
+    /// Rehydrate routes intentionally suspended by logout after authentication
+    /// succeeds again. Expired/due routes are included so a long sign-in flow
+    /// cannot leave an agent on yesterday's key. #3508
+    pub async fn resume_leases(&self, app: &AppHandle) -> Result<(), String> {
+        let now = jiff::Timestamp::now();
+        let session_ids: Vec<String> = self
+            .active
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, lease)| lease.suspended || lease_needs_renewal(&lease.expires_at, now))
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        let mut failures = Vec::new();
+        for session_id in session_ids {
+            if let Err(error) = self.renew_lease(app, &session_id, None).await {
+                log::warn!(
+                    "[credential-lease] Could not resume session lease {session_id}: {error}"
+                );
+                failures.push(session_id);
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} credential lease(s) could not be resumed",
+                failures.len()
+            ))
+        }
+    }
+
+    #[cfg(feature = "validation")]
+    pub(crate) fn expire_active_routes_for_validation(&self) -> Result<usize, String> {
+        self.broker
+            .as_ref()
+            .ok_or_else(|| "Credential broker is unavailable".to_string())?
+            .expire_all_for_validation()
+    }
+
+    async fn renew_due_leases(&self, app: &AppHandle) {
+        if self.startup_reaper_pending.load(Ordering::Acquire) {
+            return;
+        }
+        let now = jiff::Timestamp::now();
+        let session_ids: Vec<String> = self
+            .active
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, lease)| !lease.suspended && lease_needs_renewal(&lease.expires_at, now))
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        for session_id in session_ids {
+            if let Err(error) = self.renew_lease(app, &session_id, None).await {
+                log::warn!("[credential-lease] Scheduled renewal failed for {session_id}: {error}");
+            }
+        }
+    }
+
+    async fn renew_lease(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+        failed_generation: Option<u64>,
+    ) -> Result<CredentialLease, String> {
+        let _operation = self.operation_lock.lock().await;
+        self.renew_lease_locked(app, session_id, failed_generation)
+            .await
+    }
+
+    async fn renew_lease_locked(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+        failed_generation: Option<u64>,
+    ) -> Result<CredentialLease, String> {
+        let Some(broker) = self.broker.as_ref() else {
+            return Err("The publisher credential broker is unavailable.".to_string());
+        };
+        let existing = self
+            .active
+            .lock()
+            .await
+            .get(session_id)
+            .cloned()
+            .ok_or_else(|| "Credential lease is no longer active.".to_string())?;
+
+        if let Some(failed_generation) = failed_generation {
+            match broker.session_generation(session_id) {
+                Some(current_generation) if current_generation > failed_generation => {
+                    return Ok(credential_lease(session_id, &existing));
+                }
+                Some(current_generation) if current_generation == failed_generation => {}
+                _ => return Err("Credential broker route is no longer recoverable.".to_string()),
+            }
+        }
+        let rotation_generation = broker
+            .session_generation(session_id)
+            .ok_or_else(|| "Credential broker route is no longer recoverable.".to_string())?;
+
+        let created = self.create_remote_key(app).await?;
+        let expires_at = created.expires_at.clone().unwrap_or_default();
+        let record = LeaseLedgerEntry {
+            session_id: session_id.to_string(),
+            key_id: created.key_id.clone(),
+            revoke_id: created.id.clone(),
+            expires_at: expires_at.clone(),
+            pending_revocation: false,
+        };
+        if let Err(error) = validate_created_key(&created) {
+            if !record.revoke_id.trim().is_empty() {
+                let _ = self.revoke_remote_key(app, &record.revoke_id).await;
+            }
+            return Err(error);
+        }
+        if let Err(error) = self.append_ledger_record(app, record.clone()) {
+            let revoke_result = self.revoke_remote_key(app, &record.revoke_id).await;
+            return Err(match revoke_result {
+                Ok(()) => format!("Could not persist renewed lease cleanup record: {error}"),
+                Err(revoke_error) => format!(
+                    "Could not persist renewed lease cleanup record ({error}); emergency revocation failed: {revoke_error}"
+                ),
+            });
+        }
+
+        match broker.rotate_session(
+            session_id,
+            &created.api_key,
+            &expires_at,
+            rotation_generation,
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                let _ = self.revoke_records_locked(app, vec![record]).await;
+                return Err("Credential broker route disappeared during renewal.".to_string());
+            }
+            Err(error) => {
+                let _ = self.revoke_records_locked(app, vec![record]).await;
+                return Err(format!("Credential broker rotation failed: {error}"));
+            }
+        }
+
+        let renewed = ActiveLease {
+            key_id: created.key_id,
+            revoke_id: created.id,
+            expires_at,
+            endpoints: existing.endpoints.clone(),
+            suspended: false,
+        };
+        self.active
+            .lock()
+            .await
+            .insert(session_id.to_string(), renewed.clone());
+
+        if !existing.revoke_id.trim().is_empty() {
+            let old_record = lease_record(session_id, &existing);
+            if let Err(error) = self.revoke_records_locked(app, vec![old_record]).await {
+                log::warn!(
+                    "[credential-lease] Renewed {session_id}, but old-key revocation was queued: {error}"
+                );
+            }
+        }
+        Ok(credential_lease(session_id, &renewed))
+    }
+
+    async fn create_remote_key(&self, app: &AppHandle) -> Result<ApiKeyCreated, String> {
+        let request_body = serde_json::json!({
+            "name": "Seren Desktop session lease",
+            "scopes": VERIFIED_LEASE_SCOPES,
+            "expires_in_days": LEASE_EXPIRY_DAYS,
+        });
+        let response = crate::auth::authenticated_request(app, &self.client, |client, token| {
+            client
+                .post(format!("{GATEWAY_BASE_URL}{DEFAULT_ORG_API_KEYS_PATH}"))
+                .bearer_auth(token)
+                .json(&request_body)
+        })
+        .await?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Credential lease creation failed with HTTP {}",
+                response.status()
+            ));
+        }
+        response
+            .json::<DataResponse<ApiKeyCreated>>()
+            .await
+            .map_err(|error| format!("Credential lease creation response was invalid: {error}"))
+            .map(|response| response.data)
     }
 
     /// Close the broker route before anything else, so the session is denied
@@ -285,6 +517,33 @@ impl CredentialLeaseManager {
                 });
             }
         }
+        self.revoke_records_locked(app, records).await
+    }
+
+    /// Logout must remove every usable secret immediately, but a live provider
+    /// process may remain attached to its conversation. Preserve only its
+    /// opaque loopback route so a later authenticated session can rotate in a
+    /// fresh key without asking the user to abandon the thread. #3508
+    pub async fn suspend_all(&self, app: &AppHandle) -> Result<(), String> {
+        let _operation = self.operation_lock.lock().await;
+        if let Some(broker) = self.broker.as_ref() {
+            broker.suspend_all();
+        }
+        let mut active = self.active.lock().await;
+        for lease in active.values_mut() {
+            lease.suspended = true;
+        }
+        let mut records = read_ledger(app)?.leases;
+        for (session_id, lease) in active.iter() {
+            if !lease.revoke_id.trim().is_empty()
+                && !records
+                    .iter()
+                    .any(|record| record.revoke_id == lease.revoke_id)
+            {
+                records.push(lease_record(session_id, lease));
+            }
+        }
+        drop(active);
         self.revoke_records_locked(app, records).await
     }
 
@@ -334,7 +593,9 @@ impl CredentialLeaseManager {
         record: LeaseLedgerEntry,
     ) -> Result<(), String> {
         let mut ledger = read_ledger(app)?;
-        ledger.leases.retain(|entry| entry.revoke_id != record.revoke_id);
+        ledger
+            .leases
+            .retain(|entry| entry.revoke_id != record.revoke_id);
         ledger.leases.push(record);
         write_ledger(app, &ledger)
     }
@@ -453,6 +714,51 @@ impl CredentialLeaseManager {
     }
 }
 
+fn credential_lease(session_id: &str, lease: &ActiveLease) -> CredentialLease {
+    CredentialLease {
+        session_id: session_id.to_string(),
+        key_id: lease.key_id.clone(),
+        expires_at: lease.expires_at.clone(),
+        capability: lease.endpoints.capability.clone(),
+        mcp_url: lease.endpoints.mcp_url.clone(),
+        api_base_url: lease.endpoints.api_base_url.clone(),
+    }
+}
+
+fn lease_record(session_id: &str, lease: &ActiveLease) -> LeaseLedgerEntry {
+    LeaseLedgerEntry {
+        session_id: session_id.to_string(),
+        key_id: lease.key_id.clone(),
+        revoke_id: lease.revoke_id.clone(),
+        expires_at: lease.expires_at.clone(),
+        pending_revocation: false,
+    }
+}
+
+fn validate_created_key(created: &ApiKeyCreated) -> Result<(), String> {
+    if created.api_key.trim().is_empty() {
+        return Err("Credential lease creation response omitted key material.".to_string());
+    }
+    if created.id.trim().is_empty() {
+        return Err("Credential lease creation response omitted its revocation id.".to_string());
+    }
+    let expires_at = created.expires_at.as_deref().unwrap_or_default().trim();
+    if expires_at.is_empty() {
+        return Err("Credential lease creation response omitted expiry.".to_string());
+    }
+    expires_at.parse::<jiff::Timestamp>().map_err(|error| {
+        format!("Credential lease creation response had invalid expiry: {error}")
+    })?;
+    Ok(())
+}
+
+fn lease_needs_renewal(expires_at: &str, now: jiff::Timestamp) -> bool {
+    expires_at
+        .parse::<jiff::Timestamp>()
+        .map(|expiry| expiry <= now + jiff::SignedDuration::from_secs(LEASE_RENEWAL_WINDOW_SECONDS))
+        .unwrap_or(true)
+}
+
 fn validate_session_id(session_id: String) -> Result<String, String> {
     let session_id = session_id.trim().to_string();
     if session_id.is_empty() {
@@ -494,7 +800,7 @@ fn select_startup_reaper_records(records: &[LeaseLedgerEntry]) -> Vec<LeaseLedge
 mod tests {
     use super::{
         ApiKeyCreated, CredentialLease, CredentialLeaseLedger, LeaseLedgerEntry,
-        VERIFIED_LEASE_SCOPES, select_startup_reaper_records,
+        VERIFIED_LEASE_SCOPES, lease_needs_renewal, select_startup_reaper_records,
     };
 
     #[test]
@@ -614,5 +920,14 @@ mod tests {
         let encoded = serde_json::to_string(&ledger).expect("ledger serializes");
         assert!(encoded.contains("pending_revocation"));
         assert!(!encoded.contains("api_key"));
+    }
+
+    #[test]
+    fn credential_lease_renews_inside_the_six_hour_safety_window() {
+        let now: jiff::Timestamp = "2026-07-31T12:00:00Z".parse().expect("now parses");
+        assert!(!lease_needs_renewal("2026-07-31T19:00:00Z", now));
+        assert!(lease_needs_renewal("2026-07-31T18:00:00Z", now));
+        assert!(lease_needs_renewal("2026-07-31T11:59:59Z", now));
+        assert!(lease_needs_renewal("not-a-timestamp", now));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -707,6 +707,9 @@ pub fn run() {
                 {
                     log::warn!("[credential-lease] Startup reaper deferred: {error}");
                 }
+                credential_lease_manager
+                    .run_maintenance(credential_lease_app)
+                    .await;
             });
 
             // Create the configured windows here rather than letting Tauri
@@ -1185,6 +1188,8 @@ pub fn run() {
             commands::credential_lease::credential_lease_create,
             commands::credential_lease::credential_lease_revoke,
             commands::credential_lease::credential_lease_revoke_all,
+            commands::credential_lease::credential_lease_suspend_all,
+            commands::credential_lease::credential_lease_resume_all,
             commands::tool_authorization::authorize_tool_operation,
             commands::tool_authorization::record_tool_operation_decision,
             commands::tool_authorization::reserve_lease_spend,

--- a/src-tauri/src/validation/control_server.rs
+++ b/src-tauri/src/validation/control_server.rs
@@ -252,6 +252,21 @@ fn handle_request(
         }
     };
 
+    if incoming.command == "expireCredentialLeases" {
+        let Some(manager) = app.try_state::<crate::credential_lease::CredentialLeaseManager>()
+        else {
+            return text_response(StatusCode(503), "credential lease manager is unavailable");
+        };
+        return match manager.expire_active_routes_for_validation() {
+            Ok(expired) if expired > 0 => json_response(
+                StatusCode(200),
+                serde_json::json!({ "ok": true, "expiredRoutes": expired }),
+            ),
+            Ok(_) => text_response(StatusCode(409), "no active credential routes"),
+            Err(error) => text_response(StatusCode(500), &error),
+        };
+    }
+
     if !is_allowed_command(&incoming.command) {
         return text_response(StatusCode(400), "unsupported validation command");
     }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -20,7 +20,7 @@ import {
   storeRefreshToken,
   storeToken,
 } from "@/lib/tauri-bridge";
-import { revokeAllCredentialLeases } from "@/services/credential-lease";
+import { suspendAllCredentialLeases } from "@/services/credential-lease";
 import { clearAuthState, requestSignInModal } from "@/stores/auth.store";
 
 export type { LoginResult };
@@ -133,15 +133,15 @@ export async function login(
  * Logout and clear stored tokens.
  */
 export async function logout(): Promise<void> {
-  // Revoke while the Rust manager can still authenticate the API request.
-  // It drops local lease access before its remote call and retains only a
-  // non-secret retry record if the network is unavailable. Token clearing must
-  // still complete on a remote failure so logout cannot leave credentials live.
+  // Suspend while the Rust manager can still authenticate the remote revoke.
+  // Usable key material is dropped immediately, while opaque loopback routes
+  // stay reserved so a later sign-in can restore still-running threads. App
+  // exit and session teardown continue to hard-revoke those routes. #3508
   try {
-    await revokeAllCredentialLeases();
+    await suspendAllCredentialLeases();
   } catch (error) {
     console.warn(
-      "Failed to revoke session credential leases during logout:",
+      "Failed to suspend session credential leases during logout:",
       error,
     );
   }

--- a/src/services/credential-lease.ts
+++ b/src/services/credential-lease.ts
@@ -35,3 +35,16 @@ export async function revokeCredentialLease(sessionId: string): Promise<void> {
 export async function revokeAllCredentialLeases(): Promise<void> {
   await invoke("credential_lease_revoke_all");
 }
+
+/**
+ * Drop every usable session key on logout while reserving opaque loopback
+ * routes for any provider process that is still attached to its thread.
+ */
+export async function suspendAllCredentialLeases(): Promise<void> {
+  await invoke("credential_lease_suspend_all");
+}
+
+/** Restore suspended or expired live-session routes after sign-in. */
+export async function resumeCredentialLeases(): Promise<void> {
+  await invoke("credential_lease_resume_all");
+}

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -17,6 +17,7 @@ import {
   hasStoredToken,
   isLoggedIn,
 } from "@/services/auth";
+import { resumeCredentialLeases } from "@/services/credential-lease";
 import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
 import {
   getDefaultOrganizationPrivateChatPolicy,
@@ -246,6 +247,19 @@ async function activateAuthenticatedSession(
     privateChatPolicy,
     signInModalRequested: false,
   });
+
+  if (isTauriRuntime()) {
+    try {
+      await resumeCredentialLeases();
+    } catch (error) {
+      // Authentication itself succeeded. Keep the signed-in shell and let the
+      // Rust maintenance worker retry any live route on its next interval.
+      console.warn(
+        "[Auth Store] Failed to resume one or more agent credential leases:",
+        error,
+      );
+    }
+  }
 
   // Initialize MCP Gateway in background (non-blocking)
   void initializeMcpInBackground();

--- a/tests/unit/auth-credential-lease-logout.test.ts
+++ b/tests/unit/auth-credential-lease-logout.test.ts
@@ -8,7 +8,7 @@ const { events, mocks } = vi.hoisted(() => {
   return {
     events: eventLog,
     mocks: {
-      revokeAllCredentialLeases: vi.fn(async () => eventLog.push("revoke")),
+      suspendAllCredentialLeases: vi.fn(async () => eventLog.push("suspend")),
       clearToken: vi.fn(async () => eventLog.push("clear-token")),
       clearRefreshToken: vi.fn(async () => eventLog.push("clear-refresh")),
       clearDefaultOrganizationId: vi.fn(async () => eventLog.push("clear-org")),
@@ -36,7 +36,7 @@ vi.mock("@/lib/tauri-bridge", () => ({
 }));
 
 vi.mock("@/services/credential-lease", () => ({
-  revokeAllCredentialLeases: mocks.revokeAllCredentialLeases,
+  suspendAllCredentialLeases: mocks.suspendAllCredentialLeases,
 }));
 
 vi.mock("@/stores/auth.store", () => ({
@@ -46,15 +46,15 @@ vi.mock("@/stores/auth.store", () => ({
 
 import { logout } from "@/services/auth";
 
-describe("logout credential lease revocation (#3194)", () => {
+describe("logout credential lease suspension (#3508)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     events.length = 0;
   });
 
-  it("revokes all leases before clearing stored authentication", async () => {
+  it("suspends all leases before clearing stored authentication", async () => {
     await logout();
 
-    expect(events).toEqual(["revoke", "clear-token", "clear-refresh", "clear-org"]);
+    expect(events).toEqual(["suspend", "clear-token", "clear-refresh", "clear-org"]);
   });
 });

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -20,6 +20,7 @@ const {
   storedKeyRef,
   listenMock,
   eventListeners,
+  resumeCredentialLeasesMock,
 } = vi.hoisted(() => {
   const storedKey: { value: string | null } = { value: null };
   const listeners = new Map<string, (event?: unknown) => unknown>();
@@ -55,6 +56,7 @@ const {
       listeners.set(event, handler);
       return vi.fn();
     }),
+    resumeCredentialLeasesMock: vi.fn(async () => {}),
   };
 });
 
@@ -79,6 +81,10 @@ vi.mock("@/api", () => ({
 vi.mock("@/services/mcp-gateway", () => ({
   initializeGateway: initializeGatewayMock,
   resetGateway: resetGatewayMock,
+}));
+
+vi.mock("@/services/credential-lease", () => ({
+  resumeCredentialLeases: resumeCredentialLeasesMock,
 }));
 
 vi.mock("@/lib/runtime", () => ({
@@ -240,6 +246,7 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     expect(authAtStoreTime).toBe(false);
     expect(authStore.isAuthenticated).toBe(true);
     expect(authStore.signInModalRequested).toBe(false);
+    expect(resumeCredentialLeasesMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/credential-lease-bridge.test.ts
+++ b/tests/unit/credential-lease-bridge.test.ts
@@ -13,11 +13,13 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import {
   createCredentialLease,
+  resumeCredentialLeases,
   revokeAllCredentialLeases,
   revokeCredentialLease,
+  suspendAllCredentialLeases,
 } from "@/services/credential-lease";
 
-describe("credential lease renderer bridge (#3194)", () => {
+describe("credential lease renderer bridge (#3194, #3508)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -32,6 +34,8 @@ describe("credential lease renderer bridge (#3194)", () => {
 
     await createCredentialLease("session-a");
     await revokeCredentialLease("session-a");
+    await suspendAllCredentialLeases();
+    await resumeCredentialLeases();
     await revokeAllCredentialLeases();
 
     expect(invokeMock).toHaveBeenNthCalledWith(1, "credential_lease_create", {
@@ -40,6 +44,8 @@ describe("credential lease renderer bridge (#3194)", () => {
     expect(invokeMock).toHaveBeenNthCalledWith(2, "credential_lease_revoke", {
       sessionId: "session-a",
     });
-    expect(invokeMock).toHaveBeenNthCalledWith(3, "credential_lease_revoke_all");
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "credential_lease_suspend_all");
+    expect(invokeMock).toHaveBeenNthCalledWith(4, "credential_lease_resume_all");
+    expect(invokeMock).toHaveBeenNthCalledWith(5, "credential_lease_revoke_all");
   });
 });

--- a/tests/validation/scenarios/credential-lease-recovery.ts
+++ b/tests/validation/scenarios/credential-lease-recovery.ts
@@ -1,0 +1,140 @@
+// ABOUTME: Live validation of automatic Seren MCP lease rotation in one running agent.
+// ABOUTME: Expires only the scenario-created broker route and writes sanitized evidence.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface TextDump {
+  text?: string;
+}
+
+interface LeaseRecord {
+  revoke_id?: string;
+  pending_revocation?: boolean;
+}
+
+interface LeaseStore {
+  orphaned_leases?: {
+    leases?: LeaseRecord[];
+  };
+}
+
+const BEFORE_MARKER = "LEASE_INITIAL_CALL_OK_3508_LIVE";
+const AFTER_MARKER = "LEASE_RECOVERED_CALL_OK_3508_LIVE";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? ((value as TextDump).text as string)
+    : JSON.stringify(value);
+}
+
+async function waitForBodyText(
+  ctx: ScenarioContext,
+  marker: string,
+  timeoutMs: number,
+): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started <= timeoutMs) {
+    if (textOf(await ctx.client.dumpText("body")).includes(marker)) return;
+    await sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for sanitized marker ${marker}`);
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, "utf8")) as T;
+}
+
+async function waitForActiveLease(
+  leasePath: string,
+  excludedRevokeId?: string,
+): Promise<string> {
+  const started = Date.now();
+  while (Date.now() - started <= 60_000) {
+    try {
+      const store = await readJson<LeaseStore>(leasePath);
+      const lease = store.orphaned_leases?.leases?.find(
+        (entry) =>
+          !entry.pending_revocation &&
+          typeof entry.revoke_id === "string" &&
+          entry.revoke_id.length > 0 &&
+          entry.revoke_id !== excludedRevokeId,
+      );
+      if (lease?.revoke_id) return lease.revoke_id;
+    } catch {
+      // The Tauri store may not exist until the agent lease is persisted.
+    }
+    await sleep(500);
+  }
+  throw new Error("Timed out waiting for a task-owned credential lease");
+}
+
+async function sendPrompt(ctx: ScenarioContext, prompt: string): Promise<void> {
+  await ctx.client.waitFor(
+    ".chat-composer-form button[type='submit']",
+    60_000,
+  );
+  await ctx.client.fill(".chat-composer-form textarea", prompt);
+  await ctx.client.waitFor(
+    ".chat-composer-form button[type='submit']",
+    60_000,
+  );
+  await ctx.client.click(".chat-composer-form button[type='submit']");
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const appDataRoot = path.join(
+    ctx.validationHome,
+    "Library",
+    "Application Support",
+  );
+  const slotName = path.basename(ctx.validationHome);
+  if (!/^slot\d+$/.test(slotName)) {
+    throw new Error("This live scenario requires an isolated validation home");
+  }
+  const appIdentifier = `com.serendb.desktop.validation.${slotName}`;
+  const leasePath = path.join(
+    appDataRoot,
+    appIdentifier,
+    "credential-leases.json",
+  );
+
+  await ctx.client.command({ command: "setRootPath", path: process.cwd() });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-codex-agent']", 10_000);
+  await ctx.client.click("[data-testid='new-codex-agent']");
+  await ctx.client.waitFor(".chat-composer-form textarea", 60_000);
+
+  await sendPrompt(
+    ctx,
+    "Call the Seren MCP list_agent_publishers tool with no arguments. Only after the live tool succeeds, reply by concatenating LEASE_, INITIAL_, CALL_, OK_, 3508_, and LIVE with no spaces.",
+  );
+  await waitForBodyText(ctx, BEFORE_MARKER, 120_000);
+  const initialRevokeId = await waitForActiveLease(leasePath);
+
+  await ctx.client.command({ command: "expireCredentialLeases" });
+
+  await sendPrompt(
+    ctx,
+    "Call the Seren MCP list_agent_publishers tool with no arguments again. Only after the live tool succeeds, reply by concatenating LEASE_, RECOVERED_, CALL_, OK_, 3508_, and LIVE with no spaces.",
+  );
+  const renewedRevokeId = await waitForActiveLease(leasePath, initialRevokeId);
+  await waitForBodyText(ctx, AFTER_MARKER, 120_000);
+
+  await ctx.writeArtifact("credential-lease-recovery.json", {
+    signedIn: true,
+    sameAgentConversation: true,
+    liveInitialPublisherCall: true,
+    hostExpiryInjected: true,
+    leaseRotatedInPlace: renewedRevokeId !== initialRevokeId,
+    livePublisherCallAfterRotation: true,
+    beforeMarkerSeen: true,
+    afterMarkerSeen: true,
+  });
+}


### PR DESCRIPTION
## Description

Fixes Seren MCP credentials dropping permanently in long-running desktop agent sessions.

- renews one-day session leases before expiry and on an upstream lease rejection
- rotates the Rust broker key in place, preserving the child process URL and opaque capability
- suspends routes securely on logout and restores still-running threads after sign-in
- retries the failed broker request once after successful host-side recovery
- adds focused unit coverage and a sanitized live validation walkthrough

## Related Issue

Closes #3508

## Network Path Audit

- No publisher slug is added or changed by this patch.
- Lease mint/renew: `POST https://api.serendb.com/organizations/default/api-keys`
- Old-key cleanup: `DELETE https://api.serendb.com/organizations/default/api-keys/{key_id}`
- Child MCP traffic remains on the existing opaque loopback broker URL; the broker forwards it to the fixed `https://mcp.serendb.com/mcp` endpoint.
- The Core key routes and schemas were checked against the generated OpenAPI metadata.
- The live walkthrough invoked `list_agent_publishers` with no arguments through the real gateway before and after forced host-side expiry.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Validation

- `pnpm test`: 2,839 passed, 15 skipped
- `cargo test --lib`: 1,230 passed, 2 ignored
- `pnpm build`: passed
- `cargo check --no-default-features --features validation`: passed
- `pnpm check`: passed (repository warnings only)
- Live macOS Tauri walkthrough: same Codex conversation successfully called the real publisher list, the host route was expired, the lease rotated in place, and the second live call succeeded without mocks.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests (critical regression coverage only)
- [x] I have updated documentation (not applicable; no user-facing documentation changed)
- [x] `pnpm test` passes
- [x] `pnpm lint` / `pnpm check` passes
- [x] No secrets, credentials, or personal data in code

## Screenshots

Not applicable; there is no visual UI change.
