### PR TITLE
fix(orchestrator): derive terminal plan status from task outcomes; key streaming by subtask

### DIFF
--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -379,6 +379,22 @@ fn finalize_plan_row(
     )
 }
 
+fn derive_plan_status(
+    total_subtasks: usize,
+    succeeded_subtasks: usize,
+    cancelled: bool,
+) -> &'static str {
+    if cancelled {
+        "cancelled"
+    } else if succeeded_subtasks == total_subtasks {
+        "completed"
+    } else if succeeded_subtasks > 0 {
+        "partial"
+    } else {
+        "failed"
+    }
+}
+
 /// Persist a plan's terminal status. Best-effort: a database failure is not
 /// allowed to mask the orchestration outcome being returned to the caller.
 async fn finalize_plan(app: &AppHandle, plan_id: &str, status: &str) {
@@ -1372,6 +1388,7 @@ async fn execute_multi_task(
     // Execute subtasks layer by layer
     let layers = decomposer::dependency_layers(&subtasks);
     let mut consecutive_failures: u32 = 0;
+    let mut succeeded_subtasks: usize = 0;
     const MAX_CONSECUTIVE_FAILURES: u32 = 3;
 
     // Index subtasks for dependency lookups during context injection.
@@ -1580,6 +1597,7 @@ async fn execute_multi_task(
                     match result {
                         Ok(Ok(Ok(()))) => {
                             layer_had_success = true;
+                            succeeded_subtasks += 1;
                         }
                         Ok(Ok(Err(e))) => {
                             log::error!("[Orchestrator] Worker error in layer {}: {}", layer_idx, e);
@@ -1651,13 +1669,18 @@ async fn execute_multi_task(
     drop(shared_tx);
     let _ = forward_handle.await;
 
-    // Mark plan as completed
-    finalize_plan(app, &plan_id, "completed").await;
+    let plan_status = derive_plan_status(
+        subtasks.len(),
+        succeeded_subtasks,
+        *cancel_watch_rx.borrow(),
+    );
+    finalize_plan(app, &plan_id, plan_status).await;
 
     log::info!(
-        "[Orchestrator] Completed multi-task orchestration for conversation {} (plan {})",
+        "[Orchestrator] Completed multi-task orchestration for conversation {} (plan {}, status {})",
         conversation_id,
-        plan_id
+        plan_id,
+        plan_status
     );
 
     Ok(())
@@ -2310,6 +2333,48 @@ mod tests {
 
         // Finalizing a plan that does not exist touches nothing.
         assert_eq!(finalize_plan_row(&conn, "missing", "failed", 3000).unwrap(), 0);
+
+        for (plan_id, status, completed_at) in
+            [("p2", "cancelled", 2100), ("p3", "partial", 2200)]
+        {
+            conn.execute(
+                "INSERT INTO orchestration_plans (id, conversation_id, original_prompt, status, created_at)
+                 VALUES (?1, 'c1', 'prompt', 'active', 1000)",
+                rusqlite::params![plan_id],
+            )
+            .unwrap();
+
+            assert_eq!(finalize_plan_row(&conn, plan_id, status, completed_at).unwrap(), 1);
+            let persisted: (String, i64) = conn
+                .query_row(
+                    "SELECT status, completed_at FROM orchestration_plans WHERE id = ?1",
+                    rusqlite::params![plan_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            assert_eq!(persisted, (status.to_string(), completed_at));
+        }
+    }
+
+    #[test]
+    fn derive_plan_status_all_succeeded_is_completed() {
+        assert_eq!(derive_plan_status(3, 3, false), "completed");
+    }
+
+    #[test]
+    fn derive_plan_status_some_succeeded_is_partial() {
+        assert_eq!(derive_plan_status(3, 1, false), "partial");
+    }
+
+    #[test]
+    fn derive_plan_status_none_succeeded_is_failed() {
+        assert_eq!(derive_plan_status(3, 0, false), "failed");
+    }
+
+    #[test]
+    fn derive_plan_status_cancelled_overrides_counts() {
+        assert_eq!(derive_plan_status(3, 3, true), "cancelled");
+        assert_eq!(derive_plan_status(3, 0, true), "cancelled");
     }
 
     // =========================================================================

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -539,6 +539,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     const id = conversationId();
     return id ? conversationStore.getStreamingThinkingFor(id) : "";
   };
+  const streamingSegments = () => {
+    const id = conversationId();
+    return id ? conversationStore.getStreamingSegmentsFor(id) : [];
+  };
   const streamingStalled = () => {
     const id = conversationId();
     return id ? conversationStore.getStreamingStalledFor(id) : false;
@@ -753,6 +757,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     void conversationIsLoading();
     void streamingContent();
     void streamingThinking();
+    void streamingSegments();
     void Object.keys(htmlCache).length;
     requestAnimationFrame(scrollToBottom);
   });
@@ -1984,6 +1989,38 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
               </Show>
             </article>
           </Show>
+
+          <For each={streamingSegments()}>
+            {(segment) => (
+              <article class="chat-message-row px-5 py-4 border-b border-surface-2">
+                <Show when={segment.thinking}>
+                  <details open class="text-[0.8em] text-muted-foreground">
+                    <summary class="cursor-pointer select-none mb-1">
+                      Thinking…
+                    </summary>
+                    <div class="whitespace-pre-wrap opacity-70">
+                      {segment.thinking}
+                    </div>
+                  </details>
+                </Show>
+                <Show when={segment.content}>
+                  <div
+                    class="chat-message-content leading-[1.7] text-foreground break-words"
+                    innerHTML={renderMarkdown(segment.content)}
+                  />
+                  <Show when={conversationIsLoading()}>
+                    <span class="inline-block w-[6px] h-[14px] bg-primary ml-0.5 animate-pulse" />
+                  </Show>
+                  <Show when={streamingStalled()}>
+                    <div class="mt-2 text-[11.5px] text-muted-foreground italic">
+                      Still working - the runtime hasn't sent a token in a
+                      while.
+                    </div>
+                  </Show>
+                </Show>
+              </article>
+            )}
+          </For>
 
           <Show when={streamingThinking()}>
             <article class="chat-message-row px-5 py-4 border-b border-surface-2">

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -514,10 +514,10 @@ function handleWorkerEvent(event: OrchestratorEvent): void {
 
   switch (workerEvent.type) {
     case "content":
-      handleContent(event.conversation_id, workerEvent.text);
+      handleContent(event.conversation_id, workerEvent.text, event.subtask_id);
       break;
     case "thinking":
-      handleThinking(event.conversation_id, workerEvent.text);
+      handleThinking(event.conversation_id, workerEvent.text, event.subtask_id);
       break;
     case "tool_call":
       handleToolCall(event.conversation_id, workerEvent);
@@ -535,6 +535,7 @@ function handleWorkerEvent(event: OrchestratorEvent): void {
         workerEvent.thinking,
         workerEvent.cost,
         workerEvent.rlm_steps ?? null,
+        event.subtask_id,
       );
       break;
     case "error":
@@ -552,12 +553,20 @@ function handleWorkerEvent(event: OrchestratorEvent): void {
   }
 }
 
-function handleContent(conversationId: string, text: string): void {
-  conversationStore.appendStreamingContent(text, conversationId);
+function handleContent(
+  conversationId: string,
+  text: string,
+  subtaskId?: string,
+): void {
+  conversationStore.appendStreamingContent(text, conversationId, subtaskId);
 }
 
-function handleThinking(conversationId: string, text: string): void {
-  conversationStore.appendStreamingThinking(text, conversationId);
+function handleThinking(
+  conversationId: string,
+  text: string,
+  subtaskId?: string,
+): void {
+  conversationStore.appendStreamingThinking(text, conversationId, subtaskId);
 }
 
 function handleToolCall(
@@ -703,6 +712,7 @@ function handleComplete(
   thinking: string | null,
   cost?: number,
   rlmStepsJson?: string | null,
+  subtaskId?: string,
 ): void {
   const stream = activeStreams.get(conversationId);
   if (!stream) return;
@@ -715,9 +725,16 @@ function handleComplete(
     cost != null ? `$${cost}` : "none",
   );
 
-  // Use accumulated streaming content or fall back to final_content
-  const content =
-    conversationStore.getStreamingContentFor(conversationId) || finalContent;
+  const subtaskSegment = subtaskId
+    ? conversationStore
+        .getStreamingSegmentsFor(conversationId)
+        .find((segment) => segment.key === subtaskId)
+    : undefined;
+
+  // Use accumulated streaming content or fall back to final_content.
+  const content = subtaskId
+    ? subtaskSegment?.content || finalContent
+    : conversationStore.getStreamingContentFor(conversationId) || finalContent;
   const finalOutputValidation = validateFinalOutput({
     finalText: content,
     evidence: extractEvidenceFromUnifiedMessages(
@@ -725,10 +742,11 @@ function handleComplete(
     ),
   });
   const safeContent = finalOutputValidation.safeDisplayText;
-  const thinkingContent =
-    conversationStore.getStreamingThinkingFor(conversationId) ||
-    thinking ||
-    undefined;
+  const thinkingContent = subtaskId
+    ? subtaskSegment?.thinking || thinking || undefined
+    : conversationStore.getStreamingThinkingFor(conversationId) ||
+      thinking ||
+      undefined;
 
   // Parse RLM steps from JSON if present
   let rlmSteps: UnifiedMessage["rlmSteps"] | undefined;
@@ -741,7 +759,7 @@ function handleComplete(
   }
 
   const assistantMessage: UnifiedMessage = {
-    id: stream.messageId,
+    id: subtaskId ? `${stream.messageId}:${subtaskId}` : stream.messageId,
     type: "assistant",
     role: "assistant",
     content: safeContent,
@@ -759,7 +777,11 @@ function handleComplete(
   };
 
   conversationStore.setRLMProcessing(false, conversationId);
-  conversationStore.finalizeStreaming(conversationId);
+  if (subtaskId) {
+    conversationStore.clearStreamingSegment(conversationId, subtaskId);
+  } else {
+    conversationStore.finalizeStreaming(conversationId);
+  }
   conversationStore.addMessage(assistantMessage, conversationId);
   conversationStore.persistMessage(assistantMessage, conversationId);
 

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -23,6 +23,7 @@ import { deserializeMetadata, serializeMetadata } from "@/types/conversation";
 
 const DEFAULT_MODEL = "arcee-ai/trinity-large-thinking";
 const MAX_MESSAGES_PER_CONVERSATION = 1000;
+type StreamingSegment = { content: string; thinking: string };
 
 export interface Conversation {
   id: string;
@@ -45,6 +46,7 @@ interface ConversationState {
   error: string | null;
   streamingContent: Record<string, string>;
   streamingThinking: Record<string, string>;
+  streamingSegments: Record<string, Record<string, StreamingSegment>>;
   streamingStalled: Record<string, boolean>;
 }
 
@@ -57,6 +59,7 @@ const [state, setState] = createStore<ConversationState>({
   error: null,
   streamingContent: {},
   streamingThinking: {},
+  streamingSegments: {},
   streamingStalled: {},
 });
 
@@ -144,6 +147,24 @@ function findConversationIdForToolCall(toolCallId: string): string | null {
   return null;
 }
 
+function appendStreamingSegment(
+  conversationId: string,
+  streamKey: string,
+  field: keyof StreamingSegment,
+  text: string,
+): void {
+  setState("streamingSegments", conversationId, (segments = {}) => {
+    const segment = segments[streamKey] ?? { content: "", thinking: "" };
+    return {
+      ...segments,
+      [streamKey]: {
+        ...segment,
+        [field]: segment[field] + text,
+      },
+    };
+  });
+}
+
 export const conversationStore = {
   // === Getters ===
 
@@ -218,6 +239,18 @@ export const conversationStore = {
 
   getStreamingThinkingFor(conversationId: string): string {
     return state.streamingThinking[conversationId] ?? "";
+  },
+
+  getStreamingSegmentsFor(
+    conversationId: string,
+  ): Array<{ key: string; content: string; thinking: string }> {
+    return Object.entries(state.streamingSegments[conversationId] ?? {}).map(
+      ([key, segment]) => ({
+        key,
+        content: segment.content,
+        thinking: segment.thinking,
+      }),
+    );
   },
 
   /**
@@ -312,6 +345,7 @@ export const conversationStore = {
       "rlmProcessing",
       "streamingContent",
       "streamingThinking",
+      "streamingSegments",
       "streamingStalled",
     ] as const) {
       setState(key, (prev) => {
@@ -439,6 +473,7 @@ export const conversationStore = {
       "rlmProcessing",
       "streamingContent",
       "streamingThinking",
+      "streamingSegments",
       "streamingStalled",
     ] as const) {
       setState(key, id, undefined as never);
@@ -541,28 +576,49 @@ export const conversationStore = {
   appendStreamingContent(
     text: string,
     conversationId = state.activeConversationId,
+    streamKey?: string,
   ) {
     if (!conversationId) return;
+    if (streamKey !== undefined) {
+      appendStreamingSegment(conversationId, streamKey, "content", text);
+      return;
+    }
     setState("streamingContent", conversationId, (prev = "") => prev + text);
   },
 
   appendStreamingThinking(
     text: string,
     conversationId = state.activeConversationId,
+    streamKey?: string,
   ) {
     if (!conversationId) return;
+    if (streamKey !== undefined) {
+      appendStreamingSegment(conversationId, streamKey, "thinking", text);
+      return;
+    }
     setState("streamingThinking", conversationId, (prev = "") => prev + text);
   },
 
   clearStreamingContent(conversationId = state.activeConversationId) {
     if (!conversationId) return;
     setState("streamingContent", conversationId, "");
+    setState("streamingSegments", conversationId, {});
+  },
+
+  clearStreamingSegment(conversationId: string, streamKey: string) {
+    setState(
+      "streamingSegments",
+      conversationId,
+      streamKey,
+      undefined as never,
+    );
   },
 
   finalizeStreaming(conversationId = state.activeConversationId) {
     if (!conversationId) return;
     setState("streamingContent", conversationId, "");
     setState("streamingThinking", conversationId, "");
+    setState("streamingSegments", conversationId, {});
     setState("streamingStalled", conversationId, false);
   },
 
@@ -624,6 +680,7 @@ export const conversationStore = {
       error: null,
       streamingContent: {},
       streamingThinking: {},
+      streamingSegments: {},
       streamingStalled: {},
     });
   },
@@ -717,6 +774,7 @@ export const conversationStore = {
     this.clearMessages(conversationId);
     setState("streamingContent", conversationId, "");
     setState("streamingThinking", conversationId, "");
+    setState("streamingSegments", conversationId, {});
     setState("loading", conversationId, false);
     setState("rlmProcessing", conversationId, false);
   },
@@ -732,6 +790,7 @@ export const conversationStore = {
     setState("messages", {});
     setState("streamingContent", {});
     setState("streamingThinking", {});
+    setState("streamingSegments", {});
     setState("loading", {});
     setState("rlmProcessing", {});
     setState("activeConversationId", null);

--- a/tests/unit/orchestrator-subtask-streaming.test.ts
+++ b/tests/unit/orchestrator-subtask-streaming.test.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Verifies renderer streaming buffers remain isolated per orchestrator subtask.
+// ABOUTME: Protects interleaved multi-task output from collapsing into one conversation buffer.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { conversationStore } from "@/stores/conversation.store";
+
+describe("orchestrator subtask streaming", () => {
+  const conversationId = "conversation-subtask-streaming";
+
+  beforeEach(() => {
+    conversationStore.resetSessionState();
+  });
+
+  it("keeps interleaved subtask output separate and preserves unkeyed streaming", () => {
+    conversationStore.appendStreamingContent("a1", conversationId, "s1");
+    conversationStore.appendStreamingContent("b1", conversationId, "s2");
+    conversationStore.appendStreamingContent("a2", conversationId, "s1");
+
+    expect(conversationStore.getStreamingSegmentsFor(conversationId)).toEqual([
+      { key: "s1", content: "a1a2", thinking: "" },
+      { key: "s2", content: "b1", thinking: "" },
+    ]);
+    expect(conversationStore.getStreamingContentFor(conversationId)).toBe("");
+
+    conversationStore.clearStreamingSegment(conversationId, "s1");
+    expect(conversationStore.getStreamingSegmentsFor(conversationId)).toEqual([
+      { key: "s2", content: "b1", thinking: "" },
+    ]);
+
+    conversationStore.appendStreamingContent("single", conversationId);
+    expect(conversationStore.getStreamingContentFor(conversationId)).toBe(
+      "single",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Derive terminal plan status from subtask outcomes in `src-tauri/src/orchestrator/service.rs`, covering cancellation, fatal authorization failure, and consecutive-failure exits while preserving the spawn-failure path.
- Key concurrent streaming by subtask in `src/stores/conversation.store.ts`, `src/services/orchestrator.ts`, and `src/components/chat/ChatContent.tsx`, so each worker has an isolated live segment and completion persists with the matching message ID.
- Add interleaving regression coverage in `tests/unit/orchestrator-subtask-streaming.test.ts`.

## Verification

- `set -o pipefail; cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | tail -20` — exit 0
- `cargo test --manifest-path src-tauri/Cargo.toml --lib derive_plan_status 2>&1 | tail -5` — exit 0; 4 tests passed
- `pnpm vitest run tests/unit/orchestrator-subtask-streaming.test.ts` — exit 0
- `pnpm vitest run` — exit 0; 397 test files passed, 3 skipped; 2841 tests passed, 15 skipped
- `pnpm check` — exit 0
- `pnpm build` — exit 0
- `git diff --check` — exit 0
- `pnpm exec tsc --noEmit` — exit 2 from pre-existing unrelated declaration and test diagnostics

Part of #3511