### PR TITLE
fix(sandbox): block unsafe bounded Windows launches (#3514)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1434,19 +1434,11 @@ function buildClaudePolicySettings({
 
   // Claude's native sandbox constrains Bash subprocesses on macOS/Linux.
   // Built-in file tools are independently constrained by the hook above.
-  // Native Windows permits Bash only after the verified restricted-token/job
-  // launcher spec is present. Missing backend proof keeps the stage-1 deny in
-  // place; Full Access remains an explicit user-selected escape hatch. #3192
+  // Native Windows always denies Bash in bounded modes. A launcher-shaped
+  // object is not proof of read confinement, and must never re-enable arbitrary
+  // child processes. Full Access remains the explicit escape hatch. #3514
   if (process.platform === "win32") {
-    const windowsLauncherReady =
-      sandboxProfile?.kind === "windows-launcher" &&
-      typeof sandboxProfile.launcherPath === "string" &&
-      sandboxProfile.launcherPath.trim().length > 0 &&
-      typeof sandboxProfile.policyBase64 === "string" &&
-      sandboxProfile.policyBase64.trim().length > 0;
-    if (!windowsLauncherReady) {
-      settings.permissions = { deny: ["Bash"] };
-    }
+    settings.permissions = { deny: ["Bash"] };
   }
 
   if (process.platform !== "win32") {

--- a/docs/agent-sandbox-security.md
+++ b/docs/agent-sandbox-security.md
@@ -1,0 +1,37 @@
+# Local agent sandbox security matrix
+
+This note records the security behavior of local Claude Code sessions. It is a
+regression contract for the launch-spec builder, the provider runtime, and the
+platform sandbox backends. Full Access is an explicit opt-out from every
+boundary below.
+
+| Platform | Mode | Project files | Outside-project files | Network setting |
+| --- | --- | --- | --- | --- |
+| macOS | Read Only | Read allowed; writes denied | Reads limited to enumerated system/runtime paths; credential and Seren app-data paths denied | Enabled allows network; disabled denies network |
+| macOS | Workspace Write | Read/write allowed | Same read allowlist; writes denied; credential and Seren app-data paths remain denied even if nested in the project | Enabled allows network; disabled denies network |
+| Linux | Read Only | Read allowed; writes denied | Reads limited to enumerated system/command paths and exact generated config files; credential and Seren app-data paths denied | Enabled allows network; disabled restricts TCP when Landlock ABI V4 is available, but cannot restrict UDP |
+| Linux | Workspace Write | Read/write allowed | Same read allowlist; writes denied; a sensitive path overlapping an allowed path fails the launch closed | Enabled allows network; disabled restricts TCP when Landlock ABI V4 is available, but cannot restrict UDP |
+| Native Windows | Read Only or Workspace Write | No child starts | No child starts | No child starts |
+| Any | Full Access | Host-user access | Host-user access | Host-user access |
+
+## Native Windows containment
+
+The current Windows restricted-token backend uses `WRITE_RESTRICTED`. That
+primitive applies the restricting SID check to writes, while reads continue to
+use the signed-in user's ordinary access. A workspace capability ACL therefore
+does not create a read allowlist.
+
+Until a real Windows read boundary is implemented and proven on-box, the
+trusted `__seren-sandbox-spec` path refuses every bounded native-Windows Claude
+launch. The renderer reports the mode as unavailable, the provider runtime
+fails before spawning Claude, and bounded Windows policy settings keep Bash
+denied even if a stale launcher-shaped object is supplied. Full Access remains
+available only as an explicit unconfined choice.
+
+Restoring bounded Windows sessions requires live child and grandchild canaries
+for outside-workspace reads and writes, sensitive paths inside the workspace,
+path aliases and reparse points, plus an installed-app walkthrough. Merely
+serializing a launch spec is not evidence that those controls are effective.
+
+See issue #3514 for the security audit and permanent-backend acceptance
+criteria.

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -28,6 +28,12 @@ const GITHUB_PAT = requiredEnv("SEREN_E2E_GITHUB_PAT");
 // The paired workflow ships as one agent type backed by two CLIs. Declared
 // locally because the e2e payload only bundles this script — never bin/.
 const PAIRED_AGENT_TYPE = "claude-codex";
+const WINDOWS_BOUNDED_BLOCKED_AGENT_TYPES = new Set([
+  "claude-code",
+  PAIRED_AGENT_TYPE,
+]);
+const WINDOWS_BOUNDED_BLOCK_REASON =
+  "cannot prevent reads outside the selected project";
 // npm-backed CLIs are installed and version-checked by the disposable Windows
 // test-user setup before the app starts. Exercise the production resolver for
 // every corresponding provider here without requiring credentials or turning
@@ -1058,6 +1064,90 @@ async function runSingleAgentJourney(ws, buffer, agentType) {
   }
 }
 
+async function verifyWindowsBoundedSandboxStatus(page) {
+  for (const mode of ["read-only", "workspace-write"]) {
+    for (const networkEnabled of [true, false]) {
+      const status = await tauriInvoke(page, "agent_sandbox_status", {
+        mode,
+        projectRoot: AGENT_CWD,
+        networkEnabled,
+      });
+      assert(
+        status?.backend === "windows-bounded-blocked",
+        `${mode} returned unexpected Windows sandbox backend: ${status?.backend}`,
+      );
+      assert(status.spec_available === false, `${mode} unexpectedly exposed a launch spec`);
+      assert(
+        status.enforced_at_launch === false,
+        `${mode} was incorrectly reported as enforced at launch`,
+      );
+      assert(status.fail_closed === true, `${mode} did not report fail-closed behavior`);
+      assert(
+        String(status.detail ?? "").includes(WINDOWS_BOUNDED_BLOCK_REASON),
+        `${mode} did not report the audited Windows containment reason`,
+      );
+    }
+  }
+  console.log(
+    "[windows-e2e] bounded Windows sandbox status verified unavailable for both modes and network settings",
+  );
+}
+
+async function runBlockedWindowsBoundedJourney(ws, agentType) {
+  const localSessionId = randomUUID();
+  let spawnError;
+  try {
+    await rpcWithTimeout(
+      ws,
+      "provider_spawn",
+      {
+        agentType,
+        cwd: AGENT_CWD,
+        localSessionId,
+        resumeAgentSessionId: null,
+        sandboxMode: "workspace-write",
+        apiKey: null,
+        approvalPolicy: "never",
+        searchEnabled: false,
+        networkEnabled: true,
+        timeoutSecs: 120,
+        initialModelId: AGENT_MODEL ?? undefined,
+      },
+      PROVIDER_SPAWN_TIMEOUT_MS,
+      `${agentType} bounded containment spawn`,
+    );
+  } catch (error) {
+    spawnError = error;
+  }
+
+  assert(spawnError, `${agentType} bounded Windows spawn unexpectedly succeeded`);
+  const message = spawnError instanceof Error ? spawnError.message : String(spawnError);
+  assert(
+    message.includes("Agent launch blocked: the trusted sandbox launch spec failed"),
+    `${agentType} bounded spawn did not fail at the trusted launch-spec boundary: ${message}`,
+  );
+  assert(
+    message.includes(WINDOWS_BOUNDED_BLOCK_REASON),
+    `${agentType} bounded spawn omitted the audited containment reason: ${message}`,
+  );
+
+  const sessions = await rpcWithTimeout(
+    ws,
+    "provider_list_sessions",
+    {},
+    PROVIDER_RPC_TIMEOUT_MS,
+    `${agentType} post-containment session list`,
+  );
+  assert(Array.isArray(sessions), "provider_list_sessions did not return an array");
+  assert(
+    !sessions.some((session) => session?.id === localSessionId),
+    `${agentType} left a live session behind after the bounded spawn was blocked`,
+  );
+  console.log(
+    `[windows-e2e] ${agentType} bounded spawn failed closed before session creation`,
+  );
+}
+
 async function runPairedJourney(ws, buffer) {
   const localSessionId = randomUUID();
   const marker = buffer.mark();
@@ -1230,6 +1320,7 @@ async function runPairedJourney(ws, buffer) {
 }
 
 async function exerciseAgentRuntime(page) {
+  await verifyWindowsBoundedSandboxStatus(page);
   logStage("Resolving provider runtime config");
   const config = await resolveProviderRuntimeConfig(page);
   logStage(
@@ -1240,7 +1331,9 @@ async function exerciseAgentRuntime(page) {
   try {
     await verifyAgentCliCompatibility(ws);
     for (const journey of AGENT_JOURNEYS) {
-      if (journey === PAIRED_AGENT_TYPE) {
+      if (WINDOWS_BOUNDED_BLOCKED_AGENT_TYPES.has(journey)) {
+        await runBlockedWindowsBoundedJourney(ws, journey);
+      } else if (journey === PAIRED_AGENT_TYPE) {
         await runPairedJourney(ws, buffer);
       } else {
         await runSingleAgentJourney(ws, buffer, journey);

--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -1,20 +1,22 @@
-// ABOUTME: Builds the verified OS provider sandbox launch spec and exposes it to trusted callers.
-// ABOUTME: Credential-store paths are denied before the policy crosses into the child runtime.
+// ABOUTME: Builds the trusted OS provider sandbox launch spec and exposes it to trusted callers.
+// ABOUTME: Fails closed when a platform cannot enforce the requested filesystem boundary.
 
 use std::io::Write;
+#[cfg(not(target_os = "windows"))]
 use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::Serialize;
 
+use crate::sandbox::SandboxMode;
+#[cfg(not(target_os = "windows"))]
+use crate::sandbox::SandboxPolicy;
 #[cfg(target_os = "linux")]
-use crate::sandbox::encode_policy;
-#[cfg(target_os = "windows")]
 use crate::sandbox::encode_policy;
 #[cfg(target_os = "macos")]
 use crate::sandbox::seatbelt_profile;
-use crate::sandbox::{SandboxMode, SandboxPolicy};
 
+#[cfg(not(target_os = "windows"))]
 const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
     ".ssh",
     ".aws",
@@ -26,6 +28,12 @@ const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
     "Library/LaunchAgents",
     ".netrc",
 ];
+
+#[cfg(not(target_os = "windows"))]
+const SEREN_APP_IDENTIFIER: &str = "com.serendb.desktop";
+
+#[cfg(target_os = "windows")]
+const WINDOWS_BOUNDED_UNAVAILABLE: &str = "Bounded local Claude Code sessions are blocked on native Windows because the current restricted-token backend cannot prevent reads outside the selected project. Select Full Access only if you accept unconfined file and network access.";
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind")]
@@ -199,7 +207,7 @@ fn resolve_backend_kind() -> &'static str {
 
     #[cfg(target_os = "windows")]
     {
-        return "windows-restricted-token";
+        return "windows-bounded-blocked";
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -221,7 +229,7 @@ fn launch_enforcement_detail() -> &'static str {
 
     #[cfg(target_os = "windows")]
     {
-        return "Restricted-token support is checked when the agent launches; a missing OS primitive fails the bounded session closed.";
+        return WINDOWS_BOUNDED_UNAVAILABLE;
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -245,71 +253,63 @@ fn build_launch_spec(
         return Err("A project root is required to generate a sandbox profile.".to_string());
     }
 
-    let home =
-        dirs::home_dir().ok_or_else(|| "Could not resolve the home directory.".to_string())?;
-    // The Seatbelt and Landlock backends deny reads of the user's credential
-    // directories. The Windows restricted-token backend confines writes but
-    // cannot deny reads, so populating deny_read there only makes the launcher
-    // refuse to run (leaving Windows with no bounded sandbox at all). Ship
-    // write-confinement on Windows now; a DACL-based deny-read is tracked in
-    // serenorg/seren-desktop#3342.
+    #[cfg(target_os = "windows")]
+    {
+        let _ = network_enabled;
+        return Err(WINDOWS_BOUNDED_UNAVAILABLE.to_string());
+    }
+
     #[cfg(not(target_os = "windows"))]
-    let deny_read = CREDENTIAL_STORE_SUFFIXES
-        .iter()
-        .map(|suffix| home.join(suffix))
-        .filter(|path| path.exists())
-        .collect::<Vec<PathBuf>>();
-    #[cfg(target_os = "windows")]
-    let deny_read = {
-        let _ = &home;
-        Vec::<PathBuf>::new()
-    };
-
-    let policy = SandboxPolicy::new(
-        mode,
-        vec![PathBuf::from(project_root)],
-        deny_read,
-        network_enabled,
-    )
-    .map_err(|error| error.to_string())?;
-
-    #[cfg(target_os = "macos")]
     {
-        return seatbelt_profile(&policy)
-            .map(|profile| AgentSandboxLaunchSpec::Seatbelt { profile })
-            .map_err(|error| error.to_string());
-    }
+        let home =
+            dirs::home_dir().ok_or_else(|| "Could not resolve the home directory.".to_string())?;
+        let mut deny_read = CREDENTIAL_STORE_SUFFIXES
+            .iter()
+            .map(|suffix| home.join(suffix))
+            .filter(|path| path.exists())
+            .collect::<Vec<PathBuf>>();
+        if let Some(data_dir) = dirs::data_dir() {
+            let app_data_dir = data_dir.join(SEREN_APP_IDENTIFIER);
+            if app_data_dir.exists() {
+                deny_read.push(app_data_dir);
+            }
+        }
+        deny_read.sort();
+        deny_read.dedup();
 
-    #[cfg(target_os = "linux")]
-    {
-        let launcher_path = std::env::current_exe()
-            .map_err(|error| format!("Could not resolve the sandbox launcher: {error}"))?
-            .to_string_lossy()
-            .into_owned();
-        let policy_base64 = encode_policy(&policy).map_err(|error| error.to_string())?;
-        return Ok(AgentSandboxLaunchSpec::LinuxLauncher {
-            launcher_path,
-            policy_base64,
-        });
-    }
+        let policy = SandboxPolicy::new(
+            mode,
+            vec![PathBuf::from(project_root)],
+            deny_read,
+            network_enabled,
+        )
+        .map_err(|error| error.to_string())?;
 
-    #[cfg(target_os = "windows")]
-    {
-        let launcher_path = std::env::current_exe()
-            .map_err(|error| format!("Could not resolve the sandbox launcher: {error}"))?
-            .to_string_lossy()
-            .into_owned();
-        let policy_base64 = encode_policy(&policy).map_err(|error| error.to_string())?;
-        return Ok(AgentSandboxLaunchSpec::WindowsLauncher {
-            launcher_path,
-            policy_base64,
-        });
-    }
+        #[cfg(target_os = "macos")]
+        {
+            return seatbelt_profile(&policy)
+                .map(|profile| AgentSandboxLaunchSpec::Seatbelt { profile })
+                .map_err(|error| error.to_string());
+        }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        let _ = policy;
-        Err("The provider sandbox backend is unavailable on this platform.".to_string())
+        #[cfg(target_os = "linux")]
+        {
+            let launcher_path = std::env::current_exe()
+                .map_err(|error| format!("Could not resolve the sandbox launcher: {error}"))?
+                .to_string_lossy()
+                .into_owned();
+            let policy_base64 = encode_policy(&policy).map_err(|error| error.to_string())?;
+            return Ok(AgentSandboxLaunchSpec::LinuxLauncher {
+                launcher_path,
+                policy_base64,
+            });
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            let _ = policy;
+            Err("The provider sandbox backend is unavailable on this platform.".to_string())
+        }
     }
 }
 
@@ -329,6 +329,7 @@ mod tests {
         assert!(status.detail.contains("unconfined"));
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn workspace_write_status_reports_a_launchable_fail_closed_spec() {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
@@ -344,6 +345,24 @@ mod tests {
         assert!(status.fail_closed);
         assert_eq!(status.effective_mode, "workspace-write");
         assert!(!status.network_enabled);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn workspace_write_status_reports_windows_containment_block() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let status = agent_sandbox_status(
+            "workspace-write".to_string(),
+            workspace.path().display().to_string(),
+            Some(true),
+        );
+
+        assert_eq!(status.backend, "windows-bounded-blocked");
+        assert!(!status.spec_available);
+        assert!(!status.enforced_at_launch);
+        assert!(status.fail_closed);
+        assert_eq!(status.effective_mode, "workspace-write");
+        assert!(status.detail.contains("cannot prevent reads outside"));
     }
 
     #[test]

--- a/src-tauri/tests/sandbox_spec_dispatch.rs
+++ b/src-tauri/tests/sandbox_spec_dispatch.rs
@@ -12,6 +12,7 @@ fn spec_command(args: &[&str]) -> Output {
         .expect("run the sandbox spec subcommand")
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn spec_dispatch_emits_a_launch_spec_for_a_bounded_session() {
     let workspace = tempdir().expect("workspace tempdir");
@@ -28,7 +29,7 @@ fn spec_dispatch_emits_a_launch_spec_for_a_bounded_session() {
         serde_json::from_slice(&output.stdout).expect("spec is a single JSON document");
     let kind = spec["kind"].as_str().expect("spec carries a kind");
     assert!(
-        matches!(kind, "seatbelt" | "linux-launcher" | "windows-launcher"),
+        matches!(kind, "seatbelt" | "linux-launcher"),
         "unexpected launch spec kind: {kind}"
     );
 }

--- a/src-tauri/tests/sandbox_windows.rs
+++ b/src-tauri/tests/sandbox_windows.rs
@@ -37,6 +37,51 @@ fn workspace_fixture() -> (TempDir, PathBuf) {
     (root, workspace)
 }
 
+/// Production must refuse to serialize the unsafe restricted-token policy.
+/// `provider_spawn` cannot reach `__seren-sandbox-run` without this spec, so a
+/// sibling sentinel that the signed-in user can read never becomes reachable
+/// by a bounded Claude child. This is intentionally the production spec path,
+/// not a hand-built empty-deny policy like the lower-level backend canaries.
+#[test]
+fn sandbox_windows_production_spec_blocks_outside_read_canary() {
+    let (root, workspace) = workspace_fixture();
+    let outside_sentinel = root.path().join("outside-read-sentinel.txt");
+    fs::write(&outside_sentinel, b"sentinel-only").expect("outside sentinel is written");
+    assert_eq!(
+        fs::read(&outside_sentinel).expect("host can read the outside sentinel"),
+        b"sentinel-only"
+    );
+    let workspace_arg = workspace.to_string_lossy().into_owned();
+
+    for mode in ["read-only", "workspace-write"] {
+        for network_enabled in ["true", "false"] {
+            let output = Command::new(env!("CARGO_BIN_EXE_Seren"))
+                .args([
+                    "__seren-sandbox-spec",
+                    mode,
+                    network_enabled,
+                    workspace_arg.as_str(),
+                ])
+                .output()
+                .expect("production sandbox spec command starts");
+
+            assert_eq!(
+                output.status.code(),
+                Some(70),
+                "unsafe Windows bounded spec was serialized for mode={mode} network={network_enabled}: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                String::from_utf8_lossy(&output.stderr)
+                    .contains("cannot prevent reads outside the selected project"),
+                "containment reason missing for mode={mode} network={network_enabled}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
+
 fn prove_target_is_writable(target: &Path) {
     fs::write(target, b"preflight").expect("canary target is writable before sandboxing");
     fs::remove_file(target).expect("canary preflight target is removed");

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1411,7 +1411,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               <div class="flex items-start justify-between gap-4">
                 <div class="flex flex-col gap-0.5">
                   <span class="text-[0.95rem] font-medium text-foreground">
-                    Verified effective sandbox
+                    Effective agent sandbox
                   </span>
                   <span class="text-[0.8rem] text-muted-foreground">
                     Whether the OS sandbox can actually protect agent sessions
@@ -1532,11 +1532,11 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             >
               <p class="m-0 py-3 border-b border-border text-[0.8rem] text-muted-foreground leading-normal">
                 <span class="font-medium text-foreground">
-                  On native Windows, shell commands are disabled unless Full
-                  Access is explicitly selected.
+                  Bounded Claude Code sessions are blocked on native Windows.
                 </span>{" "}
-                File, search, and web tools remain bounded by the selected
-                workspace.
+                The current Windows backend cannot prevent reads outside the
+                selected project. Full Access remains available only as an
+                explicit, unconfined choice.
               </p>
             </Show>
 

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -157,7 +157,7 @@ describe("Claude promptless containment (#3091)", () => {
   });
 });
 
-describe("Windows shell boundary requires the verified launcher (#3149, #3192)", () => {
+describe("Windows bounded-session containment (#3514)", () => {
   const settingsPanel = readFileSync(
     resolve("src/components/settings/SettingsPanel.tsx"),
     "utf8",
@@ -177,10 +177,10 @@ describe("Windows shell boundary requires the verified launcher (#3149, #3192)",
       networkEnabled: false,
     });
     expect(settings.hooks.PreToolUse[0].matcher).not.toContain("Bash");
-    expect(claudeRuntime).toContain("#3192");
+    expect(claudeRuntime).toContain("#3514");
   });
 
-  it("keeps Bash denied without a launcher and permits it only with one", () => {
+  it("keeps Bash denied even when a launcher-shaped object is supplied", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       value: "win32",
@@ -206,7 +206,7 @@ describe("Windows shell boundary requires the verified launcher (#3149, #3192)",
             policyBase64: "encoded-policy",
           },
         });
-        expect(containedSettings.permissions).toBeUndefined();
+        expect(containedSettings.permissions.deny).toContain("Bash");
         expect(containedSettings.sandbox).toBeUndefined();
       }
 
@@ -225,9 +225,11 @@ describe("Windows shell boundary requires the verified launcher (#3149, #3192)",
     }
   });
 
-  it("tells Windows users shell commands are disabled unless Full Access", () => {
+  it("tells Windows users bounded Claude Code sessions are blocked", () => {
     expect(settingsPanel).toContain("isWindowsPlatform");
-    const noteAt = settingsPanel.indexOf("shell commands are disabled unless Full");
+    const noteAt = settingsPanel.indexOf(
+      "Bounded Claude Code sessions are blocked on native Windows",
+    );
     expect(noteAt).toBeGreaterThan(-1);
     const gateAt = settingsPanel.lastIndexOf("isWindowsPlatform()", noteAt);
     expect(gateAt).toBeGreaterThan(-1);


### PR DESCRIPTION
Refs #3514

## Summary
- fail closed before launching bounded native-Windows Claude Code sessions because the current restricted-token backend cannot enforce an outside-project read boundary
- keep Bash denied in bounded Windows policy even if a legacy launcher-shaped object reaches the local runtime
- report the unavailable bounded backend truthfully in Settings
- deny Seren app-data credential storage on the existing macOS/Linux bounded backends
- document the effective platform enforcement matrix
- certify the containment through the installed-Windows-app release walkthrough

## Scope
This PR is the immediate P0 containment for #3514. The issue remains open until an elevated or dedicated-account Windows backend satisfies the remaining read-boundary, descendant-process, path-alias, and network acceptance criteria. Full Access remains an explicit unconfined opt-in on Windows.

## Critical coverage
- production Windows spec-path canary rejects both bounded modes with network enabled and disabled
- launcher-shaped Windows policy regression test proves Bash stays denied
- existing spec-dispatch tests remain green on supported platforms
- real macOS sandboxed-child canaries continue to enforce file, descendant-process, and network boundaries
- installed-app Windows release harness now verifies truthful status and fail-closed provider spawns with no residual session

## Validation
- focused TypeScript containment tests: 22 passed
- Rust sandbox unit tests: 3 passed
- Rust launch-spec integration tests: 5 passed
- real macOS sandboxed-child tests: 7 passed
- real provider-runtime smoke passed
- `pnpm check` passed (48 pre-existing unrelated warnings)
- production frontend build passed
- final CI passed on Linux, macOS, and Windows
- native Windows Tauri build and production app spec-path canary passed without mocks
- Rust formatting and commit whitespace checks passed
- public-artifact scan found no local paths, PII, or secrets

CI evidence: https://github.com/serenorg/seren-desktop/actions/runs/30661304251

## Network path audit
No outbound publisher or API request path is introduced or modified. This change is limited to local Rust launch-spec generation, local provider policy, Windows canary coverage, documentation, the installed-app release harness, and Settings UI copy.

## Permanent backend note
Current upstream Codex requires its elevated Windows sandbox backend for restricted read-only or deny-read access; its legacy restricted-token backend also uses `WRITE_RESTRICTED`. That supports fail-closed containment here rather than presenting the legacy token as a read boundary.