### PR TITLE
feat(runtime): admission control and run-aware reclaim

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -30,6 +30,7 @@ import {
   writeForkedTranscript,
 } from "./synthetic-transcript.mjs";
 import { providerLogPrefix } from "./logging.mjs";
+import { createAdmissionGate } from "./session-admission.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -727,6 +728,14 @@ function buildSessionStatus(session, status = session.status) {
     modes: buildModeState(session.currentModeId),
     configOptions: buildConfigOptions(session),
   };
+}
+
+function resolveClaudeSessionLimit() {
+  const configured = Number.parseInt(
+    process.env.SEREN_CLAUDE_SESSION_LIMIT ?? "",
+    10,
+  );
+  return Number.isFinite(configured) && configured > 0 ? configured : 3;
 }
 
 function normalizeModelRecords(result) {
@@ -2613,7 +2622,13 @@ function handleLine(emit, session, line) {
   }
 }
 
-function attachProcessListeners(emit, sessions, session, exitPromises) {
+function attachProcessListeners(
+  emit,
+  sessions,
+  session,
+  exitPromises,
+  admissionGate,
+) {
   const logPrefix = session.logPrefix ?? providerLogPrefix("claude");
   session.output.on("line", (line) => handleLine(emit, session, line));
 
@@ -2675,6 +2690,7 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
     // to reuse this session ID.
     const finish = () => {
       exitPromises.delete(session.id);
+      admissionGate.release(session.id);
       resolveExit();
     };
 
@@ -2744,6 +2760,36 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
   // the promise resolves. Before spawning with a reused ID, we await
   // this to prevent the old exit handler from deleting the new session.
   const exitPromises = new Map();
+  const admissionMetadata = new Map();
+  const admissionGate = createAdmissionGate({
+    limit: resolveClaudeSessionLimit(),
+    onQueued(sessionId, position) {
+      const metadata = admissionMetadata.get(sessionId);
+      if (!metadata) return;
+      console.log(
+        claudeLogPrefix +
+          " session queued sessionId=" +
+          sessionId +
+          " position=" +
+          position,
+      );
+      emit("provider://session-status", {
+        ...buildSessionStatus(
+          {
+            id: sessionId,
+            agentSessionId: metadata.agentSessionId,
+            claudeVersion: null,
+            availableModelRecords: [],
+            currentModelId: metadata.currentModelId,
+            currentModeId: "default",
+            reasoningEffort: metadata.reasoningEffort,
+          },
+          "queued",
+        ),
+        queuePosition: position,
+      });
+    },
+  });
 
   function createSessionRecord({
     sessionId,
@@ -2830,6 +2876,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     if (pendingExit) {
       await pendingExit;
     }
+    let admissionAcquired = false;
 
     const remoteSessionId = resumeAgentSessionId ?? randomUUID();
     const serenCredential = resolveBrokeredSerenCredential(params);
@@ -2856,6 +2903,14 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       typeof initialModelId === "string" && initialModelId.length > 0
         ? initialModelId
         : DEFAULT_PREFERRED_MODEL;
+    admissionMetadata.set(sessionId, {
+      agentSessionId: remoteSessionId,
+      currentModelId: preferredModel,
+      reasoningEffort: effectiveEffort,
+    });
+    await admissionGate.acquire(sessionId);
+    admissionAcquired = true;
+    admissionMetadata.delete(sessionId);
     let serenMcpProxy = null;
     let mcpConfig;
     let claudeArgs;
@@ -2982,6 +3037,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         }
         console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
         sessions.delete(sessionId);
+        admissionGate.release(sessionId);
         void serenMcpProxy?.close();
         // A process that never started may never emit "exit", so this launch's
         // temp config files are cleared here or not at all. The orphan guard
@@ -3036,7 +3092,13 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       });
 
       sessions.set(sessionId, launchedSession);
-      attachProcessListeners(emit, sessions, launchedSession, exitPromises);
+      attachProcessListeners(
+        emit,
+        sessions,
+        launchedSession,
+        exitPromises,
+        admissionGate,
+      );
       return { processHandle, session: launchedSession };
     };
 
@@ -3178,6 +3240,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       sessions.delete(sessionId);
+      admissionMetadata.delete(sessionId);
+      if (admissionAcquired) {
+        admissionGate.release(sessionId);
+      }
       if (processHandle) killChildTree(processHandle);
       await serenMcpProxy?.close();
       emit("provider://error", {
@@ -3322,6 +3388,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       status: "terminated",
       agentSessionId: session.agentSessionId,
     });
+    admissionGate.release(sessionId);
   }
 
   async function listSessions() {

--- a/bin/browser-local/session-admission.mjs
+++ b/bin/browser-local/session-admission.mjs
@@ -1,0 +1,75 @@
+// ABOUTME: Provides FIFO admission control for concurrent local Claude sessions.
+// ABOUTME: Keeps active capacity bounded and exposes queue state for runtime status events.
+
+export function createAdmissionGate({ limit, onQueued } = {}) {
+  const normalizedLimit = Number.isFinite(Number(limit)) && Number(limit) > 0
+    ? Math.floor(Number(limit))
+    : 1;
+  const active = new Set();
+  const pending = [];
+
+  function drain() {
+    while (active.size < normalizedLimit && pending.length > 0) {
+      const request = pending.shift();
+      if (!request) return;
+      if (active.has(request.sessionId)) {
+        request.resolve();
+        continue;
+      }
+      active.add(request.sessionId);
+      request.resolve();
+    }
+  }
+
+  function acquire(sessionId) {
+    if (active.has(sessionId)) {
+      return Promise.resolve();
+    }
+
+    const existing = pending.find((request) => request.sessionId === sessionId);
+    if (existing) {
+      return existing.promise;
+    }
+
+    if (active.size < normalizedLimit) {
+      active.add(sessionId);
+      return Promise.resolve();
+    }
+
+    let resolveRequest;
+    const promise = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+    const request = {
+      sessionId,
+      promise,
+      resolve: resolveRequest,
+    };
+    pending.push(request);
+    try {
+      onQueued?.(sessionId, pending.length);
+    } catch {
+      // Queue telemetry must never prevent a session from waiting for capacity.
+    }
+    return promise;
+  }
+
+  function release(sessionId) {
+    if (!active.delete(sessionId)) {
+      return false;
+    }
+    drain();
+    return true;
+  }
+
+  return {
+    acquire,
+    release,
+    pendingCount() {
+      return pending.length;
+    },
+    activeCount() {
+      return active.size;
+    },
+  };
+}

--- a/docs/20260731_Runtime_Concurrency_Experiment.md
+++ b/docs/20260731_Runtime_Concurrency_Experiment.md
@@ -1,0 +1,62 @@
+<!-- ABOUTME: Records the real embedded Claude runtime concurrency experiment and its evidence. -->
+<!-- ABOUTME: Includes per-session identity/timing data, the cap decision, and queue-proof evidence. -->
+
+# Runtime concurrency experiment
+
+Date: 2026-07-31
+Host: macOS 26.5.2
+Embedded Node: v26.5.0
+Claude CLI: 2.1.220 (Claude Code)
+Runtime: bin/provider-runtime.mjs, desktop-native mode, port 4317
+Project: /Users/taariqlewis/Projects/Seren_Projects/seren-desktop/.worktrees/runtime-concurrency
+
+## Method
+
+The harness used the real authenticated claude-code provider through the
+embedded runtime WebSocket. It called provider_check_agent_available,
+provider_spawn, provider_prompt, and provider_terminate. Session A stayed
+alive while B was spawned in the same runtime process; after concurrent prompt
+round-trips, C was spawned and prompted in that same process. The experiment
+used SEREN_CONCURRENCY_SANDBOX_MODE=full-access because the host's
+workspace-write policy denied the Claude login credential path even though the
+direct CLI login was valid.
+
+## Raw per-session results
+
+| Label | Runtime port | Local session id | Native session id | Spawn to ready (ms) | Prompt round-trip (ms) | Result | Error |
+| --- | ---: | --- | --- | ---: | ---: | --- | --- |
+| A | 4317 | 87e9a214-15d7-4a8a-a52a-44521ed55cb9 | 059b035a-2f0b-43ea-bd64-3622858c6de4 | 805 | 1475 | PONG_A | — |
+| B | 4317 | f81d7e8c-fc73-4857-a31d-9b22c8037d08 | 4076b029-c582-40df-a1ad-d6717720b493 | 898 | 1715 | PONG_B | — |
+| C | 4317 | 3a2c16ee-f1d5-42d5-b1fa-0b742cb6b916 | 8f36d942-4073-494c-8596-dda780d047cf | 833 | 1614 | PONG_C | — |
+
+The exact no-argument run completed with exit code 0. The emitted machine
+result reported cliVersion as 2.1.220 (Claude Code) and three ready sessions
+in one process.
+
+## Diagnostic boundary
+
+With SEREN_CONCURRENCY_SANDBOX_MODE=workspace-write, the same real runtime
+reached ready but the first prompt returned the verbatim error
+Not logged in · Please run /login. A direct non-interactive CLI probe in the
+same worktree returned AUTH_PROBE, so this is a credential-store boundary of
+the sandboxed child path, not an account-authentication result. The concurrency
+verdict below therefore covers the full-access embedded runtime path; the
+workspace-write auth path remains a separate integration risk.
+
+OUTCOME: coexist
+
+The observed verdict supports a default admission limit of 3 Claude sessions
+per runtime process.
+
+## Queue proof
+
+The node scripts/experiment-claude-concurrency.mjs --queue-proof run set
+SEREN_CLAUDE_SESSION_LIMIT=1 and used the same real runtime. The queued
+session remained unresolved while A was active, and the gate released it only
+after A termination:
+
+[queue-proof] queued sessionId=359678a4-1676-4e44-a242-375c792acb27 position=1 activeTerminationsBeforeRelease=0 promiseUnresolvedBeforeRelease=true
+
+[queue-proof] sessionId=359678a4-1676-4e44-a242-375c792acb27 queuedDurationMs=922 reachedReadyAfterFirstTermination=true
+
+[queue-proof] passed

--- a/scripts/experiment-claude-concurrency.mjs
+++ b/scripts/experiment-claude-concurrency.mjs
@@ -1,0 +1,614 @@
+// ABOUTME: Measures concurrent Claude Code session behavior in the embedded provider runtime.
+// ABOUTME: Uses real provider RPCs and records session identity, readiness, prompts, and failures.
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import process from "node:process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { randomUUID } from "node:crypto";
+import { WebSocket } from "ws";
+
+const ROOT = new URL("../", import.meta.url);
+const ROOT_PATH = fileURLToPath(ROOT);
+const HOST = "127.0.0.1";
+const PRIMARY_PORT = 4317;
+const SECONDARY_PORT = 4318;
+const RUNTIME_TOKEN = "claude-concurrency-experiment-token";
+const CWD = process.cwd();
+const AGENT_TYPE = "claude-code";
+const PROMPT_TIMEOUT_MS = 180_000;
+const INIT_ERROR_TEXT = [
+  "timed out waiting for claude control request initialize",
+  "server shut down unexpectedly",
+  "signal: 9",
+  "sigkill",
+];
+
+function ensureSandboxSpecBin() {
+  if (typeof process.env.SEREN_SANDBOX_SPEC_BIN === "string" &&
+      process.env.SEREN_SANDBOX_SPEC_BIN.trim().length > 0) {
+    return;
+  }
+
+  const names = process.platform === "win32"
+    ? ["Seren.exe", "seren-desktop.exe"]
+    : ["Seren", "seren-desktop"];
+  const candidates = [];
+  for (const profile of ["release", "debug"]) {
+    for (const name of names) {
+      candidates.push(join(ROOT_PATH, "src-tauri", "target", profile, name));
+    }
+  }
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      "The embedded app binary is required for bounded Claude Code sessions. " +
+        "Build it with cargo build --manifest-path src-tauri/Cargo.toml.",
+    );
+  }
+  process.env.SEREN_SANDBOX_SPEC_BIN = found;
+  console.log("[concurrency] sandbox spec binary: " + found);
+}
+
+function isAuthRequiredError(message) {
+  const lower = String(message).toLowerCase();
+  return lower.includes("authentication required") ||
+    lower.includes("auth required") ||
+    lower.includes("login flow") ||
+    lower.includes("not logged in") ||
+    lower.includes("failed to authenticate") ||
+    lower.includes("please login") ||
+    lower.includes("please sign in");
+}
+
+function isRetryableClaudeInitError(message) {
+  const lower = String(message).toLowerCase();
+  return INIT_ERROR_TEXT.some((fragment) => lower.includes(fragment));
+}
+
+async function fetchJson(url, attempts = 80) {
+  let lastError = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error("HTTP " + response.status);
+      }
+      return await response.json();
+    } catch (error) {
+      lastError = error;
+      await sleep(200);
+    }
+  }
+  throw lastError ?? new Error("Timed out waiting for " + url);
+}
+
+function createNotificationBuffer(ws) {
+  const notifications = [];
+  const waiters = new Set();
+
+  const onMessage = (raw) => {
+    let message;
+    try {
+      message = JSON.parse(String(raw));
+    } catch {
+      return;
+    }
+    if (!message?.method) return;
+    notifications.push(message);
+    for (const waiter of [...waiters]) {
+      if (waiter.predicate(message)) {
+        clearTimeout(waiter.timeout);
+        waiters.delete(waiter);
+        waiter.resolve(message);
+      }
+    }
+  };
+
+  ws.on("message", onMessage);
+  return {
+    close() {
+      ws.off("message", onMessage);
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error("Notification buffer closed"));
+      }
+      waiters.clear();
+    },
+    mark() {
+      return notifications.length;
+    },
+    slice(fromIndex = 0) {
+      return notifications.slice(fromIndex);
+    },
+    waitFor(predicate, timeoutMs = 30_000, fromIndex = 0) {
+      const existing = notifications.slice(fromIndex).find(predicate);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve, reject) => {
+        const waiter = {
+          predicate,
+          resolve,
+          reject,
+          timeout: setTimeout(() => {
+            waiters.delete(waiter);
+            reject(new Error("Timed out waiting for runtime notification"));
+          }, timeoutMs),
+        };
+        waiters.add(waiter);
+      });
+    },
+  };
+}
+
+let nextRpcId = 1;
+function rpcCall(ws, method, params = {}) {
+  const id = nextRpcId++;
+  return new Promise((resolve, reject) => {
+    const onMessage = (raw) => {
+      try {
+        const message = JSON.parse(String(raw));
+        if (message.id !== id) return;
+        ws.off("message", onMessage);
+        if (message.error) {
+          reject(new Error(String(message.error.message ?? "Unknown RPC error")));
+          return;
+        }
+        resolve(message.result);
+      } catch (error) {
+        ws.off("message", onMessage);
+        reject(error);
+      }
+    };
+    ws.on("message", onMessage);
+    ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  });
+}
+
+async function connectRuntime(port) {
+  const ws = new WebSocket("ws://" + HOST + ":" + port);
+  await new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  await rpcCall(ws, "auth", { token: RUNTIME_TOKEN });
+  return ws;
+}
+
+function startRuntimeProcess(port, label) {
+  const child = spawn(
+    process.execPath,
+    [
+      "bin/provider-runtime.mjs",
+      "--host",
+      HOST,
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: ROOT_PATH,
+      env: {
+        ...process.env,
+        SEREN_PROVIDER_RUNTIME_TOKEN: RUNTIME_TOKEN,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write("[" + label + "] " + chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write("[" + label + "] " + chunk);
+  });
+  return child;
+}
+
+async function startRuntime(port, label) {
+  const child = startRuntimeProcess(port, label);
+  try {
+    await fetchJson("http://" + HOST + ":" + port + "/__seren/health");
+    const ws = await connectRuntime(port);
+    return {
+      child,
+      port,
+      ws,
+      buffer: createNotificationBuffer(ws),
+      sessions: new Map(),
+    };
+  } catch (error) {
+    child.kill("SIGTERM");
+    throw error;
+  }
+}
+
+function waitForExit(child, timeoutMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish();
+    }, timeoutMs);
+    child.once("exit", finish);
+  });
+}
+
+function spawnParams(localSessionId) {
+  return {
+    agentType: AGENT_TYPE,
+    cwd: CWD,
+    localSessionId,
+    resumeAgentSessionId: null,
+    sandboxMode: process.env.SEREN_CONCURRENCY_SANDBOX_MODE ?? "full-access",
+    apiKey: null,
+    approvalPolicy: "on-request",
+    searchEnabled: false,
+    networkEnabled: true,
+    timeoutSecs: 60,
+  };
+}
+
+async function checkClaude(runtime) {
+  const available = await rpcCall(runtime.ws, "provider_check_agent_available", {
+    agentType: AGENT_TYPE,
+  });
+  if (available !== true) {
+    throw new Error("provider_check_agent_available returned false for claude-code");
+  }
+  try {
+    const authenticated = await rpcCall(
+      runtime.ws,
+      "provider_check_agent_authenticated",
+      { agentType: AGENT_TYPE },
+    );
+    if (authenticated === false) {
+      throw new Error("Claude Code authentication required by provider runtime");
+    }
+  } catch (error) {
+    if (isAuthRequiredError(error.message)) throw error;
+    if (!String(error.message).toLowerCase().includes("method not found")) {
+      console.log("[concurrency] authentication probe detail: " + error.message);
+    }
+  }
+}
+
+async function spawnMeasured(runtime, label, requestedSessionId = randomUUID()) {
+  const startedAt = performance.now();
+  const localSessionId = requestedSessionId;
+  const marker = runtime.buffer.mark();
+  try {
+    const result = await rpcCall(
+      runtime.ws,
+      "provider_spawn",
+      spawnParams(localSessionId),
+    );
+    const readyEvent = await runtime.buffer
+      .waitFor(
+        (message) =>
+          message.method === "provider://session-status" &&
+          message.params?.sessionId === result.id &&
+          message.params?.status === "ready",
+        1_000,
+        marker,
+      )
+      .catch(() => null);
+    const record = {
+      label,
+      runtime: runtime.port,
+      status: "ready",
+      sessionId: result.id,
+      agentSessionId: result.agentSessionId ?? null,
+      spawnToReadyMs: Math.round(performance.now() - startedAt),
+      readyAtMs: performance.now(),
+      cliVersion: readyEvent?.params?.agentInfo?.version ?? null,
+      error: null,
+      retryableInitError: false,
+    };
+    runtime.sessions.set(record.sessionId, record);
+    console.log(
+      "[concurrency] " + label +
+        " ready sessionId=" + record.sessionId +
+        " agentSessionId=" + (record.agentSessionId ?? "<missing>") +
+        " spawnToReadyMs=" + record.spawnToReadyMs,
+    );
+    return record;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const record = {
+      label,
+      runtime: runtime.port,
+      status: "error",
+      sessionId: null,
+      agentSessionId: null,
+      spawnToReadyMs: Math.round(performance.now() - startedAt),
+      readyAtMs: null,
+      cliVersion: null,
+      error: message,
+      retryableInitError: isRetryableClaudeInitError(message),
+    };
+    console.log(
+      "[concurrency] " + label +
+        " error spawnToReadyMs=" + record.spawnToReadyMs +
+        " retryableInitError=" + record.retryableInitError +
+        " error=" + message,
+    );
+    if (isAuthRequiredError(message)) throw error;
+    return record;
+  }
+}
+
+async function promptMeasured(runtime, session, letter) {
+  const marker = runtime.buffer.mark();
+  const startedAt = performance.now();
+  const expected = "PONG_" + letter;
+  try {
+    await rpcCall(runtime.ws, "provider_prompt", {
+      sessionId: session.sessionId,
+      prompt: "Reply with EXACTLY the text " + expected,
+      context: null,
+    });
+    await runtime.buffer.waitFor(
+      (message) =>
+        message.method === "provider://prompt-complete" &&
+        message.params?.sessionId === session.sessionId &&
+        message.params?.historyReplay !== true,
+      1_000,
+      marker,
+    ).catch(() => null);
+    const text = runtime.buffer
+      .slice(marker)
+      .filter(
+        (message) =>
+          message.method === "provider://message-chunk" &&
+          message.params?.sessionId === session.sessionId &&
+          message.params?.isThought !== true,
+      )
+      .map((message) => String(message.params?.text ?? ""))
+      .join("")
+      .trim();
+    if (!text.includes(expected)) {
+      throw new Error("Unexpected assistant text: " + (text || "<empty>"));
+    }
+    const record = {
+      label: session.label,
+      status: "passed",
+      promptRoundTripMs: Math.round(performance.now() - startedAt),
+      text,
+      error: null,
+    };
+    session.prompt = record;
+    console.log(
+      "[concurrency] " + session.label +
+        " promptRoundTripMs=" + record.promptRoundTripMs +
+        " text=" + JSON.stringify(text),
+    );
+    return record;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const record = {
+      label: session.label,
+      status: "error",
+      promptRoundTripMs: Math.round(performance.now() - startedAt),
+      text: null,
+      error: message,
+    };
+    session.prompt = record;
+    console.log(
+      "[concurrency] " + session.label +
+        " prompt error promptRoundTripMs=" + record.promptRoundTripMs +
+        " error=" + message,
+    );
+    if (isAuthRequiredError(message)) throw error;
+    return record;
+  }
+}
+
+async function terminateRuntimeSessions(runtime) {
+  for (const session of runtime.sessions.values()) {
+    await rpcCall(runtime.ws, "provider_terminate", {
+      sessionId: session.sessionId,
+    }).catch(() => {});
+  }
+  runtime.sessions.clear();
+}
+
+async function closeRuntime(runtime) {
+  if (!runtime) return;
+  await terminateRuntimeSessions(runtime);
+  runtime.buffer.close();
+  runtime.ws.close();
+  runtime.child.kill("SIGTERM");
+  await waitForExit(runtime.child);
+}
+
+async function runQueueProof() {
+  process.env.SEREN_CLAUDE_SESSION_LIMIT = "1";
+  const runtime = await startRuntime(PRIMARY_PORT, "queue-runtime");
+  try {
+    await checkClaude(runtime);
+    const sessionA = await spawnMeasured(runtime, "A-queue-proof");
+    if (sessionA.status !== "ready") {
+      throw new Error("Queue proof session A did not reach ready: " + sessionA.error);
+    }
+
+    const queuedSessionId = randomUUID();
+    const marker = runtime.buffer.mark();
+    let bSettled = false;
+    const bPromise = spawnMeasured(runtime, "B-queue-proof", queuedSessionId)
+      .finally(() => {
+        bSettled = true;
+      });
+    const queuedEvent = await runtime.buffer.waitFor(
+      (message) =>
+        message.method === "provider://session-status" &&
+        message.params?.sessionId === queuedSessionId &&
+        message.params?.status === "queued",
+      30_000,
+      marker,
+    );
+    const queuedAtMs = performance.now();
+    await sleep(250);
+    const activeTerminationsBeforeRelease = runtime.buffer
+      .slice(marker)
+      .filter(
+        (message) =>
+          message.method === "provider://session-status" &&
+          message.params?.sessionId === sessionA.sessionId &&
+          message.params?.status === "terminated",
+      ).length;
+    const bSettledBeforeRelease = bSettled;
+    console.log(
+      "[queue-proof] queued sessionId=" + queuedSessionId +
+        " position=" + (queuedEvent.params?.queuePosition ?? "<missing>") +
+        " activeTerminationsBeforeRelease=" + activeTerminationsBeforeRelease +
+        " promiseUnresolvedBeforeRelease=" + (!bSettledBeforeRelease),
+    );
+
+    await rpcCall(runtime.ws, "provider_terminate", {
+      sessionId: sessionA.sessionId,
+    });
+    await runtime.buffer.waitFor(
+      (message) =>
+        message.method === "provider://session-status" &&
+        message.params?.sessionId === sessionA.sessionId &&
+        message.params?.status === "terminated",
+      30_000,
+      marker,
+    );
+    const firstTerminatedAtMs = performance.now();
+    const sessionB = await bPromise;
+    const reachedReadyAfterTermination =
+      sessionB.status === "ready" &&
+      sessionB.readyAtMs >= firstTerminatedAtMs;
+    const queuedDurationMs = Math.round(
+      (sessionB.readyAtMs ?? performance.now()) - queuedAtMs,
+    );
+    console.log(
+      "[queue-proof] sessionId=" + queuedSessionId +
+        " queuedDurationMs=" + queuedDurationMs +
+        " reachedReadyAfterFirstTermination=" + reachedReadyAfterTermination,
+    );
+    if (
+      activeTerminationsBeforeRelease !== 0 ||
+      bSettledBeforeRelease ||
+      !reachedReadyAfterTermination
+    ) {
+      throw new Error("Queue proof invariants failed");
+    }
+    console.log("[queue-proof] passed");
+  } finally {
+    await closeRuntime(runtime);
+  }
+}
+
+function cliVersionFallback() {
+  try {
+    return execFileSync("claude", ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main() {
+  ensureSandboxSpecBin();
+  if (process.argv.includes("--queue-proof")) {
+    try {
+      await runQueueProof();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("[queue-proof] BLOCKER: " + message);
+      process.exitCode = isAuthRequiredError(message) ? 2 : 1;
+    }
+    return;
+  }
+  const runtimes = [];
+  let outcome = "serialize";
+  let blocker = null;
+  try {
+    const primary = await startRuntime(PRIMARY_PORT, "runtime-1");
+    runtimes.push(primary);
+    await checkClaude(primary);
+
+    const sessionA = await spawnMeasured(primary, "A");
+    if (sessionA.status !== "ready") {
+      throw new Error("Session A did not reach ready: " + sessionA.error);
+    }
+
+    const sessionB = await spawnMeasured(primary, "B");
+    if (sessionB.status === "ready") {
+      await Promise.all([
+        promptMeasured(primary, sessionA, "A"),
+        promptMeasured(primary, sessionB, "B"),
+      ]);
+
+      const sessionC = await spawnMeasured(primary, "C");
+      if (sessionC.status === "ready") {
+        await promptMeasured(primary, sessionC, "C");
+        outcome = "coexist";
+      } else {
+        const secondary = await startRuntime(SECONDARY_PORT, "runtime-2");
+        runtimes.push(secondary);
+        const crossProcessC = await spawnMeasured(secondary, "C-cross-process");
+        outcome = crossProcessC.status === "ready" ? "process-pool" : "serialize";
+      }
+    } else {
+      const secondary = await startRuntime(SECONDARY_PORT, "runtime-2");
+      runtimes.push(secondary);
+      await checkClaude(secondary);
+      const crossProcessB = await spawnMeasured(secondary, "B-cross-process");
+      if (crossProcessB.status === "ready") {
+        await promptMeasured(secondary, crossProcessB, "B");
+        outcome = "process-pool";
+      }
+    }
+
+    const allSessions = runtimes.flatMap((runtime) => [...runtime.sessions.values()]);
+    const cliVersion =
+      allSessions
+        .map((session) => session.cliVersion)
+        .find((version) => version && version !== "unknown") ??
+      cliVersionFallback();
+    console.log("OUTCOME: " + outcome);
+    console.log(
+      "RESULT_JSON: " +
+        JSON.stringify({
+          generatedAt: new Date().toISOString(),
+          cwd: CWD,
+          cliVersion,
+          sessions: allSessions,
+          outcome,
+        }),
+    );
+  } catch (error) {
+    blocker = error instanceof Error ? error.message : String(error);
+    console.error("[concurrency] BLOCKER: " + blocker);
+    if (isAuthRequiredError(blocker)) {
+      process.exitCode = 2;
+    } else {
+      process.exitCode = 1;
+    }
+  } finally {
+    await Promise.all(runtimes.map((runtime) => closeRuntime(runtime)));
+  }
+
+  if (blocker) {
+    console.log("OUTCOME: serialize");
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1370,6 +1370,8 @@ export interface ActiveSession {
    * to the UI, not dispatch-eligible until promoted. #1631.
    */
   role: "serving" | "standby";
+  /** Run id that currently owns this session and fences it from idle reclaim. */
+  ownedByRunId?: string;
   /**
    * True once the standby session finished its compaction seed prompt and
    * is eligible for `promoteStandbyAndDispatch`. Always false for serving
@@ -2176,6 +2178,7 @@ function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
       // point of predictive compaction. Killing one mid-warm-up defeats
       // the invisibility budget for the next user submit. #1631.
       if (session.role === "standby") return false;
+      if (session.ownedByRunId) return false;
       if (
         excludeConversationId &&
         session.conversationId === excludeConversationId
@@ -2220,6 +2223,18 @@ export const agentStore = {
 
   get sessions() {
     return state.sessions;
+  },
+
+  /** Claim ownedByRunId for a live run. */
+  markSessionRunOwned(sessionId: string, runId: string): void {
+    if (!state.sessions[sessionId]) return;
+    setState("sessions", sessionId, "ownedByRunId", runId);
+  },
+
+  /** Clear ownedByRunId when the run no longer needs the session. */
+  releaseSessionRunOwnership(sessionId: string): void {
+    if (!state.sessions[sessionId]) return;
+    setState("sessions", sessionId, "ownedByRunId", undefined);
   },
 
   get activeSessionId() {
@@ -9084,3 +9099,5 @@ export type {
   DiffProposalEvent,
   SessionStatus,
 };
+
+export { getIdleClaudeSessionIds as _getIdleClaudeSessionIds };

--- a/tests/unit/agent-run-owned-reclaim.test.ts
+++ b/tests/unit/agent-run-owned-reclaim.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Verifies run-owned Claude sessions are fenced from idle reclaim.
+// ABOUTME: Confirms releasing run ownership restores the normal reclaim candidate.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _getIdleClaudeSessionIds,
+  agentStore,
+  type ActiveSession,
+} from "@/stores/agent.store";
+import { setState, state } from "@/lib/agent/runtime";
+
+function session(createdAt: string): ActiveSession {
+  return {
+    info: {
+      agentType: "claude-code",
+      status: "ready",
+      createdAt,
+    },
+    role: "serving",
+    conversationId: "",
+  } as unknown as ActiveSession;
+}
+
+describe("run-owned Claude session reclaim", () => {
+  beforeEach(() => {
+    setState("sessions", {
+      owned: session("2026-07-31T00:00:00.000Z"),
+      free: session("2026-07-31T00:01:00.000Z"),
+    });
+    setState("activeSessionId", null);
+  });
+
+  afterEach(() => {
+    setState("sessions", {});
+    setState("activeSessionId", null);
+  });
+
+  it("excludes a run-owned ready session while retaining an unowned candidate", () => {
+    agentStore.markSessionRunOwned("owned", "run-123");
+
+    expect(state.sessions.owned.ownedByRunId).toBe("run-123");
+    expect(_getIdleClaudeSessionIds()).toEqual(["free"]);
+  });
+
+  it("releaseSessionRunOwnership makes the session reclaimable again", () => {
+    agentStore.markSessionRunOwned("owned", "run-123");
+    agentStore.releaseSessionRunOwnership("owned");
+
+    expect(state.sessions.owned.ownedByRunId).toBeUndefined();
+    expect(_getIdleClaudeSessionIds()).toEqual(["owned", "free"]);
+  });
+
+  it("does not mutate state when ownership targets a missing session", () => {
+    agentStore.markSessionRunOwned("missing", "run-123");
+    agentStore.releaseSessionRunOwnership("missing");
+
+    expect(Object.keys(state.sessions)).toEqual(["owned", "free"]);
+  });
+});

--- a/tests/unit/session-admission.test.ts
+++ b/tests/unit/session-admission.test.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Verifies FIFO admission and capacity limits for local Claude sessions.
+// ABOUTME: Covers queued positions, idempotent release, and release-driven progress.
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — the browser-local admission module is plain ESM without declarations.
+import { createAdmissionGate } from "../../bin/browser-local/session-admission.mjs";
+
+describe("session admission gate", () => {
+  it("respects the configured cap under concurrent acquires", async () => {
+    const gate = createAdmissionGate({ limit: 2 });
+    await gate.acquire("a");
+    await gate.acquire("b");
+    let thirdResolved = false;
+    const third = gate.acquire("c").then(() => {
+      thirdResolved = true;
+    });
+
+    expect(gate.activeCount()).toBe(2);
+    expect(gate.pendingCount()).toBe(1);
+    expect(thirdResolved).toBe(false);
+
+    gate.release("a");
+    await third;
+    expect(gate.activeCount()).toBe(2);
+    expect(gate.pendingCount()).toBe(0);
+  });
+
+  it("preserves FIFO order for queued sessions", async () => {
+    const order: string[] = [];
+    const gate = createAdmissionGate({ limit: 1 });
+    await gate.acquire("a");
+    const b = gate.acquire("b").then(() => order.push("b"));
+    const c = gate.acquire("c").then(() => order.push("c"));
+    const d = gate.acquire("d").then(() => order.push("d"));
+
+    gate.release("a");
+    await b;
+    expect(order).toEqual(["b"]);
+    gate.release("b");
+    await c;
+    expect(order).toEqual(["b", "c"]);
+    gate.release("c");
+    await d;
+    expect(order).toEqual(["b", "c", "d"]);
+  });
+
+  it("release unblocks exactly the next waiter", async () => {
+    const gate = createAdmissionGate({ limit: 1 });
+    await gate.acquire("a");
+    let bResolved = false;
+    let cResolved = false;
+    const b = gate.acquire("b").then(() => {
+      bResolved = true;
+    });
+    const c = gate.acquire("c").then(() => {
+      cResolved = true;
+    });
+
+    gate.release("a");
+    await b;
+    expect(bResolved).toBe(true);
+    expect(cResolved).toBe(false);
+    expect(gate.pendingCount()).toBe(1);
+
+    gate.release("b");
+    await c;
+    expect(cResolved).toBe(true);
+  });
+
+  it("release is idempotent per session", async () => {
+    const gate = createAdmissionGate({ limit: 1 });
+    await gate.acquire("a");
+    expect(gate.release("a")).toBe(true);
+    expect(gate.release("a")).toBe(false);
+    expect(gate.activeCount()).toBe(0);
+  });
+
+  it("reports queued positions", async () => {
+    const queued: Array<[string, number]> = [];
+    const gate = createAdmissionGate({
+      limit: 1,
+      onQueued(sessionId: string, position: number) {
+        queued.push([sessionId, position]);
+      },
+    });
+    await gate.acquire("a");
+    const b = gate.acquire("b");
+    const c = gate.acquire("c");
+
+    expect(queued).toEqual([
+      ["b", 1],
+      ["c", 2],
+    ]);
+
+    gate.release("a");
+    await b;
+    gate.release("b");
+    await c;
+  });
+});


### PR DESCRIPTION
## Summary

- Experiment verdict: OUTCOME: coexist — three concurrent claude-code sessions ran in one embedded Node process with CLI 2.1.220 in full-access mode.
- The default admission cap is 3 sessions per runtime process; SEREN_CLAUDE_SESSION_LIMIT overrides it.
- Run-aware reclaim fences sessions owned by an active run from idle reclaim.
- Queue proof passed with queuedDurationMs=922 and zero premature terminations of the active session.
- The workspace-write sandbox path reached the documented credential boundary: Not logged in · Please run /login.

## Verification

- set -o pipefail; cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | tail -5 — exit 0
- pnpm test — exit 0 (2,848 tests passed)
- pnpm check — exit 0
- pnpm vitest run tests/unit/session-admission.test.ts tests/unit/agent-run-owned-reclaim.test.ts — exit 0 (8/8 tests)
- pnpm build — exit 0

Artifact: [Runtime concurrency experiment](docs/20260731_Runtime_Concurrency_Experiment.md)

Part of #3511