### PR TITLE
fix(auth): store desktop credentials in OS keychain

### DIFF
--- a/.github/release-notes/v3.76.0.md
+++ b/.github/release-notes/v3.76.0.md
@@ -1,0 +1,5 @@
+## What's New
+
+## 🔒 Privacy & Security
+
+- Seren Desktop now keeps authentication tokens, Seren and direct-provider API keys, and OAuth credentials in the native OS credential store. Existing credentials migrate automatically on first launch after updating; the OS may ask you to unlock or approve access to its credential store. Seren verifies the native write before removing legacy app-data values and preserves them for a safe retry if the credential store is unavailable (#3513).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev dbus-x11 gnome-keyring
       - run: pnpm install --frozen-lockfile
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'
@@ -268,6 +268,17 @@ jobs:
       - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: pnpm tauri build --bundles deb,appimage --config src-tauri/tauri.ci.json
+      - name: Verify native credential store (macOS and Windows)
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml --lib native_backend_round_trip_uses_platform_credential_store -- --nocapture
+      - name: Verify native credential store (Linux Secret Service)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          dbus-run-session -- bash -euo pipefail -c '
+            eval "$(echo -n seren-ci-keyring | gnome-keyring-daemon --unlock --components=secrets)"
+            cargo test --locked --manifest-path src-tauri/Cargo.toml --lib native_backend_round_trip_uses_platform_credential_store -- --ignored --nocapture
+          '
       - name: Verify Happy bridge graceful shutdown (Windows)
         # Windows has no SIGTERM, so the bridge is stopped by a supervisor
         # notification instead (#3031). That path cannot be exercised on the

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Run any skill, employee, or custom prompt as a hosted workflow that keeps workin
 
 ### Security and control
 
-- All credentials stored with OS-level encryption - never in plain text
+- Desktop authentication tokens, Seren/provider API keys, and provider OAuth credentials are stored in the native OS credential store (macOS Keychain, Windows Credential Manager, or Linux Secret Service) - never in app-data JSON or browser storage in packaged builds
 - All connections made over HTTPS
 - Agents operate within the limits and permissions you define - no surprises
 - Option to connect directly to AI providers using your own API keys

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ All contributions must follow these rules:
 // WRONG - never do this
 const API_KEY = "sk_live_abc123";
 
-// CORRECT - use Tauri secure storage
+// CORRECT - use the native OS credential-store command
 const apiKey = await invoke("get_api_key");
 ```
 
@@ -72,12 +72,11 @@ if (url.protocol !== "https:" && url.protocol !== "http:") {
 // WRONG - plaintext storage
 std::fs::write("token.txt", token);
 
-// CORRECT - use Tauri secure storage
-use tauri_plugin_store::StoreExt;
-let store = app.store("auth.json")?;
-store.set("token", serde_json::json!(token));
-store.save()?;
+// CORRECT - use Seren's native OS credential-store boundary
+crate::credential_store::store_access_token(&app, &token)?;
 ```
+
+`tauri-plugin-store` is for non-secret preferences and credential metadata only. Desktop authentication tokens, API keys, and OAuth credentials must use the native OS credential store (macOS Keychain, Windows Credential Manager, or Linux Secret Service). Other secret classes must use their approved secret boundary. Production code must fail closed when that boundary is unavailable; it must not fall back to app-data JSON or browser storage.
 
 ### 6. Scrub PII from Error Reports
 

--- a/src-tauri/src/audio/seren_notes_publish.rs
+++ b/src-tauri/src/audio/seren_notes_publish.rs
@@ -207,7 +207,7 @@ pub async fn publish_meeting_notes(
     title: &str,
     content: &str,
 ) -> Result<String, PublishError> {
-    if !has_stored_credentials(app) {
+    if !has_stored_credentials(app).map_err(PublishError::Other)? {
         return Err(PublishError::NotAuthenticated);
     }
     let client = Client::new();
@@ -230,7 +230,7 @@ pub async fn update_meeting_note_title(
     note_id: &str,
     title: &str,
 ) -> Result<(), PublishError> {
-    if !has_stored_credentials(app) {
+    if !has_stored_credentials(app).map_err(PublishError::Other)? {
         return Err(PublishError::NotAuthenticated);
     }
     if !is_uuid(note_id) {
@@ -379,7 +379,7 @@ fn parse_update_response_body(text: &str) -> Result<(), PublishError> {
 /// live against the real service: `DELETE /notes/{id}` returns 204 and a
 /// subsequent GET returns 404.
 pub async fn delete_meeting_note(app: &AppHandle, note_id: &str) -> Result<(), PublishError> {
-    if !has_stored_credentials(app) {
+    if !has_stored_credentials(app).map_err(PublishError::Other)? {
         return Err(PublishError::NotAuthenticated);
     }
     if !is_uuid(note_id) {

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -3,12 +3,8 @@
 
 use std::sync::OnceLock;
 use tauri::Emitter;
-use tauri_plugin_store::StoreExt;
 use tokio::sync::Mutex as TokioMutex;
 
-const AUTH_STORE: &str = "auth.json";
-const TOKEN_KEY: &str = "token";
-const REFRESH_TOKEN_KEY: &str = "refresh_token";
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 
 /// Global mutex to prevent concurrent refresh attempts from multiple workers.
@@ -59,21 +55,15 @@ pub(crate) fn decide_after_refresh_unauthorized(
     RefreshUnauthorizedDecision::ExpireSession
 }
 
-/// Read the current access token from the encrypted store.
+/// Read the current access token from the native OS credential store.
 pub fn get_access_token(app: &tauri::AppHandle) -> Result<String, String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store
-        .get(TOKEN_KEY)
-        .and_then(|v| v.as_str().map(String::from))
-        .ok_or_else(|| "No access token in store".to_string())
+    crate::credential_store::get_access_token(app)?
+        .ok_or_else(|| "No access token in OS credential store".to_string())
 }
 
-/// Read the refresh token from the encrypted store.
+/// Read the refresh token from the native OS credential store.
 fn get_refresh_token(app: &tauri::AppHandle) -> Result<Option<String>, String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    Ok(store
-        .get(REFRESH_TOKEN_KEY)
-        .and_then(|v| v.as_str().map(String::from)))
+    crate::credential_store::get_refresh_token(app)
 }
 
 /// True when either an access token or a refresh token is present.
@@ -82,8 +72,11 @@ fn get_refresh_token(app: &tauri::AppHandle) -> Result<Option<String>, String> {
 /// stored auth at all. A signed-out cold start has neither token, so public
 /// endpoints (catalog, provider list) must go through unauthenticated rather
 /// than failing through the refresh path. See #1860.
-pub fn has_stored_credentials(app: &tauri::AppHandle) -> bool {
-    get_access_token(app).is_ok() || matches!(get_refresh_token(app), Ok(Some(_)))
+pub fn has_stored_credentials(app: &tauri::AppHandle) -> Result<bool, String> {
+    if crate::credential_store::get_access_token(app)?.is_some() {
+        return Ok(true);
+    }
+    Ok(get_refresh_token(app)?.is_some())
 }
 
 /// Store new tokens after a successful refresh.
@@ -92,22 +85,18 @@ fn store_tokens(
     access_token: &str,
     refresh_token: Option<&str>,
 ) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.set(TOKEN_KEY, serde_json::json!(access_token));
     if let Some(rt) = refresh_token {
-        store.set(REFRESH_TOKEN_KEY, serde_json::json!(rt));
+        crate::credential_store::store_refresh_token(app, rt)?;
     }
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    crate::credential_store::store_access_token(app, access_token)
 }
 
 /// Clear both tokens (session expired, user must re-login).
 fn clear_tokens(app: &tauri::AppHandle) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.delete(TOKEN_KEY);
-    store.delete(REFRESH_TOKEN_KEY);
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    // Clear refresh first so a partial failure never leaves a refresh token
+    // capable of resurrecting a session after its access token was removed.
+    crate::credential_store::clear_refresh_token(app)?;
+    crate::credential_store::clear_access_token(app)
 }
 
 /// Attempt to refresh the access token using the stored refresh token.

--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -10,12 +10,10 @@ use std::sync::{Arc, Mutex};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
-use tauri_plugin_store::StoreExt;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
-const AUTH_STORE: &str = "auth.json";
 /// Sentinel comments wrapping the auto-rendered index inside `MEMORY.md`.
 /// Only content between these markers is replaced when SerenDB intercepts
 /// refresh the file; everything outside is hand-curated and must survive.
@@ -23,10 +21,8 @@ const AUTO_INDEX_BEGIN: &str = "<!-- BEGIN AUTO-INDEX -->";
 const AUTO_INDEX_END: &str = "<!-- END AUTO-INDEX -->";
 /// The user's SerenDB API key. This is the credential for the SerenDB SQL
 /// data plane at `api.serendb.com/publishers/seren-db/query` — NOT the
-/// OAuth bearer token in `auth.json.token`, which is the Seren Desktop
-/// session credential for Gateway API calls. They are different keys and
-/// are not interchangeable on the SQL endpoint.
-const SEREN_API_KEY_KEY: &str = "seren_api_key";
+/// Seren Desktop OAuth bearer token. Both live in the native OS credential
+/// store under different accounts and are not interchangeable.
 const RENDERED_INDEX_FILENAME: &str = "MEMORY.md";
 const PROJECT_ID_FILENAME: &str = "project_id";
 const DEFAULT_PREF_TYPE: &str = "claude_preference";
@@ -1047,18 +1043,13 @@ pub async fn recall_preference_from_db(
 // Tauri-facing auth + client bootstrap
 // ---------------------------------------------------------------------------
 
-/// Read the user's SerenDB API key from the Tauri store. This is the data
+/// Read the user's SerenDB API key from the native OS credential store. This is the data
 /// plane credential for `api.serendb.com/publishers/seren-db/query` and is
 /// different from the OAuth bearer token used elsewhere in the app. If the
 /// API key is missing the user needs to log in to Seren Desktop (the login
 /// flow stores the key via `storeSerenApiKey()`).
 fn read_seren_api_key(app: &AppHandle) -> Result<String, String> {
-    let key = app
-        .store(AUTH_STORE)
-        .map_err(|e| e.to_string())?
-        .get(SEREN_API_KEY_KEY)
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .unwrap_or_default();
+    let key = crate::credential_store::get_seren_api_key(app)?.unwrap_or_default();
     if key.is_empty() {
         return Err(
             "SerenDB API key not available — log in to Seren Desktop so the key is provisioned"

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -197,14 +197,7 @@ pub async fn claude_memory_render_memory_md(
     let encoded = claude_memory::encode_project_dir(Path::new(&project_cwd));
     let claude_project_dir: PathBuf = root.join(&encoded);
 
-    let api_key = {
-        use tauri_plugin_store::StoreExt;
-        app.store("auth.json")
-            .map_err(|e| e.to_string())?
-            .get("seren_api_key")
-            .and_then(|v| v.as_str().map(|s| s.to_string()))
-            .unwrap_or_default()
-    };
+    let api_key = crate::credential_store::get_seren_api_key(&app)?.unwrap_or_default();
     if api_key.is_empty() {
         return Err(
             "SerenDB API key not available — log in to Seren Desktop so the key is provisioned"

--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -383,7 +383,7 @@ pub async fn gateway_http_start(
 
     let client = state.client.clone();
 
-    let has_credentials = crate::auth::has_stored_credentials(&app);
+    let has_credentials = crate::auth::has_stored_credentials(&app)?;
     let response = if should_attach_stored_auth(&url, &headers, has_credentials) {
         crate::auth::authenticated_request(&app, &client, |client, token| {
             build_request(

--- a/src-tauri/src/credential_store.rs
+++ b/src-tauri/src/credential_store.rs
@@ -1,0 +1,1190 @@
+// ABOUTME: Stores desktop credentials in the native OS credential store.
+// ABOUTME: Migrates legacy Tauri JSON values only after a verified keychain write.
+
+use sha2::{Digest, Sha256};
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex, MutexGuard};
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_store::StoreExt;
+
+const AUTH_STORE: &str = "auth.json";
+const PROVIDERS_STORE: &str = "providers.json";
+const OAUTH_STORE: &str = "oauth.json";
+const MCP_OAUTH_STORE: &str = "mcp-oauth.json";
+const METADATA_STORE: &str = "credential-metadata.json";
+
+const TOKEN_KEY: &str = "token";
+const REFRESH_TOKEN_KEY: &str = "refresh_token";
+const SEREN_API_KEY: &str = "seren_api_key";
+const MCP_ACCESS_TOKEN_KEY: &str = "mcp_access_token";
+const MCP_REFRESH_TOKEN_KEY: &str = "mcp_refresh_token";
+
+const FIXED_CREDENTIALS: &str = "fixed_credentials";
+const PROVIDER_API_KEYS: &str = "provider_api_keys";
+const PROVIDER_OAUTH: &str = "provider_oauth";
+
+const ACCESS_TOKEN_ACCOUNT: &str = "seren.auth.access-token.v1";
+const REFRESH_TOKEN_ACCOUNT: &str = "seren.auth.refresh-token.v1";
+const SEREN_API_KEY_ACCOUNT: &str = "seren.api-key.v1";
+const MCP_ACCESS_TOKEN_ACCOUNT: &str = "seren.mcp-oauth.access-token.v1";
+const MCP_REFRESH_TOKEN_ACCOUNT: &str = "seren.mcp-oauth.refresh-token.v1";
+
+trait SecureBackend: Send + Sync {
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>, String>;
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<(), String>;
+    fn delete(&self, service: &str, account: &str) -> Result<(), String>;
+}
+
+struct KeyringBackend;
+
+impl KeyringBackend {
+    fn entry(service: &str, account: &str) -> Result<keyring::Entry, String> {
+        keyring::Entry::new(service, account).map_err(|error| error.to_string())
+    }
+}
+
+impl SecureBackend for KeyringBackend {
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>, String> {
+        match Self::entry(service, account)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<(), String> {
+        Self::entry(service, account)?
+            .set_password(value)
+            .map_err(|error| error.to_string())
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<(), String> {
+        match Self::entry(service, account)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}
+
+/// Process-local owner for credential mutations. The mutex serializes migration,
+/// refresh, sign-in, and sign-out so a legacy value cannot race a newer keychain
+/// write back into service.
+pub(crate) struct CredentialStoreState {
+    secure: Arc<dyn SecureBackend>,
+    mutation: Mutex<()>,
+    #[cfg(test)]
+    test_persistence: Option<Mutex<TestPersistence>>,
+}
+
+impl CredentialStoreState {
+    pub(crate) fn new_os() -> Self {
+        Self {
+            secure: Arc::new(KeyringBackend),
+            mutation: Mutex::new(()),
+            #[cfg(test)]
+            test_persistence: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_test(secure: Arc<dyn SecureBackend>) -> Self {
+        Self {
+            secure,
+            mutation: Mutex::new(()),
+            test_persistence: Some(Mutex::new(TestPersistence::default())),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_memory_for_tests() -> Self {
+        Self::new_test(Arc::new(TestMemorySecureBackend::default()))
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestMemorySecureBackend {
+    values: Mutex<std::collections::HashMap<(String, String), String>>,
+}
+
+#[cfg(test)]
+impl SecureBackend for TestMemorySecureBackend {
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>, String> {
+        Ok(self
+            .values
+            .lock()
+            .map_err(|_| "test OS credential store lock poisoned".to_string())?
+            .get(&(service.to_string(), account.to_string()))
+            .cloned())
+    }
+
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<(), String> {
+        self.values
+            .lock()
+            .map_err(|_| "test OS credential store lock poisoned".to_string())?
+            .insert(
+                (service.to_string(), account.to_string()),
+                value.to_string(),
+            );
+        Ok(())
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<(), String> {
+        self.values
+            .lock()
+            .map_err(|_| "test OS credential store lock poisoned".to_string())?
+            .remove(&(service.to_string(), account.to_string()));
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProtectedSetting {
+    SerenApiKey,
+    McpAccessToken,
+    McpRefreshToken,
+}
+
+pub(crate) fn protected_setting(store: &str, key: &str) -> Option<ProtectedSetting> {
+    match (store, key) {
+        (AUTH_STORE, SEREN_API_KEY) => Some(ProtectedSetting::SerenApiKey),
+        (MCP_OAUTH_STORE, MCP_ACCESS_TOKEN_KEY) => Some(ProtectedSetting::McpAccessToken),
+        (MCP_OAUTH_STORE, MCP_REFRESH_TOKEN_KEY) => Some(ProtectedSetting::McpRefreshToken),
+        _ => None,
+    }
+}
+
+struct CredentialDescriptor<'a> {
+    account: String,
+    legacy_store: &'static str,
+    legacy_key: Cow<'a, str>,
+    metadata_group: &'static str,
+    metadata_id: Cow<'a, str>,
+    label: &'static str,
+}
+
+impl CredentialDescriptor<'static> {
+    fn access_token() -> Self {
+        Self::fixed(
+            ACCESS_TOKEN_ACCOUNT,
+            AUTH_STORE,
+            TOKEN_KEY,
+            "Seren access token",
+        )
+    }
+
+    fn refresh_token() -> Self {
+        Self::fixed(
+            REFRESH_TOKEN_ACCOUNT,
+            AUTH_STORE,
+            REFRESH_TOKEN_KEY,
+            "Seren refresh token",
+        )
+    }
+
+    fn seren_api_key() -> Self {
+        Self::fixed(
+            SEREN_API_KEY_ACCOUNT,
+            AUTH_STORE,
+            SEREN_API_KEY,
+            "Seren API key",
+        )
+    }
+
+    fn mcp_access_token() -> Self {
+        Self::fixed(
+            MCP_ACCESS_TOKEN_ACCOUNT,
+            MCP_OAUTH_STORE,
+            MCP_ACCESS_TOKEN_KEY,
+            "MCP OAuth access token",
+        )
+    }
+
+    fn mcp_refresh_token() -> Self {
+        Self::fixed(
+            MCP_REFRESH_TOKEN_ACCOUNT,
+            MCP_OAUTH_STORE,
+            MCP_REFRESH_TOKEN_KEY,
+            "MCP OAuth refresh token",
+        )
+    }
+
+    fn fixed(
+        account: &'static str,
+        legacy_store: &'static str,
+        legacy_key: &'static str,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            account: account.to_string(),
+            legacy_store,
+            legacy_key: Cow::Borrowed(legacy_key),
+            metadata_group: FIXED_CREDENTIALS,
+            metadata_id: Cow::Borrowed(account),
+            label,
+        }
+    }
+}
+
+impl<'a> CredentialDescriptor<'a> {
+    fn provider_api_key(provider: &'a str) -> Self {
+        Self::provider(
+            "seren.provider-api-key.v1",
+            PROVIDERS_STORE,
+            PROVIDER_API_KEYS,
+            provider,
+            "provider API key",
+        )
+    }
+
+    fn provider_oauth(provider: &'a str) -> Self {
+        Self::provider(
+            "seren.provider-oauth.v1",
+            OAUTH_STORE,
+            PROVIDER_OAUTH,
+            provider,
+            "provider OAuth credentials",
+        )
+    }
+
+    fn provider(
+        account_prefix: &'static str,
+        legacy_store: &'static str,
+        metadata_group: &'static str,
+        provider: &'a str,
+        label: &'static str,
+    ) -> Self {
+        let provider_hash = hex::encode(Sha256::digest(provider.as_bytes()));
+        Self {
+            account: format!("{account_prefix}.{provider_hash}"),
+            legacy_store,
+            legacy_key: Cow::Borrowed(provider),
+            metadata_group,
+            metadata_id: Cow::Borrowed(provider),
+            label,
+        }
+    }
+}
+
+fn credential_state<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<tauri::State<'_, CredentialStoreState>, String> {
+    app.try_state::<CredentialStoreState>().ok_or_else(|| {
+        "OS credential store is not initialized; restart Seren Desktop and retry".to_string()
+    })
+}
+
+fn mutation_guard(state: &CredentialStoreState) -> Result<MutexGuard<'_, ()>, String> {
+    state.mutation.lock().map_err(|_| {
+        "OS credential store mutation lock is unavailable; restart and retry".to_string()
+    })
+}
+
+fn credential_error(label: &str, operation: &str, error: &str) -> String {
+    format!(
+        "OS credential store could not {operation} {label}: {error}. Unlock or configure the platform credential store and retry; Seren will not fall back to plaintext storage"
+    )
+}
+
+fn secure_get<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<Option<String>, String> {
+    state
+        .secure
+        .get(&app.config().identifier, &descriptor.account)
+        .map_err(|error| credential_error(descriptor.label, "read", &error))
+}
+
+fn secure_set_verified<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+    value: &str,
+) -> Result<(), String> {
+    let service = &app.config().identifier;
+    state
+        .secure
+        .set(service, &descriptor.account, value)
+        .map_err(|error| credential_error(descriptor.label, "store", &error))?;
+
+    match state.secure.get(service, &descriptor.account) {
+        Ok(Some(stored)) if stored == value => Ok(()),
+        Ok(Some(_)) => Err(credential_error(
+            descriptor.label,
+            "verify",
+            "the value read back did not match the value written",
+        )),
+        Ok(None) => Err(credential_error(
+            descriptor.label,
+            "verify",
+            "the value was absent immediately after writing",
+        )),
+        Err(error) => Err(credential_error(descriptor.label, "verify", &error)),
+    }
+}
+
+fn secure_delete<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<(), String> {
+    state
+        .secure
+        .delete(&app.config().identifier, &descriptor.account)
+        .map_err(|error| credential_error(descriptor.label, "delete", &error))
+}
+
+#[cfg(test)]
+#[derive(Default, serde::Serialize)]
+struct TestPersistence {
+    legacy: std::collections::BTreeMap<(String, String), String>,
+    metadata: std::collections::BTreeMap<String, BTreeSet<String>>,
+}
+
+fn legacy_get<R: Runtime>(
+    app: &AppHandle<R>,
+    _state: &CredentialStoreState,
+    store_name: &str,
+    key: &str,
+) -> Result<Option<String>, String> {
+    #[cfg(test)]
+    if let Some(persistence) = &_state.test_persistence {
+        return Ok(persistence
+            .lock()
+            .map_err(|_| "test credential persistence lock poisoned".to_string())?
+            .legacy
+            .get(&(store_name.to_string(), key.to_string()))
+            .cloned());
+    }
+
+    let store = app.store(store_name).map_err(|error| {
+        format!("failed to open legacy credential store for migration: {error}")
+    })?;
+    match store.get(key) {
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| {
+                "legacy credential value has an unexpected format; it was preserved".to_string()
+            }),
+        None => Ok(None),
+    }
+}
+
+fn legacy_keys<R: Runtime>(
+    app: &AppHandle<R>,
+    _state: &CredentialStoreState,
+    store_name: &str,
+) -> Result<Vec<String>, String> {
+    #[cfg(test)]
+    if let Some(persistence) = &_state.test_persistence {
+        let persistence = persistence
+            .lock()
+            .map_err(|_| "test credential persistence lock poisoned".to_string())?;
+        return Ok(persistence
+            .legacy
+            .keys()
+            .filter(|(candidate_store, _)| candidate_store == store_name)
+            .map(|(_, key)| key.clone())
+            .collect());
+    }
+
+    app.store(store_name)
+        .map(|store| store.keys())
+        .map_err(|error| format!("failed to enumerate legacy credential store: {error}"))
+}
+
+fn legacy_delete<R: Runtime>(
+    app: &AppHandle<R>,
+    _state: &CredentialStoreState,
+    store_name: &str,
+    key: &str,
+) -> Result<(), String> {
+    #[cfg(test)]
+    if let Some(persistence) = &_state.test_persistence {
+        persistence
+            .lock()
+            .map_err(|_| "test credential persistence lock poisoned".to_string())?
+            .legacy
+            .remove(&(store_name.to_string(), key.to_string()));
+        return Ok(());
+    }
+
+    let store = app
+        .store(store_name)
+        .map_err(|error| format!("failed to open legacy credential store for cleanup: {error}"))?;
+    let previous = store.get(key);
+    if previous.is_none() {
+        return Ok(());
+    }
+
+    store.delete(key);
+    if let Err(error) = store.save() {
+        if let Some(previous) = previous {
+            store.set(key, previous);
+            let _ = store.save();
+        }
+        return Err(format!(
+            "failed to remove a migrated plaintext credential; the legacy value was preserved for retry: {error}"
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_list<R: Runtime>(
+    app: &AppHandle<R>,
+    _state: &CredentialStoreState,
+    group: &str,
+) -> Result<BTreeSet<String>, String> {
+    #[cfg(test)]
+    if let Some(persistence) = &_state.test_persistence {
+        return Ok(persistence
+            .lock()
+            .map_err(|_| "test credential persistence lock poisoned".to_string())?
+            .metadata
+            .get(group)
+            .cloned()
+            .unwrap_or_default());
+    }
+
+    let store = app
+        .store(METADATA_STORE)
+        .map_err(|error| format!("failed to open credential metadata: {error}"))?;
+    match store.get(group) {
+        Some(value) => serde_json::from_value::<BTreeSet<String>>(value.clone())
+            .map_err(|_| "credential metadata is invalid; no secret was read".to_string()),
+        None => Ok(BTreeSet::new()),
+    }
+}
+
+fn metadata_replace<R: Runtime>(
+    app: &AppHandle<R>,
+    _state: &CredentialStoreState,
+    group: &str,
+    values: &BTreeSet<String>,
+) -> Result<(), String> {
+    #[cfg(test)]
+    if let Some(persistence) = &_state.test_persistence {
+        let mut persistence = persistence
+            .lock()
+            .map_err(|_| "test credential persistence lock poisoned".to_string())?;
+        if values.is_empty() {
+            persistence.metadata.remove(group);
+        } else {
+            persistence
+                .metadata
+                .insert(group.to_string(), values.clone());
+        }
+        return Ok(());
+    }
+
+    let store = app
+        .store(METADATA_STORE)
+        .map_err(|error| format!("failed to open credential metadata: {error}"))?;
+    let previous = store.get(group);
+    if values.is_empty() {
+        store.delete(group);
+    } else {
+        store.set(group, serde_json::json!(values));
+    }
+
+    if let Err(error) = store.save() {
+        match previous {
+            Some(previous) => store.set(group, previous),
+            None => {
+                store.delete(group);
+            }
+        }
+        let _ = store.save();
+        return Err(format!(
+            "failed to persist non-secret credential metadata: {error}"
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_contains<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<bool, String> {
+    Ok(metadata_list(app, state, descriptor.metadata_group)?
+        .contains(descriptor.metadata_id.as_ref()))
+}
+
+fn metadata_mark<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<(), String> {
+    let mut values = metadata_list(app, state, descriptor.metadata_group)?;
+    if values.insert(descriptor.metadata_id.to_string()) {
+        metadata_replace(app, state, descriptor.metadata_group, &values)?;
+    }
+    Ok(())
+}
+
+fn metadata_unmark<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<(), String> {
+    let mut values = metadata_list(app, state, descriptor.metadata_group)?;
+    if values.remove(descriptor.metadata_id.as_ref()) {
+        metadata_replace(app, state, descriptor.metadata_group, &values)?;
+    }
+    Ok(())
+}
+
+fn read_inner<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<Option<String>, String> {
+    let legacy = legacy_get(
+        app,
+        state,
+        descriptor.legacy_store,
+        descriptor.legacy_key.as_ref(),
+    )?;
+    let marked = metadata_contains(app, state, descriptor)?;
+
+    if !marked {
+        let Some(legacy_value) = legacy else {
+            // Every successful keychain write records metadata before deleting
+            // plaintext. With neither marker nor legacy value, no credential is
+            // canonical, so do not probe or expose an orphaned keychain entry.
+            return Ok(None);
+        };
+        if legacy_value.trim().is_empty() {
+            legacy_delete(
+                app,
+                state,
+                descriptor.legacy_store,
+                descriptor.legacy_key.as_ref(),
+            )?;
+            return Ok(None);
+        }
+        return migrate_legacy_inner(app, state, descriptor, legacy_value);
+    }
+
+    match secure_get(app, state, descriptor)? {
+        Some(value) => {
+            if legacy.is_some() {
+                legacy_delete(
+                    app,
+                    state,
+                    descriptor.legacy_store,
+                    descriptor.legacy_key.as_ref(),
+                )?;
+            }
+            Ok(Some(value))
+        }
+        None => match legacy {
+            Some(legacy_value) if !legacy_value.trim().is_empty() => {
+                // A marker with a missing native entry can happen after an OS
+                // credential-store reset. Preserve availability by remigrating
+                // the still-present legacy value through the same verify gate.
+                migrate_legacy_inner(app, state, descriptor, legacy_value)
+            }
+            Some(_) => {
+                legacy_delete(
+                    app,
+                    state,
+                    descriptor.legacy_store,
+                    descriptor.legacy_key.as_ref(),
+                )?;
+                metadata_unmark(app, state, descriptor)?;
+                Ok(None)
+            }
+            None => {
+                metadata_unmark(app, state, descriptor)?;
+                Ok(None)
+            }
+        },
+    }
+}
+
+fn migrate_legacy_inner<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+    legacy_value: String,
+) -> Result<Option<String>, String> {
+    secure_set_verified(app, state, descriptor, &legacy_value)?;
+    if let Err(error) = metadata_mark(app, state, descriptor) {
+        let _ = secure_delete(app, state, descriptor);
+        return Err(error);
+    }
+    legacy_delete(
+        app,
+        state,
+        descriptor.legacy_store,
+        descriptor.legacy_key.as_ref(),
+    )?;
+    Ok(Some(legacy_value))
+}
+
+fn store_inner<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+    value: &str,
+) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{} must not be empty", descriptor.label));
+    }
+
+    secure_set_verified(app, state, descriptor, value)?;
+    if let Err(error) = metadata_mark(app, state, descriptor) {
+        let _ = secure_delete(app, state, descriptor);
+        return Err(error);
+    }
+    legacy_delete(
+        app,
+        state,
+        descriptor.legacy_store,
+        descriptor.legacy_key.as_ref(),
+    )
+}
+
+fn delete_inner<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &CredentialStoreState,
+    descriptor: &CredentialDescriptor<'_>,
+) -> Result<(), String> {
+    // Scrub legacy first so a failed native delete cannot be followed by a
+    // retry that resurrects old plaintext into the keychain.
+    legacy_delete(
+        app,
+        state,
+        descriptor.legacy_store,
+        descriptor.legacy_key.as_ref(),
+    )?;
+    secure_delete(app, state, descriptor)?;
+    metadata_unmark(app, state, descriptor)
+}
+
+fn read<R: Runtime>(
+    app: &AppHandle<R>,
+    descriptor: CredentialDescriptor<'_>,
+) -> Result<Option<String>, String> {
+    let state = credential_state(app)?;
+    let _guard = mutation_guard(&state)?;
+    read_inner(app, &state, &descriptor)
+}
+
+fn store<R: Runtime>(
+    app: &AppHandle<R>,
+    descriptor: CredentialDescriptor<'_>,
+    value: &str,
+) -> Result<(), String> {
+    let state = credential_state(app)?;
+    let _guard = mutation_guard(&state)?;
+    store_inner(app, &state, &descriptor, value)
+}
+
+fn delete<R: Runtime>(
+    app: &AppHandle<R>,
+    descriptor: CredentialDescriptor<'_>,
+) -> Result<(), String> {
+    let state = credential_state(app)?;
+    let _guard = mutation_guard(&state)?;
+    delete_inner(app, &state, &descriptor)
+}
+
+pub(crate) fn store_access_token<R: Runtime>(
+    app: &AppHandle<R>,
+    value: &str,
+) -> Result<(), String> {
+    store(app, CredentialDescriptor::access_token(), value)
+}
+
+pub(crate) fn get_access_token<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
+    read(app, CredentialDescriptor::access_token())
+}
+
+pub(crate) fn clear_access_token<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    delete(app, CredentialDescriptor::access_token())
+}
+
+pub(crate) fn store_refresh_token<R: Runtime>(
+    app: &AppHandle<R>,
+    value: &str,
+) -> Result<(), String> {
+    store(app, CredentialDescriptor::refresh_token(), value)
+}
+
+pub(crate) fn get_refresh_token<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
+    read(app, CredentialDescriptor::refresh_token())
+}
+
+pub(crate) fn clear_refresh_token<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    delete(app, CredentialDescriptor::refresh_token())
+}
+
+pub(crate) fn store_seren_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+    value: &str,
+) -> Result<(), String> {
+    store(app, CredentialDescriptor::seren_api_key(), value)
+}
+
+pub(crate) fn get_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
+    read(app, CredentialDescriptor::seren_api_key())
+}
+
+pub(crate) fn clear_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    delete(app, CredentialDescriptor::seren_api_key())
+}
+
+pub(crate) fn store_provider_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+    value: &str,
+) -> Result<(), String> {
+    validate_provider(provider)?;
+    store(app, CredentialDescriptor::provider_api_key(provider), value)
+}
+
+pub(crate) fn get_provider_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+) -> Result<Option<String>, String> {
+    validate_provider(provider)?;
+    read(app, CredentialDescriptor::provider_api_key(provider))
+}
+
+pub(crate) fn clear_provider_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+) -> Result<(), String> {
+    validate_provider(provider)?;
+    delete(app, CredentialDescriptor::provider_api_key(provider))
+}
+
+pub(crate) fn configured_api_key_providers<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Vec<String>, String> {
+    configured_providers(app, PROVIDERS_STORE, PROVIDER_API_KEYS, |provider| {
+        CredentialDescriptor::provider_api_key(provider)
+    })
+}
+
+pub(crate) fn store_provider_oauth<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+    value: &str,
+) -> Result<(), String> {
+    validate_provider(provider)?;
+    store(app, CredentialDescriptor::provider_oauth(provider), value)
+}
+
+pub(crate) fn get_provider_oauth<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+) -> Result<Option<String>, String> {
+    validate_provider(provider)?;
+    read(app, CredentialDescriptor::provider_oauth(provider))
+}
+
+pub(crate) fn clear_provider_oauth<R: Runtime>(
+    app: &AppHandle<R>,
+    provider: &str,
+) -> Result<(), String> {
+    validate_provider(provider)?;
+    delete(app, CredentialDescriptor::provider_oauth(provider))
+}
+
+pub(crate) fn configured_oauth_providers<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Vec<String>, String> {
+    configured_providers(app, OAUTH_STORE, PROVIDER_OAUTH, |provider| {
+        CredentialDescriptor::provider_oauth(provider)
+    })
+}
+
+fn configured_providers<R, F>(
+    app: &AppHandle<R>,
+    legacy_store: &str,
+    metadata_group: &str,
+    descriptor: F,
+) -> Result<Vec<String>, String>
+where
+    R: Runtime,
+    F: for<'a> Fn(&'a str) -> CredentialDescriptor<'a>,
+{
+    let state = credential_state(app)?;
+    let _guard = mutation_guard(&state)?;
+    for provider in legacy_keys(app, &state, legacy_store)? {
+        validate_provider(&provider)?;
+        read_inner(app, &state, &descriptor(&provider))?;
+    }
+    Ok(metadata_list(app, &state, metadata_group)?
+        .into_iter()
+        .collect())
+}
+
+fn validate_provider(provider: &str) -> Result<(), String> {
+    if provider.trim().is_empty() {
+        Err("provider identifier must not be empty".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn get_protected_setting<R: Runtime>(
+    app: &AppHandle<R>,
+    setting: ProtectedSetting,
+) -> Result<Option<String>, String> {
+    match setting {
+        ProtectedSetting::SerenApiKey => get_seren_api_key(app),
+        ProtectedSetting::McpAccessToken => read(app, CredentialDescriptor::mcp_access_token()),
+        ProtectedSetting::McpRefreshToken => read(app, CredentialDescriptor::mcp_refresh_token()),
+    }
+}
+
+pub(crate) fn set_protected_setting<R: Runtime>(
+    app: &AppHandle<R>,
+    setting: ProtectedSetting,
+    value: &str,
+) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return match setting {
+            ProtectedSetting::SerenApiKey => clear_seren_api_key(app),
+            ProtectedSetting::McpAccessToken => {
+                delete(app, CredentialDescriptor::mcp_access_token())
+            }
+            ProtectedSetting::McpRefreshToken => {
+                delete(app, CredentialDescriptor::mcp_refresh_token())
+            }
+        };
+    }
+
+    match setting {
+        ProtectedSetting::SerenApiKey => store_seren_api_key(app, value),
+        ProtectedSetting::McpAccessToken => {
+            store(app, CredentialDescriptor::mcp_access_token(), value)
+        }
+        ProtectedSetting::McpRefreshToken => {
+            store(app, CredentialDescriptor::mcp_refresh_token(), value)
+        }
+    }
+}
+
+/// Migrate every known legacy credential class. Startup logs an error and
+/// continues if this fails so the renderer can surface the same actionable
+/// error on access; no command falls back to plaintext.
+pub(crate) fn migrate_legacy_credentials<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    let state = credential_state(app)?;
+    let _guard = mutation_guard(&state)?;
+
+    for descriptor in [
+        CredentialDescriptor::access_token(),
+        CredentialDescriptor::refresh_token(),
+        CredentialDescriptor::seren_api_key(),
+        CredentialDescriptor::mcp_access_token(),
+        CredentialDescriptor::mcp_refresh_token(),
+    ] {
+        if legacy_get(
+            app,
+            &state,
+            descriptor.legacy_store,
+            descriptor.legacy_key.as_ref(),
+        )?
+        .is_some()
+        {
+            read_inner(app, &state, &descriptor)?;
+        }
+    }
+
+    for provider in legacy_keys(app, &state, PROVIDERS_STORE)? {
+        validate_provider(&provider)?;
+        read_inner(
+            app,
+            &state,
+            &CredentialDescriptor::provider_api_key(&provider),
+        )?;
+    }
+    for provider in legacy_keys(app, &state, OAUTH_STORE)? {
+        validate_provider(&provider)?;
+        read_inner(
+            app,
+            &state,
+            &CredentialDescriptor::provider_oauth(&provider),
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct MemorySecureBackend {
+        values: Mutex<HashMap<(String, String), String>>,
+        set_calls: AtomicUsize,
+        fail_set_call: AtomicUsize,
+        corrupt_next_read: AtomicUsize,
+    }
+
+    impl MemorySecureBackend {
+        fn fail_on_set_call(&self, call: usize) {
+            self.fail_set_call.store(call, Ordering::SeqCst);
+        }
+
+        fn corrupt_next_read(&self) {
+            self.corrupt_next_read.store(1, Ordering::SeqCst);
+        }
+    }
+
+    impl SecureBackend for MemorySecureBackend {
+        fn get(&self, service: &str, account: &str) -> Result<Option<String>, String> {
+            let value = self
+                .values
+                .lock()
+                .expect("memory secure store locks")
+                .get(&(service.to_string(), account.to_string()))
+                .cloned();
+            if self.corrupt_next_read.swap(0, Ordering::SeqCst) == 1 && value.is_some() {
+                return Ok(Some("verification-mismatch".to_string()));
+            }
+            Ok(value)
+        }
+
+        fn set(&self, service: &str, account: &str, value: &str) -> Result<(), String> {
+            let call = self.set_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.fail_set_call.load(Ordering::SeqCst) == call {
+                return Err("injected secure-store failure".to_string());
+            }
+            self.values
+                .lock()
+                .expect("memory secure store locks")
+                .insert(
+                    (service.to_string(), account.to_string()),
+                    value.to_string(),
+                );
+            Ok(())
+        }
+
+        fn delete(&self, service: &str, account: &str) -> Result<(), String> {
+            self.values
+                .lock()
+                .expect("memory secure store locks")
+                .remove(&(service.to_string(), account.to_string()));
+            Ok(())
+        }
+    }
+
+    fn test_app(secure: Arc<MemorySecureBackend>) -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_app();
+        app.manage(CredentialStoreState::new_test(secure));
+        app
+    }
+
+    fn seed_legacy<R: Runtime>(
+        app: &tauri::App<R>,
+        descriptor: &CredentialDescriptor<'_>,
+        value: &str,
+    ) {
+        let state = app.state::<CredentialStoreState>();
+        state
+            .test_persistence
+            .as_ref()
+            .expect("test persistence configured")
+            .lock()
+            .expect("test persistence locks")
+            .legacy
+            .insert(
+                (
+                    descriptor.legacy_store.to_string(),
+                    descriptor.legacy_key.to_string(),
+                ),
+                value.to_string(),
+            );
+    }
+
+    fn all_descriptors() -> Vec<CredentialDescriptor<'static>> {
+        vec![
+            CredentialDescriptor::access_token(),
+            CredentialDescriptor::refresh_token(),
+            CredentialDescriptor::seren_api_key(),
+            CredentialDescriptor::mcp_access_token(),
+            CredentialDescriptor::mcp_refresh_token(),
+            CredentialDescriptor::provider_api_key("test-provider"),
+            CredentialDescriptor::provider_oauth("test-oauth-provider"),
+        ]
+    }
+
+    #[test]
+    fn every_credential_class_supports_create_read_update_and_delete() {
+        let secure = Arc::new(MemorySecureBackend::default());
+        let app = test_app(secure);
+        let state = app.state::<CredentialStoreState>();
+
+        for (index, descriptor) in all_descriptors().iter().enumerate() {
+            let first = format!("test-secret-{index}-first");
+            let second = format!("test-secret-{index}-second");
+            store_inner(app.handle(), &state, descriptor, &first).unwrap();
+            assert_eq!(
+                read_inner(app.handle(), &state, descriptor).unwrap(),
+                Some(first)
+            );
+            store_inner(app.handle(), &state, descriptor, &second).unwrap();
+            assert_eq!(
+                read_inner(app.handle(), &state, descriptor).unwrap(),
+                Some(second)
+            );
+            delete_inner(app.handle(), &state, descriptor).unwrap();
+            assert_eq!(read_inner(app.handle(), &state, descriptor).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn partial_migration_preserves_plaintext_then_retries_all_classes() {
+        let secure = Arc::new(MemorySecureBackend::default());
+        secure.fail_on_set_call(3);
+        let app = test_app(secure.clone());
+        let descriptors = all_descriptors();
+        let seeded: Vec<String> = descriptors
+            .iter()
+            .enumerate()
+            .map(|(index, descriptor)| {
+                let value = format!("legacy-test-secret-{index}");
+                seed_legacy(&app, descriptor, &value);
+                value
+            })
+            .collect();
+
+        let first = migrate_legacy_credentials(app.handle());
+        assert!(
+            first.is_err(),
+            "the injected third write must stop migration"
+        );
+
+        let state = app.state::<CredentialStoreState>();
+        let persistence = state.test_persistence.as_ref().unwrap().lock().unwrap();
+        assert!(
+            !persistence.legacy.contains_key(&(
+                descriptors[0].legacy_store.to_string(),
+                descriptors[0].legacy_key.to_string()
+            )),
+            "successfully verified migrations scrub their legacy value"
+        );
+        assert!(
+            persistence.legacy.contains_key(&(
+                descriptors[2].legacy_store.to_string(),
+                descriptors[2].legacy_key.to_string()
+            )),
+            "the failed migration preserves plaintext for retry"
+        );
+        drop(persistence);
+
+        migrate_legacy_credentials(app.handle()).unwrap();
+        let persistence = state.test_persistence.as_ref().unwrap().lock().unwrap();
+        assert!(persistence.legacy.is_empty());
+
+        let persisted_fixture = serde_json::to_string(&*persistence).unwrap();
+        for value in &seeded {
+            assert!(
+                !persisted_fixture.contains(value),
+                "persisted app-store metadata must not contain seeded secret material"
+            );
+        }
+        drop(persistence);
+
+        for (descriptor, expected) in descriptors.iter().zip(seeded) {
+            assert_eq!(
+                read_inner(app.handle(), &state, descriptor).unwrap(),
+                Some(expected)
+            );
+        }
+        assert_eq!(
+            configured_api_key_providers(app.handle()).unwrap(),
+            vec!["test-provider".to_string()]
+        );
+        assert_eq!(
+            configured_oauth_providers(app.handle()).unwrap(),
+            vec!["test-oauth-provider".to_string()]
+        );
+    }
+
+    #[test]
+    fn failed_write_verification_keeps_legacy_value_for_retry() {
+        let secure = Arc::new(MemorySecureBackend::default());
+        secure.corrupt_next_read();
+        let app = test_app(secure);
+        let descriptor = CredentialDescriptor::provider_oauth("verification-test-provider");
+        seed_legacy(&app, &descriptor, "legacy-verification-test-secret");
+
+        let state = app.state::<CredentialStoreState>();
+        assert!(read_inner(app.handle(), &state, &descriptor).is_err());
+        assert_eq!(
+            legacy_get(
+                app.handle(),
+                &state,
+                descriptor.legacy_store,
+                descriptor.legacy_key.as_ref()
+            )
+            .unwrap(),
+            Some("legacy-verification-test-secret".to_string())
+        );
+
+        assert_eq!(
+            read_inner(app.handle(), &state, &descriptor).unwrap(),
+            Some("legacy-verification-test-secret".to_string())
+        );
+        assert_eq!(
+            legacy_get(
+                app.handle(),
+                &state,
+                descriptor.legacy_store,
+                descriptor.legacy_key.as_ref()
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        target_os = "linux",
+        ignore = "requires a running Secret Service session"
+    )]
+    fn native_backend_round_trip_uses_platform_credential_store() {
+        let service = "com.serendb.desktop.credential-store-test";
+        let account = format!(
+            "credential-store-test-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        );
+        let backend = KeyringBackend;
+        let _ = backend.delete(service, &account);
+
+        backend
+            .set(service, &account, "native-test-secret")
+            .unwrap();
+        #[cfg(target_os = "macos")]
+        assert!(
+            std::process::Command::new("security")
+                .args(["find-generic-password", "-s", service, "-a", &account])
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+        assert_eq!(
+            backend.get(service, &account).unwrap(),
+            Some("native-test-secret".to_string())
+        );
+        backend.delete(service, &account).unwrap();
+        assert_eq!(backend.get(service, &account).unwrap(), None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub mod authorization_audit;
 pub mod capability_lease;
 pub mod credential_broker;
 pub mod credential_lease;
+mod credential_store;
 // Public so the headless `claude_memory_sync` example can drive the
 // AppHandle-free sync core (#2639) without launching the app.
 pub mod claude_memory;
@@ -80,12 +81,6 @@ pub mod tool_authorization;
 mod tray;
 mod validation;
 mod wallet;
-
-const AUTH_STORE: &str = "auth.json";
-const TOKEN_KEY: &str = "token";
-const REFRESH_TOKEN_KEY: &str = "refresh_token";
-const PROVIDERS_STORE: &str = "providers.json";
-const OAUTH_STORE: &str = "oauth.json";
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -145,52 +140,32 @@ async fn get_oauth_redirect_url(url: String, bearer_token: String) -> Result<Str
 
 #[tauri::command]
 fn store_token(app: tauri::AppHandle, token: String) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.set(TOKEN_KEY, serde_json::json!(token));
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::store_access_token(&app, &token)
 }
 
 #[tauri::command]
 fn get_token(app: tauri::AppHandle) -> Result<Option<String>, String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    let token = store
-        .get(TOKEN_KEY)
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
-    Ok(token)
+    credential_store::get_access_token(&app)
 }
 
 #[tauri::command]
 fn clear_token(app: tauri::AppHandle) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.delete(TOKEN_KEY);
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::clear_access_token(&app)
 }
 
 #[tauri::command]
 fn store_refresh_token(app: tauri::AppHandle, token: String) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.set(REFRESH_TOKEN_KEY, serde_json::json!(token));
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::store_refresh_token(&app, &token)
 }
 
 #[tauri::command]
 fn get_refresh_token(app: tauri::AppHandle) -> Result<Option<String>, String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    let token = store
-        .get(REFRESH_TOKEN_KEY)
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
-    Ok(token)
+    credential_store::get_refresh_token(&app)
 }
 
 #[tauri::command]
 fn clear_refresh_token(app: tauri::AppHandle) -> Result<(), String> {
-    let store = app.store(AUTH_STORE).map_err(|e| e.to_string())?;
-    store.delete(REFRESH_TOKEN_KEY);
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::clear_refresh_token(&app)
 }
 
 #[tauri::command]
@@ -212,6 +187,9 @@ fn get_setting(
     store: String,
     key: String,
 ) -> Result<Option<String>, String> {
+    if let Some(setting) = credential_store::protected_setting(&store, &key) {
+        return credential_store::get_protected_setting(&app, setting);
+    }
     let store_handle = app.store(&store).map_err(|e| e.to_string())?;
     let value = store_handle
         .get(&key)
@@ -226,6 +204,9 @@ fn set_setting(
     key: String,
     value: String,
 ) -> Result<(), String> {
+    if let Some(setting) = credential_store::protected_setting(&store, &key) {
+        return credential_store::set_protected_setting(&app, setting, &value);
+    }
     let store_handle = app.store(&store).map_err(|e| e.to_string())?;
     store_handle.set(&key, serde_json::json!(value));
     store_handle.save().map_err(|e| e.to_string())?;
@@ -238,38 +219,22 @@ fn store_provider_key(
     provider: String,
     api_key: String,
 ) -> Result<(), String> {
-    let store = app.store(PROVIDERS_STORE).map_err(|e| e.to_string())?;
-    store.set(&provider, serde_json::json!(api_key));
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::store_provider_api_key(&app, &provider, &api_key)
 }
 
 #[tauri::command]
 fn get_provider_key(app: tauri::AppHandle, provider: String) -> Result<Option<String>, String> {
-    let store = app.store(PROVIDERS_STORE).map_err(|e| e.to_string())?;
-    let key = store
-        .get(&provider)
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
-    Ok(key)
+    credential_store::get_provider_api_key(&app, &provider)
 }
 
 #[tauri::command]
 fn clear_provider_key(app: tauri::AppHandle, provider: String) -> Result<(), String> {
-    let store = app.store(PROVIDERS_STORE).map_err(|e| e.to_string())?;
-    store.delete(&provider);
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::clear_provider_api_key(&app, &provider)
 }
 
 #[tauri::command]
 fn get_configured_providers(app: tauri::AppHandle) -> Result<Vec<String>, String> {
-    let store = app.store(PROVIDERS_STORE).map_err(|e| e.to_string())?;
-    let providers: Vec<String> = store
-        .keys()
-        .into_iter()
-        .filter(|k| store.get(k).map(|v| v.as_str().is_some()).unwrap_or(false))
-        .collect();
-    Ok(providers)
+    credential_store::configured_api_key_providers(&app)
 }
 
 // OAuth credential storage commands
@@ -279,10 +244,7 @@ fn store_oauth_credentials(
     provider: String,
     credentials: String,
 ) -> Result<(), String> {
-    let store = app.store(OAUTH_STORE).map_err(|e| e.to_string())?;
-    store.set(&provider, serde_json::json!(credentials));
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::store_provider_oauth(&app, &provider, &credentials)
 }
 
 #[tauri::command]
@@ -290,30 +252,17 @@ fn get_oauth_credentials(
     app: tauri::AppHandle,
     provider: String,
 ) -> Result<Option<String>, String> {
-    let store = app.store(OAUTH_STORE).map_err(|e| e.to_string())?;
-    let creds = store
-        .get(&provider)
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
-    Ok(creds)
+    credential_store::get_provider_oauth(&app, &provider)
 }
 
 #[tauri::command]
 fn clear_oauth_credentials(app: tauri::AppHandle, provider: String) -> Result<(), String> {
-    let store = app.store(OAUTH_STORE).map_err(|e| e.to_string())?;
-    store.delete(&provider);
-    store.save().map_err(|e| e.to_string())?;
-    Ok(())
+    credential_store::clear_provider_oauth(&app, &provider)
 }
 
 #[tauri::command]
 fn get_oauth_providers(app: tauri::AppHandle) -> Result<Vec<String>, String> {
-    let store = app.store(OAUTH_STORE).map_err(|e| e.to_string())?;
-    let providers: Vec<String> = store
-        .keys()
-        .into_iter()
-        .filter(|k| store.get(k).map(|v| v.as_str().is_some()).unwrap_or(false))
-        .collect();
-    Ok(providers)
+    credential_store::configured_oauth_providers(&app)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -674,6 +623,7 @@ pub fn run() {
                     }
                 },
             ))
+            .manage(credential_store::CredentialStoreState::new_os())
             .manage(happy_bridge::HappyBridgeManager::new())
             .manage(std::sync::Arc::new(
                 commands::updater::ShutdownGuard::default(),
@@ -833,6 +783,13 @@ pub fn run() {
                 return Err(
                     "validation bundle identity requires a build with --features validation".into(),
                 );
+            }
+
+            if let Err(error) = credential_store::migrate_legacy_credentials(app.handle()) {
+                // Credential reads retry the fail-safe migration and surface
+                // the same actionable error. Keep the shell available so the
+                // user can unlock/configure the OS credential store and retry.
+                log::error!("[credential-store] Legacy migration deferred: {error}");
             }
 
             // Inject the Seren Desktop host marker into the process environment.

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
-use tauri_plugin_store::StoreExt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -42,8 +41,6 @@ fn consume_subprocess_handle<R: Runtime>(
 const SHELL_PROGRESS_EVENT: &str = "shell://progress";
 const SHELL_PROGRESS_CHANNEL_DEPTH: usize = 256;
 
-const AUTH_STORE: &str = "auth.json";
-const SEREN_API_KEY_KEY: &str = "seren_api_key";
 const MAX_OUTPUT_BYTES: usize = 50_000;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 300;
@@ -682,12 +679,7 @@ async fn spawn_one_shot(
 }
 
 fn read_stored_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
-    let key = app
-        .store(AUTH_STORE)
-        .map_err(|err| err.to_string())?
-        .get(SEREN_API_KEY_KEY)
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_default();
+    let key = crate::credential_store::get_seren_api_key(app)?.unwrap_or_default();
 
     let trimmed = key.trim();
     if trimmed.is_empty() {
@@ -812,8 +804,6 @@ fn truncate_output(s: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-    use tauri_plugin_store::StoreExt;
 
     fn print_seren_key_env_command() -> &'static str {
         if cfg!(target_os = "windows") {
@@ -825,21 +815,13 @@ mod tests {
 
     fn mock_app_with_api_key(api_key: Option<&str>) -> tauri::App<tauri::test::MockRuntime> {
         let app = tauri::test::mock_builder()
-            .plugin(tauri_plugin_store::Builder::default().build())
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("mock app builds");
 
-        // Open the store and ALWAYS reset the key — `tauri-plugin-store`
-        // persists `auth.json` to the mock runtime's data dir, which is
-        // shared across sibling test invocations on the same host. Without
-        // an explicit delete, a prior `mock_app_with_api_key(Some("..."))`
-        // call leaves the key on disk; the next `Some(None)` call inherits
-        // it and the "logged out" assertion fails. Per-test self-containment
-        // is the only safe contract here. #1945.
-        let store = app.store(AUTH_STORE).expect("auth store opens");
-        store.delete(SEREN_API_KEY_KEY);
+        app.manage(crate::credential_store::CredentialStoreState::new_memory_for_tests());
         if let Some(api_key) = api_key {
-            store.set(SEREN_API_KEY_KEY, json!(api_key));
+            crate::credential_store::store_seren_api_key(app.handle(), api_key)
+                .expect("test API key stores in memory");
         }
 
         // The subprocess commands redeem a dispatch handle before spawning

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -12,9 +12,9 @@ const API_KEY_STORAGE_KEY = "seren_api_key";
 const DEFAULT_ORG_ID_STORAGE_KEY = "seren_default_org_id";
 
 /**
- * Development-only localStorage wrapper.
- * In production builds, all operations are no-ops to prevent
- * credentials from being stored insecurely outside Tauri.
+ * Development-only browser fallback for tests and non-packaged Vite sessions.
+ * Packaged Tauri builds always use native commands backed by the OS credential
+ * store; production browser builds make these operations no-ops.
  */
 const devStorage = {
   getItem: (key: string): string | null =>
@@ -141,7 +141,7 @@ export async function clearRefreshToken(): Promise<void> {
 // ============================================================================
 
 /**
- * Store Seren API key securely.
+ * Store the Seren API key in the native OS credential store.
  * This key is used to authenticate with seren-mcp.
  */
 export async function storeSerenApiKey(apiKey: string): Promise<void> {
@@ -485,7 +485,7 @@ export async function openPathWithDefaultApp(path: string): Promise<void> {
 // ============================================================================
 
 /**
- * Store an API key for a provider securely.
+ * Store an API key for a provider in the native OS credential store.
  */
 export async function storeProviderKey(
   provider: string,
@@ -550,7 +550,7 @@ export async function getConfiguredProviders(): Promise<string[]> {
 // ============================================================================
 
 /**
- * Store OAuth credentials for a provider securely.
+ * Store OAuth credentials for a provider in the native OS credential store.
  * @param provider - Provider ID (e.g., "openai")
  * @param credentials - JSON string of OAuthCredentials
  */

--- a/src/services/mcp-oauth.ts
+++ b/src/services/mcp-oauth.ts
@@ -357,7 +357,9 @@ export async function isMcpAuthenticated(): Promise<boolean> {
   return token !== null;
 }
 
-// Token storage functions using Tauri store
+// Access and refresh values are intercepted by the Rust setting command and
+// stored in the native OS credential store. Expiry and client id are non-secret
+// metadata and remain in the Tauri JSON store.
 
 async function storeTokens(tokens: TokenResponse): Promise<void> {
   const expiry = Date.now() + tokens.expires_in * 1000;

--- a/tests/unit/claude-memory-user-scoped-auth.test.ts
+++ b/tests/unit/claude-memory-user-scoped-auth.test.ts
@@ -9,6 +9,10 @@ const rustWatcher = readFileSync(
   resolve("src-tauri/src/claude_memory.rs"),
   "utf-8",
 );
+const credentialStore = readFileSync(
+  resolve("src-tauri/src/credential_store.rs"),
+  "utf-8",
+);
 const databasesService = readFileSync(
   resolve("src/services/databases.ts"),
   "utf-8",
@@ -17,13 +21,17 @@ const tauriBridge = readFileSync(resolve("src/lib/tauri-bridge.ts"), "utf-8");
 const setupAuth = readFileSync(resolve("src/api/setup-auth.ts"), "utf-8");
 
 describe("seren-db memory path uses the user-scoped credential (#2497 Defect 2)", () => {
-  it("the Rust watcher bears the SerenDB API key read from the user's store entry", () => {
+  it("the Rust watcher bears the SerenDB API key read from the user's native credential entry", () => {
     // The /publishers/seren-db/query call must bearer the API key field…
     expect(rustWatcher).toMatch(/\.bearer_auth\(&self\.api_key\)/);
-    // …and that key is read from the same store entry the desktop key lands in.
-    expect(rustWatcher).toMatch(/const SEREN_API_KEY_KEY: &str = "seren_api_key"/);
+    // …and that key is read through the same OS-backed boundary the desktop
+    // key lands in, never directly from auth.json.
     expect(rustWatcher).toMatch(/fn read_seren_api_key/);
-    expect(rustWatcher).toMatch(/\.get\(SEREN_API_KEY_KEY\)/);
+    expect(rustWatcher).toMatch(/credential_store::get_seren_api_key\(app\)/);
+    expect(credentialStore).toMatch(
+      /const SEREN_API_KEY_ACCOUNT: &str = "seren\.api-key\.v1"/,
+    );
+    expect(rustWatcher).not.toMatch(/\.store\("auth\.json"\)/);
   });
 
   it("the desktop stores the minted user key under that same `seren_api_key` entry", () => {


### PR DESCRIPTION
## Summary

- move Seren access/refresh tokens, the Seren API key, direct-provider API keys, provider OAuth credentials, and MCP OAuth token values behind a single native OS credential-store boundary
- migrate legacy JSON values with write/readback verification before deletion, preserving plaintext only for a fail-safe retry when migration cannot complete
- keep configured-provider discovery in non-secret metadata and fail closed when the platform credential store is unavailable
- correct security documentation and release notes, and certify the real native backend on macOS, Windows, and Linux in CI

Closes #3513

## Audited code paths

- Tauri auth token commands and authenticated request refresh handling
- direct-provider API-key and provider OAuth commands
- SerenDB key consumers in memory and shell paths
- MCP OAuth values routed through generic setting commands
- the existing Happy bridge `keyring` implementation used as the repository-native reference

This storage-layer change adds or changes no outbound publisher/API slug, HTTP method, or request path. Existing consumers continue to send credentials over their pre-existing network paths.

## Migration guarantees

- native write is read back and compared before the legacy value is removed
- interrupted or failed migration retains the legacy value for retry
- successful migrations scrub the secret from legacy app-data JSON
- keychain errors are actionable and never fall back to plaintext production storage
- provider enumeration reads non-secret metadata rather than returning secret material

## Validation

- full Rust test run: 1,238 passed, 0 failed, 2 ignored; integration and doctests passed
- focused post-rebase credential suite: 4 passed, including the real macOS Keychain backend
- full frontend test run: 2,841 passed, 15 skipped; 397 files passed
- focused source-boundary regression: 4 passed
- lint, Rust formatting, diff whitespace, and workflow YAML parsing passed
- real macOS app walkthrough with an isolated app-data profile and synthetic legacy provider credential: migration removed plaintext, produced non-secret metadata, surfaced the configured provider in Settings, did not render the credential, and cleaned the Keychain test entry afterward
- public diff scan found no personal data, local paths, email addresses, or credential-like values

## User-visible behavior

The OS may ask the user to unlock or approve access to its credential store on first use after updating. A release note documents this migration.