### PR TITLE
feat(run): run engine core with event log and scheduler

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -1,0 +1,90 @@
+// ABOUTME: Thin Tauri command wrappers for the durable run engine.
+// ABOUTME: Mutations use the scheduler; snapshots and event replay read SQLite directly.
+
+use crate::run::scheduler::RunEngineState;
+use crate::run::store;
+use crate::run::types::{AgentAssignment, Run, RunEvent, RunSnapshot, Task};
+use crate::services::database::init_db;
+use rusqlite::Connection;
+use tauri::{AppHandle, State};
+
+async fn read_db<T, F>(app: AppHandle, operation: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(move || {
+        let conn = init_db(&app).map_err(|error| error.to_string())?;
+        operation(&conn).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+pub async fn run_create(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    objective: String,
+    root_path: Option<String>,
+) -> Result<Run, String> {
+    state.create_run(&app, objective, root_path).await
+}
+
+#[tauri::command]
+pub async fn run_add_task(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    title: String,
+    brief: String,
+    depends_on: Vec<String>,
+) -> Result<Task, String> {
+    state
+        .add_task(&app, run_id, title, brief, depends_on)
+        .await
+}
+
+#[tauri::command]
+pub async fn run_add_agent(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    agent_type: String,
+    model_id: Option<String>,
+    role_label: Option<String>,
+) -> Result<AgentAssignment, String> {
+    state
+        .add_assignment(&app, run_id, agent_type, model_id, role_label)
+        .await
+}
+
+#[tauri::command]
+pub async fn run_cancel(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+) -> Result<Run, String> {
+    state.request_cancel(&app, run_id).await
+}
+
+#[tauri::command]
+pub async fn run_get_state(app: AppHandle, run_id: String) -> Result<RunSnapshot, String> {
+    read_db(app, move |conn| store::load_run_snapshot(conn, &run_id))
+        .await?
+        .ok_or_else(|| "run not found".to_string())
+}
+
+#[tauri::command]
+pub async fn run_list_events(
+    app: AppHandle,
+    run_id: String,
+    after_sequence: i64,
+) -> Result<Vec<RunEvent>, String> {
+    read_db(app, move |conn| store::list_events(conn, &run_id, after_sequence)).await
+}
+
+#[tauri::command]
+pub async fn run_list(app: AppHandle) -> Result<Vec<Run>, String> {
+    read_db(app, store::list_runs).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod commands {
     pub mod orchestrator;
     pub mod provider_runtime;
     pub mod recording;
+    pub mod run;
     pub mod sandbox;
     pub mod session;
     pub mod tool_authorization;
@@ -69,6 +70,7 @@ mod path_util;
 mod pdf;
 mod polymarket;
 mod provider_runtime;
+mod run;
 mod secret_broker;
 mod shell;
 mod skills;
@@ -653,6 +655,7 @@ pub fn run() {
             .manage(mcp::McpState::new())
             .manage(mcp::HttpMcpState::new())
             .manage(orchestrator::service::OrchestratorState::new())
+            .manage(run::scheduler::RunEngineState::new())
             .manage(audio::pipeline::CaptureRegistry::default())
             .manage(std::sync::Mutex::new(
                 audio::lifecycle::LifecycleController::new(
@@ -1435,6 +1438,14 @@ pub fn run() {
             commands::orchestrator::cancel_orchestration,
             commands::orchestrator::submit_tool_result,
             commands::orchestrator::submit_eval_signal,
+            // Durable run-engine commands
+            commands::run::run_create,
+            commands::run::run_add_task,
+            commands::run::run_add_agent,
+            commands::run::run_cancel,
+            commands::run::run_get_state,
+            commands::run::run_list_events,
+            commands::run::run_list,
             // Claude Code auto-memory interceptor commands
             commands::claude_memory::claude_memory_start,
             commands::claude_memory::claude_memory_stop,

--- a/src-tauri/src/run/mod.rs
+++ b/src-tauri/src/run/mod.rs
@@ -1,0 +1,7 @@
+// ABOUTME: Durable run-engine primitives for task state, persistence, and scheduling.
+// ABOUTME: Keeps the run writer isolated from the existing conversational orchestrator.
+
+pub mod scheduler;
+pub mod status;
+pub mod store;
+pub mod types;

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -1,0 +1,589 @@
+// ABOUTME: Serial run-engine scheduler and its lazily started Tauri state.
+// ABOUTME: Owns the only scheduler write connection and emits durable run events in order.
+
+use super::status::derive_run_status;
+use super::store::{self, AppendOutcome};
+use super::types::{
+    AgentAssignment, NewRunEvent, Run, RunEvent, RunEventType, RunStatus, Task, TaskState,
+};
+use crate::services::database::{init_db, now_ms};
+use rusqlite::{Connection, params};
+use serde_json::json;
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+enum SchedulerCommand {
+    CreateRun {
+        objective: String,
+        root_path: Option<String>,
+        reply: oneshot::Sender<Result<Run, String>>,
+    },
+    AddTask {
+        run_id: String,
+        title: String,
+        brief: String,
+        depends_on: Vec<String>,
+        reply: oneshot::Sender<Result<Task, String>>,
+    },
+    AddAssignment {
+        run_id: String,
+        agent_type: String,
+        model_id: Option<String>,
+        role_label: Option<String>,
+        reply: oneshot::Sender<Result<AgentAssignment, String>>,
+    },
+    RequestCancel {
+        run_id: String,
+        reply: oneshot::Sender<Result<Run, String>>,
+    },
+    RecordEvent {
+        event: NewRunEvent,
+        reply: oneshot::Sender<Result<AppendOutcome, String>>,
+    },
+}
+
+pub struct RunEngineState {
+    sender: Mutex<Option<mpsc::Sender<SchedulerCommand>>>,
+    start_lock: tokio::sync::Mutex<()>,
+}
+
+impl RunEngineState {
+    pub fn new() -> Self {
+        Self {
+            sender: Mutex::new(None),
+            start_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    async fn sender(&self, app: &AppHandle) -> Result<mpsc::Sender<SchedulerCommand>, String> {
+        if let Some(sender) = self
+            .sender
+            .lock()
+            .map_err(|_| "run scheduler sender lock poisoned".to_string())?
+            .clone()
+        {
+            return Ok(sender);
+        }
+
+        let _start_guard = self.start_lock.lock().await;
+        if let Some(sender) = self
+            .sender
+            .lock()
+            .map_err(|_| "run scheduler sender lock poisoned".to_string())?
+            .clone()
+        {
+            return Ok(sender);
+        }
+
+        let connection = init_db(app).map_err(|error| error.to_string())?;
+        let (sender, receiver) = mpsc::channel(128);
+        let scheduler_app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            scheduler_loop(scheduler_app, connection, receiver).await;
+        });
+        *self
+            .sender
+            .lock()
+            .map_err(|_| "run scheduler sender lock poisoned".to_string())? = Some(sender.clone());
+        Ok(sender)
+    }
+
+    pub async fn create_run(
+        &self,
+        app: &AppHandle,
+        objective: String,
+        root_path: Option<String>,
+    ) -> Result<Run, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::CreateRun {
+                objective,
+                root_path,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped create response".to_string())?
+    }
+
+    pub async fn add_task(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        title: String,
+        brief: String,
+        depends_on: Vec<String>,
+    ) -> Result<Task, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::AddTask {
+                run_id,
+                title,
+                brief,
+                depends_on,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped add-task response".to_string())?
+    }
+
+    pub async fn add_assignment(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        agent_type: String,
+        model_id: Option<String>,
+        role_label: Option<String>,
+    ) -> Result<AgentAssignment, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::AddAssignment {
+                run_id,
+                agent_type,
+                model_id,
+                role_label,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped add-assignment response".to_string())?
+    }
+
+    pub async fn request_cancel(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+    ) -> Result<Run, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::RequestCancel { run_id, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped cancel response".to_string())?
+    }
+
+    pub async fn record_event(
+        &self,
+        app: &AppHandle,
+        event: NewRunEvent,
+    ) -> Result<AppendOutcome, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::RecordEvent { event, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped event response".to_string())?
+    }
+}
+
+impl Default for RunEngineState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn scheduler_loop(
+    app: AppHandle,
+    connection: Connection,
+    mut receiver: mpsc::Receiver<SchedulerCommand>,
+) {
+    while let Some(command) = receiver.recv().await {
+        process_command(&app, &connection, command);
+    }
+}
+
+fn process_command(app: &AppHandle, conn: &Connection, command: SchedulerCommand) {
+    match command {
+        SchedulerCommand::CreateRun {
+            objective,
+            root_path,
+            reply,
+        } => {
+            let _ = reply.send(create_run(app, conn, objective, root_path));
+        }
+        SchedulerCommand::AddTask {
+            run_id,
+            title,
+            brief,
+            depends_on,
+            reply,
+        } => {
+            let _ = reply.send(add_task(app, conn, run_id, title, brief, depends_on));
+        }
+        SchedulerCommand::AddAssignment {
+            run_id,
+            agent_type,
+            model_id,
+            role_label,
+            reply,
+        } => {
+            let _ = reply.send(add_assignment(
+                app,
+                conn,
+                run_id,
+                agent_type,
+                model_id,
+                role_label,
+            ));
+        }
+        SchedulerCommand::RequestCancel { run_id, reply } => {
+            let _ = reply.send(request_cancel(app, conn, run_id));
+        }
+        SchedulerCommand::RecordEvent { event, reply } => {
+            let _ = reply.send(record_event(app, conn, event));
+        }
+    }
+}
+
+fn create_run(
+    app: &AppHandle,
+    conn: &Connection,
+    objective: String,
+    root_path: Option<String>,
+) -> Result<Run, String> {
+    if objective.trim().is_empty() {
+        return Err("objective must not be empty".to_string());
+    }
+    let timestamp = now_ms();
+    let run = Run {
+        id: Uuid::new_v4().to_string(),
+        objective,
+        root_path,
+        status: RunStatus::Running,
+        cancel_requested: false,
+        created_at: timestamp,
+        updated_at: timestamp,
+        completed_at: None,
+    };
+    store::create_run(conn, &run).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: run.id.clone(),
+            task_id: None,
+            attempt_id: None,
+            agent_id: None,
+            event_type: RunEventType::RunCreated,
+            payload: json!({"objective": run.objective}),
+            provider_event_id: None,
+            created_at: timestamp,
+        },
+    )?;
+    recompute_ready_and_status(app, conn, &run.id)?;
+    Ok(run)
+}
+
+fn add_task(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    title: String,
+    brief: String,
+    depends_on: Vec<String>,
+) -> Result<Task, String> {
+    if title.trim().is_empty() {
+        return Err("task title must not be empty".to_string());
+    }
+    let timestamp = now_ms();
+    let task = Task {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.clone(),
+        title,
+        brief,
+        state: TaskState::Pending,
+        blocked_reason: None,
+        created_at: timestamp,
+        updated_at: timestamp,
+    };
+    store::add_task(conn, &task, &depends_on).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        event_for_task(&task, RunEventType::TaskAdded, json!({"title": task.title})),
+    )?;
+    for dependency in depends_on {
+        append_and_emit(
+            app,
+            conn,
+            NewRunEvent {
+                id: Uuid::new_v4().to_string(),
+                run_id: run_id.clone(),
+                task_id: Some(task.id.clone()),
+                attempt_id: None,
+                agent_id: None,
+                event_type: RunEventType::DependencyAdded,
+                payload: json!({"depends_on_task_id": dependency}),
+                provider_event_id: None,
+                created_at: timestamp,
+            },
+        )?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)?;
+    store::load_run_snapshot(conn, &run_id)
+        .map_err(|error| error.to_string())?
+        .and_then(|snapshot| snapshot.tasks.into_iter().find(|candidate| candidate.id == task.id))
+        .ok_or_else(|| "task disappeared after insertion".to_string())
+}
+
+fn add_assignment(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    agent_type: String,
+    model_id: Option<String>,
+    role_label: Option<String>,
+) -> Result<AgentAssignment, String> {
+    if agent_type.trim().is_empty() {
+        return Err("agent_type must not be empty".to_string());
+    }
+    let assignment = AgentAssignment {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.clone(),
+        agent_type,
+        model_id,
+        role_label,
+        created_at: now_ms(),
+    };
+    store::add_assignment(conn, &assignment).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.clone(),
+            task_id: None,
+            attempt_id: None,
+            agent_id: Some(assignment.id.clone()),
+            event_type: RunEventType::AssignmentAdded,
+            payload: json!({
+                "agent_type": assignment.agent_type,
+                "model_id": assignment.model_id,
+                "role_label": assignment.role_label,
+            }),
+            provider_event_id: None,
+            created_at: assignment.created_at,
+        },
+    )?;
+    recompute_ready_and_status(app, conn, &run_id)?;
+    Ok(assignment)
+}
+
+fn request_cancel(app: &AppHandle, conn: &Connection, run_id: String) -> Result<Run, String> {
+    let updated = conn
+        .execute(
+            "UPDATE runs SET cancel_requested = 1, updated_at = ?1 WHERE id = ?2",
+            params![now_ms(), run_id],
+        )
+        .map_err(|error| error.to_string())?;
+    if updated == 0 {
+        return Err("run not found".to_string());
+    }
+    append_and_emit(
+        app,
+        conn,
+        NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.clone(),
+            task_id: None,
+            attempt_id: None,
+            agent_id: None,
+            event_type: RunEventType::RunCancelRequested,
+            payload: json!({}),
+            provider_event_id: None,
+            created_at: now_ms(),
+        },
+    )?;
+
+    let mut statement = conn
+        .prepare("SELECT id, state FROM run_tasks WHERE run_id = ?1 ORDER BY created_at, id")
+        .map_err(|error| error.to_string())?;
+    let tasks = statement
+        .query_map(params![run_id.clone()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| error.to_string())?;
+    for (task_id, state) in tasks {
+        let state = TaskState::parse(&state)
+            .ok_or_else(|| format!("invalid task state in database: {state}"))?;
+        if state.is_terminal() {
+            continue;
+        }
+        store::transition_task(conn, &task_id, TaskState::Cancelled, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(
+            app,
+            conn,
+            NewRunEvent {
+                id: Uuid::new_v4().to_string(),
+                run_id: run_id.clone(),
+                task_id: Some(task_id),
+                attempt_id: None,
+                agent_id: None,
+                event_type: RunEventType::TaskStateChanged,
+                payload: json!({"state": TaskState::Cancelled}),
+                provider_event_id: None,
+                created_at: now_ms(),
+            },
+        )?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)?;
+    append_and_emit(
+        app,
+        conn,
+        NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.clone(),
+            task_id: None,
+            attempt_id: None,
+            agent_id: None,
+            event_type: RunEventType::RunFinalized,
+            payload: json!({"status": RunStatus::Cancelled}),
+            provider_event_id: None,
+            created_at: now_ms(),
+        },
+    )?;
+    load_run(conn, &run_id)
+}
+
+fn record_event(
+    app: &AppHandle,
+    conn: &Connection,
+    event: NewRunEvent,
+) -> Result<AppendOutcome, String> {
+    let outcome = append_and_emit(app, conn, event.clone())?;
+    recompute_ready_and_status(app, conn, &event.run_id)?;
+    Ok(outcome)
+}
+
+fn append_and_emit(
+    app: &AppHandle,
+    conn: &Connection,
+    event: NewRunEvent,
+) -> Result<AppendOutcome, String> {
+    let outcome = store::append_event(conn, &event).map_err(|error| error.to_string())?;
+    if let AppendOutcome::Inserted(sequence) = outcome {
+        let persisted = RunEvent {
+            id: event.id,
+            run_id: event.run_id,
+            task_id: event.task_id,
+            attempt_id: event.attempt_id,
+            agent_id: event.agent_id,
+            sequence,
+            event_type: event.event_type,
+            payload: event.payload,
+            provider_event_id: event.provider_event_id,
+            created_at: event.created_at,
+        };
+        if let Err(error) = app.emit("run://event", &persisted) {
+            log::warn!("[run-engine] failed to emit run event: {error}");
+        }
+    }
+    Ok(outcome)
+}
+
+fn event_for_task(task: &Task, event_type: RunEventType, payload: serde_json::Value) -> NewRunEvent {
+    NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: task.run_id.clone(),
+        task_id: Some(task.id.clone()),
+        attempt_id: None,
+        agent_id: None,
+        event_type,
+        payload,
+        provider_event_id: None,
+        created_at: now_ms(),
+    }
+}
+
+fn recompute_ready_and_status(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: &str,
+) -> Result<(), String> {
+    for task_id in store::ready_task_ids(conn, run_id).map_err(|error| error.to_string())? {
+        store::transition_task(conn, &task_id, TaskState::Ready, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(
+            app,
+            conn,
+            NewRunEvent {
+                id: Uuid::new_v4().to_string(),
+                run_id: run_id.to_string(),
+                task_id: Some(task_id),
+                attempt_id: None,
+                agent_id: None,
+                event_type: RunEventType::TaskStateChanged,
+                payload: json!({"state": TaskState::Ready}),
+                provider_event_id: None,
+                created_at: now_ms(),
+            },
+        )?;
+    }
+
+    let (cancel_requested, task_states) = load_status_inputs(conn, run_id)?;
+    let status = derive_run_status(&task_states, cancel_requested);
+    let completed_at = status.is_terminal().then_some(now_ms());
+    let updated = conn
+        .execute(
+            "UPDATE runs
+             SET status = ?1, updated_at = ?2, completed_at = ?3
+             WHERE id = ?4",
+            params![status.as_str(), now_ms(), completed_at, run_id],
+        )
+        .map_err(|error| error.to_string())?;
+    if updated == 0 {
+        return Err("run not found".to_string());
+    }
+    Ok(())
+}
+
+fn load_status_inputs(conn: &Connection, run_id: &str) -> Result<(bool, Vec<TaskState>), String> {
+    let cancel_requested: i64 = conn
+        .query_row(
+            "SELECT cancel_requested FROM runs WHERE id = ?1",
+            params![run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    let mut statement = conn
+        .prepare("SELECT state FROM run_tasks WHERE run_id = ?1 ORDER BY created_at, id")
+        .map_err(|error| error.to_string())?;
+    let states = statement
+        .query_map(params![run_id], |row| row.get::<_, String>(0))
+        .map_err(|error| error.to_string())?
+        .map(|state| {
+            let value = state.map_err(|error| error.to_string())?;
+            TaskState::parse(&value).ok_or_else(|| format!("invalid task state in database: {value}"))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok((cancel_requested != 0, states))
+}
+
+fn load_run(conn: &Connection, run_id: &str) -> Result<Run, String> {
+    let snapshot = store::load_run_snapshot(conn, run_id).map_err(|error| error.to_string())?;
+    snapshot
+        .map(|snapshot| snapshot.run)
+        .ok_or_else(|| "run not found".to_string())
+}

--- a/src-tauri/src/run/status.rs
+++ b/src-tauri/src/run/status.rs
@@ -1,0 +1,140 @@
+// ABOUTME: Pure run-engine state-machine and terminal-status derivation rules.
+// ABOUTME: Unit tests keep task transitions and aggregate run outcomes deterministic.
+
+use super::types::{RunStatus, TaskState};
+
+pub fn is_legal_transition(from: TaskState, to: TaskState) -> bool {
+    match from {
+        TaskState::Pending => matches!(to, TaskState::Ready | TaskState::Cancelled),
+        TaskState::Ready => matches!(to, TaskState::Provisioning | TaskState::Cancelled),
+        TaskState::Provisioning => matches!(
+            to,
+            TaskState::Running | TaskState::Ready | TaskState::Failed | TaskState::Cancelled
+        ),
+        TaskState::Running => matches!(
+            to,
+            TaskState::Blocked
+                | TaskState::Verifying
+                | TaskState::Failed
+                | TaskState::Cancelled
+        ),
+        TaskState::Blocked => matches!(to, TaskState::Running | TaskState::Failed | TaskState::Cancelled),
+        TaskState::Verifying => matches!(
+            to,
+            TaskState::Review | TaskState::Running | TaskState::Failed | TaskState::Cancelled
+        ),
+        TaskState::Review => matches!(to, TaskState::Done | TaskState::Running | TaskState::Cancelled),
+        TaskState::Done | TaskState::Failed | TaskState::Cancelled => false,
+    }
+}
+
+pub fn derive_run_status(task_states: &[TaskState], cancel_requested: bool) -> RunStatus {
+    if cancel_requested {
+        return RunStatus::Cancelled;
+    }
+    if task_states.is_empty() {
+        return RunStatus::Running;
+    }
+    if task_states.iter().any(|state| !state.is_terminal()) {
+        return RunStatus::Running;
+    }
+    if task_states.iter().all(|state| *state == TaskState::Done) {
+        RunStatus::Completed
+    } else if task_states.iter().any(|state| *state == TaskState::Done) {
+        RunStatus::Partial
+    } else {
+        RunStatus::Failed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legal_task_edges_are_accepted() {
+        let edges = [
+            (TaskState::Pending, TaskState::Ready),
+            (TaskState::Pending, TaskState::Cancelled),
+            (TaskState::Ready, TaskState::Provisioning),
+            (TaskState::Ready, TaskState::Cancelled),
+            (TaskState::Provisioning, TaskState::Running),
+            (TaskState::Provisioning, TaskState::Ready),
+            (TaskState::Provisioning, TaskState::Failed),
+            (TaskState::Provisioning, TaskState::Cancelled),
+            (TaskState::Running, TaskState::Blocked),
+            (TaskState::Running, TaskState::Verifying),
+            (TaskState::Running, TaskState::Failed),
+            (TaskState::Running, TaskState::Cancelled),
+            (TaskState::Blocked, TaskState::Running),
+            (TaskState::Blocked, TaskState::Failed),
+            (TaskState::Blocked, TaskState::Cancelled),
+            (TaskState::Verifying, TaskState::Review),
+            (TaskState::Verifying, TaskState::Running),
+            (TaskState::Verifying, TaskState::Failed),
+            (TaskState::Verifying, TaskState::Cancelled),
+            (TaskState::Review, TaskState::Done),
+            (TaskState::Review, TaskState::Running),
+            (TaskState::Review, TaskState::Cancelled),
+        ];
+        for (from, to) in edges {
+            assert!(is_legal_transition(from, to), "{from:?} -> {to:?}");
+        }
+    }
+
+    #[test]
+    fn representative_illegal_task_edges_are_rejected() {
+        assert!(!is_legal_transition(TaskState::Pending, TaskState::Running));
+        assert!(!is_legal_transition(TaskState::Done, TaskState::Running));
+        assert!(!is_legal_transition(TaskState::Cancelled, TaskState::Ready));
+    }
+
+    #[test]
+    fn derive_run_status_completed() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Done, TaskState::Done], false),
+            RunStatus::Completed
+        );
+    }
+
+    #[test]
+    fn derive_run_status_partial() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Done, TaskState::Failed], false),
+            RunStatus::Partial
+        );
+    }
+
+    #[test]
+    fn derive_run_status_failed() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Failed, TaskState::Cancelled], false),
+            RunStatus::Failed
+        );
+    }
+
+    #[test]
+    fn derive_run_status_cancelled() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Running, TaskState::Done], true),
+            RunStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn derive_run_status_cancel_requested_overrides_all_done() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Done, TaskState::Done], true),
+            RunStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn derive_run_status_any_nonterminal_is_running() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Done, TaskState::Review], false),
+            RunStatus::Running
+        );
+        assert_eq!(derive_run_status(&[], false), RunStatus::Running);
+    }
+}

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -1,0 +1,733 @@
+// ABOUTME: SQLite persistence for the durable run engine and its append-only event log.
+// ABOUTME: All functions accept a borrowed connection so the scheduler remains the single writer.
+
+use super::status::is_legal_transition;
+use super::types::{
+    AgentAssignment, Attempt, Evidence, Finding, FindingConfidence, FindingStatus, LeaseMode,
+    NewRunEvent, ProposedArtifact, Run, RunEvent, RunEventType, RunSnapshot, RunStatus, Task,
+    TaskDependency, TaskState, WorkspaceLease,
+};
+use crate::services::database::now_ms;
+use rusqlite::{Connection, OptionalExtension, Result, params};
+use serde::de::DeserializeOwned;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendOutcome {
+    Inserted(i64),
+    Duplicate,
+}
+
+fn invalid_value(kind: &str, value: &str) -> rusqlite::Error {
+    rusqlite::Error::InvalidParameterName(format!("invalid {kind}: {value}"))
+}
+
+fn parse_task_state(value: String) -> Result<TaskState> {
+    TaskState::parse(&value).ok_or_else(|| invalid_value("task state", &value))
+}
+
+fn parse_run_status(value: String) -> Result<RunStatus> {
+    RunStatus::parse(&value).ok_or_else(|| invalid_value("run status", &value))
+}
+
+fn parse_lease_mode(value: String) -> Result<LeaseMode> {
+    LeaseMode::parse(&value).ok_or_else(|| invalid_value("lease mode", &value))
+}
+
+fn parse_finding_confidence(value: String) -> Result<FindingConfidence> {
+    FindingConfidence::parse(&value).ok_or_else(|| invalid_value("finding confidence", &value))
+}
+
+fn parse_finding_status(value: String) -> Result<FindingStatus> {
+    FindingStatus::parse(&value).ok_or_else(|| invalid_value("finding status", &value))
+}
+
+fn parse_event_type(value: String) -> Result<RunEventType> {
+    RunEventType::parse(&value).ok_or_else(|| invalid_value("run event type", &value))
+}
+
+fn serialize_json<T: serde::Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string(value)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))
+}
+
+fn deserialize_json<T: DeserializeOwned>(value: String) -> Result<T> {
+    serde_json::from_str(&value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+pub fn create_run(conn: &Connection, run: &Run) -> Result<()> {
+    conn.execute(
+        "INSERT INTO runs
+            (id, objective, root_path, status, cancel_requested, created_at, updated_at, completed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            run.id,
+            run.objective,
+            run.root_path,
+            run.status.as_str(),
+            i64::from(run.cancel_requested),
+            run.created_at,
+            run.updated_at,
+            run.completed_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn add_task(conn: &Connection, task: &Task, depends_on: &[String]) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_tasks
+            (id, run_id, title, brief, state, blocked_reason, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            task.id,
+            task.run_id,
+            task.title,
+            task.brief,
+            task.state.as_str(),
+            task.blocked_reason,
+            task.created_at,
+            task.updated_at,
+        ],
+    )?;
+    for depends_on_task_id in depends_on {
+        add_dependency(
+            conn,
+            &TaskDependency {
+                task_id: task.id.clone(),
+                depends_on_task_id: depends_on_task_id.clone(),
+            },
+        )?;
+    }
+    Ok(())
+}
+
+pub fn add_dependency(conn: &Connection, dependency: &TaskDependency) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_task_dependencies (task_id, depends_on_task_id)
+         VALUES (?1, ?2)",
+        params![dependency.task_id, dependency.depends_on_task_id],
+    )?;
+    Ok(())
+}
+
+pub fn add_assignment(conn: &Connection, assignment: &AgentAssignment) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_agent_assignments
+            (id, run_id, agent_type, model_id, role_label, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            assignment.id,
+            assignment.run_id,
+            assignment.agent_type,
+            assignment.model_id,
+            assignment.role_label,
+            assignment.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn insert_attempt(conn: &Connection, attempt: &Attempt) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_attempts
+            (id, task_id, agent_assignment_id, agent_session_id, attempt_number, outcome,
+             started_at, ended_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            attempt.id,
+            attempt.task_id,
+            attempt.agent_assignment_id,
+            attempt.agent_session_id,
+            attempt.attempt_number,
+            attempt.outcome,
+            attempt.started_at,
+            attempt.ended_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn insert_workspace_lease(conn: &Connection, lease: &WorkspaceLease) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_workspace_leases
+            (id, run_id, task_id, mode, root_path, base_revision, state, created_at, released_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            lease.id,
+            lease.run_id,
+            lease.task_id,
+            lease.mode.as_str(),
+            lease.root_path,
+            lease.base_revision,
+            lease.state,
+            lease.created_at,
+            lease.released_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn insert_finding(conn: &Connection, finding: &Finding) -> Result<()> {
+    let evidence_json = serialize_json(&finding.evidence)?;
+    let proposed_artifact_json = finding
+        .proposed_artifact
+        .as_ref()
+        .map(serialize_json)
+        .transpose()?;
+    conn.execute(
+        "INSERT INTO run_findings
+            (id, run_id, task_id, attempt_id, claim, confidence, evidence_json,
+             proposed_artifact_json, needs_approval, status, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        params![
+            finding.id,
+            finding.run_id,
+            finding.task_id,
+            finding.attempt_id,
+            finding.claim,
+            finding.confidence.as_str(),
+            evidence_json,
+            proposed_artifact_json,
+            i64::from(finding.needs_approval),
+            finding.status.as_str(),
+            finding.created_at,
+            finding.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn transition_task(
+    conn: &Connection,
+    task_id: &str,
+    to: TaskState,
+    blocked_reason: Option<&str>,
+) -> Result<()> {
+    let current_value: String = conn.query_row(
+        "SELECT state FROM run_tasks WHERE id = ?1",
+        params![task_id],
+        |row| row.get(0),
+    )?;
+    let current = parse_task_state(current_value)?;
+    if !is_legal_transition(current, to) {
+        return Err(invalid_value(
+            "task transition",
+            &format!("{} -> {}", current.as_str(), to.as_str()),
+        ));
+    }
+
+    conn.execute(
+        "UPDATE run_tasks
+         SET state = ?1, blocked_reason = ?2, updated_at = ?3
+         WHERE id = ?4",
+        params![to.as_str(), blocked_reason, now_ms(), task_id],
+    )?;
+    Ok(())
+}
+
+pub fn ready_task_ids(conn: &Connection, run_id: &str) -> Result<Vec<String>> {
+    let mut statement = conn.prepare(
+        "SELECT t.id
+         FROM run_tasks t
+         WHERE t.run_id = ?1
+           AND t.state = 'pending'
+           AND NOT EXISTS (
+               SELECT 1
+               FROM run_task_dependencies d
+               JOIN run_tasks dependency ON dependency.id = d.depends_on_task_id
+               WHERE d.task_id = t.id AND dependency.state <> 'done'
+           )
+         ORDER BY t.created_at ASC, t.id ASC",
+    )?;
+    statement
+        .query_map(params![run_id], |row| row.get(0))?
+        .collect()
+}
+
+pub fn list_runs(conn: &Connection) -> Result<Vec<Run>> {
+    let mut statement = conn.prepare(
+        "SELECT id, objective, root_path, status, cancel_requested,
+                created_at, updated_at, completed_at
+         FROM runs
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    statement
+        .query_map([], |row| {
+            Ok(Run {
+                id: row.get(0)?,
+                objective: row.get(1)?,
+                root_path: row.get(2)?,
+                status: parse_run_status(row.get(3)?)?,
+                cancel_requested: row.get::<_, i64>(4)? != 0,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+                completed_at: row.get(7)?,
+            })
+        })?
+        .collect()
+}
+
+pub fn load_run_snapshot(conn: &Connection, run_id: &str) -> Result<Option<RunSnapshot>> {
+    let run = conn
+        .query_row(
+            "SELECT id, objective, root_path, status, cancel_requested,
+                    created_at, updated_at, completed_at
+             FROM runs WHERE id = ?1",
+            params![run_id],
+            |row| {
+                Ok(Run {
+                    id: row.get(0)?,
+                    objective: row.get(1)?,
+                    root_path: row.get(2)?,
+                    status: parse_run_status(row.get(3)?)?,
+                    cancel_requested: row.get::<_, i64>(4)? != 0,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                    completed_at: row.get(7)?,
+                })
+            },
+        )
+        .optional()?;
+    let Some(run) = run else {
+        return Ok(None);
+    };
+
+    let mut task_statement = conn.prepare(
+        "SELECT id, run_id, title, brief, state, blocked_reason, created_at, updated_at
+         FROM run_tasks WHERE run_id = ?1 ORDER BY created_at ASC, id ASC",
+    )?;
+    let tasks = task_statement
+        .query_map(params![run_id], |row| {
+            Ok(Task {
+                id: row.get(0)?,
+                run_id: row.get(1)?,
+                title: row.get(2)?,
+                brief: row.get(3)?,
+                state: parse_task_state(row.get(4)?)?,
+                blocked_reason: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut dependency_statement = conn.prepare(
+        "SELECT d.task_id, d.depends_on_task_id
+         FROM run_task_dependencies d
+         JOIN run_tasks t ON t.id = d.task_id
+         WHERE t.run_id = ?1
+         ORDER BY d.task_id, d.depends_on_task_id",
+    )?;
+    let dependencies = dependency_statement
+        .query_map(params![run_id], |row| {
+            Ok(TaskDependency {
+                task_id: row.get(0)?,
+                depends_on_task_id: row.get(1)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut assignment_statement = conn.prepare(
+        "SELECT id, run_id, agent_type, model_id, role_label, created_at
+         FROM run_agent_assignments WHERE run_id = ?1 ORDER BY created_at ASC, id ASC",
+    )?;
+    let assignments = assignment_statement
+        .query_map(params![run_id], |row| {
+            Ok(AgentAssignment {
+                id: row.get(0)?,
+                run_id: row.get(1)?,
+                agent_type: row.get(2)?,
+                model_id: row.get(3)?,
+                role_label: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut attempt_statement = conn.prepare(
+        "SELECT a.id, a.task_id, a.agent_assignment_id, a.agent_session_id,
+                a.attempt_number, a.outcome, a.started_at, a.ended_at
+         FROM run_attempts a
+         JOIN run_tasks t ON t.id = a.task_id
+         WHERE t.run_id = ?1 ORDER BY a.started_at ASC, a.id ASC",
+    )?;
+    let attempts = attempt_statement
+        .query_map(params![run_id], |row| {
+            Ok(Attempt {
+                id: row.get(0)?,
+                task_id: row.get(1)?,
+                agent_assignment_id: row.get(2)?,
+                agent_session_id: row.get(3)?,
+                attempt_number: row.get(4)?,
+                outcome: row.get(5)?,
+                started_at: row.get(6)?,
+                ended_at: row.get(7)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut finding_statement = conn.prepare(
+        "SELECT id, run_id, task_id, attempt_id, claim, confidence, evidence_json,
+                proposed_artifact_json, needs_approval, status, created_at, updated_at
+         FROM run_findings WHERE run_id = ?1 ORDER BY created_at ASC, id ASC",
+    )?;
+    let findings = finding_statement
+        .query_map(params![run_id], |row| {
+            let evidence_json: String = row.get(6)?;
+            let proposed_artifact_json: Option<String> = row.get(7)?;
+            Ok(Finding {
+                id: row.get(0)?,
+                run_id: row.get(1)?,
+                task_id: row.get(2)?,
+                attempt_id: row.get(3)?,
+                claim: row.get(4)?,
+                confidence: parse_finding_confidence(row.get(5)?)?,
+                evidence: deserialize_json(evidence_json)?,
+                proposed_artifact: proposed_artifact_json
+                    .map(deserialize_json)
+                    .transpose()?,
+                needs_approval: row.get::<_, i64>(8)? != 0,
+                status: parse_finding_status(row.get(9)?)?,
+                created_at: row.get(10)?,
+                updated_at: row.get(11)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(Some(RunSnapshot {
+        run,
+        tasks,
+        dependencies,
+        assignments,
+        attempts,
+        findings,
+    }))
+}
+
+pub fn list_events(conn: &Connection, run_id: &str, after_sequence: i64) -> Result<Vec<RunEvent>> {
+    let mut statement = conn.prepare(
+        "SELECT id, run_id, task_id, attempt_id, agent_id, sequence, event_type,
+                payload_json, provider_event_id, created_at
+         FROM run_events
+         WHERE run_id = ?1 AND sequence > ?2
+         ORDER BY sequence ASC",
+    )?;
+    statement
+        .query_map(params![run_id, after_sequence], |row| {
+            let payload_json: String = row.get(7)?;
+            Ok(RunEvent {
+                id: row.get(0)?,
+                run_id: row.get(1)?,
+                task_id: row.get(2)?,
+                attempt_id: row.get(3)?,
+                agent_id: row.get(4)?,
+                sequence: row.get(5)?,
+                event_type: parse_event_type(row.get(6)?)?,
+                payload: deserialize_json(payload_json)?,
+                provider_event_id: row.get(8)?,
+                created_at: row.get(9)?,
+            })
+        })?
+        .collect()
+}
+
+pub fn append_event(conn: &Connection, event: &NewRunEvent) -> Result<AppendOutcome> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let outcome = (|| -> Result<AppendOutcome> {
+        let payload_json = serialize_json(&event.payload)?;
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO run_events
+                (id, run_id, task_id, attempt_id, agent_id, sequence, event_type,
+                 payload_json, provider_event_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5,
+                 (SELECT COALESCE(MAX(sequence), 0) + 1 FROM run_events WHERE run_id = ?2),
+                 ?6, ?7, ?8, ?9)",
+            params![
+                event.id,
+                event.run_id,
+                event.task_id,
+                event.attempt_id,
+                event.agent_id,
+                event.event_type.as_str(),
+                payload_json,
+                event.provider_event_id,
+                event.created_at,
+            ],
+        )?;
+        if inserted == 0 {
+            return Ok(AppendOutcome::Duplicate);
+        }
+        let sequence = conn.query_row(
+            "SELECT sequence FROM run_events WHERE id = ?1",
+            params![event.id],
+            |row| row.get(0),
+        )?;
+        Ok(AppendOutcome::Inserted(sequence))
+    })();
+
+    match outcome {
+        Ok(outcome) => match conn.execute_batch("COMMIT") {
+            Ok(()) => Ok(outcome),
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        },
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::database::{configure_connection, setup_schema};
+    use serde_json::json;
+    use rusqlite::Connection;
+
+    fn connection() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        setup_schema(&conn).unwrap();
+        let foreign_keys: i64 = conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(foreign_keys, 1);
+        conn
+    }
+
+    fn run(id: &str) -> Run {
+        Run {
+            id: id.to_string(),
+            objective: "Test objective".to_string(),
+            root_path: Some("/tmp/run-engine".to_string()),
+            status: RunStatus::Running,
+            cancel_requested: false,
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+        }
+    }
+
+    fn task(id: &str, run_id: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            run_id: run_id.to_string(),
+            title: id.to_string(),
+            brief: format!("Brief for {id}"),
+            state: TaskState::Pending,
+            blocked_reason: None,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    fn event(id: &str, run_id: &str, provider_event_id: Option<&str>) -> NewRunEvent {
+        NewRunEvent {
+            id: id.to_string(),
+            run_id: run_id.to_string(),
+            task_id: None,
+            attempt_id: Some("attempt-1".to_string()),
+            agent_id: None,
+            event_type: RunEventType::TaskAdded,
+            payload: json!({"id": id}),
+            provider_event_id: provider_event_id.map(str::to_string),
+            created_at: 1,
+        }
+    }
+
+    #[test]
+    fn cascade_delete_removes_all_run_children() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        add_task(&conn, &task("task-a", "run-1"), &[]).unwrap();
+        add_task(
+            &conn,
+            &task("task-b", "run-1"),
+            &["task-a".to_string()],
+        )
+        .unwrap();
+        add_assignment(
+            &conn,
+            &AgentAssignment {
+                id: "assignment-1".to_string(),
+                run_id: "run-1".to_string(),
+                agent_type: "test-agent".to_string(),
+                model_id: None,
+                role_label: Some("worker".to_string()),
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        insert_attempt(
+            &conn,
+            &Attempt {
+                id: "attempt-1".to_string(),
+                task_id: "task-a".to_string(),
+                agent_assignment_id: Some("assignment-1".to_string()),
+                agent_session_id: Some("session-1".to_string()),
+                attempt_number: 1,
+                outcome: None,
+                started_at: 1,
+                ended_at: None,
+            },
+        )
+        .unwrap();
+        insert_workspace_lease(
+            &conn,
+            &WorkspaceLease {
+                id: "lease-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: Some("task-a".to_string()),
+                mode: LeaseMode::Worktree,
+                root_path: Some("/tmp/worktree".to_string()),
+                base_revision: Some("abc".to_string()),
+                state: "requested".to_string(),
+                created_at: 1,
+                released_at: None,
+            },
+        )
+        .unwrap();
+        insert_finding(
+            &conn,
+            &Finding {
+                id: "finding-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: Some("task-a".to_string()),
+                attempt_id: Some("attempt-1".to_string()),
+                claim: "A claim".to_string(),
+                confidence: FindingConfidence::Asserted,
+                evidence: vec![Evidence {
+                    kind: super::super::types::EvidenceKind::CommandResult,
+                    reference: "cargo test".to_string(),
+                    excerpt: None,
+                }],
+                proposed_artifact: Some(ProposedArtifact {
+                    kind: super::super::types::ArtifactKind::Diff,
+                    title: "A diff".to_string(),
+                    content: None,
+                }),
+                needs_approval: false,
+                status: FindingStatus::Open,
+                created_at: 1,
+                updated_at: 1,
+            },
+        )
+        .unwrap();
+        append_event(&conn, &event("event-1", "run-1", None)).unwrap();
+
+        conn.execute("DELETE FROM runs WHERE id = 'run-1'", [])
+            .unwrap();
+        for table in [
+            "run_tasks",
+            "run_task_dependencies",
+            "run_agent_assignments",
+            "run_attempts",
+            "run_workspace_leases",
+            "run_findings",
+            "run_events",
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 0, "{table} should cascade");
+        }
+    }
+
+    #[test]
+    fn append_event_inserted_then_duplicate_final_count_1() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        let first = append_event(&conn, &event("event-1", "run-1", Some("provider-1"))).unwrap();
+        let second = append_event(&conn, &event("event-2", "run-1", Some("provider-1"))).unwrap();
+        assert_eq!(first, AppendOutcome::Inserted(1));
+        assert_eq!(second, AppendOutcome::Duplicate);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM run_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        assert_eq!(
+            append_event(&conn, &event("event-3", "run-1", Some("provider-2"))).unwrap(),
+            AppendOutcome::Inserted(2)
+        );
+        assert_eq!(
+            append_event(&conn, &event("event-4", "run-1", Some("provider-3"))).unwrap(),
+            AppendOutcome::Inserted(3)
+        );
+
+        create_run(&conn, &run("run-2")).unwrap();
+        assert_eq!(
+            append_event(&conn, &event("event-5", "run-2", Some("provider-4"))).unwrap(),
+            AppendOutcome::Inserted(1)
+        );
+    }
+
+    #[test]
+    fn transition_task_rejects_illegal_and_clears_blocked_reason() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        add_task(&conn, &task("task-1", "run-1"), &[]).unwrap();
+        assert!(transition_task(&conn, "task-1", TaskState::Running, None).is_err());
+        transition_task(&conn, "task-1", TaskState::Ready, None).unwrap();
+        transition_task(&conn, "task-1", TaskState::Provisioning, None).unwrap();
+        transition_task(&conn, "task-1", TaskState::Running, None).unwrap();
+        transition_task(
+            &conn,
+            "task-1",
+            TaskState::Blocked,
+            Some("waiting for approval"),
+        )
+        .unwrap();
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM run_tasks WHERE id = 'task-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked_reason.as_deref(), Some("waiting for approval"));
+        transition_task(&conn, "task-1", TaskState::Running, None).unwrap();
+        let cleared: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM run_tasks WHERE id = 'task-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cleared, None);
+        transition_task(&conn, "task-1", TaskState::Verifying, None).unwrap();
+        transition_task(&conn, "task-1", TaskState::Review, None).unwrap();
+        transition_task(&conn, "task-1", TaskState::Done, None).unwrap();
+    }
+
+    #[test]
+    fn ready_set_unblocks_after_dependency_done() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        add_task(&conn, &task("task-a", "run-1"), &[]).unwrap();
+        add_task(
+            &conn,
+            &task("task-b", "run-1"),
+            &["task-a".to_string()],
+        )
+        .unwrap();
+        assert_eq!(ready_task_ids(&conn, "run-1").unwrap(), vec!["task-a"]);
+        transition_task(&conn, "task-a", TaskState::Ready, None).unwrap();
+        assert_eq!(ready_task_ids(&conn, "run-1").unwrap(), Vec::<String>::new());
+        transition_task(&conn, "task-a", TaskState::Provisioning, None).unwrap();
+        transition_task(&conn, "task-a", TaskState::Running, None).unwrap();
+        transition_task(&conn, "task-a", TaskState::Verifying, None).unwrap();
+        transition_task(&conn, "task-a", TaskState::Review, None).unwrap();
+        transition_task(&conn, "task-a", TaskState::Done, None).unwrap();
+        assert_eq!(ready_task_ids(&conn, "run-1").unwrap(), vec!["task-b"]);
+    }
+}

--- a/src-tauri/src/run/types.rs
+++ b/src-tauri/src/run/types.rs
@@ -1,0 +1,439 @@
+// ABOUTME: Serde-facing types for durable runs, tasks, attempts, findings, and events.
+// ABOUTME: Enum spellings are the stable snake_case values stored in SQLite.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskState {
+    Pending,
+    Ready,
+    Provisioning,
+    Running,
+    Blocked,
+    Verifying,
+    Review,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+impl TaskState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Ready => "ready",
+            Self::Provisioning => "provisioning",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Verifying => "verifying",
+            Self::Review => "review",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "pending" => Self::Pending,
+            "ready" => Self::Ready,
+            "provisioning" => Self::Provisioning,
+            "running" => Self::Running,
+            "blocked" => Self::Blocked,
+            "verifying" => Self::Verifying,
+            "review" => Self::Review,
+            "done" => Self::Done,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            _ => return None,
+        })
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Done | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Running,
+    Completed,
+    Partial,
+    Failed,
+    Cancelled,
+}
+
+impl RunStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "running" => Self::Running,
+            "completed" => Self::Completed,
+            "partial" => Self::Partial,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            _ => return None,
+        })
+    }
+
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, Self::Running)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LeaseMode {
+    SharedReadonly,
+    Worktree,
+    Scratch,
+    ExternalRead,
+    ExternalWrite,
+}
+
+impl LeaseMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SharedReadonly => "shared_readonly",
+            Self::Worktree => "worktree",
+            Self::Scratch => "scratch",
+            Self::ExternalRead => "external_read",
+            Self::ExternalWrite => "external_write",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "shared_readonly" => Self::SharedReadonly,
+            "worktree" => Self::Worktree,
+            "scratch" => Self::Scratch,
+            "external_read" => Self::ExternalRead,
+            "external_write" => Self::ExternalWrite,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingConfidence {
+    Asserted,
+    Verified,
+    Refuted,
+}
+
+impl FindingConfidence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Asserted => "asserted",
+            Self::Verified => "verified",
+            Self::Refuted => "refuted",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "asserted" => Self::Asserted,
+            "verified" => Self::Verified,
+            "refuted" => Self::Refuted,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingStatus {
+    Open,
+    Accepted,
+    Rejected,
+    Superseded,
+}
+
+impl FindingStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+            Self::Superseded => "superseded",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "open" => Self::Open,
+            "accepted" => Self::Accepted,
+            "rejected" => Self::Rejected,
+            "superseded" => Self::Superseded,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    CommandResult,
+    FileRange,
+    Email,
+    Document,
+    Url,
+    LogExcerpt,
+    PublisherResult,
+}
+
+impl EvidenceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CommandResult => "command_result",
+            Self::FileRange => "file_range",
+            Self::Email => "email",
+            Self::Document => "document",
+            Self::Url => "url",
+            Self::LogExcerpt => "log_excerpt",
+            Self::PublisherResult => "publisher_result",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "command_result" => Self::CommandResult,
+            "file_range" => Self::FileRange,
+            "email" => Self::Email,
+            "document" => Self::Document,
+            "url" => Self::Url,
+            "log_excerpt" => Self::LogExcerpt,
+            "publisher_result" => Self::PublisherResult,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    Diff,
+    Document,
+    Email,
+    Comment,
+}
+
+impl ArtifactKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Diff => "diff",
+            Self::Document => "document",
+            Self::Email => "email",
+            Self::Comment => "comment",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "diff" => Self::Diff,
+            "document" => Self::Document,
+            "email" => Self::Email,
+            "comment" => Self::Comment,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunEventType {
+    RunCreated,
+    TaskAdded,
+    DependencyAdded,
+    AssignmentAdded,
+    TaskStateChanged,
+    AttemptStarted,
+    AttemptFinished,
+    FindingRecorded,
+    EvidenceAttached,
+    ApprovalRequested,
+    RunCancelRequested,
+    RunFinalized,
+}
+
+impl RunEventType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RunCreated => "run_created",
+            Self::TaskAdded => "task_added",
+            Self::DependencyAdded => "dependency_added",
+            Self::AssignmentAdded => "assignment_added",
+            Self::TaskStateChanged => "task_state_changed",
+            Self::AttemptStarted => "attempt_started",
+            Self::AttemptFinished => "attempt_finished",
+            Self::FindingRecorded => "finding_recorded",
+            Self::EvidenceAttached => "evidence_attached",
+            Self::ApprovalRequested => "approval_requested",
+            Self::RunCancelRequested => "run_cancel_requested",
+            Self::RunFinalized => "run_finalized",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "run_created" => Self::RunCreated,
+            "task_added" => Self::TaskAdded,
+            "dependency_added" => Self::DependencyAdded,
+            "assignment_added" => Self::AssignmentAdded,
+            "task_state_changed" => Self::TaskStateChanged,
+            "attempt_started" => Self::AttemptStarted,
+            "attempt_finished" => Self::AttemptFinished,
+            "finding_recorded" => Self::FindingRecorded,
+            "evidence_attached" => Self::EvidenceAttached,
+            "approval_requested" => Self::ApprovalRequested,
+            "run_cancel_requested" => Self::RunCancelRequested,
+            "run_finalized" => Self::RunFinalized,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Run {
+    pub id: String,
+    pub objective: String,
+    pub root_path: Option<String>,
+    pub status: RunStatus,
+    pub cancel_requested: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub completed_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub run_id: String,
+    pub title: String,
+    pub brief: String,
+    pub state: TaskState,
+    pub blocked_reason: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskDependency {
+    pub task_id: String,
+    pub depends_on_task_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAssignment {
+    pub id: String,
+    pub run_id: String,
+    pub agent_type: String,
+    pub model_id: Option<String>,
+    pub role_label: Option<String>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attempt {
+    pub id: String,
+    pub task_id: String,
+    pub agent_assignment_id: Option<String>,
+    pub agent_session_id: Option<String>,
+    pub attempt_number: i64,
+    pub outcome: Option<String>,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceLease {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub mode: LeaseMode,
+    pub root_path: Option<String>,
+    pub base_revision: Option<String>,
+    pub state: String,
+    pub created_at: i64,
+    pub released_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Evidence {
+    pub kind: EvidenceKind,
+    pub reference: String,
+    pub excerpt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProposedArtifact {
+    pub kind: ArtifactKind,
+    pub title: String,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub attempt_id: Option<String>,
+    pub claim: String,
+    pub confidence: FindingConfidence,
+    pub evidence: Vec<Evidence>,
+    pub proposed_artifact: Option<ProposedArtifact>,
+    pub needs_approval: bool,
+    pub status: FindingStatus,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NewRunEvent {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub attempt_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub event_type: RunEventType,
+    pub payload: Value,
+    pub provider_event_id: Option<String>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunEvent {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub attempt_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub sequence: i64,
+    pub event_type: RunEventType,
+    pub payload: Value,
+    pub provider_event_id: Option<String>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunSnapshot {
+    pub run: Run,
+    pub tasks: Vec<Task>,
+    pub dependencies: Vec<TaskDependency>,
+    pub assignments: Vec<AgentAssignment>,
+    pub attempts: Vec<Attempt>,
+    pub findings: Vec<Finding>,
+}

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1228,6 +1228,138 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    // Durable run-engine tables. These are intentionally separate from the
+    // conversational orchestration tables so later execution phases can
+    // evolve without changing existing plan semantics.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS runs (
+            id TEXT PRIMARY KEY,
+            objective TEXT NOT NULL,
+            root_path TEXT,
+            status TEXT NOT NULL DEFAULT 'running',
+            cancel_requested INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            completed_at INTEGER
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_tasks (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            brief TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'pending',
+            blocked_reason TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_task_dependencies (
+            task_id TEXT NOT NULL,
+            depends_on_task_id TEXT NOT NULL,
+            PRIMARY KEY (task_id, depends_on_task_id),
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY (depends_on_task_id) REFERENCES run_tasks(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_agent_assignments (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            agent_type TEXT NOT NULL,
+            model_id TEXT,
+            role_label TEXT,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_attempts (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            agent_assignment_id TEXT,
+            agent_session_id TEXT,
+            attempt_number INTEGER NOT NULL,
+            outcome TEXT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER,
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY (agent_assignment_id) REFERENCES run_agent_assignments(id) ON DELETE SET NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_workspace_leases (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            task_id TEXT,
+            mode TEXT NOT NULL,
+            root_path TEXT,
+            base_revision TEXT,
+            state TEXT NOT NULL DEFAULT 'requested',
+            created_at INTEGER NOT NULL,
+            released_at INTEGER,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_findings (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            task_id TEXT,
+            attempt_id TEXT,
+            claim TEXT NOT NULL,
+            confidence TEXT NOT NULL DEFAULT 'asserted',
+            evidence_json TEXT NOT NULL DEFAULT '[]',
+            proposed_artifact_json TEXT,
+            needs_approval INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'open',
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY (attempt_id) REFERENCES run_attempts(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_events (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            task_id TEXT,
+            attempt_id TEXT,
+            agent_id TEXT,
+            sequence INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            payload_json TEXT NOT NULL DEFAULT '{}',
+            provider_event_id TEXT,
+            created_at INTEGER NOT NULL,
+            UNIQUE (run_id, sequence),
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_run_events_idempotency
+         ON run_events(attempt_id, provider_event_id)
+         WHERE attempt_id IS NOT NULL AND provider_event_id IS NOT NULL",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_run_events_run_seq
+         ON run_events(run_id, sequence)",
+        [],
+    )?;
+
     // Runtime sessions table for computer-use sessions
     conn.execute(
         "CREATE TABLE IF NOT EXISTS runtime_sessions (


### PR DESCRIPTION
## Summary

- New run-engine schema in `src-tauri/src/services/database.rs`: eight tables (`runs`, `run_tasks`, `run_task_dependencies`, `run_agent_assignments`, `run_attempts`, `run_workspace_leases`, `run_findings`, `run_events`) with explicit `ON DELETE CASCADE` chains, a per-run `UNIQUE(run_id, sequence)` constraint, and a partial unique idempotency index on `(attempt_id, provider_event_id)`.
- New `src-tauri/src/run/` module: serde-typed entities and the ten-value task state machine (`types.rs`); pure `is_legal_transition` and `derive_run_status` functions (`status.rs`); a store with idempotent, in-transaction event sequencing via `INSERT OR IGNORE` + `MAX(sequence)+1` (`store.rs`); and a single-writer scheduler that owns the only write connection, recomputes the ready-set and derived run status after every mutation, and emits each appended event on the `run://event` channel (`scheduler.rs`).
- Seven new Tauri commands (`run_create`, `run_add_task`, `run_add_agent`, `run_cancel`, `run_get_state`, `run_list_events`, `run_list`) in `src-tauri/src/commands/run.rs`, registered in `lib.rs`.
- Run status is derived, never assigned: no code path writes a terminal status except through `derive_run_status`.
- The run engine is additive: `git diff main --stat -- src-tauri/src/orchestrator/` is empty.

## Verification

- Focused module suite: `cargo test --manifest-path src-tauri/Cargo.toml --lib run::` — exit 0, 12/12 passed (cascade delete, event idempotency, transition legality, ready-set unblocking, status derivation).
- Full Rust suite: exit 0 (1,246 lib tests).
- `pnpm test` — exit 0 (2,841 tests).
- `pnpm check` — exit 0.

Part of #3511

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
