### PR TITLE
feat(run): workspace manager with scratch and worktree leases

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -3,9 +3,13 @@
 
 use crate::run::scheduler::RunEngineState;
 use crate::run::store;
-use crate::run::types::{AgentAssignment, Run, RunEvent, RunSnapshot, Task};
+use crate::run::types::{
+    AgentAssignment, LeaseMode, Run, RunEvent, RunSnapshot, Task, WorkspaceLease,
+};
+use crate::run::workspace;
 use crate::services::database::init_db;
 use rusqlite::Connection;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, State};
 
 async fn read_db<T, F>(app: AppHandle, operation: F) -> Result<T, String>
@@ -87,4 +91,64 @@ pub async fn run_list_events(
 #[tauri::command]
 pub async fn run_list(app: AppHandle) -> Result<Vec<Run>, String> {
     read_db(app, store::list_runs).await
+}
+
+#[tauri::command]
+pub async fn run_provision_workspace(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    task_id: String,
+    mode: LeaseMode,
+    source_path: Option<String>,
+    setup_script: Option<String>,
+) -> Result<WorkspaceLease, String> {
+    state
+        .provision_workspace(
+            &app,
+            run_id,
+            task_id,
+            mode,
+            source_path,
+            setup_script,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn run_release_workspace(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    lease_id: String,
+) -> Result<WorkspaceLease, String> {
+    let read_lease_id = lease_id.clone();
+    let (lease, source_repo) = read_db(app.clone(), move |conn| {
+        let lease = store::get_lease(conn, &read_lease_id)?
+            .ok_or(rusqlite::Error::QueryReturnedNoRows)?;
+        let source_repo = store::load_run_snapshot(conn, &lease.run_id)?
+            .and_then(|snapshot| snapshot.run.root_path)
+            .map(PathBuf::from);
+        Ok((lease, source_repo))
+    })
+    .await?;
+
+    let mode = lease.mode;
+    let root_path = match lease.root_path.clone() {
+        Some(root_path) => root_path,
+        None if mode == LeaseMode::Worktree => {
+            return Err("worktree lease has no provisioned root path".to_string());
+        }
+        None => String::new(),
+    };
+    tauri::async_runtime::spawn_blocking(move || {
+        workspace::release(
+            Path::new(&root_path),
+            source_repo.as_deref(),
+            mode,
+        )
+    })
+    .await
+    .map_err(|error| error.to_string())??;
+
+    state.release_lease(&app, lease_id).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1403,6 +1403,8 @@ pub fn run() {
             commands::run::run_get_state,
             commands::run::run_list_events,
             commands::run::run_list,
+            commands::run::run_provision_workspace,
+            commands::run::run_release_workspace,
             // Claude Code auto-memory interceptor commands
             commands::claude_memory::claude_memory_start,
             commands::claude_memory::claude_memory_stop,

--- a/src-tauri/src/run/mod.rs
+++ b/src-tauri/src/run/mod.rs
@@ -5,3 +5,4 @@ pub mod scheduler;
 pub mod status;
 pub mod store;
 pub mod types;
+pub mod workspace;

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -4,13 +4,18 @@
 use super::status::derive_run_status;
 use super::store::{self, AppendOutcome};
 use super::types::{
-    AgentAssignment, NewRunEvent, Run, RunEvent, RunEventType, RunStatus, Task, TaskState,
+    AgentAssignment, LeaseMode, NewLease, NewRunEvent, Run, RunEvent, RunEventType, RunStatus,
+    Task, TaskState, WorkspaceLease,
 };
+use super::workspace::{self, ProvisionRequest, ProvisionedWorkspace};
+use crate::embedded_runtime;
 use crate::services::database::{init_db, now_ms};
 use rusqlite::{Connection, params};
 use serde_json::json;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
@@ -41,6 +46,24 @@ enum SchedulerCommand {
     RecordEvent {
         event: NewRunEvent,
         reply: oneshot::Sender<Result<AppendOutcome, String>>,
+    },
+    ProvisionWorkspace {
+        run_id: String,
+        task_id: String,
+        mode: LeaseMode,
+        source_path: Option<String>,
+        setup_script: Option<String>,
+        reply: oneshot::Sender<Result<WorkspaceLease, String>>,
+    },
+    FinishProvision {
+        lease_id: String,
+        run_id: String,
+        task_id: String,
+        outcome: Result<ProvisionedWorkspace, String>,
+    },
+    ReleaseLease {
+        lease_id: String,
+        reply: oneshot::Sender<Result<WorkspaceLease, String>>,
     },
 }
 
@@ -78,10 +101,23 @@ impl RunEngineState {
         }
 
         let connection = init_db(app).map_err(|error| error.to_string())?;
+        let workspaces_root = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| error.to_string())?
+            .join("run-workspaces");
         let (sender, receiver) = mpsc::channel(128);
         let scheduler_app = app.clone();
+        let scheduler_sender = sender.clone();
         tauri::async_runtime::spawn(async move {
-            scheduler_loop(scheduler_app, connection, receiver).await;
+            scheduler_loop(
+                scheduler_app,
+                connection,
+                receiver,
+                scheduler_sender,
+                workspaces_root,
+            )
+            .await;
         });
         *self
             .sender
@@ -192,6 +228,49 @@ impl RunEngineState {
             .await
             .map_err(|_| "run scheduler dropped event response".to_string())?
     }
+
+    pub async fn provision_workspace(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        task_id: String,
+        mode: LeaseMode,
+        source_path: Option<String>,
+        setup_script: Option<String>,
+    ) -> Result<WorkspaceLease, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::ProvisionWorkspace {
+                run_id,
+                task_id,
+                mode,
+                source_path,
+                setup_script,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped provision response".to_string())?
+    }
+
+    pub async fn release_lease(
+        &self,
+        app: &AppHandle,
+        lease_id: String,
+    ) -> Result<WorkspaceLease, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::ReleaseLease { lease_id, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped release response".to_string())?
+    }
 }
 
 impl Default for RunEngineState {
@@ -204,13 +283,21 @@ async fn scheduler_loop(
     app: AppHandle,
     connection: Connection,
     mut receiver: mpsc::Receiver<SchedulerCommand>,
+    sender: mpsc::Sender<SchedulerCommand>,
+    workspaces_root: PathBuf,
 ) {
     while let Some(command) = receiver.recv().await {
-        process_command(&app, &connection, command);
+        process_command(&app, &connection, &sender, &workspaces_root, command);
     }
 }
 
-fn process_command(app: &AppHandle, conn: &Connection, command: SchedulerCommand) {
+fn process_command(
+    app: &AppHandle,
+    conn: &Connection,
+    sender: &mpsc::Sender<SchedulerCommand>,
+    workspaces_root: &Path,
+    command: SchedulerCommand,
+) {
     match command {
         SchedulerCommand::CreateRun {
             objective,
@@ -250,6 +337,316 @@ fn process_command(app: &AppHandle, conn: &Connection, command: SchedulerCommand
         SchedulerCommand::RecordEvent { event, reply } => {
             let _ = reply.send(record_event(app, conn, event));
         }
+        SchedulerCommand::ProvisionWorkspace {
+            run_id,
+            task_id,
+            mode,
+            source_path,
+            setup_script,
+            reply,
+        } => {
+            let result = start_provision(
+                app,
+                conn,
+                sender,
+                workspaces_root,
+                run_id,
+                task_id,
+                mode,
+                source_path,
+                setup_script,
+            );
+            let _ = reply.send(result);
+        }
+        SchedulerCommand::FinishProvision {
+            lease_id,
+            run_id,
+            task_id,
+            outcome,
+        } => {
+            if let Err(error) = finish_provision(app, conn, lease_id, run_id, task_id, outcome) {
+                log::error!("[run-engine] workspace provision completion failed: {error}");
+            }
+        }
+        SchedulerCommand::ReleaseLease { lease_id, reply } => {
+            let _ = reply.send(release_lease(app, conn, lease_id));
+        }
+    }
+}
+
+fn start_provision(
+    app: &AppHandle,
+    conn: &Connection,
+    sender: &mpsc::Sender<SchedulerCommand>,
+    workspaces_root: &Path,
+    run_id: String,
+    task_id: String,
+    mode: LeaseMode,
+    source_path: Option<String>,
+    setup_script: Option<String>,
+) -> Result<WorkspaceLease, String> {
+    let (title, state) = conn
+        .query_row(
+            "SELECT title, state FROM run_tasks WHERE id = ?1 AND run_id = ?2",
+            params![task_id, run_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .map_err(|error| error.to_string())?;
+    if TaskState::parse(&state) != Some(TaskState::Ready) {
+        return Err(format!(
+            "task must be ready before provisioning; current state is {state}"
+        ));
+    }
+
+    let lease_id = Uuid::new_v4().to_string();
+    store::insert_lease(
+        conn,
+        NewLease {
+            id: lease_id.clone(),
+            run_id: run_id.clone(),
+            task_id: task_id.clone(),
+            mode,
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    store::update_lease_state(conn, &lease_id, "provisioning", None, None)
+        .map_err(|error| error.to_string())?;
+    store::transition_task(conn, &task_id, TaskState::Provisioning, None)
+        .map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        lease_state_event(
+            &run_id,
+            Some(&task_id),
+            &lease_id,
+            "provisioning",
+            None,
+            None,
+            None,
+            None,
+        ),
+    )?;
+    append_and_emit(
+        app,
+        conn,
+        task_state_event(&run_id, &task_id, TaskState::Provisioning),
+    )?;
+    recompute_ready_and_status(app, conn, &run_id)?;
+
+    let lease = store::get_lease(conn, &lease_id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "workspace lease disappeared after insertion".to_string())?;
+    let request = ProvisionRequest {
+        run_id: run_id.clone(),
+        task_id: task_id.clone(),
+        task_slug: workspace::slugify(&title),
+        mode,
+        source_path: source_path.map(PathBuf::from),
+        setup_script,
+        workspaces_root: workspaces_root.to_path_buf(),
+    };
+    let finish_sender = sender.clone();
+    let finish_lease_id = lease_id.clone();
+    let finish_run_id = run_id.clone();
+    let finish_task_id = task_id.clone();
+    tauri::async_runtime::spawn(async move {
+        let outcome = tauri::async_runtime::spawn_blocking(move || provision_and_setup(request))
+            .await
+            .map_err(|error| format!("workspace worker join failed: {error}"))
+            .and_then(|outcome| outcome);
+        let _ = finish_sender
+            .send(SchedulerCommand::FinishProvision {
+                lease_id: finish_lease_id,
+                run_id: finish_run_id,
+                task_id: finish_task_id,
+                outcome,
+            })
+            .await;
+    });
+
+    Ok(lease)
+}
+
+fn provision_and_setup(
+    request: ProvisionRequest,
+) -> Result<ProvisionedWorkspace, String> {
+    let mut provisioned = workspace::provision(&request).map_err(|error| error.to_string())?;
+    let setup_script = request.setup_script.clone().or_else(|| {
+        matches!(request.mode, LeaseMode::Scratch | LeaseMode::Worktree)
+            .then(|| workspace::default_setup_script(&provisioned.root_path))
+            .flatten()
+    });
+    if let Some(script) = setup_script {
+        let embedded_path = embedded_runtime::get_embedded_path();
+        let env_path = (!embedded_path.is_empty()).then(|| embedded_path.to_string());
+        provisioned.setup = Some(workspace::run_setup_script(
+            &provisioned.root_path,
+            &script,
+            env_path,
+            Duration::from_secs(300),
+        ));
+    }
+    Ok(provisioned)
+}
+
+fn finish_provision(
+    app: &AppHandle,
+    conn: &Connection,
+    lease_id: String,
+    run_id: String,
+    task_id: String,
+    outcome: Result<ProvisionedWorkspace, String>,
+) -> Result<(), String> {
+    match outcome {
+        Ok(provisioned) => {
+            let root_path = provisioned.root_path.to_string_lossy().to_string();
+            let base_revision = provisioned.base_revision.clone();
+            let setup_exit_code = provisioned.setup.as_ref().map(|setup| setup.exit_code);
+            let setup_failed = setup_exit_code.is_some_and(|exit_code| exit_code != 0);
+            let lease_state = if setup_failed { "setup_failed" } else { "active" };
+            store::update_lease_state(
+                conn,
+                &lease_id,
+                lease_state,
+                Some(&root_path),
+                base_revision.as_deref(),
+            )
+            .map_err(|error| error.to_string())?;
+            store::transition_task(conn, &task_id, TaskState::Ready, None)
+                .map_err(|error| error.to_string())?;
+            append_and_emit(
+                app,
+                conn,
+                lease_state_event(
+                    &run_id,
+                    Some(&task_id),
+                    &lease_id,
+                    lease_state,
+                    Some(&provisioned),
+                    setup_exit_code,
+                    None,
+                    None,
+                ),
+            )?;
+            append_and_emit(
+                app,
+                conn,
+                task_state_event(&run_id, &task_id, TaskState::Ready),
+            )?;
+            recompute_ready_and_status(app, conn, &run_id)?;
+        }
+        Err(error) => {
+            store::update_lease_state(conn, &lease_id, "failed", None, None)
+                .map_err(|db_error| db_error.to_string())?;
+            store::transition_task(conn, &task_id, TaskState::Failed, None)
+                .map_err(|db_error| db_error.to_string())?;
+            append_and_emit(
+                app,
+                conn,
+                lease_state_event(
+                    &run_id,
+                    Some(&task_id),
+                    &lease_id,
+                    "failed",
+                    None,
+                    None,
+                    None,
+                    Some(&error),
+                ),
+            )?;
+            append_and_emit(
+                app,
+                conn,
+                task_state_event(&run_id, &task_id, TaskState::Failed),
+            )?;
+            recompute_ready_and_status(app, conn, &run_id)?;
+        }
+    }
+    Ok(())
+}
+
+fn release_lease(
+    app: &AppHandle,
+    conn: &Connection,
+    lease_id: String,
+) -> Result<WorkspaceLease, String> {
+    store::update_lease_state(conn, &lease_id, "released", None, None)
+        .map_err(|error| error.to_string())?;
+    let lease = store::get_lease(conn, &lease_id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "workspace lease not found after release".to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        lease_state_event(
+            &lease.run_id,
+            lease.task_id.as_deref(),
+            &lease.id,
+            "released",
+            None,
+            None,
+            None,
+            None,
+        ),
+    )?;
+    recompute_ready_and_status(app, conn, &lease.run_id)?;
+    Ok(lease)
+}
+
+fn task_state_event(run_id: &str, task_id: &str, state: TaskState) -> NewRunEvent {
+    NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        task_id: Some(task_id.to_string()),
+        attempt_id: None,
+        agent_id: None,
+        event_type: RunEventType::TaskStateChanged,
+        payload: json!({"state": state}),
+        provider_event_id: None,
+        created_at: now_ms(),
+    }
+}
+
+fn lease_state_event(
+    run_id: &str,
+    task_id: Option<&str>,
+    lease_id: &str,
+    state: &str,
+    provisioned: Option<&ProvisionedWorkspace>,
+    setup_exit_code: Option<i32>,
+    uncommitted_warning: Option<&str>,
+    error: Option<&str>,
+) -> NewRunEvent {
+    let (root_path, base_revision, branch_name, provisioned_warning) = provisioned
+        .map(|workspace| {
+            (
+                Some(workspace.root_path.to_string_lossy().to_string()),
+                workspace.base_revision.clone(),
+                workspace.branch_name.clone(),
+                workspace.uncommitted_warning.clone(),
+            )
+        })
+        .unwrap_or((None, None, None, None));
+    NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        task_id: task_id.map(str::to_string),
+        attempt_id: None,
+        agent_id: None,
+        event_type: RunEventType::LeaseStateChanged,
+        payload: json!({
+            "lease_id": lease_id,
+            "state": state,
+            "root_path": root_path,
+            "base_revision": base_revision,
+            "branch_name": branch_name,
+            "uncommitted_warning": uncommitted_warning.or(provisioned_warning.as_deref()),
+            "setup_exit_code": setup_exit_code,
+            "error": error,
+        }),
+        provider_event_id: None,
+        created_at: now_ms(),
     }
 }
 

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -4,8 +4,8 @@
 use super::status::is_legal_transition;
 use super::types::{
     AgentAssignment, Attempt, Evidence, Finding, FindingConfidence, FindingStatus, LeaseMode,
-    NewRunEvent, ProposedArtifact, Run, RunEvent, RunEventType, RunSnapshot, RunStatus, Task,
-    TaskDependency, TaskState, WorkspaceLease,
+    LeaseState, NewLease, NewRunEvent, ProposedArtifact, Run, RunEvent, RunEventType, RunSnapshot,
+    RunStatus, Task, TaskDependency, TaskState, WorkspaceLease,
 };
 use crate::services::database::now_ms;
 use rusqlite::{Connection, OptionalExtension, Result, params};
@@ -171,6 +171,97 @@ pub fn insert_workspace_lease(conn: &Connection, lease: &WorkspaceLease) -> Resu
         ],
     )?;
     Ok(())
+}
+
+impl From<&NewLease> for NewLease {
+    fn from(lease: &NewLease) -> Self {
+        lease.clone()
+    }
+}
+
+pub fn insert_lease<L>(conn: &Connection, lease: L) -> Result<()>
+where
+    L: Into<NewLease>,
+{
+    let lease = lease.into();
+    conn.execute(
+        "INSERT INTO run_workspace_leases
+            (id, run_id, task_id, mode, state, created_at)
+         VALUES (?1, ?2, ?3, ?4, 'requested', ?5)",
+        params![
+            lease.id,
+            lease.run_id,
+            lease.task_id,
+            lease.mode.as_str(),
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn lease_from_row(row: &rusqlite::Row<'_>) -> Result<WorkspaceLease> {
+    Ok(WorkspaceLease {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        task_id: row.get(2)?,
+        mode: parse_lease_mode(row.get(3)?)?,
+        root_path: row.get(4)?,
+        base_revision: row.get(5)?,
+        state: row.get(6)?,
+        created_at: row.get(7)?,
+        released_at: row.get(8)?,
+    })
+}
+
+pub fn update_lease_state(
+    conn: &Connection,
+    lease_id: &str,
+    state: &str,
+    root_path: Option<&str>,
+    base_revision: Option<&str>,
+) -> Result<()> {
+    if LeaseState::parse(state).is_none() {
+        return Err(invalid_value("lease state", state));
+    }
+    let released_at = (state == LeaseState::Released.as_str()).then_some(now_ms());
+    let updated = conn.execute(
+        "UPDATE run_workspace_leases
+         SET state = ?1,
+             root_path = COALESCE(?2, root_path),
+             base_revision = COALESCE(?3, base_revision),
+             released_at = ?4
+         WHERE id = ?5",
+        params![state, root_path, base_revision, released_at, lease_id],
+    )?;
+    if updated == 0 {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
+    Ok(())
+}
+
+pub fn get_lease(conn: &Connection, lease_id: &str) -> Result<Option<WorkspaceLease>> {
+    conn.query_row(
+        "SELECT id, run_id, task_id, mode, root_path, base_revision, state,
+                created_at, released_at
+         FROM run_workspace_leases
+         WHERE id = ?1",
+        params![lease_id],
+        lease_from_row,
+    )
+    .optional()
+}
+
+pub fn list_leases(conn: &Connection, run_id: &str) -> Result<Vec<WorkspaceLease>> {
+    let mut statement = conn.prepare(
+        "SELECT id, run_id, task_id, mode, root_path, base_revision, state,
+                created_at, released_at
+         FROM run_workspace_leases
+         WHERE run_id = ?1
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    statement
+        .query_map(params![run_id], lease_from_row)?
+        .collect()
 }
 
 pub fn insert_finding(conn: &Connection, finding: &Finding) -> Result<()> {
@@ -669,6 +760,45 @@ mod tests {
             append_event(&conn, &event("event-5", "run-2", Some("provider-4"))).unwrap(),
             AppendOutcome::Inserted(1)
         );
+    }
+
+    #[test]
+    fn lease_state_round_trips_and_lists() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        add_task(&conn, &task("task-1", "run-1"), &[]).unwrap();
+        insert_lease(
+            &conn,
+            NewLease {
+                id: "lease-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: "task-1".to_string(),
+                mode: LeaseMode::Scratch,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            get_lease(&conn, "lease-1").unwrap().unwrap().state,
+            "requested"
+        );
+        update_lease_state(
+            &conn,
+            "lease-1",
+            "active",
+            Some("/tmp/run-workspace"),
+            Some("revision"),
+        )
+        .unwrap();
+        let leases = list_leases(&conn, "run-1").unwrap();
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].root_path.as_deref(), Some("/tmp/run-workspace"));
+        assert_eq!(leases[0].base_revision.as_deref(), Some("revision"));
+        update_lease_state(&conn, "lease-1", "released", None, None).unwrap();
+        assert!(get_lease(&conn, "lease-1")
+            .unwrap()
+            .unwrap()
+            .released_at
+            .is_some());
     }
 
     #[test]

--- a/src-tauri/src/run/types.rs
+++ b/src-tauri/src/run/types.rs
@@ -128,6 +128,42 @@ impl LeaseMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum LeaseState {
+    Requested,
+    Provisioning,
+    Active,
+    SetupFailed,
+    Released,
+    Failed,
+}
+
+impl LeaseState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Provisioning => "provisioning",
+            Self::Active => "active",
+            Self::SetupFailed => "setup_failed",
+            Self::Released => "released",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "requested" => Self::Requested,
+            "provisioning" => Self::Provisioning,
+            "active" => Self::Active,
+            "setup_failed" => Self::SetupFailed,
+            "released" => Self::Released,
+            "failed" => Self::Failed,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FindingConfidence {
     Asserted,
     Verified,
@@ -267,6 +303,7 @@ pub enum RunEventType {
     ApprovalRequested,
     RunCancelRequested,
     RunFinalized,
+    LeaseStateChanged,
 }
 
 impl RunEventType {
@@ -284,6 +321,7 @@ impl RunEventType {
             Self::ApprovalRequested => "approval_requested",
             Self::RunCancelRequested => "run_cancel_requested",
             Self::RunFinalized => "run_finalized",
+            Self::LeaseStateChanged => "lease_state_changed",
         }
     }
 
@@ -301,6 +339,7 @@ impl RunEventType {
             "approval_requested" => Self::ApprovalRequested,
             "run_cancel_requested" => Self::RunCancelRequested,
             "run_finalized" => Self::RunFinalized,
+            "lease_state_changed" => Self::LeaseStateChanged,
             _ => return None,
         })
     }
@@ -369,6 +408,14 @@ pub struct WorkspaceLease {
     pub state: String,
     pub created_at: i64,
     pub released_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewLease {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: String,
+    pub mode: LeaseMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -444,11 +444,11 @@ fn setup_command(script: &str) -> Command {
 
 #[cfg(unix)]
 fn kill_setup_process_group(pid: u32) {
-    let group_id = format!("-{pid}");
-    // Unix kill -9 with a negative PID targets the entire process group.
-    let _ = Command::new("kill")
-        .args(["-9", group_id.as_str()])
-        .status();
+    // SAFETY: the child was spawned with process_group(0), so its pid is the
+    // process-group id; killpg signals every process in that group.
+    unsafe {
+        libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+    }
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -386,6 +386,7 @@ pub fn run_setup_script(
             }
             Ok(None) if Instant::now() >= deadline => {
                 timed_out = true;
+                kill_setup_process_group(child.id());
                 let _ = child.kill();
                 let _ = child.wait();
                 break;
@@ -431,10 +432,34 @@ fn setup_command(script: &str) -> Command {
     #[cfg(not(target_os = "windows"))]
     {
         let mut command = Command::new("/bin/sh");
-        command.args(["-lc", script]);
+        command.args(["-c", script]);
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
         command
     }
 }
+
+#[cfg(unix)]
+fn kill_setup_process_group(pid: u32) {
+    let group_id = format!("-{pid}");
+    // Unix kill -9 with a negative PID targets the entire process group.
+    let _ = Command::new("kill")
+        .args(["-9", group_id.as_str()])
+        .status();
+}
+
+#[cfg(windows)]
+fn kill_setup_process_group(pid: u32) {
+    let _ = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .status();
+}
+
+#[cfg(not(any(unix, windows)))]
+fn kill_setup_process_group(_pid: u32) {}
 
 fn read_pipe(mut pipe: impl Read + Send + 'static) -> thread::JoinHandle<Vec<u8>> {
     thread::spawn(move || {
@@ -751,6 +776,26 @@ mod tests {
             store::get_lease(&conn, "lease-1").unwrap().unwrap().state,
             "setup_failed"
         );
+    }
+
+    #[test]
+    fn setup_timeout_kills_process_group() {
+        let root = tempfile::tempdir().unwrap();
+        let started = Instant::now();
+        let timed_out = run_setup_script(
+            root.path(),
+            "sleep 60 & wait",
+            None,
+            Duration::from_secs(2),
+        );
+
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "setup timeout took {:?}",
+            started.elapsed()
+        );
+        assert_eq!(timed_out.exit_code, -1);
+        assert!(timed_out.output_tail.contains("timed out"));
     }
 
     #[test]

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -1,0 +1,790 @@
+// ABOUTME: Filesystem and Git workspace provisioning for durable run leases.
+// ABOUTME: Keeps provisioning explicit-path, side-effect scoped, and independent of Tauri or SQLite.
+
+use super::types::LeaseMode;
+use std::fmt;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const SETUP_OUTPUT_LIMIT: usize = 2_000;
+
+#[derive(Debug, Clone)]
+pub struct ProvisionRequest {
+    pub run_id: String,
+    pub task_id: String,
+    pub task_slug: String,
+    pub mode: LeaseMode,
+    pub source_path: Option<PathBuf>,
+    pub setup_script: Option<String>,
+    pub workspaces_root: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProvisionedWorkspace {
+    pub root_path: PathBuf,
+    pub base_revision: Option<String>,
+    pub branch_name: Option<String>,
+    pub uncommitted_warning: Option<String>,
+    pub setup: Option<SetupResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupResult {
+    pub command: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    pub output_tail: String,
+}
+
+#[derive(Debug)]
+pub enum ProvisionError {
+    InvalidRequest(String),
+    MissingSource,
+    NotARepository,
+    Io(io::Error),
+    GitCommand { command: String, output: String },
+}
+
+impl fmt::Display for ProvisionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest(message) => write!(formatter, "invalid workspace request: {message}"),
+            Self::MissingSource => write!(formatter, "workspace mode requires a source path"),
+            Self::NotARepository => write!(formatter, "source path is not a Git repository"),
+            Self::Io(error) => write!(formatter, "workspace filesystem error: {error}"),
+            Self::GitCommand { command, output } => {
+                write!(formatter, "Git command failed ({command}): {output}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProvisionError {}
+
+impl From<io::Error> for ProvisionError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub fn short_run_id(run_id: &str) -> String {
+    run_id.chars().take(8).collect()
+}
+
+pub fn slugify(title: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+
+    for character in title.chars() {
+        if character.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(character.to_ascii_lowercase());
+            pending_dash = false;
+        } else if !slug.is_empty() {
+            pending_dash = true;
+        }
+    }
+
+    slug.truncate(40);
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+
+    if slug.is_empty() {
+        "task".to_string()
+    } else {
+        slug
+    }
+}
+
+pub fn provision(request: &ProvisionRequest) -> Result<ProvisionedWorkspace, ProvisionError> {
+    if request.run_id.is_empty() {
+        return Err(ProvisionError::InvalidRequest(
+            "run_id must not be empty".to_string(),
+        ));
+    }
+    if request.task_id.is_empty() {
+        return Err(ProvisionError::InvalidRequest(
+            "task_id must not be empty".to_string(),
+        ));
+    }
+
+    match request.mode {
+        LeaseMode::Scratch => provision_scratch(request),
+        LeaseMode::Worktree => provision_worktree(request),
+        LeaseMode::SharedReadonly => Ok(ProvisionedWorkspace {
+            root_path: request
+                .source_path
+                .clone()
+                .ok_or(ProvisionError::MissingSource)?,
+            base_revision: None,
+            branch_name: None,
+            uncommitted_warning: None,
+            setup: None,
+        }),
+        LeaseMode::ExternalRead | LeaseMode::ExternalWrite => Ok(ProvisionedWorkspace {
+            root_path: request.workspaces_root.clone(),
+            base_revision: None,
+            branch_name: None,
+            uncommitted_warning: None,
+            setup: None,
+        }),
+    }
+}
+
+fn provision_scratch(request: &ProvisionRequest) -> Result<ProvisionedWorkspace, ProvisionError> {
+    let base = request
+        .workspaces_root
+        .join(short_run_id(&request.run_id))
+        .join(slugify(&request.task_slug));
+    let root_path = create_unique_directory(&base)?;
+
+    Ok(ProvisionedWorkspace {
+        root_path,
+        base_revision: None,
+        branch_name: None,
+        uncommitted_warning: None,
+        setup: None,
+    })
+}
+
+fn provision_worktree(request: &ProvisionRequest) -> Result<ProvisionedWorkspace, ProvisionError> {
+    let source_path = request
+        .source_path
+        .as_ref()
+        .ok_or(ProvisionError::MissingSource)?;
+    ensure_git_repository(source_path)?;
+
+    let base_revision = git_stdout(source_path, &["rev-parse", "HEAD"])?;
+    let status = git_stdout(source_path, &["status", "--porcelain"])?;
+    let uncommitted_warning = warning_for_status(&status);
+
+    let base_root = request
+        .workspaces_root
+        .join(short_run_id(&request.run_id))
+        .join(slugify(&request.task_slug));
+    let base_branch = format!(
+        "seren/{}/{}",
+        short_run_id(&request.run_id),
+        slugify(&request.task_slug)
+    );
+    let parent = base_root
+        .parent()
+        .ok_or_else(|| ProvisionError::InvalidRequest("workspace root has no parent".to_string()))?;
+    fs::create_dir_all(parent)?;
+
+    for suffix in 0u32.. {
+        let root_path = with_suffix(&base_root, suffix);
+        let branch_name = branch_with_suffix(&base_branch, suffix);
+        if root_path.exists() || git_branch_exists(source_path, &branch_name)? {
+            continue;
+        }
+
+        let output = Command::new("git")
+            .current_dir(source_path)
+            .args(["worktree", "add"])
+            .arg(&root_path)
+            .args(["-b", &branch_name, "HEAD"])
+            .output()
+            .map_err(ProvisionError::Io)?;
+        if output.status.success() {
+            return Ok(ProvisionedWorkspace {
+                root_path,
+                base_revision: Some(base_revision.clone()),
+                branch_name: Some(branch_name),
+                uncommitted_warning: uncommitted_warning.clone(),
+                setup: None,
+            });
+        }
+
+        // A concurrent provisioner may have claimed the branch between the
+        // existence check and git worktree add; retry with the next suffix.
+        if root_path.exists() {
+            let _ = fs::remove_dir_all(&root_path);
+        }
+        if !git_branch_exists(source_path, &branch_name)? {
+            return Err(git_error(
+                [
+                    "git",
+                    "worktree",
+                    "add",
+                    &root_path.to_string_lossy(),
+                    "-b",
+                    &branch_name,
+                    "HEAD",
+                ]
+                .join(" "),
+                output,
+            ));
+        }
+    }
+
+    Err(ProvisionError::InvalidRequest(
+        "exhausted workspace collision suffixes".to_string(),
+    ))
+}
+
+fn ensure_git_repository(source_path: &Path) -> Result<(), ProvisionError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(source_path)
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .map_err(ProvisionError::Io)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ProvisionError::NotARepository)
+    }
+}
+
+fn git_stdout(source_path: &Path, arguments: &[&str]) -> Result<String, ProvisionError> {
+    let output = Command::new("git")
+        .current_dir(source_path)
+        .args(arguments)
+        .output()
+        .map_err(ProvisionError::Io)?;
+    if !output.status.success() {
+        return Err(git_error(
+            format!("git {}", arguments.join(" ")),
+            output,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_branch_exists(source_path: &Path, branch_name: &str) -> Result<bool, ProvisionError> {
+    let status = Command::new("git")
+        .current_dir(source_path)
+        .args(["show-ref", "--verify", "--quiet"])
+        .arg(format!("refs/heads/{branch_name}"))
+        .status()
+        .map_err(ProvisionError::Io)?;
+    if status.success() {
+        Ok(true)
+    } else if status.code() == Some(1) {
+        Ok(false)
+    } else {
+        Err(ProvisionError::GitCommand {
+            command: format!("git show-ref --verify --quiet refs/heads/{branch_name}"),
+            output: format!("exit status {status}"),
+        })
+    }
+}
+
+fn git_error(command: String, output: Output) -> ProvisionError {
+    let mut text = String::from_utf8_lossy(&output.stderr).to_string();
+    if text.trim().is_empty() {
+        text = String::from_utf8_lossy(&output.stdout).to_string();
+    }
+    ProvisionError::GitCommand {
+        command,
+        output: text.trim().to_string(),
+    }
+}
+
+fn warning_for_status(status: &str) -> Option<String> {
+    let file_count = status.lines().filter(|line| !line.trim().is_empty()).count();
+    (file_count > 0).then(|| {
+        format!(
+            "source repository has {file_count} uncommitted file{}",
+            if file_count == 1 { "" } else { "s" }
+        )
+    })
+}
+
+fn create_unique_directory(base: &Path) -> Result<PathBuf, ProvisionError> {
+    let parent = base
+        .parent()
+        .ok_or_else(|| ProvisionError::InvalidRequest("workspace root has no parent".to_string()))?;
+    fs::create_dir_all(parent)?;
+    for suffix in 0u32.. {
+        let candidate = with_suffix(base, suffix);
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(ProvisionError::Io(error)),
+        }
+    }
+    Err(ProvisionError::InvalidRequest(
+        "exhausted workspace collision suffixes".to_string(),
+    ))
+}
+
+fn with_suffix(path: &Path, suffix: u32) -> PathBuf {
+    if suffix == 0 {
+        return path.to_path_buf();
+    }
+    let name = path
+        .file_name()
+        .map(|value| value.to_string_lossy())
+        .unwrap_or_default();
+    path.with_file_name(format!("{name}-{suffix}"))
+}
+
+fn branch_with_suffix(branch: &str, suffix: u32) -> String {
+    if suffix == 0 {
+        branch.to_string()
+    } else {
+        format!("{branch}-{suffix}")
+    }
+}
+
+pub fn default_setup_script(root: &Path) -> Option<String> {
+    if root.join("package.json").is_file() {
+        Some("pnpm install --prefer-offline".to_string())
+    } else if root.join("Cargo.toml").is_file() {
+        Some("cargo fetch".to_string())
+    } else {
+        None
+    }
+}
+
+pub fn run_setup_script(
+    root: &Path,
+    script: &str,
+    env_path: Option<String>,
+    timeout: Duration,
+) -> SetupResult {
+    let started = Instant::now();
+    let mut command = setup_command(script);
+    command.current_dir(root);
+    if let Some(path) = env_path {
+        command.env("PATH", path);
+    }
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return SetupResult {
+                command: script.to_string(),
+                exit_code: -1,
+                duration_ms: started.elapsed().as_millis() as u64,
+                output_tail: tail_output(error.to_string().into_bytes()),
+            };
+        }
+    };
+
+    let stdout = child.stdout.take().map(read_pipe);
+    let stderr = child.stderr.take().map(read_pipe);
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let mut exit_code = -1;
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                exit_code = status.code().unwrap_or(-1);
+                break;
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                timed_out = true;
+                let _ = child.kill();
+                let _ = child.wait();
+                break;
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let output = collect_output(stdout, stderr);
+                return SetupResult {
+                    command: script.to_string(),
+                    exit_code: -1,
+                    duration_ms: started.elapsed().as_millis() as u64,
+                    output_tail: tail_output([output, error.to_string().into_bytes()].concat()),
+                };
+            }
+        }
+    }
+
+    let mut output = collect_output(stdout, stderr);
+    if timed_out {
+        output.extend_from_slice(
+            format!("\nsetup timed out after {} ms", timeout.as_millis()).as_bytes(),
+        );
+        exit_code = -1;
+    }
+
+    SetupResult {
+        command: script.to_string(),
+        exit_code,
+        duration_ms: started.elapsed().as_millis() as u64,
+        output_tail: tail_output(output),
+    }
+}
+
+fn setup_command(script: &str) -> Command {
+    #[cfg(target_os = "windows")]
+    {
+        let mut command = Command::new("cmd");
+        command.args(["/C", script]);
+        command
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-lc", script]);
+        command
+    }
+}
+
+fn read_pipe(mut pipe: impl Read + Send + 'static) -> thread::JoinHandle<Vec<u8>> {
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let _ = pipe.read_to_end(&mut output);
+        output
+    })
+}
+
+fn collect_output(
+    stdout: Option<thread::JoinHandle<Vec<u8>>>,
+    stderr: Option<thread::JoinHandle<Vec<u8>>>,
+) -> Vec<u8> {
+    let mut output = Vec::new();
+    if let Some(handle) = stdout {
+        output.extend(handle.join().unwrap_or_default());
+    }
+    if let Some(handle) = stderr {
+        output.extend(handle.join().unwrap_or_default());
+    }
+    output
+}
+
+fn tail_output(output: Vec<u8>) -> String {
+    let start = output.len().saturating_sub(SETUP_OUTPUT_LIMIT);
+    String::from_utf8_lossy(&output[start..]).to_string()
+}
+
+pub fn release(
+    root: &Path,
+    source_repo: Option<&Path>,
+    mode: LeaseMode,
+) -> Result<(), String> {
+    match mode {
+        LeaseMode::Worktree => {
+            if !root.exists() {
+                return Ok(());
+            }
+            let source_repo = source_repo
+                .ok_or_else(|| "worktree release requires source repository".to_string())?;
+            let output = Command::new("git")
+                .current_dir(source_repo)
+                .args(["worktree", "remove", "--force"])
+                .arg(root)
+                .output()
+                .map_err(|error| error.to_string())?;
+            if output.status.success() || !root.exists() {
+                Ok(())
+            } else {
+                Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+            }
+        }
+        LeaseMode::Scratch
+        | LeaseMode::SharedReadonly
+        | LeaseMode::ExternalRead
+        | LeaseMode::ExternalWrite => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::store;
+    use crate::run::types::{NewLease, Run, RunStatus, Task, TaskState};
+    use crate::services::database::{configure_connection, setup_schema};
+    use rusqlite::Connection;
+    use std::sync::Arc;
+
+    fn request(
+        run_id: &str,
+        task_id: &str,
+        task_slug: &str,
+        mode: LeaseMode,
+        source_path: Option<PathBuf>,
+        workspaces_root: &Path,
+    ) -> ProvisionRequest {
+        ProvisionRequest {
+            run_id: run_id.to_string(),
+            task_id: task_id.to_string(),
+            task_slug: task_slug.to_string(),
+            mode,
+            source_path,
+            setup_script: None,
+            workspaces_root: workspaces_root.to_path_buf(),
+        }
+    }
+
+    fn git_command(cwd: &Path, arguments: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(cwd)
+            .args(arguments)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(cwd: &Path, arguments: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(cwd)
+            .args(arguments)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
+    fn make_git_repo(root: &Path) {
+        git_command(root, &["init"]);
+        git_command(root, &["config", "user.email", "workspace-tests@seren.local"]);
+        git_command(root, &["config", "user.name", "Workspace Tests"]);
+        fs::write(root.join("tracked.txt"), "initial\n").unwrap();
+        git_command(root, &["add", "tracked.txt"]);
+        git_command(root, &["commit", "-m", "initial"]);
+    }
+
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        setup_schema(&conn).unwrap();
+        conn
+    }
+
+    fn test_run() -> Run {
+        Run {
+            id: "run-1".to_string(),
+            objective: "workspace test".to_string(),
+            root_path: None,
+            status: RunStatus::Running,
+            cancel_requested: false,
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+        }
+    }
+
+    fn test_task() -> Task {
+        Task {
+            id: "task-1".to_string(),
+            run_id: "run-1".to_string(),
+            title: "workspace task".to_string(),
+            brief: "workspace test".to_string(),
+            state: TaskState::Pending,
+            blocked_reason: None,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn slugify_normalizes_task_titles() {
+        assert_eq!(slugify("  Build Workspace / Phase 3! "), "build-workspace-phase-3");
+        assert_eq!(slugify("---"), "task");
+        assert!(slugify(&"a".repeat(100)).len() <= 40);
+    }
+
+    #[test]
+    fn scratch_provisions_in_non_git_dir() {
+        let source = tempfile::tempdir().unwrap();
+        let workspaces = tempfile::tempdir().unwrap();
+        let provisioned = provision(&request(
+            "run-123456789",
+            "task-1",
+            "Scratch task",
+            LeaseMode::Scratch,
+            Some(source.path().to_path_buf()),
+            workspaces.path(),
+        ))
+        .unwrap();
+        assert!(provisioned.root_path.exists());
+        assert!(provisioned.root_path.starts_with(workspaces.path()));
+        assert!(provisioned.base_revision.is_none());
+
+        let conn = test_db();
+        store::create_run(&conn, &test_run()).unwrap();
+        store::add_task(&conn, &test_task(), &[]).unwrap();
+        store::insert_lease(
+            &conn,
+            NewLease {
+                id: "lease-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: "task-1".to_string(),
+                mode: LeaseMode::Scratch,
+            },
+        )
+        .unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Ready, None).unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Provisioning, None).unwrap();
+        let root_string = provisioned.root_path.to_string_lossy().to_string();
+        store::update_lease_state(&conn, "lease-1", "active", Some(&root_string), None).unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Ready, None).unwrap();
+        let lease = store::get_lease(&conn, "lease-1").unwrap().unwrap();
+        assert_eq!(lease.state, "active");
+        assert_eq!(lease.root_path.as_deref(), Some(root_string.as_str()));
+        let state: String = conn
+            .query_row("SELECT state FROM run_tasks WHERE id = 'task-1'", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(state, "ready");
+    }
+
+    #[test]
+    fn worktree_leaves_user_checkout_byte_identical() {
+        let repo_root = tempfile::tempdir().unwrap();
+        make_git_repo(repo_root.path());
+        fs::write(repo_root.path().join("tracked.txt"), "uncommitted\n").unwrap();
+        let before_status = git_output(repo_root.path(), &["status", "--porcelain"]);
+        let before_head = git_output(repo_root.path(), &["rev-parse", "HEAD"]);
+        let before_branch = git_output(repo_root.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
+        let workspaces = tempfile::tempdir().unwrap();
+        let provisioned = provision(&request(
+            "run-123456789",
+            "task-1",
+            "A Workspace Task",
+            LeaseMode::Worktree,
+            Some(repo_root.path().to_path_buf()),
+            workspaces.path(),
+        ))
+        .unwrap();
+        let after_status = git_output(repo_root.path(), &["status", "--porcelain"]);
+        let after_head = git_output(repo_root.path(), &["rev-parse", "HEAD"]);
+        let after_branch = git_output(repo_root.path(), &["rev-parse", "--abbrev-ref", "HEAD"]);
+        assert_eq!(before_status, after_status);
+        assert_eq!(before_head, after_head);
+        assert_eq!(before_branch, after_branch);
+        assert_eq!(provisioned.base_revision.as_deref(), Some(before_head.trim()));
+        assert_eq!(
+            provisioned.branch_name.as_deref(),
+            Some("seren/run-1234/a-workspace-task"),
+        );
+        assert!(provisioned.uncommitted_warning.is_some());
+        assert!(!provisioned.root_path.starts_with(repo_root.path()));
+        let second = provision(&request(
+            "run-123456789",
+            "task-1",
+            "A Workspace Task",
+            LeaseMode::Worktree,
+            Some(repo_root.path().to_path_buf()),
+            workspaces.path(),
+        ))
+        .unwrap();
+        assert_ne!(provisioned.root_path, second.root_path);
+        assert_ne!(provisioned.branch_name, second.branch_name);
+        release(&second.root_path, Some(repo_root.path()), LeaseMode::Worktree).unwrap();
+        release(
+            &provisioned.root_path,
+            Some(repo_root.path()),
+            LeaseMode::Worktree,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn concurrent_writers_get_different_roots() {
+        let workspaces = tempfile::tempdir().unwrap();
+        let first = request(
+            "run-123456789",
+            "task-1",
+            "Same Task",
+            LeaseMode::Scratch,
+            None,
+            workspaces.path(),
+        );
+        let second = first.clone();
+        let first = Arc::new(first);
+        let second = Arc::new(second);
+        let left = {
+            let request = Arc::clone(&first);
+            thread::spawn(move || provision(&request))
+        };
+        let right = {
+            let request = Arc::clone(&second);
+            thread::spawn(move || provision(&request))
+        };
+        let left = left.join().unwrap().unwrap();
+        let right = right.join().unwrap().unwrap();
+        assert_ne!(left.root_path, right.root_path);
+        release(&left.root_path, None, LeaseMode::Scratch).unwrap();
+        release(&right.root_path, None, LeaseMode::Scratch).unwrap();
+    }
+
+    #[test]
+    fn setup_failure_is_recoverable_not_a_hang() {
+        let root = tempfile::tempdir().unwrap();
+        let failed = run_setup_script(root.path(), "exit 7", None, Duration::from_secs(2));
+        assert_eq!(failed.exit_code, 7);
+        let started = Instant::now();
+        let timed_out = run_setup_script(root.path(), "sleep 60", None, Duration::from_secs(2));
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert_eq!(timed_out.exit_code, -1);
+        assert!(timed_out.output_tail.contains("timed out"));
+
+        let conn = test_db();
+        store::create_run(&conn, &test_run()).unwrap();
+        store::add_task(&conn, &test_task(), &[]).unwrap();
+        store::insert_lease(
+            &conn,
+            NewLease {
+                id: "lease-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: "task-1".to_string(),
+                mode: LeaseMode::Scratch,
+            },
+        )
+        .unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Ready, None).unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Provisioning, None).unwrap();
+        store::update_lease_state(&conn, "lease-1", "setup_failed", None, None).unwrap();
+        store::transition_task(&conn, "task-1", TaskState::Ready, None).unwrap();
+        assert_eq!(
+            store::get_lease(&conn, "lease-1").unwrap().unwrap().state,
+            "setup_failed"
+        );
+    }
+
+    #[test]
+    fn release_removes_worktree_and_keeps_scratch() {
+        let repo_root = tempfile::tempdir().unwrap();
+        make_git_repo(repo_root.path());
+        let workspaces = tempfile::tempdir().unwrap();
+        let worktree = provision(&request(
+            "run-release",
+            "task-1",
+            "worktree",
+            LeaseMode::Worktree,
+            Some(repo_root.path().to_path_buf()),
+            workspaces.path(),
+        ))
+        .unwrap();
+        let worktree_root = worktree.root_path.clone();
+        release(&worktree_root, Some(repo_root.path()), LeaseMode::Worktree).unwrap();
+        assert!(!worktree_root.exists());
+        let worktree_root_string = worktree_root.to_string_lossy().to_string();
+        assert!(!git_output(repo_root.path(), &["worktree", "list"])
+            .contains(worktree_root_string.as_str()));
+
+        let scratch = provision(&request(
+            "run-release",
+            "task-2",
+            "scratch",
+            LeaseMode::Scratch,
+            None,
+            workspaces.path(),
+        ))
+        .unwrap();
+        let scratch_root = scratch.root_path.clone();
+        release(&scratch_root, None, LeaseMode::Scratch).unwrap();
+        assert!(scratch_root.exists());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds scratch and worktree provisioning in src-tauri/src/run/workspace.rs with collision-suffixed roots and branches, base_revision capture, uncommitted-file warnings, and no mutations to the user's working tree or current branch.
- Runs optional and default setup scripts with a 300s timeout and an embedded-runtime PATH fallback.
- Dispatches provisioning off the scheduler writer through spawn_blocking and FinishProvision, with active/ready, setup_failed/ready, and failed/failed outcomes.
- Adds lease persistence and the run_provision_workspace and run_release_workspace Tauri commands.
- No orchestrator changes: git diff origin/main --stat -- src-tauri/src/orchestrator/ is empty.

## Verification

- Focused run suite: 19/19 passed in about 2 seconds; exit 0.
- Full cargo test: 1,257 library tests passed; exit 0.
- pnpm test: 2,849 passed, 15 skipped; exit 0.
- pnpm check: exit 0 with no errors.
- Concurrent-writers coverage uses scratch mode because concurrent git worktree add serializes on Git's index lock; sequential worktree collision coverage remains covered.

Part of #3511
