### PR TITLE
feat(run): findings evidence checks with baseline and coverage

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -4,7 +4,8 @@
 use crate::run::scheduler::RunEngineState;
 use crate::run::store;
 use crate::run::types::{
-    AgentAssignment, LeaseMode, Run, RunEvent, RunSnapshot, Task, WorkspaceLease,
+    AgentAssignment, CheckDeclaration, CheckResult, CoverageGap, Finding, LeaseMode, Run, RunCheck,
+    RunEvent, RunSnapshot, Task, WorkspaceLease,
 };
 use crate::run::workspace;
 use crate::services::database::init_db;
@@ -91,6 +92,72 @@ pub async fn run_list_events(
 #[tauri::command]
 pub async fn run_list(app: AppHandle) -> Result<Vec<Run>, String> {
     read_db(app, store::list_runs).await
+}
+
+#[tauri::command]
+pub async fn run_declare_checks(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    checks: Vec<CheckDeclaration>,
+) -> Result<Vec<RunCheck>, String> {
+    state.declare_checks(&app, run_id, checks).await
+}
+
+#[tauri::command]
+pub async fn run_approve_check(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    check_id: String,
+) -> Result<RunCheck, String> {
+    state.approve_check(&app, check_id).await
+}
+
+#[tauri::command]
+pub async fn run_baseline(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+) -> Result<Vec<CheckResult>, String> {
+    state.run_baseline(&app, run_id).await
+}
+
+#[tauri::command]
+pub async fn run_verify_task(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    task_id: String,
+) -> Result<Vec<CheckResult>, String> {
+    state.verify_task(&app, run_id, task_id).await
+}
+
+#[tauri::command]
+pub async fn run_complete_task(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    task_id: String,
+) -> Result<Vec<String>, String> {
+    state.complete_task(&app, run_id, task_id).await
+}
+
+#[tauri::command]
+pub async fn run_record_finding(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    finding: Finding,
+) -> Result<(), String> {
+    state.record_finding(&app, finding).await
+}
+
+#[tauri::command]
+pub async fn run_add_coverage_gap(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    gap: CoverageGap,
+) -> Result<(), String> {
+    state.record_coverage_gap(&app, gap).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1403,6 +1403,13 @@ pub fn run() {
             commands::run::run_get_state,
             commands::run::run_list_events,
             commands::run::run_list,
+            commands::run::run_declare_checks,
+            commands::run::run_approve_check,
+            commands::run::run_baseline,
+            commands::run::run_verify_task,
+            commands::run::run_complete_task,
+            commands::run::run_record_finding,
+            commands::run::run_add_coverage_gap,
             commands::run::run_provision_workspace,
             commands::run::run_release_workspace,
             // Claude Code auto-memory interceptor commands

--- a/src-tauri/src/run/checks.rs
+++ b/src-tauri/src/run/checks.rs
@@ -1,0 +1,356 @@
+// ABOUTME: Executes approved run checks and derives evidence-aware completion blockers.
+// ABOUTME: Check policy is pure and keeps baseline failures from becoming regressions.
+
+use super::types::CheckResult;
+use super::workspace::{self, SetupResult};
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckGate {
+    pub name: String,
+    pub baseline_failed: bool,
+    pub verify_exit: Option<i32>,
+}
+
+pub fn execute_check(
+    root: &Path,
+    command: &str,
+    env_path: Option<String>,
+    timeout: Duration,
+) -> SetupResult {
+    workspace::run_setup_script(root, command, env_path, timeout)
+}
+
+pub fn completion_blockers(has_evidence: bool, checks: &[CheckGate]) -> Vec<String> {
+    let mut blockers = Vec::new();
+    if !has_evidence {
+        blockers.push("no finding with evidence".to_string());
+    }
+    for check in checks {
+        if check.baseline_failed {
+            continue;
+        }
+        match check.verify_exit {
+            Some(0) => {}
+            Some(_) => blockers.push(format!("check {} regressed", check.name)),
+            None => blockers.push(format!("check {} not verified", check.name)),
+        }
+    }
+    blockers
+}
+
+pub(crate) fn check_result_from_setup(
+    check_id: String,
+    task_id: Option<String>,
+    kind: &str,
+    setup: SetupResult,
+) -> CheckResult {
+    CheckResult {
+        id: uuid::Uuid::new_v4().to_string(),
+        check_id,
+        task_id,
+        attempt_id: None,
+        kind: kind.to_string(),
+        exit_code: Some(setup.exit_code),
+        duration_ms: setup.duration_ms as i64,
+        output_tail: setup.output_tail,
+        pre_existing_failure: setup.exit_code != 0,
+        created_at: crate::services::database::now_ms(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::store;
+    use crate::run::types::{
+        Evidence, EvidenceKind, Finding, FindingConfidence, FindingStatus, Run, RunCheck,
+        RunStatus, Task, TaskState,
+    };
+    use crate::services::database::{configure_connection, setup_schema};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn gate(name: &str, baseline_failed: bool, verify_exit: Option<i32>) -> CheckGate {
+        CheckGate {
+            name: name.to_string(),
+            baseline_failed,
+            verify_exit,
+        }
+    }
+
+    #[test]
+    fn no_evidence_blocks_completion() {
+        assert_eq!(
+            completion_blockers(true, &[]),
+            Vec::<String>::new(),
+            "evidence alone is sufficient when there are no checks"
+        );
+        assert_eq!(
+            completion_blockers(false, &[]),
+            vec!["no finding with evidence"]
+        );
+    }
+
+    #[test]
+    fn evidence_and_zero_checks_are_clear() {
+        assert!(completion_blockers(true, &[]).is_empty());
+    }
+
+    #[test]
+    fn baseline_failed_check_does_not_block_when_verify_fails_again() {
+        assert!(completion_blockers(true, &[gate("lint", true, Some(7))]).is_empty());
+    }
+
+    #[test]
+    fn baseline_green_check_failing_verify_blocks() {
+        assert_eq!(
+            completion_blockers(true, &[gate("tests", false, Some(1))]),
+            vec!["check tests regressed"]
+        );
+    }
+
+    #[test]
+    fn baseline_green_check_not_run_blocks() {
+        assert_eq!(
+            completion_blockers(true, &[gate("tests", false, None)]),
+            vec!["check tests not verified"]
+        );
+    }
+
+    #[test]
+    fn baseline_failed_check_not_run_does_not_block() {
+        assert!(completion_blockers(true, &[gate("tests", true, None)]).is_empty());
+    }
+
+    fn connection() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        setup_schema(&conn).unwrap();
+        conn
+    }
+
+    fn seed_run_and_task(conn: &Connection) {
+        store::create_run(
+            conn,
+            &Run {
+                id: "run-checks".to_string(),
+                objective: "check objective".to_string(),
+                root_path: None,
+                status: RunStatus::Running,
+                cancel_requested: false,
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+        store::add_task(
+            conn,
+            &Task {
+                id: "task-checks".to_string(),
+                run_id: "run-checks".to_string(),
+                title: "Checks".to_string(),
+                brief: "Run checks".to_string(),
+                state: TaskState::Pending,
+                blocked_reason: None,
+                created_at: 1,
+                updated_at: 1,
+            },
+            &[],
+        )
+        .unwrap();
+    }
+
+    fn move_task_to_review(conn: &Connection) {
+        store::transition_task(conn, "task-checks", TaskState::Ready, None).unwrap();
+        store::transition_task(conn, "task-checks", TaskState::Provisioning, None).unwrap();
+        store::transition_task(conn, "task-checks", TaskState::Running, None).unwrap();
+        store::transition_task(conn, "task-checks", TaskState::Verifying, None).unwrap();
+        store::transition_task(conn, "task-checks", TaskState::Review, None).unwrap();
+    }
+
+    fn check(id: &str, name: &str, approved: bool) -> RunCheck {
+        RunCheck {
+            id: id.to_string(),
+            run_id: "run-checks".to_string(),
+            name: name.to_string(),
+            command: "echo ok".to_string(),
+            approved,
+            created_at: 1,
+        }
+    }
+
+    fn evidence_finding() -> Finding {
+        Finding {
+            id: "finding-checks".to_string(),
+            run_id: "run-checks".to_string(),
+            task_id: Some("task-checks".to_string()),
+            attempt_id: None,
+            claim: "The check result is recorded".to_string(),
+            confidence: FindingConfidence::Asserted,
+            evidence: vec![Evidence {
+                kind: EvidenceKind::CommandResult,
+                reference: "echo ok".to_string(),
+                excerpt: Some("ok".to_string()),
+            }],
+            proposed_artifact: None,
+            needs_approval: false,
+            status: FindingStatus::Open,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn baseline_marks_failing_check_pre_existing() {
+        let directory = tempdir().unwrap();
+        let passing = execute_check(
+            directory.path(),
+            "echo ok",
+            None,
+            Duration::from_secs(2),
+        );
+        let failing = execute_check(
+            directory.path(),
+            "exit 3",
+            None,
+            Duration::from_secs(2),
+        );
+        assert_eq!(passing.exit_code, 0);
+        assert_eq!(failing.exit_code, 3);
+
+        let conn = connection();
+        seed_run_and_task(&conn);
+        store::insert_check(&conn, &check("check-ok", "echo", true)).unwrap();
+        store::insert_check(&conn, &check("check-fail", "exit", true)).unwrap();
+        store::insert_check_result(
+            &conn,
+            &check_result_from_setup("check-ok".to_string(), None, "baseline", passing),
+        )
+        .unwrap();
+        store::insert_check_result(
+            &conn,
+            &check_result_from_setup("check-fail".to_string(), None, "baseline", failing),
+        )
+        .unwrap();
+        let results = store::list_check_results(&conn, "run-checks").unwrap();
+        assert_eq!(results.len(), 2);
+        let failed_result = results
+            .iter()
+            .find(|result| result.check_id == "check-fail")
+            .expect("failing check result");
+        assert_eq!(failed_result.exit_code, Some(3));
+        assert!(failed_result.pre_existing_failure);
+        assert!(results.iter().all(|result| result.duration_ms >= 0));
+    }
+
+    #[test]
+    fn unapproved_check_never_executes_and_records_gap() {
+        let conn = connection();
+        seed_run_and_task(&conn);
+        store::insert_check(&conn, &check("check-unapproved", "danger", false)).unwrap();
+        store::insert_coverage_gap(
+            &conn,
+            &crate::run::types::CoverageGap {
+                id: "gap-unapproved".to_string(),
+                run_id: "run-checks".to_string(),
+                task_id: None,
+                kind: "check_unapproved".to_string(),
+                subject: "danger".to_string(),
+                detail: Some("approval required".to_string()),
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        assert!(store::list_check_results(&conn, "run-checks").unwrap().is_empty());
+        let gaps = store::list_coverage_gaps(&conn, "run-checks").unwrap();
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0].kind, "check_unapproved");
+    }
+
+    #[test]
+    fn completion_requires_evidence() {
+        let conn = connection();
+        seed_run_and_task(&conn);
+        move_task_to_review(&conn);
+        assert!(!store::task_has_evidence(&conn, "task-checks").unwrap());
+        assert_eq!(
+            completion_blockers(false, &[]),
+            vec!["no finding with evidence"]
+        );
+        store::insert_finding(&conn, &evidence_finding()).unwrap();
+        assert!(store::task_has_evidence(&conn, "task-checks").unwrap());
+        assert!(completion_blockers(true, &[]).is_empty());
+    }
+
+    #[test]
+    fn pre_existing_failure_does_not_block_done() {
+        let conn = connection();
+        seed_run_and_task(&conn);
+        move_task_to_review(&conn);
+        store::insert_check(&conn, &check("check-baseline-failed", "lint", true)).unwrap();
+        store::insert_check_result(
+            &conn,
+            &CheckResult {
+                id: "baseline-failed-result".to_string(),
+                check_id: "check-baseline-failed".to_string(),
+                task_id: None,
+                attempt_id: None,
+                kind: "baseline".to_string(),
+                exit_code: Some(3),
+                duration_ms: 1,
+                output_tail: "failed before the task".to_string(),
+                pre_existing_failure: true,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        store::insert_check_result(
+            &conn,
+            &CheckResult {
+                id: "verify-failed-result".to_string(),
+                check_id: "check-baseline-failed".to_string(),
+                task_id: Some("task-checks".to_string()),
+                attempt_id: None,
+                kind: "verify".to_string(),
+                exit_code: Some(3),
+                duration_ms: 1,
+                output_tail: "still failed".to_string(),
+                pre_existing_failure: true,
+                created_at: 2,
+            },
+        )
+        .unwrap();
+        store::insert_finding(&conn, &evidence_finding()).unwrap();
+        assert!(completion_blockers(
+            true,
+            &[gate("lint", true, Some(3))]
+        )
+        .is_empty());
+        store::transition_task(&conn, "task-checks", TaskState::Done, None).unwrap();
+    }
+
+    #[test]
+    fn regression_blocks_done() {
+        let conn = connection();
+        seed_run_and_task(&conn);
+        move_task_to_review(&conn);
+        store::insert_check(&conn, &check("check-regression", "tests", true)).unwrap();
+        store::insert_finding(&conn, &evidence_finding()).unwrap();
+        let blockers = completion_blockers(
+            true,
+            &[gate("tests", false, Some(1))],
+        );
+        assert_eq!(blockers, vec!["check tests regressed"]);
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM run_tasks WHERE id = 'task-checks'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "review");
+    }
+}

--- a/src-tauri/src/run/checks.rs
+++ b/src-tauri/src/run/checks.rs
@@ -55,7 +55,7 @@ pub(crate) fn check_result_from_setup(
         exit_code: Some(setup.exit_code),
         duration_ms: setup.duration_ms as i64,
         output_tail: setup.output_tail,
-        pre_existing_failure: setup.exit_code != 0,
+        pre_existing_failure: kind == "baseline" && setup.exit_code != 0,
         created_at: crate::services::database::now_ms(),
     }
 }

--- a/src-tauri/src/run/mod.rs
+++ b/src-tauri/src/run/mod.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Durable run-engine primitives for task state, persistence, and scheduling.
 // ABOUTME: Keeps the run writer isolated from the existing conversational orchestrator.
 
+pub mod checks;
 pub mod scheduler;
 pub mod status;
 pub mod store;

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -1117,7 +1117,11 @@ fn completion_gates(
     run_id: &str,
     task_id: &str,
 ) -> Result<Vec<CheckGate>, String> {
-    let checks = store::list_checks(conn, run_id).map_err(|error| error.to_string())?;
+    let checks = store::list_checks(conn, run_id)
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .filter(|check| check.approved)
+        .collect::<Vec<_>>();
     checks
         .into_iter()
         .map(|check| {
@@ -1685,4 +1689,138 @@ fn load_run(conn: &Connection, run_id: &str) -> Result<Run, String> {
     snapshot
         .map(|snapshot| snapshot.run)
         .ok_or_else(|| "run not found".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::types::{
+        Evidence, EvidenceKind, FindingConfidence, FindingStatus, RunCheck, RunStatus,
+    };
+    use crate::services::database::{configure_connection, setup_schema};
+
+    fn connection() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        setup_schema(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn unapproved_check_does_not_block_completion() {
+        let conn = connection();
+        store::create_run(
+            &conn,
+            &Run {
+                id: "run-unapproved".to_string(),
+                objective: "completion gating".to_string(),
+                root_path: None,
+                status: RunStatus::Running,
+                cancel_requested: false,
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+        store::add_task(
+            &conn,
+            &Task {
+                id: "task-unapproved".to_string(),
+                run_id: "run-unapproved".to_string(),
+                title: "Completion task".to_string(),
+                brief: "Verify completion gates".to_string(),
+                state: TaskState::Review,
+                blocked_reason: None,
+                created_at: 1,
+                updated_at: 1,
+            },
+            &[],
+        )
+        .unwrap();
+        store::insert_check(
+            &conn,
+            &RunCheck {
+                id: "check-approved".to_string(),
+                run_id: "run-unapproved".to_string(),
+                name: "approved check".to_string(),
+                command: "echo ok".to_string(),
+                approved: true,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        store::insert_check(
+            &conn,
+            &RunCheck {
+                id: "check-unapproved".to_string(),
+                run_id: "run-unapproved".to_string(),
+                name: "unapproved check".to_string(),
+                command: "exit 9".to_string(),
+                approved: false,
+                created_at: 2,
+            },
+        )
+        .unwrap();
+        store::insert_check_result(
+            &conn,
+            &CheckResult {
+                id: "baseline-approved".to_string(),
+                check_id: "check-approved".to_string(),
+                task_id: None,
+                attempt_id: None,
+                kind: "baseline".to_string(),
+                exit_code: Some(0),
+                duration_ms: 1,
+                output_tail: "ok".to_string(),
+                pre_existing_failure: false,
+                created_at: 3,
+            },
+        )
+        .unwrap();
+        store::insert_check_result(
+            &conn,
+            &CheckResult {
+                id: "verify-approved".to_string(),
+                check_id: "check-approved".to_string(),
+                task_id: Some("task-unapproved".to_string()),
+                attempt_id: None,
+                kind: "verify".to_string(),
+                exit_code: Some(0),
+                duration_ms: 1,
+                output_tail: "ok".to_string(),
+                pre_existing_failure: false,
+                created_at: 4,
+            },
+        )
+        .unwrap();
+        store::insert_finding(
+            &conn,
+            &Finding {
+                id: "finding-completion".to_string(),
+                run_id: "run-unapproved".to_string(),
+                task_id: Some("task-unapproved".to_string()),
+                attempt_id: None,
+                claim: "The task has evidence".to_string(),
+                confidence: FindingConfidence::Asserted,
+                evidence: vec![Evidence {
+                    kind: EvidenceKind::CommandResult,
+                    reference: "echo ok".to_string(),
+                    excerpt: Some("ok".to_string()),
+                }],
+                proposed_artifact: None,
+                needs_approval: false,
+                status: FindingStatus::Open,
+                created_at: 5,
+                updated_at: 5,
+            },
+        )
+        .unwrap();
+
+        let gates = completion_gates(&conn, "run-unapproved", "task-unapproved").unwrap();
+        assert_eq!(gates.len(), 1);
+        assert_eq!(gates[0].name, "approved check");
+        let has_evidence = store::task_has_evidence(&conn, "task-unapproved").unwrap();
+        assert!(checks::completion_blockers(has_evidence, &gates).is_empty());
+    }
 }

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -1,16 +1,17 @@
 // ABOUTME: Serial run-engine scheduler and its lazily started Tauri state.
 // ABOUTME: Owns the only scheduler write connection and emits durable run events in order.
 
+use super::checks::{self, CheckGate};
 use super::status::derive_run_status;
 use super::store::{self, AppendOutcome};
 use super::types::{
-    AgentAssignment, LeaseMode, NewLease, NewRunEvent, Run, RunEvent, RunEventType, RunStatus,
-    Task, TaskState, WorkspaceLease,
+    AgentAssignment, CheckDeclaration, CheckResult, CoverageGap, Finding, LeaseMode, NewLease,
+    NewRunEvent, Run, RunCheck, RunEvent, RunEventType, RunStatus, Task, TaskState, WorkspaceLease,
 };
 use super::workspace::{self, ProvisionRequest, ProvisionedWorkspace};
 use crate::embedded_runtime;
 use crate::services::database::{init_db, now_ms};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -60,6 +61,48 @@ enum SchedulerCommand {
         run_id: String,
         task_id: String,
         outcome: Result<ProvisionedWorkspace, String>,
+    },
+    DeclareChecks {
+        run_id: String,
+        checks: Vec<CheckDeclaration>,
+        reply: oneshot::Sender<Result<Vec<RunCheck>, String>>,
+    },
+    ApproveCheck {
+        check_id: String,
+        reply: oneshot::Sender<Result<RunCheck, String>>,
+    },
+    RunBaseline {
+        run_id: String,
+        reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    },
+    FinishBaseline {
+        run_id: String,
+        results: Vec<CheckResult>,
+        reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    },
+    VerifyTask {
+        run_id: String,
+        task_id: String,
+        reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    },
+    FinishVerify {
+        run_id: String,
+        task_id: String,
+        results: Vec<CheckResult>,
+        reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    },
+    CompleteTask {
+        run_id: String,
+        task_id: String,
+        reply: oneshot::Sender<Result<Vec<String>, String>>,
+    },
+    RecordFinding {
+        finding: Finding,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    RecordCoverageGap {
+        gap: CoverageGap,
+        reply: oneshot::Sender<Result<(), String>>,
     },
     ReleaseLease {
         lease_id: String,
@@ -229,6 +272,133 @@ impl RunEngineState {
             .map_err(|_| "run scheduler dropped event response".to_string())?
     }
 
+    pub async fn declare_checks(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        checks: Vec<CheckDeclaration>,
+    ) -> Result<Vec<RunCheck>, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::DeclareChecks {
+                run_id,
+                checks,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped declare-checks response".to_string())?
+    }
+
+    pub async fn approve_check(
+        &self,
+        app: &AppHandle,
+        check_id: String,
+    ) -> Result<RunCheck, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::ApproveCheck { check_id, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped approve-check response".to_string())?
+    }
+
+    pub async fn run_baseline(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+    ) -> Result<Vec<CheckResult>, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::RunBaseline { run_id, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped baseline response".to_string())?
+    }
+
+    pub async fn verify_task(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        task_id: String,
+    ) -> Result<Vec<CheckResult>, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::VerifyTask {
+                run_id,
+                task_id,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped verify response".to_string())?
+    }
+
+    pub async fn complete_task(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        task_id: String,
+    ) -> Result<Vec<String>, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::CompleteTask {
+                run_id,
+                task_id,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped completion response".to_string())?
+    }
+
+    pub async fn record_finding(
+        &self,
+        app: &AppHandle,
+        finding: Finding,
+    ) -> Result<(), String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::RecordFinding { finding, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped finding response".to_string())?
+    }
+
+    pub async fn record_coverage_gap(
+        &self,
+        app: &AppHandle,
+        gap: CoverageGap,
+    ) -> Result<(), String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::RecordCoverageGap { gap, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped coverage-gap response".to_string())?
+    }
+
     pub async fn provision_workspace(
         &self,
         app: &AppHandle,
@@ -367,6 +537,58 @@ fn process_command(
             if let Err(error) = finish_provision(app, conn, lease_id, run_id, task_id, outcome) {
                 log::error!("[run-engine] workspace provision completion failed: {error}");
             }
+        }
+        SchedulerCommand::DeclareChecks {
+            run_id,
+            checks,
+            reply,
+        } => {
+            let _ = reply.send(declare_checks(app, conn, run_id, checks));
+        }
+        SchedulerCommand::ApproveCheck { check_id, reply } => {
+            let _ = reply.send(approve_check(app, conn, check_id));
+        }
+        SchedulerCommand::RunBaseline { run_id, reply } => {
+            if let Err(error) = start_baseline(app, conn, sender, run_id, reply) {
+                log::error!("[run-engine] baseline dispatch failed: {error}");
+            }
+        }
+        SchedulerCommand::FinishBaseline {
+            run_id,
+            results,
+            reply,
+        } => {
+            let _ = reply.send(finish_baseline(app, conn, run_id, results));
+        }
+        SchedulerCommand::VerifyTask {
+            run_id,
+            task_id,
+            reply,
+        } => {
+            if let Err(error) = start_verify(app, conn, sender, run_id, task_id, reply) {
+                log::error!("[run-engine] verify dispatch failed: {error}");
+            }
+        }
+        SchedulerCommand::FinishVerify {
+            run_id,
+            task_id,
+            results,
+            reply,
+        } => {
+            let _ = reply.send(finish_verify(app, conn, run_id, task_id, results));
+        }
+        SchedulerCommand::CompleteTask {
+            run_id,
+            task_id,
+            reply,
+        } => {
+            let _ = reply.send(complete_task(app, conn, run_id, task_id));
+        }
+        SchedulerCommand::RecordFinding { finding, reply } => {
+            let _ = reply.send(record_finding(app, conn, finding));
+        }
+        SchedulerCommand::RecordCoverageGap { gap, reply } => {
+            let _ = reply.send(record_coverage_gap(app, conn, gap));
         }
         SchedulerCommand::ReleaseLease { lease_id, reply } => {
             let _ = reply.send(release_lease(app, conn, lease_id));
@@ -564,6 +786,486 @@ fn finish_provision(
         }
     }
     Ok(())
+}
+
+fn declare_checks(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    declarations: Vec<CheckDeclaration>,
+) -> Result<Vec<RunCheck>, String> {
+    if store::load_run_snapshot(conn, &run_id)
+        .map_err(|error| error.to_string())?
+        .is_none()
+    {
+        return Err("run not found".to_string());
+    }
+    let mut checks = Vec::with_capacity(declarations.len());
+    for declaration in declarations {
+        if declaration.name.trim().is_empty() {
+            return Err("check name must not be empty".to_string());
+        }
+        if declaration.command.trim().is_empty() {
+            return Err(format!("check {} command must not be empty", declaration.name));
+        }
+        let check = RunCheck {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.clone(),
+            name: declaration.name,
+            command: declaration.command,
+            approved: false,
+            created_at: now_ms(),
+        };
+        store::insert_check(conn, &check).map_err(|error| error.to_string())?;
+        append_and_emit(
+            app,
+            conn,
+            NewRunEvent {
+                id: Uuid::new_v4().to_string(),
+                run_id: run_id.clone(),
+                task_id: None,
+                attempt_id: None,
+                agent_id: None,
+                event_type: RunEventType::CheckDeclared,
+                payload: json!({
+                    "check_id": check.id,
+                    "name": check.name,
+                    "command": check.command,
+                    "approved": false,
+                }),
+                provider_event_id: None,
+                created_at: check.created_at,
+            },
+        )?;
+        checks.push(check);
+    }
+    Ok(checks)
+}
+
+fn approve_check(
+    app: &AppHandle,
+    conn: &Connection,
+    check_id: String,
+) -> Result<RunCheck, String> {
+    let check = store::approve_check(conn, &check_id).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: check.run_id.clone(),
+            task_id: None,
+            attempt_id: None,
+            agent_id: None,
+            event_type: RunEventType::CheckApproved,
+            payload: json!({"check_id": check.id, "name": check.name}),
+            provider_event_id: None,
+            created_at: now_ms(),
+        },
+    )?;
+    Ok(check)
+}
+
+fn approved_check_root(conn: &Connection, run_id: &str) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT root_path FROM runs WHERE id = ?1",
+        params![run_id],
+        |row| row.get(0),
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn check_env_path() -> Option<String> {
+    let embedded_path = embedded_runtime::get_embedded_path();
+    (!embedded_path.is_empty()).then(|| embedded_path.to_string())
+}
+
+fn run_check_commands(
+    root: &Path,
+    checks: &[RunCheck],
+    kind: &str,
+    task_id: Option<String>,
+) -> Vec<CheckResult> {
+    let env_path = check_env_path();
+    checks
+        .iter()
+        .map(|check| {
+            let setup = checks::execute_check(
+                root,
+                &check.command,
+                env_path.clone(),
+                Duration::from_secs(300),
+            );
+            checks::check_result_from_setup(check.id.clone(), task_id.clone(), kind, setup)
+        })
+        .collect()
+}
+
+fn start_baseline(
+    app: &AppHandle,
+    conn: &Connection,
+    sender: &mpsc::Sender<SchedulerCommand>,
+    run_id: String,
+    reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+) -> Result<(), String> {
+    let checks = store::list_checks(conn, &run_id).map_err(|error| error.to_string())?;
+    let root_path = approved_check_root(conn, &run_id)?;
+    let approved: Vec<RunCheck> = checks.iter().filter(|check| check.approved).cloned().collect();
+    for check in checks.iter().filter(|check| !check.approved) {
+        let gap = CoverageGap {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.clone(),
+            task_id: None,
+            kind: "check_unapproved".to_string(),
+            subject: check.name.clone(),
+            detail: Some("check was declared but not approved for baseline execution".to_string()),
+            created_at: now_ms(),
+        };
+        record_coverage_gap(app, conn, gap)?;
+    }
+    if approved.is_empty() || root_path.is_none() {
+        if root_path.is_none() {
+            for check in &approved {
+                record_coverage_gap(
+                    app,
+                    conn,
+                    CoverageGap {
+                        id: Uuid::new_v4().to_string(),
+                        run_id: run_id.clone(),
+                        task_id: None,
+                        kind: "not_provisioned".to_string(),
+                        subject: check.name.clone(),
+                        detail: Some("run has no root path for check execution".to_string()),
+                        created_at: now_ms(),
+                    },
+                )?;
+            }
+        }
+        let result = finish_baseline(app, conn, run_id, Vec::new());
+        let _ = reply.send(result);
+        return Ok(());
+    }
+
+    let root_path = PathBuf::from(root_path.expect("checked above"));
+    let finish_sender = sender.clone();
+    tauri::async_runtime::spawn(async move {
+        let worker = tauri::async_runtime::spawn_blocking(move || {
+            run_check_commands(&root_path, &approved, "baseline", None)
+        })
+        .await
+        .map_err(|error| format!("baseline worker join failed: {error}"));
+        match worker {
+            Ok(results) => {
+                let _ = finish_sender
+                    .send(SchedulerCommand::FinishBaseline {
+                        run_id,
+                        results,
+                        reply,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                let _ = reply.send(Err(error));
+            }
+        }
+    });
+    Ok(())
+}
+
+fn finish_baseline(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    results: Vec<CheckResult>,
+) -> Result<Vec<CheckResult>, String> {
+    for result in &results {
+        store::insert_check_result(conn, result).map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, check_result_event(&run_id, result, "baseline"))?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)?;
+    Ok(results)
+}
+
+fn task_root_path(conn: &Connection, run_id: &str, task_id: &str) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT COALESCE(
+            (SELECT root_path FROM run_workspace_leases
+             WHERE run_id = ?1 AND task_id = ?2 AND state = 'active'
+             ORDER BY created_at DESC LIMIT 1),
+            (SELECT root_path FROM runs WHERE id = ?1)
+         )",
+        params![run_id, task_id],
+        |row| row.get(0),
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn start_verify(
+    app: &AppHandle,
+    conn: &Connection,
+    sender: &mpsc::Sender<SchedulerCommand>,
+    run_id: String,
+    task_id: String,
+    reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+) -> Result<(), String> {
+    let state: String = conn
+        .query_row(
+            "SELECT state FROM run_tasks WHERE id = ?1 AND run_id = ?2",
+            params![task_id, run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    let task_state = TaskState::parse(&state).ok_or_else(|| format!("invalid task state: {state}"))?;
+    if task_state == TaskState::Running {
+        store::transition_task(conn, &task_id, TaskState::Verifying, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Verifying))?;
+    } else if task_state != TaskState::Verifying {
+        return Err(format!("task must be running or verifying; current state is {state}"));
+    }
+
+    let checks = store::list_checks(conn, &run_id).map_err(|error| error.to_string())?;
+    let approved: Vec<RunCheck> = checks.into_iter().filter(|check| check.approved).collect();
+    let root_path = task_root_path(conn, &run_id, &task_id)?;
+    if approved.is_empty() || root_path.is_none() {
+        if root_path.is_none() {
+            for check in &approved {
+                record_coverage_gap(
+                    app,
+                    conn,
+                    CoverageGap {
+                        id: Uuid::new_v4().to_string(),
+                        run_id: run_id.clone(),
+                        task_id: Some(task_id.clone()),
+                        kind: "not_provisioned".to_string(),
+                        subject: check.name.clone(),
+                        detail: Some("task has no active workspace or run root".to_string()),
+                        created_at: now_ms(),
+                    },
+                )?;
+            }
+        }
+        let result = finish_verify(app, conn, run_id, task_id, Vec::new());
+        let _ = reply.send(result);
+        return Ok(());
+    }
+
+    let root_path = PathBuf::from(root_path.expect("checked above"));
+    let finish_sender = sender.clone();
+    let finish_run_id = run_id.clone();
+    let finish_task_id = task_id.clone();
+    let worker_task_id = finish_task_id.clone();
+    tauri::async_runtime::spawn(async move {
+        let worker = tauri::async_runtime::spawn_blocking(move || {
+            run_check_commands(
+                &root_path,
+                &approved,
+                "verify",
+                Some(worker_task_id),
+            )
+        })
+        .await
+        .map_err(|error| format!("verify worker join failed: {error}"));
+        match worker {
+            Ok(results) => {
+                let _ = finish_sender
+                    .send(SchedulerCommand::FinishVerify {
+                        run_id: finish_run_id,
+                        task_id: finish_task_id,
+                        results,
+                        reply,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                let _ = reply.send(Err(error));
+            }
+        }
+    });
+    Ok(())
+}
+
+fn finish_verify(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    task_id: String,
+    results: Vec<CheckResult>,
+) -> Result<Vec<CheckResult>, String> {
+    for result in &results {
+        store::insert_check_result(conn, result).map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, check_result_event(&run_id, result, "verify"))?;
+    }
+    let current_state: String = conn
+        .query_row(
+            "SELECT state FROM run_tasks WHERE id = ?1",
+            params![task_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if TaskState::parse(&current_state) == Some(TaskState::Verifying) {
+        store::transition_task(conn, &task_id, TaskState::Review, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Review))?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)?;
+    Ok(results)
+}
+
+fn completion_gates(
+    conn: &Connection,
+    run_id: &str,
+    task_id: &str,
+) -> Result<Vec<CheckGate>, String> {
+    let checks = store::list_checks(conn, run_id).map_err(|error| error.to_string())?;
+    checks
+        .into_iter()
+        .map(|check| {
+            let baseline_failed: bool = conn
+                .query_row(
+                    "SELECT pre_existing_failure FROM run_check_results
+                     WHERE check_id = ?1 AND kind = 'baseline'
+                     ORDER BY created_at DESC, id DESC LIMIT 1",
+                    params![check.id],
+                    |row| Ok(row.get::<_, i64>(0)? != 0),
+                )
+                .optional()
+                .map_err(|error| error.to_string())?
+                .unwrap_or(false);
+            let verify_exit: Option<i32> = conn
+                .query_row(
+                    "SELECT exit_code FROM run_check_results
+                     WHERE check_id = ?1 AND task_id = ?2 AND kind = 'verify'
+                     ORDER BY created_at DESC, id DESC LIMIT 1",
+                    params![check.id, task_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|error| error.to_string())?
+                .flatten();
+            Ok(CheckGate {
+                name: check.name,
+                baseline_failed,
+                verify_exit,
+            })
+        })
+        .collect()
+}
+
+fn complete_task(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    task_id: String,
+) -> Result<Vec<String>, String> {
+    let state: String = conn
+        .query_row(
+            "SELECT state FROM run_tasks WHERE id = ?1 AND run_id = ?2",
+            params![task_id, run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if TaskState::parse(&state) != Some(TaskState::Review) {
+        return Err(format!("task must be in review; current state is {state}"));
+    }
+    let has_evidence = store::task_has_evidence(conn, &task_id).map_err(|error| error.to_string())?;
+    let blockers = checks::completion_blockers(
+        has_evidence,
+        &completion_gates(conn, &run_id, &task_id)?,
+    );
+    if !blockers.is_empty() {
+        append_and_emit(
+            app,
+            conn,
+            event_for_task_or_run(
+                &run_id,
+                Some(&task_id),
+                RunEventType::TaskCompletionRejected,
+                json!({"blockers": blockers.clone()}),
+            ),
+        )?;
+        return Ok(blockers);
+    }
+    store::transition_task(conn, &task_id, TaskState::Done, None)
+        .map_err(|error| error.to_string())?;
+    append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Done))?;
+    recompute_ready_and_status(app, conn, &run_id)?;
+    Ok(Vec::new())
+}
+
+fn record_finding(app: &AppHandle, conn: &Connection, finding: Finding) -> Result<(), String> {
+    store::insert_finding(conn, &finding).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        event_for_task_or_run(
+            &finding.run_id,
+            finding.task_id.as_deref(),
+            RunEventType::FindingRecorded,
+            json!({"finding_id": finding.id, "claim": finding.claim}),
+        ),
+    )?;
+    Ok(())
+}
+
+fn record_coverage_gap(
+    app: &AppHandle,
+    conn: &Connection,
+    gap: CoverageGap,
+) -> Result<(), String> {
+    store::insert_coverage_gap(conn, &gap).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        event_for_task_or_run(
+            &gap.run_id,
+            gap.task_id.as_deref(),
+            RunEventType::CoverageGapRecorded,
+            json!({
+                "gap_id": gap.id,
+                "kind": gap.kind,
+                "subject": gap.subject,
+                "detail": gap.detail,
+            }),
+        ),
+    )?;
+    Ok(())
+}
+
+fn event_for_task_or_run(
+    run_id: &str,
+    task_id: Option<&str>,
+    event_type: RunEventType,
+    payload: serde_json::Value,
+) -> NewRunEvent {
+    NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        task_id: task_id.map(str::to_string),
+        attempt_id: None,
+        agent_id: None,
+        event_type,
+        payload,
+        provider_event_id: None,
+        created_at: now_ms(),
+    }
+}
+
+fn check_result_event(run_id: &str, result: &CheckResult, kind: &str) -> NewRunEvent {
+    event_for_task_or_run(
+        run_id,
+        result.task_id.as_deref(),
+        RunEventType::CheckResultRecorded,
+        json!({
+            "check_result_id": result.id,
+            "check_id": result.check_id,
+            "kind": kind,
+            "exit_code": result.exit_code,
+            "duration_ms": result.duration_ms,
+            "pre_existing_failure": result.pre_existing_failure,
+            "output_tail": result.output_tail,
+        }),
+    )
 }
 
 fn release_lease(

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -3,9 +3,10 @@
 
 use super::status::is_legal_transition;
 use super::types::{
-    AgentAssignment, Attempt, Evidence, Finding, FindingConfidence, FindingStatus, LeaseMode,
-    LeaseState, NewLease, NewRunEvent, ProposedArtifact, Run, RunEvent, RunEventType, RunSnapshot,
-    RunStatus, Task, TaskDependency, TaskState, WorkspaceLease,
+    AgentAssignment, Attempt, CheckResult, CoverageGap, Evidence, Finding, FindingConfidence,
+    FindingStatus, LeaseMode, LeaseState, NewLease, NewRunEvent, ProposedArtifact, Run, RunCheck,
+    RunEvent, RunEventType, RunSnapshot, RunStatus, Task, TaskDependency, TaskState,
+    WorkspaceLease,
 };
 use crate::services::database::now_ms;
 use rusqlite::{Connection, OptionalExtension, Result, params};
@@ -294,6 +295,177 @@ pub fn insert_finding(conn: &Connection, finding: &Finding) -> Result<()> {
     Ok(())
 }
 
+pub fn insert_check(conn: &Connection, check: &RunCheck) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_checks (id, run_id, name, command, approved, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            check.id,
+            check.run_id,
+            check.name,
+            check.command,
+            i64::from(check.approved),
+            check.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn check_from_row(row: &rusqlite::Row<'_>) -> Result<RunCheck> {
+    Ok(RunCheck {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        name: row.get(2)?,
+        command: row.get(3)?,
+        approved: row.get::<_, i64>(4)? != 0,
+        created_at: row.get(5)?,
+    })
+}
+
+pub fn get_check(conn: &Connection, check_id: &str) -> Result<Option<RunCheck>> {
+    conn.query_row(
+        "SELECT id, run_id, name, command, approved, created_at
+         FROM run_checks WHERE id = ?1",
+        params![check_id],
+        check_from_row,
+    )
+    .optional()
+}
+
+pub fn approve_check(conn: &Connection, check_id: &str) -> Result<RunCheck> {
+    let updated = conn.execute(
+        "UPDATE run_checks SET approved = 1 WHERE id = ?1",
+        params![check_id],
+    )?;
+    if updated == 0 {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
+    get_check(conn, check_id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+pub fn list_checks(conn: &Connection, run_id: &str) -> Result<Vec<RunCheck>> {
+    let mut statement = conn.prepare(
+        "SELECT id, run_id, name, command, approved, created_at
+         FROM run_checks WHERE run_id = ?1 ORDER BY created_at ASC, id ASC",
+    )?;
+    statement
+        .query_map(params![run_id], check_from_row)?
+        .collect()
+}
+
+pub fn insert_check_result(conn: &Connection, result: &CheckResult) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_check_results
+            (id, check_id, task_id, attempt_id, kind, exit_code, duration_ms,
+             output_tail, pre_existing_failure, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            result.id,
+            result.check_id,
+            result.task_id,
+            result.attempt_id,
+            result.kind,
+            result.exit_code,
+            result.duration_ms,
+            result.output_tail,
+            i64::from(result.pre_existing_failure),
+            result.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn check_result_from_row(row: &rusqlite::Row<'_>) -> Result<CheckResult> {
+    Ok(CheckResult {
+        id: row.get(0)?,
+        check_id: row.get(1)?,
+        task_id: row.get(2)?,
+        attempt_id: row.get(3)?,
+        kind: row.get(4)?,
+        exit_code: row.get(5)?,
+        duration_ms: row.get(6)?,
+        output_tail: row.get(7)?,
+        pre_existing_failure: row.get::<_, i64>(8)? != 0,
+        created_at: row.get(9)?,
+    })
+}
+
+pub fn list_check_results(conn: &Connection, run_id: &str) -> Result<Vec<CheckResult>> {
+    let mut statement = conn.prepare(
+        "SELECT r.id, r.check_id, r.task_id, r.attempt_id, r.kind, r.exit_code,
+                r.duration_ms, r.output_tail, r.pre_existing_failure, r.created_at
+         FROM run_check_results r
+         JOIN run_checks c ON c.id = r.check_id
+         WHERE c.run_id = ?1
+         ORDER BY r.created_at ASC, r.id ASC",
+    )?;
+    statement
+        .query_map(params![run_id], check_result_from_row)?
+        .collect()
+}
+
+pub fn insert_coverage_gap(conn: &Connection, gap: &CoverageGap) -> Result<()> {
+    conn.execute(
+        "INSERT INTO run_coverage_gaps
+            (id, run_id, task_id, kind, subject, detail, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            gap.id,
+            gap.run_id,
+            gap.task_id,
+            gap.kind,
+            gap.subject,
+            gap.detail,
+            gap.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn coverage_gap_from_row(row: &rusqlite::Row<'_>) -> Result<CoverageGap> {
+    Ok(CoverageGap {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        task_id: row.get(2)?,
+        kind: row.get(3)?,
+        subject: row.get(4)?,
+        detail: row.get(5)?,
+        created_at: row.get(6)?,
+    })
+}
+
+pub fn list_coverage_gaps(conn: &Connection, run_id: &str) -> Result<Vec<CoverageGap>> {
+    let mut statement = conn.prepare(
+        "SELECT id, run_id, task_id, kind, subject, detail, created_at
+         FROM run_coverage_gaps WHERE run_id = ?1 ORDER BY created_at ASC, id ASC",
+    )?;
+    statement
+        .query_map(params![run_id], coverage_gap_from_row)?
+        .collect()
+}
+
+pub fn task_has_evidence(conn: &Connection, task_id: &str) -> Result<bool> {
+    let mut statement = conn.prepare(
+        "SELECT evidence_json FROM run_findings WHERE task_id = ?1
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    let mut rows = statement.query(params![task_id])?;
+    while let Some(row) = rows.next()? {
+        let evidence_json: String = row.get(0)?;
+        let evidence: Vec<Evidence> = serde_json::from_str(&evidence_json).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        if !evidence.is_empty() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub fn transition_task(
     conn: &Connection,
     task_id: &str,
@@ -491,6 +663,10 @@ pub fn load_run_snapshot(conn: &Connection, run_id: &str) -> Result<Option<RunSn
         })?
         .collect::<Result<Vec<_>>>()?;
 
+    let checks = list_checks(conn, run_id)?;
+    let check_results = list_check_results(conn, run_id)?;
+    let coverage_gaps = list_coverage_gaps(conn, run_id)?;
+
     Ok(Some(RunSnapshot {
         run,
         tasks,
@@ -498,6 +674,9 @@ pub fn load_run_snapshot(conn: &Connection, run_id: &str) -> Result<Option<RunSn
         assignments,
         attempts,
         findings,
+        checks,
+        check_results,
+        coverage_gaps,
     }))
 }
 
@@ -713,6 +892,47 @@ mod tests {
             },
         )
         .unwrap();
+        insert_check(
+            &conn,
+            &RunCheck {
+                id: "check-1".to_string(),
+                run_id: "run-1".to_string(),
+                name: "cargo test".to_string(),
+                command: "cargo test".to_string(),
+                approved: true,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        insert_check_result(
+            &conn,
+            &CheckResult {
+                id: "check-result-1".to_string(),
+                check_id: "check-1".to_string(),
+                task_id: Some("task-a".to_string()),
+                attempt_id: Some("attempt-1".to_string()),
+                kind: "baseline".to_string(),
+                exit_code: Some(0),
+                duration_ms: 1,
+                output_tail: "ok".to_string(),
+                pre_existing_failure: false,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+        insert_coverage_gap(
+            &conn,
+            &CoverageGap {
+                id: "gap-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: Some("task-a".to_string()),
+                kind: "skipped".to_string(),
+                subject: "lint".to_string(),
+                detail: Some("test gap".to_string()),
+                created_at: 1,
+            },
+        )
+        .unwrap();
         append_event(&conn, &event("event-1", "run-1", None)).unwrap();
 
         conn.execute("DELETE FROM runs WHERE id = 'run-1'", [])
@@ -725,6 +945,9 @@ mod tests {
             "run_workspace_leases",
             "run_findings",
             "run_events",
+            "run_checks",
+            "run_check_results",
+            "run_coverage_gaps",
         ] {
             let count: i64 = conn
                 .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get(0))

--- a/src-tauri/src/run/types.rs
+++ b/src-tauri/src/run/types.rs
@@ -304,6 +304,11 @@ pub enum RunEventType {
     RunCancelRequested,
     RunFinalized,
     LeaseStateChanged,
+    CheckDeclared,
+    CheckApproved,
+    CheckResultRecorded,
+    CoverageGapRecorded,
+    TaskCompletionRejected,
 }
 
 impl RunEventType {
@@ -322,6 +327,11 @@ impl RunEventType {
             Self::RunCancelRequested => "run_cancel_requested",
             Self::RunFinalized => "run_finalized",
             Self::LeaseStateChanged => "lease_state_changed",
+            Self::CheckDeclared => "check_declared",
+            Self::CheckApproved => "check_approved",
+            Self::CheckResultRecorded => "check_result_recorded",
+            Self::CoverageGapRecorded => "coverage_gap_recorded",
+            Self::TaskCompletionRejected => "task_completion_rejected",
         }
     }
 
@@ -340,6 +350,11 @@ impl RunEventType {
             "run_cancel_requested" => Self::RunCancelRequested,
             "run_finalized" => Self::RunFinalized,
             "lease_state_changed" => Self::LeaseStateChanged,
+            "check_declared" => Self::CheckDeclared,
+            "check_approved" => Self::CheckApproved,
+            "check_result_recorded" => Self::CheckResultRecorded,
+            "coverage_gap_recorded" => Self::CoverageGapRecorded,
+            "task_completion_rejected" => Self::TaskCompletionRejected,
             _ => return None,
         })
     }
@@ -448,6 +463,47 @@ pub struct Finding {
     pub updated_at: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckDeclaration {
+    pub name: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunCheck {
+    pub id: String,
+    pub run_id: String,
+    pub name: String,
+    pub command: String,
+    pub approved: bool,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckResult {
+    pub id: String,
+    pub check_id: String,
+    pub task_id: Option<String>,
+    pub attempt_id: Option<String>,
+    pub kind: String,
+    pub exit_code: Option<i32>,
+    pub duration_ms: i64,
+    pub output_tail: String,
+    pub pre_existing_failure: bool,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageGap {
+    pub id: String,
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub kind: String,
+    pub subject: String,
+    pub detail: Option<String>,
+    pub created_at: i64,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NewRunEvent {
     pub id: String,
@@ -483,4 +539,7 @@ pub struct RunSnapshot {
     pub assignments: Vec<AgentAssignment>,
     pub attempts: Vec<Attempt>,
     pub findings: Vec<Finding>,
+    pub checks: Vec<RunCheck>,
+    pub check_results: Vec<CheckResult>,
+    pub coverage_gaps: Vec<CoverageGap>,
 }

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1359,6 +1359,49 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
          ON run_events(run_id, sequence)",
         [],
     )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_checks (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            command TEXT NOT NULL,
+            approved INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_check_results (
+            id TEXT PRIMARY KEY,
+            check_id TEXT NOT NULL,
+            task_id TEXT,
+            attempt_id TEXT,
+            kind TEXT NOT NULL,
+            exit_code INTEGER,
+            duration_ms INTEGER NOT NULL,
+            output_tail TEXT NOT NULL DEFAULT '',
+            pre_existing_failure INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (check_id) REFERENCES run_checks(id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS run_coverage_gaps (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            task_id TEXT,
+            kind TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            detail TEXT,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES run_tasks(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
 
     // Runtime sessions table for computer-use sessions
     conn.execute(


### PR DESCRIPTION
## Summary

- Added durable check declaration and approval flow, baseline execution, and task verification with real command exit codes, durations, and output tails.
- Completion requires a finding with evidence. Baseline failures are recorded as pre-existing and do not block completion or get attributed to task verification.
- Coverage gaps are persisted, emitted as run events, and returned in run snapshots.
- Review correction: unapproved checks are coverage bounds, not completion gates; verify results never carry the baseline-only failure flag.

## Verification

- cargo test --manifest-path src-tauri/Cargo.toml --lib run:: — exit 0 (32 passed)
- cargo test --manifest-path src-tauri/Cargo.toml — exit 0
- pnpm check — exit 0
- pnpm test — exit 0 (2849 passed, 15 skipped)

Part of #3511
