### PR TITLE
fix(auth): reconcile Desktop API key scopes

### DIFF
--- a/src/components/settings/ApiAccessSettings.tsx
+++ b/src/components/settings/ApiAccessSettings.tsx
@@ -1,0 +1,318 @@
+// ABOUTME: Settings UI for the persistent Seren Desktop automation credential.
+// ABOUTME: Shows non-secret key metadata, scope drift, and a one-click repair path.
+
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Show,
+} from "solid-js";
+import {
+  DESKTOP_API_KEY_NAME,
+  type DesktopApiKeyStatus,
+  getDesktopApiKeyStatus,
+  repairDesktopApiKey,
+} from "@/services/desktop-api-access";
+import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
+import { authStore } from "@/stores/auth.store";
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function stateLabel(status: DesktopApiKeyStatus): string {
+  switch (status.state) {
+    case "current":
+      return "Up to date";
+    case "outdated":
+      return "Scopes missing";
+    case "revoked":
+      return "Revoked";
+    case "expired":
+      return "Expired";
+    case "unrecognized":
+      return "Not recognized";
+    case "missing":
+      return "Not provisioned";
+  }
+}
+
+function safeErrorMessage(error: unknown): string {
+  const status = (error as { status?: unknown })?.status;
+  if (status === 401 || status === 403) {
+    return "Sign in again to inspect or repair API access.";
+  }
+  return "API access could not be inspected. Check your connection and try again.";
+}
+
+export const ApiAccessSettings: Component = () => {
+  const [status, setStatus] = createSignal<DesktopApiKeyStatus | null>(null);
+  const [loading, setLoading] = createSignal(false);
+  const [repairing, setRepairing] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [notice, setNotice] = createSignal<string | null>(null);
+  let requestId = 0;
+
+  const refresh = async () => {
+    const currentRequest = ++requestId;
+    if (!authStore.isAuthenticated) {
+      setStatus(null);
+      setError("Sign in to inspect the Desktop automation key.");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getDesktopApiKeyStatus();
+      if (currentRequest === requestId) setStatus(next);
+    } catch (refreshError) {
+      if (currentRequest === requestId) {
+        setStatus(null);
+        setError(safeErrorMessage(refreshError));
+      }
+    } finally {
+      if (currentRequest === requestId) setLoading(false);
+    }
+  };
+
+  createEffect(() => {
+    void authStore.isAuthenticated;
+    void refresh();
+  });
+
+  const handleRepair = async () => {
+    setRepairing(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const repaired = await repairDesktopApiKey(status() ?? undefined);
+      setStatus(repaired.status);
+
+      try {
+        // The gateway caches its authenticated HTTP connection and tool list.
+        // Reconnect now so the replacement credential is used immediately.
+        await resetGateway();
+        await initializeGateway();
+        setNotice(
+          repaired.warning ??
+            "API access repaired. Seren MCP reconnected with the replacement key.",
+        );
+      } catch {
+        setNotice(
+          "The key is repaired, but Seren MCP could not reconnect. Restart Seren Desktop before using automation.",
+        );
+      }
+    } catch (repairError) {
+      setError(safeErrorMessage(repairError));
+    } finally {
+      setRepairing(false);
+    }
+  };
+
+  const badgeClass = createMemo(() =>
+    status()?.state === "current"
+      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+      : "border-amber-500/40 bg-amber-500/10 text-amber-200",
+  );
+
+  return (
+    <section class="max-w-3xl" data-testid="api-access-settings">
+      <div class="mb-6">
+        <p class="m-0 mb-2 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-accent">
+          Automation credential
+        </p>
+        <h3 class="m-0 mb-2 text-[1.3rem] font-semibold">API Access</h3>
+        <p class="m-0 max-w-2xl text-muted-foreground leading-relaxed">
+          Inspect the key Seren Desktop uses for MCP publishers and managed
+          automation. Its secret stays in your operating system credential store
+          and is never shown here.
+        </p>
+      </div>
+
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="rounded-lg border border-border-strong bg-surface-2/60 px-5 py-8 text-sm text-muted-foreground">
+            Inspecting Desktop API access…
+          </div>
+        }
+      >
+        <Show when={error()}>
+          {(message) => (
+            <div
+              class="mb-4 flex items-center justify-between gap-4 rounded-lg border border-amber-500/35 bg-amber-500/10 px-4 py-3"
+              role="alert"
+            >
+              <span class="text-sm text-amber-100">{message()}</span>
+              <button
+                type="button"
+                class="shrink-0 rounded-md border border-amber-400/40 bg-transparent px-3 py-1.5 text-xs font-semibold text-amber-100 transition-colors hover:bg-amber-400/10 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!authStore.isAuthenticated || loading()}
+                onClick={() => void refresh()}
+              >
+                Try again
+              </button>
+            </div>
+          )}
+        </Show>
+
+        <Show when={status()}>
+          {(current) => (
+            <>
+              <Show when={current().needsRepair}>
+                <div
+                  class="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3"
+                  data-testid="api-access-mismatch-banner"
+                  role="alert"
+                >
+                  <p class="m-0 text-sm font-semibold text-amber-100">
+                    Desktop automation access needs repair
+                  </p>
+                  <p class="m-0 mt-1 text-xs leading-relaxed text-amber-100/75">
+                    This key has an older or different scope set. Re-provision
+                    it before relying on MCP automation.
+                  </p>
+                </div>
+              </Show>
+
+              <div class="overflow-hidden rounded-xl border border-border-strong bg-surface-2/70 shadow-sm">
+                <div class="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+                  <div>
+                    <p class="m-0 text-sm font-semibold text-foreground">
+                      {current().key?.name ?? DESKTOP_API_KEY_NAME}
+                    </p>
+                    <p class="m-0 mt-1 font-mono text-xs text-muted-foreground break-all">
+                      {current().maskedValue ?? "No stored key"}
+                    </p>
+                  </div>
+                  <span
+                    class={`shrink-0 rounded-full border px-2.5 py-1 text-[0.7rem] font-semibold uppercase tracking-wide ${badgeClass()}`}
+                  >
+                    {stateLabel(current())}
+                  </span>
+                </div>
+
+                <dl class="m-0 grid grid-cols-2 border-b border-border max-sm:grid-cols-1">
+                  <div class="border-r border-border px-5 py-3.5 max-sm:border-b max-sm:border-r-0">
+                    <dt class="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Created
+                    </dt>
+                    <dd class="m-0 mt-1 text-sm text-foreground">
+                      {formatTimestamp(current().key?.created_at)}
+                    </dd>
+                  </div>
+                  <div class="px-5 py-3.5">
+                    <dt class="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Last used
+                    </dt>
+                    <dd class="m-0 mt-1 text-sm text-foreground">
+                      {formatTimestamp(current().key?.last_used_at)}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div class="grid grid-cols-2 gap-0 max-sm:grid-cols-1">
+                  <div class="border-r border-border px-5 py-4 max-sm:border-b max-sm:border-r-0">
+                    <p class="m-0 mb-2 text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Current scopes
+                    </p>
+                    <div class="flex flex-wrap gap-2">
+                      <Show
+                        when={current().currentScopes.length > 0}
+                        fallback={
+                          <span class="text-xs text-amber-200">
+                            None reported
+                          </span>
+                        }
+                      >
+                        <For each={current().currentScopes}>
+                          {(scope) => (
+                            <code
+                              class={`rounded border px-2 py-1 text-[0.72rem] ${
+                                current().unexpectedScopes.includes(scope)
+                                  ? "border-amber-500/45 bg-amber-500/10 text-amber-100"
+                                  : "border-border-strong bg-surface-3/80 text-foreground"
+                              }`}
+                            >
+                              {scope}
+                            </code>
+                          )}
+                        </For>
+                      </Show>
+                    </div>
+                  </div>
+                  <div class="px-5 py-4">
+                    <p class="m-0 mb-2 text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Required by this build
+                    </p>
+                    <div class="flex flex-wrap gap-2">
+                      <For each={current().requiredScopes}>
+                        {(scope) => (
+                          <code
+                            class={`rounded border px-2 py-1 text-[0.72rem] ${
+                              current().missingScopes.includes(scope)
+                                ? "border-amber-500/45 bg-amber-500/10 text-amber-100"
+                                : "border-emerald-500/35 bg-emerald-500/10 text-emerald-200"
+                            }`}
+                          >
+                            {scope}
+                          </code>
+                        )}
+                      </For>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-4 flex items-center justify-between gap-4 rounded-lg border border-border bg-surface-2/35 px-4 py-3 max-sm:items-stretch max-sm:flex-col">
+                <div>
+                  <p class="m-0 text-sm font-medium text-foreground">
+                    {current().needsRepair
+                      ? "Replace the unusable key"
+                      : "Re-provision this key"}
+                  </p>
+                  <p class="m-0 mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    Creates a least-privilege replacement, stores it securely,
+                    and revokes the previous key.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="shrink-0 rounded-md border border-accent bg-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-accent/85 disabled:cursor-wait disabled:opacity-60"
+                  data-testid="repair-api-access"
+                  disabled={repairing()}
+                  onClick={() => void handleRepair()}
+                >
+                  {repairing() ? "Repairing…" : "Repair / re-provision"}
+                </button>
+              </div>
+            </>
+          )}
+        </Show>
+
+        <Show when={notice()}>
+          {(message) => (
+            <p
+              class="mt-4 rounded-lg border border-emerald-500/35 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100"
+              aria-live="polite"
+            >
+              {message()}
+            </p>
+          )}
+        </Show>
+      </Show>
+    </section>
+  );
+};
+
+export default ApiAccessSettings;

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/stores/settings.store";
 import { claimDaily, walletState } from "@/stores/wallet.store";
 import { SendTransferModal } from "../wallet/SendTransferModal";
+import { ApiAccessSettings } from "./ApiAccessSettings";
 import { ConnectorSettings } from "./ConnectorSettings";
 import { HappyRemoteSettings } from "./HappyRemoteSettings";
 import { KeybindingsSettings } from "./KeybindingsSettings";
@@ -81,6 +82,7 @@ type SettingsSection =
   | "agent"
   | "providers"
   | "logins"
+  | "api-access"
   | "sync"
   | "keys"
   | "toolsets"
@@ -459,6 +461,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     { id: "agent", label: "Agent", icon: "🛡️" },
     { id: "providers", label: "AI Providers", icon: "🤖" },
     { id: "logins", label: "Logins", icon: "🔐" },
+    { id: "api-access", label: "API Access", icon: "🪪" },
     { id: "sync", label: "Cloud Sync", icon: "☁️" },
     { id: "keys", label: "Passwords", icon: "🔑" },
     { id: "toolsets", label: "Toolsets", icon: "📦" },
@@ -782,6 +785,10 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
 
         <Show when={activeSection() === "logins"}>
           <OAuthLogins onSignInClick={props.onSignInClick} />
+        </Show>
+
+        <Show when={activeSection() === "api-access"}>
+          <ApiAccessSettings />
         </Show>
 
         <Show when={activeSection() === "keys"}>

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,2 +1,3 @@
+export { ApiAccessSettings } from "./ApiAccessSettings";
 export { KeysSettings } from "./KeysSettings";
 export { SettingsPanel } from "./SettingsPanel";

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,8 +2,6 @@
 // ABOUTME: Wraps the generated seren-core SDK with token storage and rate-limit policy.
 
 import {
-  type ApiKeyType,
-  createDefaultOrgApiKey,
   getCurrentUser,
   type LoginResult,
   login as loginSdk,
@@ -22,6 +20,12 @@ import {
 } from "@/lib/tauri-bridge";
 import { suspendAllCredentialLeases } from "@/services/credential-lease";
 import { clearAuthState, requestSignInModal } from "@/stores/auth.store";
+
+export type { CreateApiKeyOptions } from "@/services/desktop-api-access";
+export {
+  ApiKeyProvisioningError,
+  createApiKey,
+} from "@/services/desktop-api-access";
 
 export type { LoginResult };
 
@@ -286,77 +290,3 @@ export async function isLoggedIn(): Promise<boolean> {
  * Returns null if not logged in.
  */
 export { getToken };
-
-const DESKTOP_API_KEY_NAME = "Seren Desktop";
-const DESKTOP_API_KEY_SCOPES = [
-  "publisher:*",
-  "managed-deployment:update",
-] as const;
-
-export interface CreateApiKeyOptions {
-  name?: string;
-  keyType?: ApiKeyType;
-  agentIdentityId?: string;
-  scopes?: readonly string[];
-}
-
-/**
- * Thrown when provisioning the SerenDB desktop API key fails. Carries the HTTP
- * `status` so the auth store can distinguish a non-transient auth/permission
- * failure (401/403 → re-sign-in) from a retryable one (5xx/network → keep the
- * session, chat still works on the JWT). See #2497.
- */
-export class ApiKeyProvisioningError extends Error {
-  readonly status?: number;
-  constructor(message: string, status?: number) {
-    super(message);
-    this.name = "ApiKeyProvisioningError";
-    this.status = status;
-  }
-}
-
-/**
- * Create a new API key for MCP authentication.
- * Uses POST /organizations/default/api-keys, which resolves "default" to
- * the user's first organization.
- * @returns API key (seren_xxx_yyy format)
- * @throws ApiKeyProvisioningError if not authenticated or the request fails
- */
-export async function createApiKey(
-  options: CreateApiKeyOptions = {},
-): Promise<string> {
-  const { data, error, response } = await createDefaultOrgApiKey({
-    body: {
-      name: options.name ?? DESKTOP_API_KEY_NAME,
-      key_type: options.keyType,
-      agent_identity_id: options.agentIdentityId,
-      scopes: options.scopes
-        ? [...options.scopes]
-        : [...DESKTOP_API_KEY_SCOPES],
-    },
-    throwOnError: false,
-  });
-
-  if (error || !data?.data) {
-    const status = response?.status;
-    let message = "Failed to create API key";
-    try {
-      const parsed = (await response?.clone().json()) as Partial<AuthError>;
-      if (typeof parsed?.message === "string") {
-        message = parsed.message;
-      }
-    } catch {
-      // Non-JSON body — fall back to default message.
-    }
-    // Carry the HTTP status both as a property (so callers can branch on
-    // 401/403 vs 5xx without regex) and in the message via the same
-    // `returned HTTP <status>` marker App.tsx already parses. Without this,
-    // downstream telemetry/dialogs can't tell a non-transient auth/permission
-    // failure from a retryable one. #2497.
-    const statusSuffix =
-      typeof status === "number" ? ` (returned HTTP ${status})` : "";
-    throw new ApiKeyProvisioningError(`${message}${statusSuffix}`, status);
-  }
-
-  return data.data.api_key;
-}

--- a/src/services/desktop-api-access.ts
+++ b/src/services/desktop-api-access.ts
@@ -1,0 +1,277 @@
+// ABOUTME: Inspects and rotates the persistent Seren Desktop automation key.
+// ABOUTME: Reconciles stored key scopes with the least-privilege scopes required by this build.
+
+import {
+  type ApiKeyCreated,
+  type ApiKeyInfo,
+  type ApiKeyType,
+  createDefaultOrgApiKey,
+  listDefaultOrgApiKeys,
+  revokeDefaultOrgApiKey,
+} from "@/api";
+import { getSerenApiKey, storeSerenApiKey } from "@/lib/tauri-bridge";
+
+export const DESKTOP_API_KEY_NAME = "Seren Desktop";
+export const DESKTOP_API_KEY_SCOPES = [
+  "publisher:*",
+  "managed-deployment:update",
+] as const;
+
+export interface CreateApiKeyOptions {
+  name?: string;
+  keyType?: ApiKeyType;
+  agentIdentityId?: string;
+  scopes?: readonly string[];
+}
+
+export type DesktopApiKeyState =
+  | "current"
+  | "missing"
+  | "unrecognized"
+  | "revoked"
+  | "expired"
+  | "outdated";
+
+export interface DesktopApiKeyStatus {
+  state: DesktopApiKeyState;
+  key: ApiKeyInfo | null;
+  maskedValue: string | null;
+  currentScopes: string[];
+  requiredScopes: string[];
+  missingScopes: string[];
+  unexpectedScopes: string[];
+  needsRepair: boolean;
+}
+
+export interface DesktopApiKeyRepairResult {
+  status: DesktopApiKeyStatus;
+  revokedPreviousKey: boolean;
+  warning: string | null;
+}
+
+/**
+ * Thrown when provisioning the Seren Desktop API key fails. Carries the HTTP
+ * status so the auth store can distinguish terminal auth failures from
+ * retryable network/server failures. See #2497 and #3520.
+ */
+export class ApiKeyProvisioningError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiKeyProvisioningError";
+    this.status = status;
+  }
+}
+
+function responseStatus(response: Response | undefined): number | undefined {
+  return typeof response?.status === "number" ? response.status : undefined;
+}
+
+async function apiKeyRequestError(
+  fallback: string,
+  response: Response | undefined,
+): Promise<ApiKeyProvisioningError> {
+  const status = responseStatus(response);
+  let message = fallback;
+  try {
+    const parsed = (await response?.clone().json()) as { message?: unknown };
+    if (typeof parsed?.message === "string") message = parsed.message;
+  } catch {
+    // Non-JSON body — retain the safe fallback.
+  }
+  const statusSuffix =
+    typeof status === "number" ? ` (returned HTTP ${status})` : "";
+  return new ApiKeyProvisioningError(`${message}${statusSuffix}`, status);
+}
+
+async function createApiKeyRecord(
+  options: CreateApiKeyOptions = {},
+): Promise<ApiKeyCreated> {
+  const { data, error, response } = await createDefaultOrgApiKey({
+    body: {
+      name: options.name ?? DESKTOP_API_KEY_NAME,
+      key_type: options.keyType,
+      agent_identity_id: options.agentIdentityId,
+      scopes: options.scopes
+        ? [...options.scopes]
+        : [...DESKTOP_API_KEY_SCOPES],
+    },
+    throwOnError: false,
+  });
+
+  if (error || !data?.data) {
+    throw await apiKeyRequestError("Failed to create API key", response);
+  }
+
+  return data.data;
+}
+
+/**
+ * Create an API key for MCP authentication. Caller-supplied scope overrides
+ * remain supported; Desktop's default stays the exact required scope set.
+ */
+export async function createApiKey(
+  options: CreateApiKeyOptions = {},
+): Promise<string> {
+  return (await createApiKeyRecord(options)).api_key;
+}
+
+function publicKeyId(storedKey: string): string | null {
+  return /^seren_([^_]+)_/.exec(storedKey)?.[1] ?? null;
+}
+
+function maskedKeyPrefix(key: ApiKeyInfo): string {
+  return `${key.key_prefix}••••••••`;
+}
+
+function requiredScopesMissing(scopes: readonly string[]): string[] {
+  const current = new Set(scopes);
+  return DESKTOP_API_KEY_SCOPES.filter((scope) => !current.has(scope));
+}
+
+function statusFromRecord(key: ApiKeyInfo): DesktopApiKeyStatus {
+  const currentScopes = [...(key.scopes ?? [])];
+  const missingScopes = requiredScopesMissing(currentScopes);
+  const required = new Set<string>(DESKTOP_API_KEY_SCOPES);
+  const unexpectedScopes = currentScopes.filter(
+    (scope) => !required.has(scope),
+  );
+  const expired =
+    key.expires_at !== null &&
+    key.expires_at !== undefined &&
+    new Date(key.expires_at).getTime() <= Date.now();
+  const state: DesktopApiKeyState = key.revoked_at
+    ? "revoked"
+    : expired
+      ? "expired"
+      : missingScopes.length > 0 || unexpectedScopes.length > 0
+        ? "outdated"
+        : "current";
+
+  return {
+    state,
+    key,
+    maskedValue: maskedKeyPrefix(key),
+    currentScopes,
+    requiredScopes: [...DESKTOP_API_KEY_SCOPES],
+    missingScopes,
+    unexpectedScopes,
+    needsRepair: state !== "current",
+  };
+}
+
+function missingStatus(state: "missing" | "unrecognized"): DesktopApiKeyStatus {
+  return {
+    state,
+    key: null,
+    maskedValue: null,
+    currentScopes: [],
+    requiredScopes: [...DESKTOP_API_KEY_SCOPES],
+    missingScopes: [...DESKTOP_API_KEY_SCOPES],
+    unexpectedScopes: [],
+    needsRepair: true,
+  };
+}
+
+/**
+ * Inspect the exact key stored by Desktop. The raw secret never leaves this
+ * service; the Settings surface receives only Core's non-secret list record.
+ */
+export async function getDesktopApiKeyStatus(
+  storedKey?: string | null,
+): Promise<DesktopApiKeyStatus> {
+  const rawKey = storedKey === undefined ? await getSerenApiKey() : storedKey;
+  if (!rawKey) return missingStatus("missing");
+
+  const keyId = publicKeyId(rawKey);
+  if (!keyId) return missingStatus("unrecognized");
+
+  const { data, error, response } = await listDefaultOrgApiKeys({
+    throwOnError: false,
+  });
+  if (error || !data?.data) {
+    throw await apiKeyRequestError("Failed to inspect API key", response);
+  }
+
+  const record = data.data.find((candidate) => candidate.key_id === keyId);
+  return record ? statusFromRecord(record) : missingStatus("unrecognized");
+}
+
+function statusFromCreated(created: ApiKeyCreated): DesktopApiKeyStatus {
+  return statusFromRecord({
+    created_at: created.created_at,
+    expires_at: created.expires_at,
+    id: created.id,
+    key_id: created.key_id,
+    key_prefix: `seren_${created.key_id}_`,
+    key_type: created.key_type,
+    last_used_at: null,
+    name: created.name,
+    organization_id: created.organization_id,
+    revoked_at: null,
+    scopes: created.scopes,
+  });
+}
+
+async function revokeKeyRecord(key: ApiKeyInfo | ApiKeyCreated): Promise<void> {
+  const { error, response } = await revokeDefaultOrgApiKey({
+    // Despite its generated name, Core's route requires the record UUID (`id`),
+    // not the short public `key_id`. The Rust lease manager pins this contract.
+    path: { key_id: key.id },
+    throwOnError: false,
+  });
+  if (error || (response && !response.ok)) {
+    throw await apiKeyRequestError("Failed to revoke API key", response);
+  }
+}
+
+let repairInFlight: Promise<DesktopApiKeyRepairResult> | null = null;
+
+/**
+ * Rotate the Desktop automation key to this build's exact least-privilege
+ * scope set. The replacement is stored before the prior record is revoked so
+ * a transient revoke failure cannot strand Desktop without a usable key.
+ */
+export function repairDesktopApiKey(
+  inspectedStatus?: DesktopApiKeyStatus,
+): Promise<DesktopApiKeyRepairResult> {
+  if (repairInFlight) return repairInFlight;
+
+  repairInFlight = (async () => {
+    const previous = inspectedStatus ?? (await getDesktopApiKeyStatus());
+    const created = await createApiKeyRecord();
+
+    try {
+      await storeSerenApiKey(created.api_key);
+    } catch (error) {
+      // Best effort: do not leave a server-side key orphaned if local secure
+      // storage rejects the replacement.
+      await revokeKeyRecord(created).catch(() => undefined);
+      throw error;
+    }
+
+    let revokedPreviousKey = false;
+    let warning: string | null = null;
+    if (previous.key && !previous.key.revoked_at) {
+      try {
+        await revokeKeyRecord(previous.key);
+        revokedPreviousKey = true;
+      } catch {
+        // The replacement is already active and stored. Report the cleanup
+        // failure without rolling back to an outdated or revoked credential.
+        warning =
+          "The replacement key is active, but the previous key could not be revoked.";
+      }
+    }
+
+    return {
+      status: statusFromCreated(created),
+      revokedPreviousKey,
+      warning,
+    };
+  })().finally(() => {
+    repairInFlight = null;
+  });
+
+  return repairInFlight;
+}

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -18,6 +18,10 @@ import {
   isLoggedIn,
 } from "@/services/auth";
 import { resumeCredentialLeases } from "@/services/credential-lease";
+import {
+  getDesktopApiKeyStatus,
+  repairDesktopApiKey,
+} from "@/services/desktop-api-access";
 import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
 import {
   getDefaultOrganizationPrivateChatPolicy,
@@ -72,14 +76,27 @@ type EnsureApiKeyResult =
 
 /**
  * Ensure we have a Seren API key for MCP authentication.
- * Checks local storage first, only creates a new key if none stored.
+ * Fresh installs create one. Existing installs reconcile the server-side scope
+ * record so keys minted by an older Desktop build cannot remain under-scoped.
  */
 export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
   try {
-    // Check if we already have a stored API key
     const existingKey = await getSerenApiKey();
     if (existingKey) {
-      verboseRuntimeConsole.debug("[Auth Store] Using existing stored API key");
+      const status = await getDesktopApiKeyStatus(existingKey);
+      if (status.needsRepair) {
+        verboseRuntimeConsole.debug(
+          `[Auth Store] Repairing ${status.state} Desktop API key`,
+        );
+        const repaired = await repairDesktopApiKey(status);
+        if (repaired.warning) {
+          console.warn(`[Auth Store] ${repaired.warning}`);
+        }
+      } else {
+        verboseRuntimeConsole.debug(
+          "[Auth Store] Stored API key scopes are current",
+        );
+      }
       return { ok: true };
     }
 

--- a/tests/unit/api-access-settings-ui.test.ts
+++ b/tests/unit/api-access-settings-ui.test.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Static contract for the Settings API Access repair surface (#3520).
+// ABOUTME: Pins navigation/event wiring and the user-visible drift repair states.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsPanel = readFileSync(
+  resolve("src/components/settings/SettingsPanel.tsx"),
+  "utf-8",
+);
+const apiAccess = readFileSync(
+  resolve("src/components/settings/ApiAccessSettings.tsx"),
+  "utf-8",
+);
+
+describe("Settings API Access surface (#3520)", () => {
+  it("is addressable through the existing settings section event", () => {
+    expect(settingsPanel).toContain(
+      '{ id: "api-access", label: "API Access"',
+    );
+    expect(settingsPanel).toContain(
+      'activeSection() === "api-access"',
+    );
+    expect(settingsPanel).toContain("<ApiAccessSettings />");
+    expect(settingsPanel).toContain('"seren:open-settings-section"');
+  });
+
+  it("surfaces detected scope drift and reconnects MCP after repair", () => {
+    expect(apiAccess).toContain("Desktop automation access needs repair");
+    expect(apiAccess).toContain("Current scopes");
+    expect(apiAccess).toContain("Required by this build");
+    expect(apiAccess).toContain("Repair / re-provision");
+    expect(apiAccess).toContain("await resetGateway()");
+    expect(apiAccess).toContain("await initializeGateway()");
+  });
+});

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -11,6 +11,8 @@ const {
   isLoggedInMock,
   hasStoredTokenMock,
   createApiKeyMock,
+  getDesktopApiKeyStatusMock,
+  repairDesktopApiKeyMock,
   authLogoutMock,
   initializeGatewayMock,
   resetGatewayMock,
@@ -37,6 +39,8 @@ const {
     isLoggedInMock: vi.fn(async () => true),
     hasStoredTokenMock: vi.fn(async () => true),
     createApiKeyMock: vi.fn(async () => "seren-api-key-fresh"),
+    getDesktopApiKeyStatusMock: vi.fn(),
+    repairDesktopApiKeyMock: vi.fn(),
     authLogoutMock: vi.fn(async () => {}),
     initializeGatewayMock: vi.fn(async () => {}),
     resetGatewayMock: vi.fn(async () => {}),
@@ -72,6 +76,11 @@ vi.mock("@/services/auth", () => ({
   hasStoredToken: hasStoredTokenMock,
   createApiKey: createApiKeyMock,
   logout: authLogoutMock,
+}));
+
+vi.mock("@/services/desktop-api-access", () => ({
+  getDesktopApiKeyStatus: getDesktopApiKeyStatusMock,
+  repairDesktopApiKey: repairDesktopApiKeyMock,
 }));
 
 vi.mock("@/api", () => ({
@@ -139,6 +148,14 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     isTauriRuntimeMock.mockReturnValue(false);
     hasStoredTokenMock.mockResolvedValue(true);
     runtimeHasCapabilityMock.mockReturnValue(false);
+    getDesktopApiKeyStatusMock.mockResolvedValue({
+      state: "current",
+      needsRepair: false,
+    });
+    repairDesktopApiKeyMock.mockResolvedValue({
+      status: { state: "current", needsRepair: false },
+      warning: null,
+    });
     resetAuthStore();
   });
 
@@ -211,7 +228,37 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
 
     expect(createApiKeyMock).not.toHaveBeenCalled();
     expect(storeSerenApiKeyMock).not.toHaveBeenCalled();
+    expect(getDesktopApiKeyStatusMock).toHaveBeenCalledWith("cached-key");
+    expect(repairDesktopApiKeyMock).not.toHaveBeenCalled();
     expect(authAtGetTime).toBe(false);
+    expect(authStore.isAuthenticated).toBe(true);
+  });
+
+  it("setAuthenticated: repairs an under-scoped stored key before authentication", async () => {
+    storedKeyRef.value = "seren_legacy_secret";
+    const staleStatus = {
+      state: "outdated",
+      needsRepair: true,
+      missingScopes: ["managed-deployment:update"],
+    };
+    getDesktopApiKeyStatusMock.mockResolvedValueOnce(staleStatus);
+
+    let authAtRepairTime: boolean | null = null;
+    repairDesktopApiKeyMock.mockImplementationOnce(async () => {
+      authAtRepairTime = authStore.isAuthenticated;
+      storedKeyRef.value = "seren_replacement_secret";
+      return {
+        status: { state: "current", needsRepair: false },
+        warning: null,
+      };
+    });
+
+    await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+    expect(repairDesktopApiKeyMock).toHaveBeenCalledWith(staleStatus);
+    expect(createApiKeyMock).not.toHaveBeenCalled();
+    expect(authAtRepairTime).toBe(false);
+    expect(storedKeyRef.value).toBe("seren_replacement_secret");
     expect(authStore.isAuthenticated).toBe(true);
   });
 
@@ -258,6 +305,14 @@ describe("auth.store #2497 — API key provisioning failure handling", () => {
     hasStoredTokenMock.mockResolvedValue(true);
     isLoggedInMock.mockResolvedValue(true);
     runtimeHasCapabilityMock.mockReturnValue(false);
+    getDesktopApiKeyStatusMock.mockResolvedValue({
+      state: "current",
+      needsRepair: false,
+    });
+    repairDesktopApiKeyMock.mockResolvedValue({
+      status: { state: "current", needsRepair: false },
+      warning: null,
+    });
     resetAuthStore();
   });
 

--- a/tests/unit/auth-store-refresh-epoch.test.ts
+++ b/tests/unit/auth-store-refresh-epoch.test.ts
@@ -13,6 +13,11 @@ const mocks = vi.hoisted(() => {
     isLoggedIn: vi.fn(async () => true),
     hasStoredToken: vi.fn(async () => true),
     createApiKey: vi.fn(async () => "seren-api-key-fresh"),
+    getDesktopApiKeyStatus: vi.fn(async () => ({
+      state: "current",
+      needsRepair: false,
+    })),
+    repairDesktopApiKey: vi.fn(),
     authLogout: vi.fn(async () => {}),
     initializeGateway: vi.fn(async () => {}),
     resetGateway: vi.fn(async () => {}),
@@ -39,6 +44,11 @@ vi.mock("@/services/auth", () => ({
   hasStoredToken: mocks.hasStoredToken,
   createApiKey: mocks.createApiKey,
   logout: mocks.authLogout,
+}));
+
+vi.mock("@/services/desktop-api-access", () => ({
+  getDesktopApiKeyStatus: mocks.getDesktopApiKeyStatus,
+  repairDesktopApiKey: mocks.repairDesktopApiKey,
 }));
 
 vi.mock("@/services/mcp-gateway", () => ({

--- a/tests/unit/desktop-api-access.test.ts
+++ b/tests/unit/desktop-api-access.test.ts
@@ -1,0 +1,137 @@
+// ABOUTME: Critical regression coverage for stale Desktop automation keys (#3520).
+// ABOUTME: Pins scope-drift detection and safe replacement/revocation behavior.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createDefaultOrgApiKey: vi.fn(),
+  listDefaultOrgApiKeys: vi.fn(),
+  revokeDefaultOrgApiKey: vi.fn(),
+  getSerenApiKey: vi.fn(),
+  storeSerenApiKey: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  createDefaultOrgApiKey: mocks.createDefaultOrgApiKey,
+  listDefaultOrgApiKeys: mocks.listDefaultOrgApiKeys,
+  revokeDefaultOrgApiKey: mocks.revokeDefaultOrgApiKey,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getSerenApiKey: mocks.getSerenApiKey,
+  storeSerenApiKey: mocks.storeSerenApiKey,
+}));
+
+import {
+  getDesktopApiKeyStatus,
+  repairDesktopApiKey,
+} from "@/services/desktop-api-access";
+
+const staleRecord = {
+  created_at: "2026-07-01T12:00:00Z",
+  expires_at: null,
+  id: "00000000-0000-4000-8000-000000000001",
+  key_id: "legacy",
+  key_prefix: "seren_legacy_",
+  key_type: "user" as const,
+  last_used_at: "2026-07-30T12:00:00Z",
+  name: "Seren Desktop",
+  organization_id: "00000000-0000-4000-8000-000000000010",
+  revoked_at: null,
+  scopes: ["publisher:*"],
+};
+
+const replacementRecord = {
+  api_key: "seren_replacement_secret",
+  created_at: "2026-08-01T12:00:00Z",
+  expires_at: null,
+  id: "00000000-0000-4000-8000-000000000002",
+  key_id: "replacement",
+  key_type: "user" as const,
+  name: "Seren Desktop",
+  organization_id: "00000000-0000-4000-8000-000000000010",
+  scopes: ["publisher:*", "managed-deployment:update"],
+};
+
+describe("Desktop API access reconciliation (#3520)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSerenApiKey.mockResolvedValue("seren_legacy_secret");
+    mocks.listDefaultOrgApiKeys.mockResolvedValue({
+      data: { data: [staleRecord] },
+      error: undefined,
+      response: { ok: true, status: 200 },
+    });
+    mocks.createDefaultOrgApiKey.mockResolvedValue({
+      data: { data: replacementRecord },
+      error: undefined,
+      response: { ok: true, status: 201 },
+    });
+    mocks.storeSerenApiKey.mockResolvedValue(undefined);
+    mocks.revokeDefaultOrgApiKey.mockResolvedValue({
+      data: {},
+      error: undefined,
+      response: { ok: true, status: 200 },
+    });
+  });
+
+  it("detects a pre-#3490 key, replaces it, and returns a green scope state", async () => {
+    const stale = await getDesktopApiKeyStatus();
+
+    expect(stale.state).toBe("outdated");
+    expect(stale.missingScopes).toEqual(["managed-deployment:update"]);
+    expect(stale.unexpectedScopes).toEqual([]);
+    expect(stale.maskedValue).toBe("seren_legacy_••••••••");
+    expect(JSON.stringify(stale)).not.toContain("seren_legacy_secret");
+
+    const repaired = await repairDesktopApiKey(stale);
+
+    expect(repaired.status.state).toBe("current");
+    expect(repaired.status.missingScopes).toEqual([]);
+    expect(repaired.warning).toBeNull();
+    expect(mocks.createDefaultOrgApiKey).toHaveBeenCalledWith({
+      body: {
+        name: "Seren Desktop",
+        key_type: undefined,
+        agent_identity_id: undefined,
+        scopes: ["publisher:*", "managed-deployment:update"],
+      },
+      throwOnError: false,
+    });
+    expect(mocks.storeSerenApiKey).toHaveBeenCalledWith(
+      "seren_replacement_secret",
+    );
+    expect(mocks.revokeDefaultOrgApiKey).toHaveBeenCalledWith({
+      path: { key_id: staleRecord.id },
+      throwOnError: false,
+    });
+    expect(
+      mocks.storeSerenApiKey.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.revokeDefaultOrgApiKey.mock.invocationCallOrder[0]);
+  });
+
+  it("flags elevated scopes that are not part of Desktop's required set", async () => {
+    mocks.listDefaultOrgApiKeys.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            ...staleRecord,
+            scopes: [
+              "publisher:*",
+              "managed-deployment:update",
+              "managed-deployment:*",
+            ],
+          },
+        ],
+      },
+      error: undefined,
+      response: { ok: true, status: 200 },
+    });
+
+    const status = await getDesktopApiKeyStatus();
+
+    expect(status.state).toBe("outdated");
+    expect(status.missingScopes).toEqual([]);
+    expect(status.unexpectedScopes).toEqual(["managed-deployment:*"]);
+  });
+});


### PR DESCRIPTION
Closes #3520

## Summary
- reconcile an existing Seren Desktop automation key against the build-required scope set before authentication completes
- add Settings → API Access with non-secret key metadata, scope drift, and one-click repair/reconnect
- preserve least privilege by rotating unexpected elevated scopes back to the exact required set
- store the replacement before revoking the previous record so a cleanup failure cannot strand Desktop

## Audited network path
- `GET /organizations/default/api-keys`
- `POST /organizations/default/api-keys`
- `DELETE /organizations/default/api-keys/{record_uuid}`

These calls use the signed-user Core SDK path. No publisher/API slug is involved in the changed feature path. The routes and record-UUID revoke contract were verified against the live Core OpenAPI metadata and the existing Rust credential-lease contract.

## Validation
- `pnpm lint` (passes; existing warnings only)
- `pnpm test` — 2,854 passed, 15 skipped
- focused regression suite — 21 passed
- `pnpm build && pnpm verify:frontend-build`
- production-bundle Playwright suite — 11 passed, 3 skipped
- `cargo test --manifest-path src-tauri/Cargo.toml` — 1,265 applicable tests passed; expected ignores only
- live Core validation with a disposable pre-#3490 scope set confirmed replacement with exactly `publisher:*` and `managed-deployment:update`
- public diff PII/secret scan clean