### PR TITLE
fix(happy): title mobile threads from first prompt

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -28,6 +28,7 @@ const SESSION_KEEP_ALIVE_MS = 2000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
 const HAPPY_CONTEXT_RESET_NOTICE =
   "Provider context reset: the original native session was unavailable, so Seren started a new provider context for this existing Happy thread.";
+const HAPPY_SESSION_TITLE_MAX_CHARS = 30;
 const BUSY_SESSION_STATUSES = new Set(["prompting", "busy", "running"]);
 const DENY_OPTION_IDS = new Set([
   "deny",
@@ -294,6 +295,16 @@ function sessionMetadata(config, summary, machineId) {
     lifecycleState: "running",
     lifecycleStateSince: Date.now(),
   };
+}
+
+export function deriveHappySessionTitle(text) {
+  if (typeof text !== "string") return null;
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  if (!trimmed) return null;
+  if (trimmed.length <= HAPPY_SESSION_TITLE_MAX_CHARS) return trimmed;
+  const prefix = trimmed.slice(0, HAPPY_SESSION_TITLE_MAX_CHARS);
+  const lastSpace = prefix.lastIndexOf(" ");
+  return `${lastSpace > 10 ? prefix.slice(0, lastSpace) : prefix}\u2026`;
 }
 
 // Modes the provider runtimes accept. A remote peer may only move a session
@@ -1876,6 +1887,9 @@ export function createHappyLayer({
         summary,
         session,
         client,
+        sessionTitlePublished:
+          typeof session.metadata?.summary?.text === "string" &&
+          session.metadata.summary.text.trim().length > 0,
         suppressProviderHistoryReplay: resumedBinding,
         liveness: createSessionLiveness(client, thinking),
       };
@@ -2068,6 +2082,25 @@ export function createHappyLayer({
       (event.payload?.replay === true || event.payload?.historyReplay === true)
     ) {
       return;
+    }
+    if (event.kind === "user-message" && entry.sessionTitlePublished !== true) {
+      const title = deriveHappySessionTitle(event.payload?.text);
+      if (title) {
+        // Happy Mobile renders the session summary as its thread title. The
+        // official Happy client uses this same message for change_title, which
+        // also updates the encrypted summary metadata on /v1/updates.
+        entry.sessionTitlePublished = true;
+        try {
+          entry.client.sendClaudeSessionMessage({
+            type: "summary",
+            summary: title,
+            leafUuid: randomUUID(),
+          });
+        } catch {
+          entry.sessionTitlePublished = false;
+          debug("failed to publish Happy session title");
+        }
+      }
     }
     if (providerThinking) {
       entry.liveness.setThinking(true);

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -84,6 +84,7 @@ function createClient() {
       ),
     },
     sendAgentMessage: vi.fn(),
+    sendClaudeSessionMessage: vi.fn(),
     sendSessionDeath: vi.fn(),
     sendSessionEvent: vi.fn(),
     sendSessionProtocolMessage: vi.fn(),
@@ -348,6 +349,72 @@ function createLayerHarness({
 }
 
 describe("Happy session liveness", () => {
+  it("publishes one first-prompt summary so Happy threads receive distinct titles", async () => {
+    const summary = {
+      sessionId: "title-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+
+    await harness.layer.start();
+    harness.publish({
+      kind: "user-message",
+      sessionId: summary.sessionId,
+      payload: {
+        text: "Investigate Happy thread title propagation",
+        origin: "desktop",
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.client.sendClaudeSessionMessage).toHaveBeenCalledWith({
+        type: "summary",
+        summary: "Investigate Happy thread\u2026",
+        leafUuid: expect.any(String),
+      }),
+    );
+
+    harness.publish({
+      kind: "user-message",
+      sessionId: summary.sessionId,
+      payload: { text: "A later prompt", origin: "desktop" },
+    });
+    await Promise.resolve();
+    expect(harness.client.sendClaudeSessionMessage).toHaveBeenCalledTimes(1);
+
+    await harness.layer.close();
+  });
+
+  it("preserves a Happy thread summary that already exists", async () => {
+    const summary = {
+      sessionId: "already-titled-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    harness.api.getOrCreateSession.mockImplementation(async ({ metadata }) => ({
+      id: "relay-session",
+      metadata: {
+        ...metadata,
+        summary: { text: "Existing Happy title", updatedAt: 1 },
+      },
+    }));
+
+    await harness.layer.start();
+    harness.publish({
+      kind: "user-message",
+      sessionId: summary.sessionId,
+      payload: { text: "Do not overwrite me", origin: "desktop" },
+    });
+    await Promise.resolve();
+
+    expect(harness.client.sendClaudeSessionMessage).not.toHaveBeenCalled();
+    await harness.layer.close();
+  });
+
   it("retires an archive delivered while the session client is being constructed", async () => {
     const summary = {
       sessionId: "constructor-archive-session",


### PR DESCRIPTION
Closes #3523

## Summary

- derive a concise Happy Mobile thread title from the first non-empty user prompt
- publish it once through Happy's official `summary` session message
- preserve any encrypted Happy summary that already exists

## Audited code path

`AgentChat` → agent prompt submission → `provider_submit_prompt` → `provider://user-message` → Happy bridge `user-message` → Happy session summary.

The existing network path remains `POST /v1/sessions` followed by the Socket.IO `/v1/updates` channel, where Happy's client emits `update-metadata`. The pinned `happy@1.2.0` SDK confirms that `sendClaudeSessionMessage({ type: "summary" })` is the official title-change mechanism. No new outbound service, publisher slug, method, or path is introduced. The live Seren publisher inventory has no Happy publisher, so the existing direct Happy SDK path remains in scope.

## Validation

- `pnpm exec vitest run tests/unit/happy-session-liveness.test.ts` — 51 passed
- `pnpm exec vitest run tests/unit/happy-*.test.ts` — 193 passed
- `pnpm test` — 2,856 passed; 15 skipped
- `pnpm check` — passed with pre-existing warnings outside this patch
- `pnpm build` — passed
- `git diff --check` — passed

Live Happy Mobile validation will be recorded after the PR is raised, using the isolated validation app and the real relay without mocks.