### PR TITLE
feat(run): mission control ui with findings centerpiece

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -161,6 +161,19 @@ pub async fn run_add_coverage_gap(
 }
 
 #[tauri::command]
+pub async fn run_update_finding_status(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    finding_id: String,
+    status: String,
+) -> Result<(), String> {
+    state
+        .update_finding_status(&app, run_id, finding_id, status)
+        .await
+}
+
+#[tauri::command]
 pub async fn run_provision_workspace(
     app: AppHandle,
     state: State<'_, RunEngineState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1410,6 +1410,7 @@ pub fn run() {
             commands::run::run_complete_task,
             commands::run::run_record_finding,
             commands::run::run_add_coverage_gap,
+            commands::run::run_update_finding_status,
             commands::run::run_provision_workspace,
             commands::run::run_release_workspace,
             // Claude Code auto-memory interceptor commands

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -104,6 +104,12 @@ enum SchedulerCommand {
         gap: CoverageGap,
         reply: oneshot::Sender<Result<(), String>>,
     },
+    UpdateFindingStatus {
+        run_id: String,
+        finding_id: String,
+        status: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
     ReleaseLease {
         lease_id: String,
         reply: oneshot::Sender<Result<WorkspaceLease, String>>,
@@ -399,6 +405,29 @@ impl RunEngineState {
             .map_err(|_| "run scheduler dropped coverage-gap response".to_string())?
     }
 
+    pub async fn update_finding_status(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        finding_id: String,
+        status: String,
+    ) -> Result<(), String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::UpdateFindingStatus {
+                run_id,
+                finding_id,
+                status,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped finding-status response".to_string())?
+    }
+
     pub async fn provision_workspace(
         &self,
         app: &AppHandle,
@@ -589,6 +618,20 @@ fn process_command(
         }
         SchedulerCommand::RecordCoverageGap { gap, reply } => {
             let _ = reply.send(record_coverage_gap(app, conn, gap));
+        }
+        SchedulerCommand::UpdateFindingStatus {
+            run_id,
+            finding_id,
+            status,
+            reply,
+        } => {
+            let _ = reply.send(update_finding_status(
+                app,
+                conn,
+                run_id,
+                finding_id,
+                status,
+            ));
         }
         SchedulerCommand::ReleaseLease { lease_id, reply } => {
             let _ = reply.send(release_lease(app, conn, lease_id));
@@ -1231,6 +1274,38 @@ fn record_coverage_gap(
                 "subject": gap.subject,
                 "detail": gap.detail,
             }),
+        ),
+    )?;
+    Ok(())
+}
+
+fn update_finding_status(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    finding_id: String,
+    status: String,
+) -> Result<(), String> {
+    let finding_run_id: String = conn
+        .query_row(
+            "SELECT run_id FROM run_findings WHERE id = ?1",
+            params![finding_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if finding_run_id != run_id {
+        return Err("finding does not belong to run".to_string());
+    }
+    store::update_finding_status(conn, &finding_id, &status)
+        .map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        event_for_task_or_run(
+            &run_id,
+            None,
+            RunEventType::FindingStatusChanged,
+            json!({"finding_id": finding_id, "status": status}),
         ),
     )?;
     Ok(())

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -295,6 +295,21 @@ pub fn insert_finding(conn: &Connection, finding: &Finding) -> Result<()> {
     Ok(())
 }
 
+pub fn update_finding_status(conn: &Connection, finding_id: &str, status: &str) -> Result<()> {
+    let parsed = FindingStatus::parse(status).ok_or_else(|| invalid_value("finding status", status))?;
+    if parsed == FindingStatus::Open {
+        return Err(invalid_value("finding status", status));
+    }
+    let updated = conn.execute(
+        "UPDATE run_findings SET status = ?1, updated_at = ?2 WHERE id = ?3",
+        params![parsed.as_str(), now_ms(), finding_id],
+    )?;
+    if updated == 0 {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
+    Ok(())
+}
+
 pub fn insert_check(conn: &Connection, check: &RunCheck) -> Result<()> {
     conn.execute(
         "INSERT INTO run_checks (id, run_id, name, command, approved, created_at)
@@ -1082,5 +1097,41 @@ mod tests {
         transition_task(&conn, "task-a", TaskState::Review, None).unwrap();
         transition_task(&conn, "task-a", TaskState::Done, None).unwrap();
         assert_eq!(ready_task_ids(&conn, "run-1").unwrap(), vec!["task-b"]);
+    }
+
+    #[test]
+    fn finding_status_round_trips_and_rejects_unknown_values() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        insert_finding(
+            &conn,
+            &Finding {
+                id: "finding-1".to_string(),
+                run_id: "run-1".to_string(),
+                task_id: None,
+                attempt_id: None,
+                claim: "A claim".to_string(),
+                confidence: FindingConfidence::Asserted,
+                evidence: Vec::new(),
+                proposed_artifact: None,
+                needs_approval: true,
+                status: FindingStatus::Open,
+                created_at: 1,
+                updated_at: 1,
+            },
+        )
+        .unwrap();
+
+        update_finding_status(&conn, "finding-1", "accepted").unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM run_findings WHERE id = 'finding-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "accepted");
+        assert!(update_finding_status(&conn, "finding-1", "unknown").is_err());
+        assert!(update_finding_status(&conn, "finding-1", "open").is_err());
     }
 }

--- a/src-tauri/src/run/types.rs
+++ b/src-tauri/src/run/types.rs
@@ -309,6 +309,7 @@ pub enum RunEventType {
     CheckResultRecorded,
     CoverageGapRecorded,
     TaskCompletionRejected,
+    FindingStatusChanged,
 }
 
 impl RunEventType {
@@ -332,6 +333,7 @@ impl RunEventType {
             Self::CheckResultRecorded => "check_result_recorded",
             Self::CoverageGapRecorded => "coverage_gap_recorded",
             Self::TaskCompletionRejected => "task_completion_rejected",
+            Self::FindingStatusChanged => "finding_status_changed",
         }
     }
 
@@ -355,6 +357,7 @@ impl RunEventType {
             "check_result_recorded" => Self::CheckResultRecorded,
             "coverage_gap_recorded" => Self::CoverageGapRecorded,
             "task_completion_rejected" => Self::TaskCompletionRejected,
+            "finding_status_changed" => Self::FindingStatusChanged,
             _ => return None,
         })
     }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -31,6 +31,7 @@ import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
 import { RecordingIndicator } from "@/components/meeting/RecordingIndicator";
+import { MissionControlPanel } from "@/components/run/MissionControlPanel";
 import { ConversationSearchOverlay } from "@/components/search/ConversationSearchOverlay";
 import { ConversationSearchResults } from "@/components/search/ConversationSearchResults";
 import { SessionPanel } from "@/components/session/SessionPanel";
@@ -100,6 +101,7 @@ export type SlidePanelView =
   | "tasks"
   | "sessions"
   | "meetings"
+  | "missioncontrol"
   | "skills"
   | null;
 
@@ -140,6 +142,7 @@ const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
   "tasks",
   "sessions",
   "meetings",
+  "missioncontrol",
   "skills",
 ]);
 
@@ -674,6 +677,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
       setSlidePanel("sessions");
     } else if (p === "meetings") {
       setSlidePanel("meetings");
+    } else if (p === "missioncontrol") {
+      setSlidePanel("missioncontrol");
     } else if (p === "skills") {
       setSlidePanel("skills");
     }
@@ -1198,7 +1203,9 @@ export const AppShell: Component<AppShellProps> = (props) => {
           onClose={handleCloseSlidePanel}
           docked={slidePanel() === "skills"}
           reader={slidePanel() === "meetings"}
-          wide={slidePanel() === "settings"}
+          wide={
+            slidePanel() === "settings" || slidePanel() === "missioncontrol"
+          }
         >
           <ShellSurfaceBoundary
             surface="slide_panel"
@@ -1223,6 +1230,9 @@ export const AppShell: Component<AppShellProps> = (props) => {
               </Match>
               <Match when={slidePanel() === "meetings"}>
                 <MeetingPanel />
+              </Match>
+              <Match when={slidePanel() === "missioncontrol"}>
+                <MissionControlPanel />
               </Match>
               <Match when={slidePanel() === "skills"}>
                 <SkillsExplorer panelMode />

--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -1,0 +1,143 @@
+// ABOUTME: Mission Control shell for launching a run and reviewing its evidence.
+// ABOUTME: Header, tabs, and coverage stay fixed while only the active body scrolls.
+
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import {
+  type Component,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { RunArtifactReview } from "@/components/run/RunArtifactReview";
+import { RunFindings } from "@/components/run/RunFindings";
+import { RunLaunchBox } from "@/components/run/RunLaunchBox";
+import { RunOverview } from "@/components/run/RunOverview";
+import { RunTaskDrawer } from "@/components/run/RunTaskDrawer";
+import { type Finding, subscribeRunEvents, type Task } from "@/services/run";
+import { runStore } from "@/stores/run.store";
+
+export const MissionControlPanel: Component = () => {
+  const [tab, setTab] = createSignal<"overview" | "findings">("overview");
+  const [reviewFinding, setReviewFinding] = createSignal<Finding | null>(null);
+  const [selectedTask, setSelectedTask] = createSignal<Task | null>(null);
+  let unlisten: UnlistenFn | null = null;
+  let disposed = false;
+
+  onMount(() => {
+    const subscription = subscribeRunEvents((event) => {
+      void runStore.applyEvent(event);
+    });
+    void subscription.then((cleanup) => {
+      if (disposed) cleanup();
+      else unlisten = cleanup;
+    });
+  });
+
+  onCleanup(() => {
+    disposed = true;
+    unlisten?.();
+  });
+
+  const statusLabel = () => runStore.snapshot?.run.status ?? "ready";
+  const agentCount = () => runStore.snapshot?.assignments.length ?? 0;
+  const findingsCount = () => runStore.findingsCount();
+
+  return (
+    <div class="relative flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top_right,rgba(34,211,238,0.08),transparent_35%),#080d18] text-foreground">
+      <Show when={runStore.snapshot} fallback={<RunLaunchBox />}>
+        <div class="flex h-full min-h-0 flex-col">
+          <header class="shrink-0 border-b border-border/70 px-5 pb-3 pt-5 lg:px-6">
+            <div class="flex items-start justify-between gap-5">
+              <div class="min-w-0">
+                <div class="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.19em] text-cyan-200/80">
+                  <span class="h-1.5 w-1.5 rounded-full bg-cyan-300 shadow-[0_0_10px_rgba(103,232,249,0.85)]" />
+                  Run · {statusLabel()}
+                </div>
+                <h1 class="mt-2 truncate text-xl font-semibold tracking-[-0.03em] text-foreground">
+                  {runStore.snapshot?.run.objective}
+                </h1>
+              </div>
+              <div class="flex shrink-0 items-center gap-4">
+                <div class="hidden text-right sm:block">
+                  <div class="font-mono text-sm text-foreground">
+                    {agentCount()}
+                  </div>
+                  <div class="text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+                    Agents
+                  </div>
+                </div>
+                <div class="hidden text-right sm:block">
+                  <div class="font-mono text-sm text-foreground">
+                    {findingsCount()}
+                  </div>
+                  <div class="text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+                    Findings
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="rounded-lg border border-red-300/25 px-3 py-1.5 text-xs font-medium text-red-200 hover:bg-red-300/10"
+                  onClick={() => void runStore.cancel()}
+                  disabled={statusLabel() !== "running"}
+                >
+                  Stop
+                </button>
+              </div>
+            </div>
+            <nav
+              class="mt-5 flex items-center gap-5"
+              aria-label="Mission Control views"
+            >
+              <button
+                type="button"
+                class={`border-b-2 pb-2 text-xs font-medium ${tab() === "overview" ? "border-cyan-300 text-cyan-100" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+                onClick={() => setTab("overview")}
+              >
+                Overview
+              </button>
+              <button
+                type="button"
+                class={`border-b-2 pb-2 text-xs font-medium ${tab() === "findings" ? "border-cyan-300 text-cyan-100" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+                onClick={() => setTab("findings")}
+              >
+                Findings{" "}
+                <span class="ml-1 font-mono text-[10px] text-amber-200">
+                  {findingsCount()}
+                </span>
+              </button>
+            </nav>
+          </header>
+
+          <div class="min-h-0 flex-1 overflow-hidden">
+            <Show when={tab() === "overview"}>
+              <div class="h-full min-h-0 overflow-y-auto">
+                <RunOverview
+                  onReview={setReviewFinding}
+                  onTaskSelect={setSelectedTask}
+                />
+              </div>
+            </Show>
+            <Show when={tab() === "findings"}>
+              <RunFindings onReview={setReviewFinding} />
+            </Show>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={reviewFinding()}>
+        {(finding) => (
+          <RunArtifactReview
+            finding={finding()}
+            onClose={() => setReviewFinding(null)}
+          />
+        )}
+      </Show>
+      <Show when={selectedTask()}>
+        {(task) => (
+          <RunTaskDrawer task={task()} onClose={() => setSelectedTask(null)} />
+        )}
+      </Show>
+    </div>
+  );
+};

--- a/src/components/run/RunArtifactReview.tsx
+++ b/src/components/run/RunArtifactReview.tsx
@@ -1,0 +1,113 @@
+// ABOUTME: Review dialog for proposed finding artifacts before external action.
+// ABOUTME: Approval and rejection use the durable finding-status command path.
+
+import { type Component, For, Show } from "solid-js";
+import type { Finding } from "@/services/run";
+import { runStore } from "@/stores/run.store";
+
+export interface RunArtifactReviewProps {
+  finding: Finding;
+  onClose: () => void;
+}
+
+export const RunArtifactReview: Component<RunArtifactReviewProps> = (props) => {
+  const artifact = () => props.finding.proposed_artifact;
+  const isOpen = () => props.finding.status === "open";
+
+  return (
+    <div class="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/75 p-5 backdrop-blur-sm">
+      <div class="flex max-h-[86vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-cyan-300/25 bg-slate-950 shadow-[0_28px_100px_rgba(2,8,23,0.7)]">
+        <div class="flex items-start justify-between gap-4 border-b border-border/70 px-5 py-4">
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
+              Artifact review
+            </div>
+            <h2 class="mt-1 text-base font-medium text-foreground">
+              {artifact()?.title ?? "Proposed response"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            class="text-xs text-muted-foreground hover:text-foreground"
+            onClick={props.onClose}
+            aria-label="Close artifact review"
+          >
+            Close
+          </button>
+        </div>
+
+        <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+          <div class="rounded-xl border border-amber-300/20 bg-amber-300/[0.06] p-4">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-200">
+              Claim
+            </div>
+            <p class="m-0 mt-2 text-sm leading-6 text-foreground">
+              {props.finding.claim}
+            </p>
+          </div>
+          <Show when={props.finding.evidence.length > 0}>
+            <div class="mt-4">
+              <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Evidence used
+              </div>
+              <div class="space-y-2">
+                <For each={props.finding.evidence}>
+                  {(evidence) => (
+                    <div class="rounded-lg border border-border/60 bg-slate-900/60 px-3 py-2 text-xs">
+                      <code class="font-mono text-cyan-100/80">
+                        {evidence.reference}
+                      </code>
+                      <Show when={evidence.excerpt}>
+                        <div class="mt-1 leading-5 text-muted-foreground">
+                          {evidence.excerpt}
+                        </div>
+                      </Show>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+          </Show>
+          <div class="mt-4 rounded-xl border border-border/60 bg-slate-900/60 p-4">
+            <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Proposed {artifact()?.kind ?? "artifact"}
+            </div>
+            <pre class="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-foreground/90">
+              {artifact()?.content ?? "No content was proposed."}
+            </pre>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between gap-3 border-t border-border/70 px-5 py-4">
+          <span class="text-[11px] text-muted-foreground">
+            Nothing sends without your approval.
+          </span>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="rounded-lg border border-red-300/25 px-3 py-2 text-xs font-medium text-red-200 hover:bg-red-300/10 disabled:opacity-40"
+              disabled={!isOpen()}
+              onClick={() => {
+                void runStore.rejectFinding(props.finding.id);
+                props.onClose();
+              }}
+            >
+              Reject
+            </button>
+            <button
+              type="button"
+              class="rounded-lg bg-cyan-300 px-3 py-2 text-xs font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+              disabled={!isOpen()}
+              onClick={() => {
+                void runStore.approveFinding(props.finding.id);
+                props.onClose();
+              }}
+            >
+              Approve
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/run/RunFindings.tsx
+++ b/src/components/run/RunFindings.tsx
@@ -1,0 +1,154 @@
+// ABOUTME: Evidence-first findings view with a pinned coverage summary.
+// ABOUTME: The single scroll region keeps coverage visible while claims are reviewed.
+
+import { type Component, createSignal, For, Show } from "solid-js";
+import type { Finding } from "@/services/run";
+import { runStore } from "@/stores/run.store";
+
+export interface RunFindingsProps {
+  onReview: (finding: Finding) => void;
+}
+
+function confidenceLabel(confidence: Finding["confidence"]): string {
+  return confidence.charAt(0).toUpperCase() + confidence.slice(1);
+}
+
+export const RunFindings: Component<RunFindingsProps> = (props) => {
+  const [coverageExpanded, setCoverageExpanded] = createSignal(false);
+  const gaps = () => runStore.coverageGaps();
+  const findings = () => runStore.snapshot?.findings ?? [];
+
+  return (
+    <div class="flex h-full min-h-0 flex-col">
+      <div
+        data-testid="coverage-strip"
+        class="shrink-0 border-b border-amber-300/20 bg-amber-300/[0.06] px-5 py-3 lg:px-6"
+      >
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-4 text-left"
+          onClick={() => setCoverageExpanded((value) => !value)}
+          aria-expanded={coverageExpanded()}
+        >
+          <span class="min-w-0">
+            <span class="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-200">
+              Coverage
+            </span>
+            <span class="ml-3 text-xs text-muted-foreground">
+              {gaps().length === 0
+                ? "No known gaps"
+                : `${gaps().length} gap${gaps().length === 1 ? "" : "s"} · ${gaps()[0].subject}`}
+            </span>
+          </span>
+          <span class="shrink-0 text-[11px] text-amber-200/80">
+            {coverageExpanded() ? "Hide" : "Details"}
+          </span>
+        </button>
+        <Show when={coverageExpanded() && gaps().length > 0}>
+          <div class="mt-3 space-y-2 border-t border-amber-300/15 pt-3">
+            <For each={gaps()}>
+              {(gap) => (
+                <div class="flex gap-3 text-xs leading-5 text-muted-foreground">
+                  <span class="font-mono text-[10px] uppercase text-amber-200/80">
+                    {gap.kind}
+                  </span>
+                  <span class="min-w-0">
+                    <span class="text-foreground/85">{gap.subject}</span>
+                    {gap.detail ? ` — ${gap.detail}` : ""}
+                  </span>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+
+      <div
+        data-testid="findings-scroll"
+        class="min-h-0 flex-1 overflow-y-auto px-5 py-5 lg:px-6"
+      >
+        <Show
+          when={findings().length > 0}
+          fallback={
+            <div class="flex h-full min-h-48 items-center justify-center rounded-xl border border-dashed border-border/70 text-sm text-muted-foreground">
+              Findings will appear here as the team verifies its work.
+            </div>
+          }
+        >
+          <div class="space-y-4">
+            <For each={findings()}>
+              {(finding) => (
+                <article class="rounded-xl border border-border/75 bg-slate-900/55 p-4 shadow-[0_12px_40px_rgba(2,8,23,0.16)]">
+                  <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="rounded-full border border-cyan-300/25 bg-cyan-300/[0.08] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.13em] text-cyan-100">
+                        {confidenceLabel(finding.confidence)}
+                      </span>
+                      <Show
+                        when={
+                          finding.needs_approval && finding.status === "open"
+                        }
+                      >
+                        <span class="rounded-full border border-amber-300/30 bg-amber-300/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.13em] text-amber-100">
+                          Needs you
+                        </span>
+                      </Show>
+                    </div>
+                    <span class="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/60">
+                      {finding.status}
+                    </span>
+                  </div>
+                  <h2 class="mt-3 text-base font-medium leading-6 text-foreground">
+                    {finding.claim}
+                  </h2>
+
+                  <Show when={finding.evidence.length > 0}>
+                    <div class="mt-4 space-y-2 border-t border-border/50 pt-3">
+                      <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Evidence
+                      </div>
+                      <For each={finding.evidence}>
+                        {(evidence) => (
+                          <div class="rounded-lg border border-border/50 bg-slate-950/35 px-3 py-2">
+                            <div class="flex items-center gap-2">
+                              <span class="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] uppercase text-cyan-100/80">
+                                {evidence.kind}
+                              </span>
+                              <code class="min-w-0 truncate font-mono text-[11px] text-cyan-100/75">
+                                {evidence.reference}
+                              </code>
+                            </div>
+                            <Show when={evidence.excerpt}>
+                              <div class="mt-1 text-xs leading-5 text-muted-foreground">
+                                {evidence.excerpt}
+                              </div>
+                            </Show>
+                          </div>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+
+                  <div class="mt-4 flex items-center justify-between gap-3 border-t border-border/50 pt-3">
+                    <span class="text-[11px] text-muted-foreground">
+                      Agent evidence · reviewable before action
+                    </span>
+                    <Show when={finding.proposed_artifact}>
+                      <button
+                        type="button"
+                        class="rounded-lg border border-cyan-300/30 px-3 py-1.5 text-[11px] font-semibold text-cyan-100 hover:bg-cyan-300/10"
+                        onClick={() => props.onReview(finding)}
+                      >
+                        Review artifact
+                      </button>
+                    </Show>
+                  </div>
+                </article>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/src/components/run/RunLaunchBox.tsx
+++ b/src/components/run/RunLaunchBox.tsx
@@ -1,0 +1,124 @@
+// ABOUTME: First-run Mission Control launch surface for a plain-language objective.
+// ABOUTME: Keeps the safety boundary visible before a durable run is created.
+
+import { type Component, createSignal, Show } from "solid-js";
+import { launchMission, runStore } from "@/stores/run.store";
+
+export interface RunLaunchBoxProps {
+  onStarted?: () => void;
+}
+
+export const RunLaunchBox: Component<RunLaunchBoxProps> = (props) => {
+  const [objective, setObjective] = createSignal("");
+
+  const start = async () => {
+    const value = objective().trim();
+    if (!value) return;
+    await launchMission(value);
+    props.onStarted?.();
+  };
+
+  return (
+    <div class="mx-auto flex w-full max-w-2xl flex-col justify-center px-8 py-12">
+      <div class="mb-8">
+        <div class="mb-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-cyan-300/75">
+          <span class="h-1.5 w-1.5 rounded-full bg-cyan-300 shadow-[0_0_12px_rgba(103,232,249,0.85)]" />
+          Mission control
+        </div>
+        <h1 class="m-0 text-3xl font-semibold tracking-[-0.04em] text-foreground">
+          What should Seren investigate?
+        </h1>
+        <p class="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+          Give the team a question with a useful finish line. Seren will keep
+          work, evidence, and anything needing your approval in one place.
+        </p>
+      </div>
+
+      <div class="rounded-2xl border border-cyan-300/20 bg-[radial-gradient(circle_at_top_right,rgba(34,211,238,0.13),transparent_42%),rgba(15,23,42,0.7)] p-5 shadow-[0_24px_80px_rgba(2,8,23,0.35)]">
+        <label
+          for="mission-objective"
+          class="mb-2 block text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+        >
+          Objective
+        </label>
+        <textarea
+          id="mission-objective"
+          rows="4"
+          value={objective()}
+          onInput={(event) => setObjective(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+              void start();
+            }
+          }}
+          placeholder="Example: Find the source of the billing mismatch and prepare a reviewable reply."
+          class="w-full resize-none rounded-xl border border-border/80 bg-slate-950/45 px-4 py-3 text-sm leading-6 text-foreground outline-none transition focus:border-cyan-300/60 focus:ring-2 focus:ring-cyan-300/10"
+        />
+
+        <div class="mt-5 grid gap-4 border-t border-border/50 pt-4 sm:grid-cols-2">
+          <div>
+            <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-300/80">
+              Seren will
+            </div>
+            <ul class="m-0 space-y-2 p-0 text-xs leading-5 text-muted-foreground">
+              <li>Break the objective into observable work.</li>
+              <li>Show evidence and coverage gaps as they appear.</li>
+              <li>Pause before anything external is sent or changed.</li>
+            </ul>
+          </div>
+          <div>
+            <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-300/80">
+              It will not
+            </div>
+            <ul class="m-0 space-y-2 p-0 text-xs leading-5 text-muted-foreground">
+              <li>Invent evidence for a blocked source.</li>
+              <li>Hide a failed check behind a green status.</li>
+              <li>Send a draft without your approval.</li>
+            </ul>
+          </div>
+        </div>
+
+        <details class="mt-5 border-t border-border/50 pt-4">
+          <summary class="cursor-pointer text-xs font-medium text-muted-foreground transition hover:text-foreground">
+            Advanced controls
+          </summary>
+          <div class="mt-3 grid gap-2 sm:grid-cols-2">
+            <div class="rounded-lg border border-border/50 bg-slate-950/25 px-3 py-2 text-xs text-muted-foreground">
+              Models <span class="float-right text-foreground/70">Auto</span>
+            </div>
+            <div class="rounded-lg border border-border/50 bg-slate-950/25 px-3 py-2 text-xs text-muted-foreground">
+              Isolation{" "}
+              <span class="float-right text-foreground/70">Workspace</span>
+            </div>
+            <div class="rounded-lg border border-border/50 bg-slate-950/25 px-3 py-2 text-xs text-muted-foreground">
+              Budget <span class="float-right text-foreground/70">Guarded</span>
+            </div>
+            <div class="rounded-lg border border-border/50 bg-slate-950/25 px-3 py-2 text-xs text-muted-foreground">
+              Permissions{" "}
+              <span class="float-right text-foreground/70">Review first</span>
+            </div>
+          </div>
+        </details>
+
+        <div class="mt-5 flex items-center justify-between gap-3">
+          <span class="text-[11px] text-muted-foreground/70">
+            ⌘/Ctrl + Enter to start
+          </span>
+          <button
+            type="button"
+            onClick={() => void start()}
+            disabled={!objective().trim() || runStore.launchPending}
+            class="rounded-lg bg-cyan-300 px-4 py-2 text-xs font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {runStore.launchPending ? "Starting…" : "Start mission"}
+          </button>
+        </div>
+        <Show when={runStore.error}>
+          <div class="mt-3 rounded-lg border border-red-400/25 bg-red-400/10 px-3 py-2 text-xs text-red-200">
+            {runStore.error}
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/src/components/run/RunOverview.tsx
+++ b/src/components/run/RunOverview.tsx
@@ -1,0 +1,127 @@
+// ABOUTME: Overview lane view for work in progress, blocked tasks, and completed work.
+// ABOUTME: It turns the durable run snapshot into a compact operator briefing.
+
+import { type Component, For, Show } from "solid-js";
+import type { Finding, Task } from "@/services/run";
+import { runStore } from "@/stores/run.store";
+
+export interface RunOverviewProps {
+  onReview: (finding: Finding) => void;
+  onTaskSelect: (task: Task) => void;
+}
+
+const laneMeta = {
+  working: { label: "Working", tone: "text-cyan-200", marker: "bg-cyan-300" },
+  review: { label: "Review", tone: "text-amber-200", marker: "bg-amber-300" },
+  done: { label: "Done", tone: "text-emerald-200", marker: "bg-emerald-300" },
+};
+
+export const RunOverview: Component<RunOverviewProps> = (props) => {
+  const assignmentLabel = () => {
+    const assignment = runStore.snapshot?.assignments[0];
+    return assignment?.role_label ?? assignment?.agent_type ?? "Seren team";
+  };
+
+  const taskCard = (task: Task) => (
+    <button
+      type="button"
+      class="group w-full rounded-xl border border-border/70 bg-slate-900/55 p-4 text-left transition hover:-translate-y-0.5 hover:border-cyan-300/35 hover:bg-slate-900"
+      onClick={() => props.onTaskSelect(task)}
+    >
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          {assignmentLabel()}
+        </span>
+        <span class="font-mono text-[10px] text-muted-foreground/70">
+          {task.state}
+        </span>
+      </div>
+      <div class="mt-2 text-sm font-medium leading-5 text-foreground group-hover:text-cyan-100">
+        {task.title}
+      </div>
+      <div class="mt-2 line-clamp-3 text-xs leading-5 text-muted-foreground">
+        {task.brief}
+      </div>
+      <Show when={task.blocked_reason}>
+        <div class="mt-3 rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
+          {task.blocked_reason}
+        </div>
+      </Show>
+      <div class="mt-3 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/60">
+        Open task detail →
+      </div>
+    </button>
+  );
+
+  return (
+    <div class="space-y-6 p-5 lg:p-6">
+      <Show when={runStore.needsYou()[0]}>
+        {(finding) => (
+          <div class="flex items-center justify-between gap-4 rounded-xl border border-amber-300/50 bg-amber-300/[0.08] p-4 shadow-[0_0_36px_rgba(251,191,36,0.06)]">
+            <div class="min-w-0">
+              <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-200">
+                Needs you
+              </div>
+              <div class="mt-1 truncate text-sm font-medium text-foreground">
+                {finding().claim}
+              </div>
+              <div class="mt-1 text-xs text-muted-foreground">
+                A proposed artifact is waiting. Nothing sends until you approve
+                it.
+              </div>
+            </div>
+            <button
+              type="button"
+              class="shrink-0 rounded-lg bg-cyan-300 px-3 py-2 text-xs font-semibold text-slate-950 hover:bg-cyan-200"
+              onClick={() => props.onReview(finding())}
+            >
+              Review artifact →
+            </button>
+          </div>
+        )}
+      </Show>
+
+      <div>
+        <div class="mb-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          <span class="h-1.5 w-1.5 rounded-full bg-cyan-300" />
+          What the team is doing
+        </div>
+        <div class="grid gap-4 xl:grid-cols-3">
+          <For each={["working", "review", "done"] as const}>
+            {(lane) => {
+              const meta = laneMeta[lane];
+              const tasks = () => runStore.lanes()[lane];
+              return (
+                <section class="min-w-0 rounded-xl border border-border/70 bg-slate-950/25 p-3">
+                  <div class="mb-3 flex items-center justify-between px-1">
+                    <div
+                      class={`flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] ${meta.tone}`}
+                    >
+                      <span class={`h-1.5 w-1.5 rounded-full ${meta.marker}`} />
+                      {meta.label}
+                    </div>
+                    <span class="font-mono text-[10px] text-muted-foreground">
+                      {tasks().length}
+                    </span>
+                  </div>
+                  <div class="space-y-3">
+                    <For
+                      each={tasks()}
+                      fallback={
+                        <div class="px-1 py-5 text-xs text-muted-foreground/60">
+                          Nothing here yet.
+                        </div>
+                      }
+                    >
+                      {taskCard}
+                    </For>
+                  </div>
+                </section>
+              );
+            }}
+          </For>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/run/RunTaskDrawer.tsx
+++ b/src/components/run/RunTaskDrawer.tsx
@@ -1,0 +1,86 @@
+// ABOUTME: Task detail drawer with durable state, blockers, attempts, and session activity.
+// ABOUTME: Reuses the existing session timeline instead of introducing a second transcript renderer.
+
+import { type Component, createEffect, Show } from "solid-js";
+import { SessionTimeline } from "@/components/session/SessionTimeline";
+import type { Task } from "@/services/run";
+import { runStore } from "@/stores/run.store";
+import { sessionStore } from "@/stores/session.store";
+
+export interface RunTaskDrawerProps {
+  task: Task;
+  onClose: () => void;
+}
+
+export const RunTaskDrawer: Component<RunTaskDrawerProps> = (props) => {
+  const attempt = () =>
+    runStore.snapshot?.attempts.find((item) => item.task_id === props.task.id);
+  const sessionId = () => attempt()?.agent_session_id ?? null;
+
+  createEffect(() => {
+    const id = sessionId();
+    if (id) void sessionStore.loadEvents(id);
+  });
+
+  return (
+    <div class="fixed inset-y-0 right-0 z-[70] flex w-full max-w-xl flex-col border-l border-border/80 bg-slate-950 shadow-[-20px_0_80px_rgba(2,8,23,0.45)]">
+      <div class="flex items-start justify-between gap-4 border-b border-border/70 px-5 py-4">
+        <div>
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
+            Task detail
+          </div>
+          <h2 class="mt-1 text-base font-medium text-foreground">
+            {props.task.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          class="text-xs text-muted-foreground hover:text-foreground"
+          onClick={props.onClose}
+        >
+          Close
+        </button>
+      </div>
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+        <div class="flex items-center justify-between rounded-xl border border-border/60 bg-slate-900/60 px-4 py-3">
+          <span class="text-xs text-muted-foreground">State</span>
+          <span class="font-mono text-xs text-cyan-100">
+            {props.task.state}
+          </span>
+        </div>
+        <Show when={props.task.blocked_reason}>
+          <div class="mt-3 rounded-xl border border-amber-300/25 bg-amber-300/[0.07] px-4 py-3 text-xs leading-5 text-amber-100">
+            {props.task.blocked_reason}
+          </div>
+        </Show>
+        <div class="mt-5">
+          <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Brief
+          </div>
+          <p class="m-0 text-sm leading-6 text-foreground/85">
+            {props.task.brief}
+          </p>
+        </div>
+        <div class="mt-5">
+          <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Agent activity
+          </div>
+          <Show
+            when={sessionId()}
+            fallback={
+              <div class="rounded-xl border border-dashed border-border/70 px-4 py-8 text-center text-xs text-muted-foreground">
+                No live session is attached yet.
+              </div>
+            }
+          >
+            {(id) => (
+              <div class="rounded-xl border border-border/60 bg-slate-900/50 px-3 py-3">
+                <SessionTimeline events={sessionStore.getEventsFor(id())} />
+              </div>
+            )}
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -1,0 +1,338 @@
+// ABOUTME: Typed renderer bridge for the durable run-engine commands.
+// ABOUTME: This is the only Mission Control module allowed to cross the Tauri IPC boundary.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type TaskState =
+  | "pending"
+  | "ready"
+  | "provisioning"
+  | "running"
+  | "blocked"
+  | "verifying"
+  | "review"
+  | "done"
+  | "failed"
+  | "cancelled";
+
+export type RunStatus =
+  | "running"
+  | "completed"
+  | "partial"
+  | "failed"
+  | "cancelled";
+export type LeaseMode =
+  | "shared_readonly"
+  | "worktree"
+  | "scratch"
+  | "external_read"
+  | "external_write";
+export type FindingConfidence = "asserted" | "verified" | "refuted";
+export type FindingStatus = "open" | "accepted" | "rejected" | "superseded";
+export type EvidenceKind =
+  | "command_result"
+  | "file_range"
+  | "email"
+  | "document"
+  | "url"
+  | "log_excerpt"
+  | "publisher_result";
+export type ArtifactKind = "diff" | "document" | "email" | "comment";
+export type RunEventType =
+  | "run_created"
+  | "task_added"
+  | "dependency_added"
+  | "assignment_added"
+  | "task_state_changed"
+  | "attempt_started"
+  | "attempt_finished"
+  | "finding_recorded"
+  | "evidence_attached"
+  | "approval_requested"
+  | "run_cancel_requested"
+  | "run_finalized"
+  | "lease_state_changed"
+  | "check_declared"
+  | "check_approved"
+  | "check_result_recorded"
+  | "coverage_gap_recorded"
+  | "task_completion_rejected"
+  | "finding_status_changed";
+
+export interface Run {
+  id: string;
+  objective: string;
+  root_path: string | null;
+  status: RunStatus;
+  cancel_requested: boolean;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+}
+
+export interface Task {
+  id: string;
+  run_id: string;
+  title: string;
+  brief: string;
+  state: TaskState;
+  blocked_reason: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface TaskDependency {
+  task_id: string;
+  depends_on_task_id: string;
+}
+
+export interface AgentAssignment {
+  id: string;
+  run_id: string;
+  agent_type: string;
+  model_id: string | null;
+  role_label: string | null;
+  created_at: number;
+}
+
+export interface Attempt {
+  id: string;
+  task_id: string;
+  agent_assignment_id: string | null;
+  agent_session_id: string | null;
+  attempt_number: number;
+  outcome: string | null;
+  started_at: number;
+  ended_at: number | null;
+}
+
+export interface WorkspaceLease {
+  id: string;
+  run_id: string;
+  task_id: string | null;
+  mode: LeaseMode;
+  root_path: string | null;
+  base_revision: string | null;
+  state: string;
+  created_at: number;
+  released_at: number | null;
+}
+
+export interface Evidence {
+  kind: EvidenceKind;
+  reference: string;
+  excerpt: string | null;
+}
+
+export interface ProposedArtifact {
+  kind: ArtifactKind;
+  title: string;
+  content: string | null;
+}
+
+export interface Finding {
+  id: string;
+  run_id: string;
+  task_id: string | null;
+  attempt_id: string | null;
+  claim: string;
+  confidence: FindingConfidence;
+  evidence: Evidence[];
+  proposed_artifact: ProposedArtifact | null;
+  needs_approval: boolean;
+  status: FindingStatus;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface CheckDeclaration {
+  name: string;
+  command: string;
+}
+
+export interface RunCheck {
+  id: string;
+  run_id: string;
+  name: string;
+  command: string;
+  approved: boolean;
+  created_at: number;
+}
+
+export interface CheckResult {
+  id: string;
+  check_id: string;
+  task_id: string | null;
+  attempt_id: string | null;
+  kind: string;
+  exit_code: number | null;
+  duration_ms: number;
+  output_tail: string;
+  pre_existing_failure: boolean;
+  created_at: number;
+}
+
+export interface CoverageGap {
+  id: string;
+  run_id: string;
+  task_id: string | null;
+  kind: string;
+  subject: string;
+  detail: string | null;
+  created_at: number;
+}
+
+export interface RunEvent {
+  id: string;
+  run_id: string;
+  task_id: string | null;
+  attempt_id: string | null;
+  agent_id: string | null;
+  sequence: number;
+  event_type: RunEventType;
+  payload: Record<string, unknown>;
+  provider_event_id: string | null;
+  created_at: number;
+}
+
+export interface FindingInput extends Finding {}
+export interface CoverageGapInput extends CoverageGap {}
+
+export interface RunSnapshot {
+  run: Run;
+  tasks: Task[];
+  dependencies: TaskDependency[];
+  assignments: AgentAssignment[];
+  attempts: Attempt[];
+  findings: Finding[];
+  checks: RunCheck[];
+  check_results: CheckResult[];
+  coverage_gaps: CoverageGap[];
+}
+
+export async function runCreate(
+  objective: string,
+  rootPath?: string | null,
+): Promise<Run> {
+  return invoke("run_create", {
+    objective,
+    root_path: rootPath ?? null,
+  }) as Promise<Run>;
+}
+
+export async function runAddTask(
+  runId: string,
+  title: string,
+  brief: string,
+  dependsOn: string[] = [],
+): Promise<Task> {
+  return invoke("run_add_task", {
+    run_id: runId,
+    title,
+    brief,
+    depends_on: dependsOn,
+  }) as Promise<Task>;
+}
+
+export async function runAddAgent(
+  runId: string,
+  agentType: string,
+  modelId?: string | null,
+  roleLabel?: string | null,
+): Promise<AgentAssignment> {
+  return invoke("run_add_agent", {
+    run_id: runId,
+    agent_type: agentType,
+    model_id: modelId ?? null,
+    role_label: roleLabel ?? null,
+  }) as Promise<AgentAssignment>;
+}
+
+export async function runCancel(runId: string): Promise<Run> {
+  return invoke("run_cancel", { run_id: runId }) as Promise<Run>;
+}
+
+export async function runGetState(runId: string): Promise<RunSnapshot> {
+  return invoke("run_get_state", { run_id: runId }) as Promise<RunSnapshot>;
+}
+
+export async function runListEvents(
+  runId: string,
+  afterSequence = 0,
+): Promise<RunEvent[]> {
+  return invoke("run_list_events", {
+    run_id: runId,
+    after_sequence: afterSequence,
+  }) as Promise<RunEvent[]>;
+}
+
+export async function runList(): Promise<Run[]> {
+  return invoke("run_list") as Promise<Run[]>;
+}
+
+export async function runDeclareChecks(
+  runId: string,
+  checks: CheckDeclaration[],
+): Promise<RunCheck[]> {
+  return invoke("run_declare_checks", {
+    run_id: runId,
+    checks,
+  }) as Promise<RunCheck[]>;
+}
+
+export async function runApproveCheck(checkId: string): Promise<RunCheck> {
+  return invoke("run_approve_check", {
+    check_id: checkId,
+  }) as Promise<RunCheck>;
+}
+
+export async function runBaseline(runId: string): Promise<CheckResult[]> {
+  return invoke("run_baseline", { run_id: runId }) as Promise<CheckResult[]>;
+}
+
+export async function runVerifyTask(
+  runId: string,
+  taskId: string,
+): Promise<CheckResult[]> {
+  return invoke("run_verify_task", {
+    run_id: runId,
+    task_id: taskId,
+  }) as Promise<CheckResult[]>;
+}
+
+export async function runCompleteTask(
+  runId: string,
+  taskId: string,
+): Promise<string[]> {
+  return invoke("run_complete_task", {
+    run_id: runId,
+    task_id: taskId,
+  }) as Promise<string[]>;
+}
+
+export async function runRecordFinding(finding: FindingInput): Promise<void> {
+  return invoke("run_record_finding", { finding }) as Promise<void>;
+}
+
+export async function runAddCoverageGap(gap: CoverageGapInput): Promise<void> {
+  return invoke("run_add_coverage_gap", { gap }) as Promise<void>;
+}
+
+export async function runUpdateFindingStatus(
+  runId: string,
+  findingId: string,
+  status: Exclude<FindingStatus, "open">,
+): Promise<void> {
+  return invoke("run_update_finding_status", {
+    run_id: runId,
+    finding_id: findingId,
+    status,
+  }) as Promise<void>;
+}
+
+export function subscribeRunEvents(
+  onEvent: (event: RunEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<RunEvent>("run://event", (event) => onEvent(event.payload));
+}

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -1,0 +1,228 @@
+// ABOUTME: Reactive Mission Control state for durable runs, findings, and coverage.
+// ABOUTME: It keeps IPC in the run service and turns ordered events into a stable UI model.
+
+import { createStore } from "solid-js/store";
+import {
+  type FindingStatus,
+  type RunEvent,
+  type RunSnapshot,
+  runCancel,
+  runCreate,
+  runGetState,
+  runUpdateFindingStatus,
+  type Task,
+} from "@/services/run";
+
+export interface RunLanes {
+  queued: Task[];
+  working: Task[];
+  review: Task[];
+  done: Task[];
+}
+
+export interface RunStoreState {
+  activeRunId: string | null;
+  snapshot: RunSnapshot | null;
+  lastSequence: number;
+  launchPending: boolean;
+  error: string | null;
+}
+
+const INITIAL_STATE: RunStoreState = {
+  activeRunId: null,
+  snapshot: null,
+  lastSequence: 0,
+  launchPending: false,
+  error: null,
+};
+
+const [state, setState] = createStore<RunStoreState>(INITIAL_STATE);
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function applyTaskState(event: RunEvent): void {
+  const taskId = event.task_id;
+  const nextState = event.payload.state;
+  if (!taskId || typeof nextState !== "string") return;
+  setState("snapshot", "tasks", (tasks) =>
+    tasks.map((task) =>
+      task.id === taskId
+        ? { ...task, state: nextState as Task["state"] }
+        : task,
+    ),
+  );
+}
+
+function applyFindingStatus(event: RunEvent): void {
+  const findingId = event.payload.finding_id;
+  const status = event.payload.status;
+  if (typeof findingId !== "string" || typeof status !== "string") return;
+  setState("snapshot", "findings", (findings) =>
+    findings.map((finding) =>
+      finding.id === findingId
+        ? {
+            ...finding,
+            status: status as FindingStatus,
+            needs_approval: status === "open" ? finding.needs_approval : false,
+          }
+        : finding,
+    ),
+  );
+}
+
+async function hydrate(runId: string): Promise<void> {
+  setState("error", null);
+  try {
+    const snapshot = await runGetState(runId);
+    setState({
+      activeRunId: runId,
+      snapshot,
+      lastSequence: 0,
+    });
+  } catch (error) {
+    setState("error", errorMessage(error));
+  }
+}
+
+async function applyEvent(event: RunEvent): Promise<void> {
+  if (state.activeRunId && event.run_id !== state.activeRunId) return;
+  if (event.sequence <= state.lastSequence) return;
+
+  if (event.sequence - state.lastSequence > 1) {
+    await hydrate(event.run_id);
+    setState("lastSequence", event.sequence);
+    return;
+  }
+
+  if (!state.activeRunId) setState("activeRunId", event.run_id);
+  if (!state.snapshot && event.event_type !== "run_created") {
+    await hydrate(event.run_id);
+  } else if (event.event_type === "task_state_changed") {
+    applyTaskState(event);
+  } else if (event.event_type === "finding_status_changed") {
+    applyFindingStatus(event);
+  } else if (
+    event.event_type === "finding_recorded" ||
+    event.event_type === "coverage_gap_recorded" ||
+    event.event_type === "check_declared" ||
+    event.event_type === "check_approved" ||
+    event.event_type === "check_result_recorded" ||
+    event.event_type === "run_created" ||
+    event.event_type === "task_added" ||
+    event.event_type === "assignment_added"
+  ) {
+    await hydrate(event.run_id);
+  }
+  setState("lastSequence", event.sequence);
+}
+
+async function launch(
+  objective: string,
+  rootPath?: string | null,
+): Promise<void> {
+  const trimmedObjective = objective.trim();
+  if (!trimmedObjective) {
+    setState("error", "Tell Seren what to investigate first.");
+    return;
+  }
+  setState({ launchPending: true, error: null });
+  try {
+    const run = await runCreate(trimmedObjective, rootPath);
+    setState("activeRunId", run.id);
+    await hydrate(run.id);
+  } catch (error) {
+    setState("error", errorMessage(error));
+  } finally {
+    setState("launchPending", false);
+  }
+}
+
+async function cancel(): Promise<void> {
+  if (!state.activeRunId) return;
+  try {
+    const run = await runCancel(state.activeRunId);
+    setState("snapshot", "run", run);
+  } catch (error) {
+    setState("error", errorMessage(error));
+  }
+}
+
+async function setFindingStatus(
+  findingId: string,
+  status: Exclude<FindingStatus, "open">,
+): Promise<void> {
+  if (!state.activeRunId) return;
+  try {
+    await runUpdateFindingStatus(state.activeRunId, findingId, status);
+    setState("snapshot", "findings", (findings) =>
+      findings.map((finding) =>
+        finding.id === findingId
+          ? { ...finding, status, needs_approval: false }
+          : finding,
+      ),
+    );
+  } catch (error) {
+    setState("error", errorMessage(error));
+  }
+}
+
+function needsYou() {
+  return (state.snapshot?.findings ?? []).filter(
+    (finding) => finding.needs_approval && finding.status === "open",
+  );
+}
+
+function lanes(): RunLanes {
+  const result: RunLanes = { queued: [], working: [], review: [], done: [] };
+  for (const task of state.snapshot?.tasks ?? []) {
+    if (
+      ["provisioning", "running", "blocked", "verifying"].includes(task.state)
+    ) {
+      result.working.push(task);
+    } else if (task.state === "review") {
+      result.review.push(task);
+    } else if (["done", "failed", "cancelled"].includes(task.state)) {
+      result.done.push(task);
+    } else {
+      result.queued.push(task);
+    }
+  }
+  return result;
+}
+
+export const runStore = {
+  get activeRunId() {
+    return state.activeRunId;
+  },
+  get snapshot() {
+    return state.snapshot;
+  },
+  get lastSequence() {
+    return state.lastSequence;
+  },
+  get launchPending() {
+    return state.launchPending;
+  },
+  get error() {
+    return state.error;
+  },
+  hydrate,
+  applyEvent,
+  launch,
+  cancel,
+  approveFinding: (findingId: string) =>
+    setFindingStatus(findingId, "accepted"),
+  rejectFinding: (findingId: string) => setFindingStatus(findingId, "rejected"),
+  needsYou,
+  lanes,
+  findingsCount: () => state.snapshot?.findings.length ?? 0,
+  coverageGaps: () => state.snapshot?.coverage_gaps ?? [],
+};
+
+export async function launchMission(objective: string): Promise<void> {
+  await runStore.launch(objective);
+}
+
+export { INITIAL_STATE, setState as setRunState, state as runState };

--- a/tests/unit/run-findings-coverage-placement.test.ts
+++ b/tests/unit/run-findings-coverage-placement.test.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Verifies the Mission Control findings layout's coverage boundary.
+// ABOUTME: The template source check keeps this test dependency-free while checking DOM order.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const findingsSource = readFileSync(
+  resolve("src/components/run/RunFindings.tsx"),
+  "utf8",
+);
+
+describe("RunFindings coverage placement", () => {
+  it("keeps the coverage strip before the findings scroll region", () => {
+    const coverageIndex = findingsSource.indexOf(
+      'data-testid="coverage-strip"',
+    );
+    const findingsIndex = findingsSource.indexOf(
+      'data-testid="findings-scroll"',
+    );
+
+    expect(coverageIndex).toBeGreaterThanOrEqual(0);
+    expect(findingsIndex).toBeGreaterThan(coverageIndex);
+    expect(findingsSource).toContain("gaps().length");
+    expect(findingsSource).toContain("findings().length");
+    expect(findingsSource).toContain(
+      'class="min-h-0 flex-1 overflow-y-auto px-5 py-5 lg:px-6"',
+    );
+  });
+});

--- a/tests/unit/run-launchbox.test.ts
+++ b/tests/unit/run-launchbox.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Covers the first-run Mission Control launch surface.
+// ABOUTME: Confirms the plain-language controls and launch service handoff.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INITIAL_STATE,
+  launchMission,
+  runStore,
+  setRunState,
+} from "@/stores/run.store";
+
+const launchBoxSource = readFileSync(
+  resolve("src/components/run/RunLaunchBox.tsx"),
+  "utf8",
+);
+
+describe("RunLaunchBox", () => {
+  beforeEach(() => {
+    setRunState(INITIAL_STATE);
+    vi.restoreAllMocks();
+  });
+
+  it("defines an objective input and advanced disclosure", () => {
+    expect(launchBoxSource).toContain('id="mission-objective"');
+    expect(launchBoxSource).toContain("<details");
+    expect(launchBoxSource).toContain("Seren will");
+    expect(launchBoxSource).toContain("It will not");
+    expect(launchBoxSource).toContain("await launchMission(value)");
+  });
+
+  it("sends the typed objective to the store launch action", async () => {
+    const launch = vi.spyOn(runStore, "launch").mockResolvedValue(undefined);
+
+    await launchMission("  Reconcile the billing records  ");
+
+    expect(launch).toHaveBeenCalledWith("  Reconcile the billing records  ");
+  });
+});

--- a/tests/unit/run-store-events.test.ts
+++ b/tests/unit/run-store-events.test.ts
@@ -1,0 +1,175 @@
+// ABOUTME: Tests ordered Mission Control event application and recovery.
+// ABOUTME: Protects duplicate suppression, gap hydration, and operator selectors.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/run", async () => {
+  const actual = await vi.importActual<typeof import("@/services/run")>(
+    "@/services/run",
+  );
+  return { ...actual, runGetState: vi.fn() };
+});
+
+import {
+  runGetState,
+  type RunEvent,
+  type RunSnapshot,
+} from "@/services/run";
+import {
+  INITIAL_STATE,
+  runState,
+  runStore,
+  setRunState,
+} from "@/stores/run.store";
+
+const getStateMock = vi.mocked(runGetState);
+
+function snapshot(): RunSnapshot {
+  return {
+    run: {
+      id: "run-1",
+      objective: "Trace the billing mismatch",
+      root_path: null,
+      status: "running",
+      cancel_requested: false,
+      created_at: 1,
+      updated_at: 1,
+      completed_at: null,
+    },
+    tasks: [
+      {
+        id: "task-working",
+        run_id: "run-1",
+        title: "Inspect the ledger",
+        brief: "Compare the source records.",
+        state: "running",
+        blocked_reason: null,
+        created_at: 1,
+        updated_at: 1,
+      },
+      {
+        id: "task-review",
+        run_id: "run-1",
+        title: "Review the finding",
+        brief: "Check the proposed answer.",
+        state: "review",
+        blocked_reason: null,
+        created_at: 1,
+        updated_at: 1,
+      },
+      {
+        id: "task-done",
+        run_id: "run-1",
+        title: "Collect context",
+        brief: "Gather the relevant context.",
+        state: "done",
+        blocked_reason: null,
+        created_at: 1,
+        updated_at: 1,
+      },
+    ],
+    dependencies: [],
+    assignments: [],
+    attempts: [],
+    findings: [
+      {
+        id: "finding-1",
+        run_id: "run-1",
+        task_id: "task-review",
+        attempt_id: null,
+        claim: "The invoice was duplicated.",
+        confidence: "asserted",
+        evidence: [],
+        proposed_artifact: null,
+        needs_approval: true,
+        status: "open",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ],
+    checks: [],
+    check_results: [],
+    coverage_gaps: [],
+  };
+}
+
+function event(
+  sequence: number,
+  eventType: RunEvent["event_type"],
+  payload: Record<string, unknown> = {},
+  taskId: string | null = null,
+): RunEvent {
+  return {
+    id: `event-${sequence}`,
+    run_id: "run-1",
+    task_id: taskId,
+    attempt_id: null,
+    agent_id: null,
+    sequence,
+    event_type: eventType,
+    payload,
+    provider_event_id: null,
+    created_at: sequence,
+  };
+}
+
+describe("run store event handling", () => {
+  beforeEach(() => {
+    setRunState(INITIAL_STATE);
+    getStateMock.mockReset();
+  });
+
+  it("ignores duplicate and lower sequence events", async () => {
+    setRunState({
+      activeRunId: "run-1",
+      snapshot: snapshot(),
+      lastSequence: 3,
+    });
+
+    await runStore.applyEvent(
+      event(3, "task_state_changed", { state: "done" }, "task-working"),
+    );
+    await runStore.applyEvent(
+      event(2, "task_state_changed", { state: "blocked" }, "task-working"),
+    );
+
+    expect(
+      runState.snapshot?.tasks.find((task) => task.id === "task-working")
+        ?.state,
+    ).toBe("running");
+    expect(runState.lastSequence).toBe(3);
+  });
+
+  it("hydrates when an event sequence gap is detected", async () => {
+    const rehydrated = snapshot();
+    rehydrated.tasks[0].state = "verifying";
+    getStateMock.mockResolvedValue(rehydrated);
+    setRunState({
+      activeRunId: "run-1",
+      snapshot: snapshot(),
+      lastSequence: 1,
+    });
+
+    await runStore.applyEvent(event(3, "task_state_changed"));
+
+    expect(getStateMock).toHaveBeenCalledWith("run-1");
+    expect(runState.snapshot?.tasks[0].state).toBe("verifying");
+    expect(runState.lastSequence).toBe(3);
+  });
+
+  it("groups lanes and exposes findings that need operator review", () => {
+    setRunState({
+      activeRunId: "run-1",
+      snapshot: snapshot(),
+      lastSequence: 0,
+    });
+
+    const lanes = runStore.lanes();
+    expect(runStore.needsYou().map((finding) => finding.id)).toEqual([
+      "finding-1",
+    ]);
+    expect(lanes.working.map((task) => task.id)).toEqual(["task-working"]);
+    expect(lanes.review.map((task) => task.id)).toEqual(["task-review"]);
+    expect(lanes.done.map((task) => task.id)).toEqual(["task-done"]);
+  });
+});


### PR DESCRIPTION
Mission Control presents the run workflow as a focused, review-first slide panel.

Included:

- Launch box with objective and plain-language execution boundaries.
- Overview lanes for working, blocked, and completed tasks.
- Findings centerpiece with a pinned, always-visible coverage strip and expandable gaps.
- Artifact review with live Approve and Reject actions backed by run_update_finding_status.
- Task drawer reusing SessionTimeline, keyed by the attempt session id.
- AppShell slide-panel wiring for the Mission Control view.

The frontend adds one reactive run store and a typed service with fifteen run command wrappers. IPC calls are confined to the service. The Rust addition persists finding-status changes, emits finding status events, and registers the run_update_finding_status command.

Verification completed locally:

- New UI tests: 6/6 passed, exit 0.
- Full Vitest: 2,860 passed and 15 skipped across 404 passing files and 3 skipped files, exit 0.
- Focused Rust run suite: 33/33 passed, exit 0.
- Full Cargo suite: exit 0.
- Biome check: exit 0.
- Frontend build: exit 0.

Known deviations:

- The referenced mockup HTML is not tracked on origin/main; the existing local overview PNG was inspected as the visual reference, and the untracked user file was not changed.
- The repository Vitest environment is Node-only, so the coverage placement test verifies source marker order rather than live DOM position; the build validates the Solid JSX.
- The branch was rebased locally onto the current origin/main auth change before publication so unrelated mainline work is preserved and the diff remains scoped.

Live agent-session attachment to attempts remains follow-up slice wiring. The task drawer is keyed for that attachment and reuses the existing session timeline.

Part of #3511
