### PR TITLE
feat(run): agent dispatch with interrupted runs and relaunch

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -174,6 +174,48 @@ pub async fn run_update_finding_status(
 }
 
 #[tauri::command]
+pub async fn run_start_attempt(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    task_id: String,
+    agent_assignment_id: Option<String>,
+    agent_session_id: Option<String>,
+) -> Result<String, String> {
+    state
+        .start_attempt(
+            &app,
+            run_id,
+            task_id,
+            agent_assignment_id,
+            agent_session_id,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn run_finish_attempt(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+    attempt_id: String,
+    outcome: String,
+) -> Result<(), String> {
+    state
+        .finish_attempt(&app, run_id, attempt_id, outcome)
+        .await
+}
+
+#[tauri::command]
+pub async fn run_relaunch(
+    app: AppHandle,
+    state: State<'_, RunEngineState>,
+    run_id: String,
+) -> Result<Run, String> {
+    state.relaunch(&app, run_id).await
+}
+
+#[tauri::command]
 pub async fn run_provision_workspace(
     app: AppHandle,
     state: State<'_, RunEngineState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1411,6 +1411,9 @@ pub fn run() {
             commands::run::run_record_finding,
             commands::run::run_add_coverage_gap,
             commands::run::run_update_finding_status,
+            commands::run::run_start_attempt,
+            commands::run::run_finish_attempt,
+            commands::run::run_relaunch,
             commands::run::run_provision_workspace,
             commands::run::run_release_workspace,
             // Claude Code auto-memory interceptor commands

--- a/src-tauri/src/run/checks.rs
+++ b/src-tauri/src/run/checks.rs
@@ -140,6 +140,7 @@ mod tests {
                 root_path: None,
                 status: RunStatus::Running,
                 cancel_requested: false,
+                interrupted_at: None,
                 created_at: 1,
                 updated_at: 1,
                 completed_at: None,

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -110,6 +110,23 @@ enum SchedulerCommand {
         status: String,
         reply: oneshot::Sender<Result<(), String>>,
     },
+    StartAttempt {
+        run_id: String,
+        task_id: String,
+        agent_assignment_id: Option<String>,
+        agent_session_id: Option<String>,
+        reply: oneshot::Sender<Result<String, String>>,
+    },
+    FinishAttempt {
+        run_id: String,
+        attempt_id: String,
+        outcome: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    Relaunch {
+        run_id: String,
+        reply: oneshot::Sender<Result<Run, String>>,
+    },
     ReleaseLease {
         lease_id: String,
         reply: oneshot::Sender<Result<WorkspaceLease, String>>,
@@ -428,6 +445,66 @@ impl RunEngineState {
             .map_err(|_| "run scheduler dropped finding-status response".to_string())?
     }
 
+    pub async fn start_attempt(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        task_id: String,
+        agent_assignment_id: Option<String>,
+        agent_session_id: Option<String>,
+    ) -> Result<String, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::StartAttempt {
+                run_id,
+                task_id,
+                agent_assignment_id,
+                agent_session_id,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped start-attempt response".to_string())?
+    }
+
+    pub async fn finish_attempt(
+        &self,
+        app: &AppHandle,
+        run_id: String,
+        attempt_id: String,
+        outcome: String,
+    ) -> Result<(), String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::FinishAttempt {
+                run_id,
+                attempt_id,
+                outcome,
+                reply,
+            })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped finish-attempt response".to_string())?
+    }
+
+    pub async fn relaunch(&self, app: &AppHandle, run_id: String) -> Result<Run, String> {
+        let sender = self.sender(app).await?;
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(SchedulerCommand::Relaunch { run_id, reply })
+            .await
+            .map_err(|_| "run scheduler stopped".to_string())?;
+        response
+            .await
+            .map_err(|_| "run scheduler dropped relaunch response".to_string())?
+    }
+
     pub async fn provision_workspace(
         &self,
         app: &AppHandle,
@@ -485,6 +562,16 @@ async fn scheduler_loop(
     sender: mpsc::Sender<SchedulerCommand>,
     workspaces_root: PathBuf,
 ) {
+    match reconcile_interrupted(&connection) {
+        Ok(events) => {
+            for event in events {
+                if let Err(error) = append_and_emit(&app, &connection, event) {
+                    log::error!("[run-engine] startup reconciliation event failed: {error}");
+                }
+            }
+        }
+        Err(error) => log::error!("[run-engine] startup reconciliation failed: {error}"),
+    }
     while let Some(command) = receiver.recv().await {
         process_command(&app, &connection, &sender, &workspaces_root, command);
     }
@@ -632,6 +719,33 @@ fn process_command(
                 finding_id,
                 status,
             ));
+        }
+        SchedulerCommand::StartAttempt {
+            run_id,
+            task_id,
+            agent_assignment_id,
+            agent_session_id,
+            reply,
+        } => {
+            let _ = reply.send(start_attempt(
+                app,
+                conn,
+                run_id,
+                task_id,
+                agent_assignment_id,
+                agent_session_id,
+            ));
+        }
+        SchedulerCommand::FinishAttempt {
+            run_id,
+            attempt_id,
+            outcome,
+            reply,
+        } => {
+            let _ = reply.send(finish_attempt(app, conn, run_id, attempt_id, outcome));
+        }
+        SchedulerCommand::Relaunch { run_id, reply } => {
+            let _ = reply.send(relaunch(app, conn, run_id));
         }
         SchedulerCommand::ReleaseLease { lease_id, reply } => {
             let _ = reply.send(release_lease(app, conn, lease_id));
@@ -1311,6 +1425,222 @@ fn update_finding_status(
     Ok(())
 }
 
+fn start_attempt(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    task_id: String,
+    agent_assignment_id: Option<String>,
+    agent_session_id: Option<String>,
+) -> Result<String, String> {
+    let state: String = conn
+        .query_row(
+            "SELECT state FROM run_tasks WHERE id = ?1 AND run_id = ?2",
+            params![task_id, run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if TaskState::parse(&state) != Some(TaskState::Ready) {
+        return Err(format!("task must be ready before starting an attempt; current state is {state}"));
+    }
+    let has_active_lease: bool = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM run_workspace_leases
+                 WHERE run_id = ?1 AND task_id = ?2 AND state = 'active'
+             )",
+            params![run_id, task_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| error.to_string())?
+        != 0;
+
+    if has_active_lease {
+        store::transition_task(conn, &task_id, TaskState::Provisioning, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Provisioning))?;
+    }
+    store::transition_task(conn, &task_id, TaskState::Running, None)
+        .map_err(|error| error.to_string())?;
+    append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Running))?;
+
+    let attempt = super::types::Attempt {
+        id: Uuid::new_v4().to_string(),
+        task_id: task_id.clone(),
+        agent_assignment_id,
+        agent_session_id,
+        attempt_number: store::max_attempt_number(conn, &task_id)
+            .map_err(|error| error.to_string())?
+            + 1,
+        outcome: None,
+        started_at: now_ms(),
+        ended_at: None,
+    };
+    store::insert_attempt(conn, &attempt).map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        attempt_event(
+            &run_id,
+            &task_id,
+            &attempt.id,
+            RunEventType::AttemptStarted,
+            json!({"attempt_number": attempt.attempt_number, "agent_session_id": attempt.agent_session_id}),
+        ),
+    )?;
+    recompute_ready_and_status(app, conn, &run_id)?;
+    Ok(attempt.id)
+}
+
+fn finish_attempt(
+    app: &AppHandle,
+    conn: &Connection,
+    run_id: String,
+    attempt_id: String,
+    outcome: String,
+) -> Result<(), String> {
+    let (task_id, task_state): (String, String) = conn
+        .query_row(
+            "SELECT a.task_id, t.state
+             FROM run_attempts a
+             JOIN run_tasks t ON t.id = a.task_id
+             WHERE a.id = ?1 AND t.run_id = ?2",
+            params![attempt_id, run_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(|error| error.to_string())?;
+    store::finish_attempt(conn, &attempt_id, &outcome, now_ms())
+        .map_err(|error| error.to_string())?;
+    append_and_emit(
+        app,
+        conn,
+        attempt_event(
+            &run_id,
+            &task_id,
+            &attempt_id,
+            RunEventType::AttemptFinished,
+            json!({"outcome": outcome}),
+        ),
+    )?;
+    if outcome == "failed" && TaskState::parse(&task_state) == Some(TaskState::Running) {
+        store::transition_task(conn, &task_id, TaskState::Failed, None)
+            .map_err(|error| error.to_string())?;
+        append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Failed))?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)
+}
+
+fn reconcile_interrupted(conn: &Connection) -> Result<Vec<NewRunEvent>, String> {
+    let run_ids = {
+        let mut statement = conn
+            .prepare("SELECT id FROM runs WHERE status = 'running' ORDER BY created_at, id")
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|error| error.to_string())?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| error.to_string())?
+    };
+    let mut events = Vec::with_capacity(run_ids.len());
+    for run_id in run_ids {
+        let interrupted_at = now_ms();
+        conn.execute(
+            "UPDATE runs
+             SET status = 'interrupted', interrupted_at = ?1, updated_at = ?1,
+                 completed_at = NULL
+             WHERE id = ?2 AND status = 'running'",
+            params![interrupted_at, run_id],
+        )
+        .map_err(|error| error.to_string())?;
+        events.push(event_for_task_or_run(
+            &run_id,
+            None,
+            RunEventType::RunInterrupted,
+            json!({"interrupted_at": interrupted_at}),
+        ));
+    }
+    Ok(events)
+}
+
+fn prepare_relaunch(conn: &Connection, run_id: &str) -> Result<Vec<NewRunEvent>, String> {
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM runs WHERE id = ?1",
+            params![run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if RunStatus::parse(&status) != Some(RunStatus::Interrupted) {
+        return Err(format!("run must be interrupted before relaunch; current status is {status}"));
+    }
+    let timestamp = now_ms();
+    conn.execute(
+        "UPDATE runs
+         SET status = 'running', interrupted_at = NULL, completed_at = NULL, updated_at = ?1
+         WHERE id = ?2",
+        params![timestamp, run_id],
+    )
+    .map_err(|error| error.to_string())?;
+
+    let tasks = {
+        let mut statement = conn
+            .prepare("SELECT id, state FROM run_tasks WHERE run_id = ?1 ORDER BY created_at, id")
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map(params![run_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|error| error.to_string())?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| error.to_string())?
+    };
+    let mut events = Vec::new();
+    for (task_id, state) in tasks {
+        let state = TaskState::parse(&state).ok_or_else(|| format!("invalid task state: {state}"))?;
+        if state.is_terminal() || state == TaskState::Ready {
+            continue;
+        }
+        store::transition_task(conn, &task_id, TaskState::Ready, None)
+            .map_err(|error| error.to_string())?;
+        events.push(task_state_event(run_id, &task_id, TaskState::Ready));
+    }
+    events.push(event_for_task_or_run(
+        run_id,
+        None,
+        RunEventType::RunRelaunched,
+        json!({"relaunched_at": timestamp}),
+    ));
+    Ok(events)
+}
+
+fn relaunch(app: &AppHandle, conn: &Connection, run_id: String) -> Result<Run, String> {
+    for event in prepare_relaunch(conn, &run_id)? {
+        append_and_emit(app, conn, event)?;
+    }
+    recompute_ready_and_status(app, conn, &run_id)?;
+    load_run(conn, &run_id)
+}
+
+fn attempt_event(
+    run_id: &str,
+    task_id: &str,
+    attempt_id: &str,
+    event_type: RunEventType,
+    payload: serde_json::Value,
+) -> NewRunEvent {
+    NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        task_id: Some(task_id.to_string()),
+        attempt_id: Some(attempt_id.to_string()),
+        agent_id: None,
+        event_type,
+        payload,
+        provider_event_id: None,
+        created_at: now_ms(),
+    }
+}
+
 fn event_for_task_or_run(
     run_id: &str,
     task_id: Option<&str>,
@@ -1447,6 +1777,7 @@ fn create_run(
         root_path,
         status: RunStatus::Running,
         cancel_requested: false,
+        interrupted_at: None,
         created_at: timestamp,
         updated_at: timestamp,
         completed_at: None,
@@ -1720,8 +2051,8 @@ fn recompute_ready_and_status(
         )?;
     }
 
-    let (cancel_requested, task_states) = load_status_inputs(conn, run_id)?;
-    let status = derive_run_status(&task_states, cancel_requested);
+    let (cancel_requested, interrupted, task_states) = load_status_inputs(conn, run_id)?;
+    let status = derive_run_status(&task_states, cancel_requested, interrupted);
     let completed_at = status.is_terminal().then_some(now_ms());
     let updated = conn
         .execute(
@@ -1737,12 +2068,15 @@ fn recompute_ready_and_status(
     Ok(())
 }
 
-fn load_status_inputs(conn: &Connection, run_id: &str) -> Result<(bool, Vec<TaskState>), String> {
-    let cancel_requested: i64 = conn
+fn load_status_inputs(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<(bool, bool, Vec<TaskState>), String> {
+    let (cancel_requested, interrupted): (i64, bool) = conn
         .query_row(
-            "SELECT cancel_requested FROM runs WHERE id = ?1",
+            "SELECT cancel_requested, interrupted_at IS NOT NULL FROM runs WHERE id = ?1",
             params![run_id],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .map_err(|error| error.to_string())?;
     let mut statement = conn
@@ -1756,7 +2090,7 @@ fn load_status_inputs(conn: &Connection, run_id: &str) -> Result<(bool, Vec<Task
             TaskState::parse(&value).ok_or_else(|| format!("invalid task state in database: {value}"))
         })
         .collect::<Result<Vec<_>, String>>()?;
-    Ok((cancel_requested != 0, states))
+    Ok((cancel_requested != 0, interrupted, states))
 }
 
 fn load_run(conn: &Connection, run_id: &str) -> Result<Run, String> {
@@ -1782,6 +2116,101 @@ mod tests {
     }
 
     #[test]
+    fn startup_reconcile_marks_running_runs_interrupted() {
+        let conn = connection();
+        store::create_run(
+            &conn,
+            &Run {
+                id: "run-reconcile".to_string(),
+                objective: "recover after restart".to_string(),
+                root_path: None,
+                status: RunStatus::Running,
+                cancel_requested: false,
+                interrupted_at: None,
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+
+        let events = reconcile_interrupted(&conn).unwrap();
+        assert_eq!(events.len(), 1);
+        for event in events {
+            store::append_event(&conn, &event).unwrap();
+        }
+        let snapshot = store::load_run_snapshot(&conn, "run-reconcile")
+            .unwrap()
+            .unwrap();
+        assert_eq!(snapshot.run.status, RunStatus::Interrupted);
+        assert!(snapshot.run.interrupted_at.is_some());
+        assert_eq!(
+            store::list_events(&conn, "run-reconcile", 0).unwrap()[0].event_type,
+            RunEventType::RunInterrupted
+        );
+    }
+
+    #[test]
+    fn relaunch_resets_non_terminal_tasks_and_clears_interrupted() {
+        let conn = connection();
+        store::create_run(
+            &conn,
+            &Run {
+                id: "run-relaunch".to_string(),
+                objective: "relaunch after restart".to_string(),
+                root_path: None,
+                status: RunStatus::Interrupted,
+                cancel_requested: false,
+                interrupted_at: Some(10),
+                created_at: 1,
+                updated_at: 10,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+        for (task_id, state) in [
+            ("task-running", "running"),
+            ("task-blocked", "blocked"),
+            ("task-review", "review"),
+        ] {
+            store::add_task(
+                &conn,
+                &Task {
+                    id: task_id.to_string(),
+                    run_id: "run-relaunch".to_string(),
+                    title: task_id.to_string(),
+                    brief: "restart me".to_string(),
+                    state: TaskState::Ready,
+                    blocked_reason: None,
+                    created_at: 1,
+                    updated_at: 1,
+                },
+                &[],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE run_tasks SET state = ?1 WHERE id = ?2",
+                params![state, task_id],
+            )
+            .unwrap();
+        }
+
+        for event in prepare_relaunch(&conn, "run-relaunch").unwrap() {
+            store::append_event(&conn, &event).unwrap();
+        }
+        let snapshot = store::load_run_snapshot(&conn, "run-relaunch")
+            .unwrap()
+            .unwrap();
+        assert_eq!(snapshot.run.status, RunStatus::Running);
+        assert_eq!(snapshot.run.interrupted_at, None);
+        assert!(snapshot.tasks.iter().all(|task| task.state == TaskState::Ready));
+        assert!(store::list_events(&conn, "run-relaunch", 0)
+            .unwrap()
+            .iter()
+            .any(|event| event.event_type == RunEventType::RunRelaunched));
+    }
+
+    #[test]
     fn unapproved_check_does_not_block_completion() {
         let conn = connection();
         store::create_run(
@@ -1792,6 +2221,7 @@ mod tests {
                 root_path: None,
                 status: RunStatus::Running,
                 cancel_requested: false,
+                interrupted_at: None,
                 created_at: 1,
                 updated_at: 1,
                 completed_at: None,

--- a/src-tauri/src/run/status.rs
+++ b/src-tauri/src/run/status.rs
@@ -6,7 +6,10 @@ use super::types::{RunStatus, TaskState};
 pub fn is_legal_transition(from: TaskState, to: TaskState) -> bool {
     match from {
         TaskState::Pending => matches!(to, TaskState::Ready | TaskState::Cancelled),
-        TaskState::Ready => matches!(to, TaskState::Provisioning | TaskState::Cancelled),
+        TaskState::Ready => matches!(
+            to,
+            TaskState::Provisioning | TaskState::Running | TaskState::Cancelled
+        ),
         TaskState::Provisioning => matches!(
             to,
             TaskState::Running | TaskState::Ready | TaskState::Failed | TaskState::Cancelled
@@ -15,20 +18,35 @@ pub fn is_legal_transition(from: TaskState, to: TaskState) -> bool {
             to,
             TaskState::Blocked
                 | TaskState::Verifying
+                | TaskState::Ready
                 | TaskState::Failed
                 | TaskState::Cancelled
         ),
-        TaskState::Blocked => matches!(to, TaskState::Running | TaskState::Failed | TaskState::Cancelled),
+        TaskState::Blocked => matches!(
+            to,
+            TaskState::Running | TaskState::Ready | TaskState::Failed | TaskState::Cancelled
+        ),
         TaskState::Verifying => matches!(
             to,
-            TaskState::Review | TaskState::Running | TaskState::Failed | TaskState::Cancelled
+            TaskState::Review
+                | TaskState::Running
+                | TaskState::Ready
+                | TaskState::Failed
+                | TaskState::Cancelled
         ),
-        TaskState::Review => matches!(to, TaskState::Done | TaskState::Running | TaskState::Cancelled),
+        TaskState::Review => matches!(
+            to,
+            TaskState::Done | TaskState::Running | TaskState::Ready | TaskState::Cancelled
+        ),
         TaskState::Done | TaskState::Failed | TaskState::Cancelled => false,
     }
 }
 
-pub fn derive_run_status(task_states: &[TaskState], cancel_requested: bool) -> RunStatus {
+pub fn derive_run_status(
+    task_states: &[TaskState],
+    cancel_requested: bool,
+    interrupted: bool,
+) -> RunStatus {
     if cancel_requested {
         return RunStatus::Cancelled;
     }
@@ -36,7 +54,11 @@ pub fn derive_run_status(task_states: &[TaskState], cancel_requested: bool) -> R
         return RunStatus::Running;
     }
     if task_states.iter().any(|state| !state.is_terminal()) {
-        return RunStatus::Running;
+        return if interrupted {
+            RunStatus::Interrupted
+        } else {
+            RunStatus::Running
+        };
     }
     if task_states.iter().all(|state| *state == TaskState::Done) {
         RunStatus::Completed
@@ -57,6 +79,7 @@ mod tests {
             (TaskState::Pending, TaskState::Ready),
             (TaskState::Pending, TaskState::Cancelled),
             (TaskState::Ready, TaskState::Provisioning),
+            (TaskState::Ready, TaskState::Running),
             (TaskState::Ready, TaskState::Cancelled),
             (TaskState::Provisioning, TaskState::Running),
             (TaskState::Provisioning, TaskState::Ready),
@@ -64,17 +87,21 @@ mod tests {
             (TaskState::Provisioning, TaskState::Cancelled),
             (TaskState::Running, TaskState::Blocked),
             (TaskState::Running, TaskState::Verifying),
+            (TaskState::Running, TaskState::Ready),
             (TaskState::Running, TaskState::Failed),
             (TaskState::Running, TaskState::Cancelled),
             (TaskState::Blocked, TaskState::Running),
+            (TaskState::Blocked, TaskState::Ready),
             (TaskState::Blocked, TaskState::Failed),
             (TaskState::Blocked, TaskState::Cancelled),
             (TaskState::Verifying, TaskState::Review),
             (TaskState::Verifying, TaskState::Running),
+            (TaskState::Verifying, TaskState::Ready),
             (TaskState::Verifying, TaskState::Failed),
             (TaskState::Verifying, TaskState::Cancelled),
             (TaskState::Review, TaskState::Done),
             (TaskState::Review, TaskState::Running),
+            (TaskState::Review, TaskState::Ready),
             (TaskState::Review, TaskState::Cancelled),
         ];
         for (from, to) in edges {
@@ -92,7 +119,7 @@ mod tests {
     #[test]
     fn derive_run_status_completed() {
         assert_eq!(
-            derive_run_status(&[TaskState::Done, TaskState::Done], false),
+            derive_run_status(&[TaskState::Done, TaskState::Done], false, false),
             RunStatus::Completed
         );
     }
@@ -100,7 +127,7 @@ mod tests {
     #[test]
     fn derive_run_status_partial() {
         assert_eq!(
-            derive_run_status(&[TaskState::Done, TaskState::Failed], false),
+            derive_run_status(&[TaskState::Done, TaskState::Failed], false, false),
             RunStatus::Partial
         );
     }
@@ -108,7 +135,7 @@ mod tests {
     #[test]
     fn derive_run_status_failed() {
         assert_eq!(
-            derive_run_status(&[TaskState::Failed, TaskState::Cancelled], false),
+            derive_run_status(&[TaskState::Failed, TaskState::Cancelled], false, false),
             RunStatus::Failed
         );
     }
@@ -116,7 +143,7 @@ mod tests {
     #[test]
     fn derive_run_status_cancelled() {
         assert_eq!(
-            derive_run_status(&[TaskState::Running, TaskState::Done], true),
+            derive_run_status(&[TaskState::Running, TaskState::Done], true, false),
             RunStatus::Cancelled
         );
     }
@@ -124,7 +151,7 @@ mod tests {
     #[test]
     fn derive_run_status_cancel_requested_overrides_all_done() {
         assert_eq!(
-            derive_run_status(&[TaskState::Done, TaskState::Done], true),
+            derive_run_status(&[TaskState::Done, TaskState::Done], true, true),
             RunStatus::Cancelled
         );
     }
@@ -132,9 +159,33 @@ mod tests {
     #[test]
     fn derive_run_status_any_nonterminal_is_running() {
         assert_eq!(
-            derive_run_status(&[TaskState::Done, TaskState::Review], false),
+            derive_run_status(&[TaskState::Done, TaskState::Review], false, false),
             RunStatus::Running
         );
-        assert_eq!(derive_run_status(&[], false), RunStatus::Running);
+        assert_eq!(derive_run_status(&[], false, false), RunStatus::Running);
+    }
+
+    #[test]
+    fn derive_run_status_cancelled_beats_interrupted() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Running], true, true),
+            RunStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn derive_run_status_all_terminal_beats_interrupted() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Done, TaskState::Failed], false, true),
+            RunStatus::Partial
+        );
+    }
+
+    #[test]
+    fn derive_run_status_interrupted_beats_running() {
+        assert_eq!(
+            derive_run_status(&[TaskState::Running], false, true),
+            RunStatus::Interrupted
+        );
     }
 }

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -64,14 +64,16 @@ fn deserialize_json<T: DeserializeOwned>(value: String) -> Result<T> {
 pub fn create_run(conn: &Connection, run: &Run) -> Result<()> {
     conn.execute(
         "INSERT INTO runs
-            (id, objective, root_path, status, cancel_requested, created_at, updated_at, completed_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            (id, objective, root_path, status, cancel_requested, interrupted_at,
+             created_at, updated_at, completed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         params![
             run.id,
             run.objective,
             run.root_path,
             run.status.as_str(),
             i64::from(run.cancel_requested),
+            run.interrupted_at,
             run.created_at,
             run.updated_at,
             run.completed_at,
@@ -151,6 +153,33 @@ pub fn insert_attempt(conn: &Connection, attempt: &Attempt) -> Result<()> {
             attempt.ended_at,
         ],
     )?;
+    Ok(())
+}
+
+pub fn max_attempt_number(conn: &Connection, task_id: &str) -> Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE(MAX(attempt_number), 0) FROM run_attempts WHERE task_id = ?1",
+        params![task_id],
+        |row| row.get(0),
+    )
+}
+
+pub fn finish_attempt(
+    conn: &Connection,
+    attempt_id: &str,
+    outcome: &str,
+    ended_at: i64,
+) -> Result<()> {
+    if !matches!(outcome, "completed" | "failed" | "parse_failed") {
+        return Err(invalid_value("attempt outcome", outcome));
+    }
+    let updated = conn.execute(
+        "UPDATE run_attempts SET outcome = ?1, ended_at = ?2 WHERE id = ?3",
+        params![outcome, ended_at, attempt_id],
+    )?;
+    if updated == 0 {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
     Ok(())
 }
 
@@ -530,7 +559,7 @@ pub fn ready_task_ids(conn: &Connection, run_id: &str) -> Result<Vec<String>> {
 
 pub fn list_runs(conn: &Connection) -> Result<Vec<Run>> {
     let mut statement = conn.prepare(
-        "SELECT id, objective, root_path, status, cancel_requested,
+        "SELECT id, objective, root_path, status, cancel_requested, interrupted_at,
                 created_at, updated_at, completed_at
          FROM runs
          ORDER BY created_at ASC, id ASC",
@@ -543,9 +572,10 @@ pub fn list_runs(conn: &Connection) -> Result<Vec<Run>> {
                 root_path: row.get(2)?,
                 status: parse_run_status(row.get(3)?)?,
                 cancel_requested: row.get::<_, i64>(4)? != 0,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
-                completed_at: row.get(7)?,
+                interrupted_at: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                completed_at: row.get(8)?,
             })
         })?
         .collect()
@@ -554,7 +584,7 @@ pub fn list_runs(conn: &Connection) -> Result<Vec<Run>> {
 pub fn load_run_snapshot(conn: &Connection, run_id: &str) -> Result<Option<RunSnapshot>> {
     let run = conn
         .query_row(
-            "SELECT id, objective, root_path, status, cancel_requested,
+            "SELECT id, objective, root_path, status, cancel_requested, interrupted_at,
                     created_at, updated_at, completed_at
              FROM runs WHERE id = ?1",
             params![run_id],
@@ -565,9 +595,10 @@ pub fn load_run_snapshot(conn: &Connection, run_id: &str) -> Result<Option<RunSn
                     root_path: row.get(2)?,
                     status: parse_run_status(row.get(3)?)?,
                     cancel_requested: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                    completed_at: row.get(7)?,
+                    interrupted_at: row.get(5)?,
+                    created_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    completed_at: row.get(8)?,
                 })
             },
         )
@@ -796,6 +827,7 @@ mod tests {
             root_path: Some("/tmp/run-engine".to_string()),
             status: RunStatus::Running,
             cancel_requested: false,
+            interrupted_at: None,
             created_at: 1,
             updated_at: 1,
             completed_at: None,
@@ -998,6 +1030,50 @@ mod tests {
             append_event(&conn, &event("event-5", "run-2", Some("provider-4"))).unwrap(),
             AppendOutcome::Inserted(1)
         );
+    }
+
+    #[test]
+    fn attempt_numbers_increment_and_finished_outcomes_persist() {
+        let conn = connection();
+        create_run(&conn, &run("run-1")).unwrap();
+        add_task(&conn, &task("task-1", "run-1"), &[]).unwrap();
+        assert_eq!(max_attempt_number(&conn, "task-1").unwrap(), 0);
+
+        for (id, attempt_number) in [("attempt-1", 1), ("attempt-2", 2)] {
+            insert_attempt(
+                &conn,
+                &Attempt {
+                    id: id.to_string(),
+                    task_id: "task-1".to_string(),
+                    agent_assignment_id: None,
+                    agent_session_id: Some(format!("session-{attempt_number}")),
+                    attempt_number,
+                    outcome: None,
+                    started_at: attempt_number,
+                    ended_at: None,
+                },
+            )
+            .unwrap();
+            assert_eq!(max_attempt_number(&conn, "task-1").unwrap(), attempt_number);
+        }
+
+        finish_attempt(&conn, "attempt-1", "failed", 10).unwrap();
+        finish_attempt(&conn, "attempt-2", "parse_failed", 20).unwrap();
+        let outcomes = conn
+            .prepare("SELECT outcome, ended_at FROM run_attempts ORDER BY attempt_number")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            outcomes,
+            vec![
+                ("failed".to_string(), Some(10)),
+                ("parse_failed".to_string(), Some(20))
+            ]
+        );
+        assert!(finish_attempt(&conn, "attempt-2", "unknown", 30).is_err());
     }
 
     #[test]

--- a/src-tauri/src/run/types.rs
+++ b/src-tauri/src/run/types.rs
@@ -60,6 +60,7 @@ impl TaskState {
 #[serde(rename_all = "snake_case")]
 pub enum RunStatus {
     Running,
+    Interrupted,
     Completed,
     Partial,
     Failed,
@@ -70,6 +71,7 @@ impl RunStatus {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Running => "running",
+            Self::Interrupted => "interrupted",
             Self::Completed => "completed",
             Self::Partial => "partial",
             Self::Failed => "failed",
@@ -80,6 +82,7 @@ impl RunStatus {
     pub fn parse(value: &str) -> Option<Self> {
         Some(match value {
             "running" => Self::Running,
+            "interrupted" => Self::Interrupted,
             "completed" => Self::Completed,
             "partial" => Self::Partial,
             "failed" => Self::Failed,
@@ -89,7 +92,7 @@ impl RunStatus {
     }
 
     pub fn is_terminal(self) -> bool {
-        !matches!(self, Self::Running)
+        !matches!(self, Self::Running | Self::Interrupted)
     }
 }
 
@@ -302,6 +305,8 @@ pub enum RunEventType {
     EvidenceAttached,
     ApprovalRequested,
     RunCancelRequested,
+    RunInterrupted,
+    RunRelaunched,
     RunFinalized,
     LeaseStateChanged,
     CheckDeclared,
@@ -326,6 +331,8 @@ impl RunEventType {
             Self::EvidenceAttached => "evidence_attached",
             Self::ApprovalRequested => "approval_requested",
             Self::RunCancelRequested => "run_cancel_requested",
+            Self::RunInterrupted => "run_interrupted",
+            Self::RunRelaunched => "run_relaunched",
             Self::RunFinalized => "run_finalized",
             Self::LeaseStateChanged => "lease_state_changed",
             Self::CheckDeclared => "check_declared",
@@ -350,6 +357,8 @@ impl RunEventType {
             "evidence_attached" => Self::EvidenceAttached,
             "approval_requested" => Self::ApprovalRequested,
             "run_cancel_requested" => Self::RunCancelRequested,
+            "run_interrupted" => Self::RunInterrupted,
+            "run_relaunched" => Self::RunRelaunched,
             "run_finalized" => Self::RunFinalized,
             "lease_state_changed" => Self::LeaseStateChanged,
             "check_declared" => Self::CheckDeclared,
@@ -370,6 +379,7 @@ pub struct Run {
     pub root_path: Option<String>,
     pub status: RunStatus,
     pub cancel_requested: bool,
+    pub interrupted_at: Option<i64>,
     pub created_at: i64,
     pub updated_at: i64,
     pub completed_at: Option<i64>,

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -594,6 +594,7 @@ mod tests {
             root_path: None,
             status: RunStatus::Running,
             cancel_requested: false,
+            interrupted_at: None,
             created_at: 1,
             updated_at: 1,
             completed_at: None,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1238,12 +1238,14 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             root_path TEXT,
             status TEXT NOT NULL DEFAULT 'running',
             cancel_requested INTEGER NOT NULL DEFAULT 0,
+            interrupted_at INTEGER,
             created_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL,
             completed_at INTEGER
         )",
         [],
     )?;
+    add_column_if_missing(conn, "runs", "interrupted_at", "INTEGER")?;
     conn.execute(
         "CREATE TABLE IF NOT EXISTS run_tasks (
             id TEXT PRIMARY KEY,

--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -15,6 +15,10 @@ import { RunLaunchBox } from "@/components/run/RunLaunchBox";
 import { RunOverview } from "@/components/run/RunOverview";
 import { RunTaskDrawer } from "@/components/run/RunTaskDrawer";
 import { type Finding, subscribeRunEvents, type Task } from "@/services/run";
+import {
+  startRunDispatcher,
+  stopRunDispatcher,
+} from "@/services/run-dispatcher";
 import { runStore } from "@/stores/run.store";
 
 export const MissionControlPanel: Component = () => {
@@ -25,6 +29,7 @@ export const MissionControlPanel: Component = () => {
   let disposed = false;
 
   onMount(() => {
+    startRunDispatcher();
     const subscription = subscribeRunEvents((event) => {
       void runStore.applyEvent(event);
     });
@@ -37,6 +42,7 @@ export const MissionControlPanel: Component = () => {
   onCleanup(() => {
     disposed = true;
     unlisten?.();
+    stopRunDispatcher();
   });
 
   const statusLabel = () => runStore.snapshot?.run.status ?? "ready";
@@ -57,6 +63,21 @@ export const MissionControlPanel: Component = () => {
                 <h1 class="mt-2 truncate text-xl font-semibold tracking-[-0.03em] text-foreground">
                   {runStore.snapshot?.run.objective}
                 </h1>
+                <Show when={statusLabel() === "interrupted"}>
+                  <div class="mt-3 flex items-center gap-3 rounded-lg border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs text-amber-100">
+                    <span>
+                      This run was interrupted by an app restart — completed
+                      work is kept.
+                    </span>
+                    <button
+                      type="button"
+                      class="shrink-0 rounded-md border border-amber-200/40 px-2 py-1 font-medium hover:bg-amber-200/10"
+                      onClick={() => void runStore.relaunch()}
+                    >
+                      Relaunch
+                    </button>
+                  </div>
+                </Show>
               </div>
               <div class="flex shrink-0 items-center gap-4">
                 <div class="hidden text-right sm:block">

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -1,0 +1,509 @@
+// ABOUTME: Deterministic Mission Control dispatcher for ready run tasks.
+// ABOUTME: It turns agent replies into durable findings, coverage gaps, and attempt results.
+
+import { createEffect, createRoot } from "solid-js";
+import type { AgentType } from "@/services/providers";
+import {
+  type AgentAssignment,
+  type CoverageGap,
+  type Evidence,
+  type EvidenceKind,
+  type Finding,
+  type FindingConfidence,
+  type RunSnapshot,
+  runAddCoverageGap,
+  runCompleteTask,
+  runFinishAttempt,
+  runRecordFinding,
+  runStartAttempt,
+  runVerifyTask,
+  type Task,
+} from "@/services/run";
+import { agentStore } from "@/stores/agent.store";
+import { fileTreeState } from "@/stores/fileTree";
+import { runState } from "@/stores/run.store";
+
+const MAX_CONCURRENT_TASKS = 3;
+const TURN_WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+const POLL_INTERVAL_MS = 50;
+
+const EVIDENCE_KINDS = new Set<EvidenceKind>([
+  "command_result",
+  "file_range",
+  "email",
+  "document",
+  "url",
+  "log_excerpt",
+  "publisher_result",
+]);
+const CONFIDENCES = new Set<FindingConfidence>([
+  "asserted",
+  "verified",
+  "refuted",
+]);
+const ARTIFACT_KINDS = new Set(["diff", "document", "email", "comment"]);
+
+export interface ParsedEvidence {
+  kind: EvidenceKind;
+  locator: string;
+  excerpt: string;
+}
+
+export interface ParsedArtifact {
+  kind: "diff" | "document" | "email" | "comment";
+  uri?: string;
+  digest?: string;
+}
+
+export interface ParsedFinding {
+  claim: string;
+  confidence: FindingConfidence;
+  evidence: ParsedEvidence[];
+  proposed_artifact?: ParsedArtifact;
+  needs_approval: boolean;
+}
+
+export interface ParsedCoverageGap {
+  kind: string;
+  subject: string;
+  detail?: string;
+}
+
+export interface ParsedAgentFindings {
+  findings: ParsedFinding[];
+  coverage_gaps: ParsedCoverageGap[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseCandidate(value: unknown): ParsedAgentFindings | null {
+  if (!isRecord(value) || !Array.isArray(value.findings)) return null;
+
+  const findings: ParsedFinding[] = [];
+  for (const item of value.findings) {
+    if (!isRecord(item) || !nonEmptyString(item.claim)) return null;
+    const confidence = item.confidence ?? "asserted";
+    if (
+      typeof confidence !== "string" ||
+      !CONFIDENCES.has(confidence as FindingConfidence)
+    ) {
+      return null;
+    }
+    if (!Array.isArray(item.evidence)) return null;
+    const evidence: ParsedEvidence[] = [];
+    for (const evidenceItem of item.evidence) {
+      if (
+        !isRecord(evidenceItem) ||
+        !nonEmptyString(evidenceItem.kind) ||
+        !EVIDENCE_KINDS.has(evidenceItem.kind as EvidenceKind) ||
+        !nonEmptyString(evidenceItem.locator) ||
+        typeof evidenceItem.excerpt !== "string"
+      ) {
+        return null;
+      }
+      evidence.push({
+        kind: evidenceItem.kind as EvidenceKind,
+        locator: evidenceItem.locator,
+        excerpt: evidenceItem.excerpt,
+      });
+    }
+
+    let proposed_artifact: ParsedArtifact | undefined;
+    if (item.proposed_artifact !== undefined) {
+      if (
+        !isRecord(item.proposed_artifact) ||
+        !nonEmptyString(item.proposed_artifact.kind)
+      ) {
+        return null;
+      }
+      if (!ARTIFACT_KINDS.has(item.proposed_artifact.kind)) return null;
+      if (
+        item.proposed_artifact.uri !== undefined &&
+        !nonEmptyString(item.proposed_artifact.uri)
+      ) {
+        return null;
+      }
+      if (
+        item.proposed_artifact.digest !== undefined &&
+        !nonEmptyString(item.proposed_artifact.digest)
+      ) {
+        return null;
+      }
+      proposed_artifact = {
+        kind: item.proposed_artifact.kind as ParsedArtifact["kind"],
+        ...(item.proposed_artifact.uri
+          ? { uri: item.proposed_artifact.uri }
+          : {}),
+        ...(item.proposed_artifact.digest
+          ? { digest: item.proposed_artifact.digest }
+          : {}),
+      };
+    }
+
+    if (
+      item.needs_approval !== undefined &&
+      typeof item.needs_approval !== "boolean"
+    ) {
+      return null;
+    }
+    const inferredApproval =
+      proposed_artifact?.kind === "email" ||
+      proposed_artifact?.kind === "comment";
+    findings.push({
+      claim: item.claim,
+      confidence: confidence as FindingConfidence,
+      evidence,
+      proposed_artifact,
+      needs_approval: item.needs_approval ?? inferredApproval,
+    });
+  }
+
+  const rawGaps = value.coverage_gaps ?? [];
+  if (!Array.isArray(rawGaps)) return null;
+  const coverage_gaps: ParsedCoverageGap[] = [];
+  for (const item of rawGaps) {
+    if (!isRecord(item) || !nonEmptyString(item.subject)) return null;
+    if (item.kind !== undefined && !nonEmptyString(item.kind)) return null;
+    if (item.detail !== undefined && typeof item.detail !== "string")
+      return null;
+    coverage_gaps.push({
+      kind: (item.kind as string | undefined) ?? "other",
+      subject: item.subject,
+      ...(item.detail ? { detail: item.detail } : {}),
+    });
+  }
+  return { findings, coverage_gaps };
+}
+
+function fencedCandidates(text: string): unknown[] {
+  const matches = [
+    ...text.matchAll(/```\s*seren-findings\s*\n?([\s\S]*?)```/gi),
+  ];
+  return matches.map((match) => {
+    try {
+      return JSON.parse(match[1].trim()) as unknown;
+    } catch {
+      return null;
+    }
+  });
+}
+
+function trailingJsonCandidate(text: string): unknown | null {
+  const end = text.lastIndexOf("}");
+  if (end < 0) return null;
+  for (
+    let start = text.lastIndexOf("{", end);
+    start >= 0;
+    start = text.lastIndexOf("{", start - 1)
+  ) {
+    try {
+      const candidate: unknown = JSON.parse(text.slice(start, end + 1));
+      if (isRecord(candidate) && "findings" in candidate) return candidate;
+    } catch {
+      // Try the next enclosing object. Prose may contain braces of its own.
+    }
+  }
+  return null;
+}
+
+export function parseAgentFindings(text: string): ParsedAgentFindings | null {
+  const candidates = fencedCandidates(text);
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const parsed = parseCandidate(candidates[index]);
+    if (parsed) return parsed;
+  }
+  const trailing = trailingJsonCandidate(text);
+  return trailing ? parseCandidate(trailing) : null;
+}
+
+export function buildTaskPrompt(
+  objective: string,
+  task: Pick<Task, "title" | "brief">,
+): string {
+  return [
+    `Mission objective: ${objective}`,
+    `Task: ${task.title}`,
+    `Task brief: ${task.brief}`,
+    "",
+    "Investigate the task using the available tools and workspace.",
+    "Report only claims you can support. State what you could not check as coverage_gaps.",
+    "End your reply with a fenced JSON block tagged seren-findings using this shape:",
+    "```seren-findings",
+    '{"findings":[{"claim":"...","confidence":"asserted|verified|refuted","evidence":[{"kind":"command_result|file_range|email|document|url|log_excerpt|publisher_result","locator":"...","excerpt":"..."}],"proposed_artifact":{"kind":"diff|document|email|comment","uri":"...","digest":"..."},"needs_approval":false}],"coverage_gaps":[{"kind":"other","subject":"...","detail":"..."}]}',
+    "```",
+  ].join("\n");
+}
+
+export function selectReadyTasks(
+  tasks: Task[],
+  inFlight: ReadonlySet<string>,
+  cap = MAX_CONCURRENT_TASKS,
+): Task[] {
+  return tasks
+    .filter((task) => task.state === "ready" && !inFlight.has(task.id))
+    .slice(0, Math.max(0, cap));
+}
+
+export interface DispatchPlan {
+  task: Task;
+  assignment: AgentAssignment;
+}
+
+export function selectDispatchPlan(
+  tasks: Task[],
+  assignments: AgentAssignment[],
+  inFlight: ReadonlySet<string>,
+  cap = MAX_CONCURRENT_TASKS,
+  assignmentOffset = 0,
+): DispatchPlan[] {
+  if (assignments.length === 0) return [];
+  return selectReadyTasks(tasks, inFlight, cap).map((task, index) => ({
+    task,
+    assignment: assignments[(assignmentOffset + index) % assignments.length],
+  }));
+}
+
+function toFinding(
+  runId: string,
+  taskId: string,
+  attemptId: string,
+  finding: ParsedFinding,
+): Finding {
+  const timestamp = Date.now();
+  const evidence: Evidence[] = finding.evidence.map((item) => ({
+    kind: item.kind,
+    reference: item.locator,
+    excerpt: item.excerpt || null,
+  }));
+  const artifact = finding.proposed_artifact;
+  return {
+    id: crypto.randomUUID(),
+    run_id: runId,
+    task_id: taskId,
+    attempt_id: attemptId,
+    claim: finding.claim,
+    confidence: finding.confidence,
+    evidence,
+    proposed_artifact: artifact
+      ? {
+          kind: artifact.kind,
+          title: artifact.uri ?? artifact.digest ?? finding.claim,
+          content: artifact.uri ?? artifact.digest ?? null,
+        }
+      : null,
+    needs_approval: finding.needs_approval,
+    status: "open",
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
+function toCoverageGap(
+  runId: string,
+  taskId: string,
+  gap: ParsedCoverageGap,
+): CoverageGap {
+  return {
+    id: crypto.randomUUID(),
+    run_id: runId,
+    task_id: taskId,
+    kind: gap.kind,
+    subject: gap.subject,
+    detail: gap.detail ?? null,
+    created_at: Date.now(),
+  };
+}
+
+function isTerminalRun(snapshot: RunSnapshot | null): boolean {
+  return (
+    !!snapshot &&
+    ["completed", "partial", "failed", "cancelled"].includes(
+      snapshot.run.status,
+    )
+  );
+}
+
+async function waitForTurn(sessionId: string): Promise<void> {
+  const deadline = Date.now() + TURN_WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const session = agentStore.sessions[sessionId];
+    if (!session)
+      throw new Error("agent session disappeared before completion");
+    const threadId = session.conversationId;
+    const active =
+      agentStore.isTurnInFlight(threadId) ||
+      session.info.status === "prompting";
+    if (!active) {
+      if (
+        session.info.status === "error" ||
+        session.info.status === "terminated"
+      ) {
+        throw new Error(
+          session.error ?? `agent session ended with ${session.info.status}`,
+        );
+      }
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error("agent turn exceeded the dispatcher wait limit");
+}
+
+function finalAssistantMessage(sessionId: string): string | null {
+  const session = agentStore.sessions[sessionId];
+  if (!session) return null;
+  for (let index = session.messages.length - 1; index >= 0; index -= 1) {
+    const message = session.messages[index];
+    if (message.type === "assistant" && message.content.trim())
+      return message.content;
+  }
+  return null;
+}
+
+async function recordGap(
+  runId: string,
+  taskId: string,
+  kind: string,
+  subject: string,
+  detail: string,
+): Promise<void> {
+  await runAddCoverageGap(
+    toCoverageGap(runId, taskId, { kind, subject, detail }),
+  );
+}
+
+async function dispatchTask(
+  snapshot: RunSnapshot,
+  task: Task,
+  assignment: AgentAssignment,
+  ownedSessionIds: Map<string, string>,
+): Promise<void> {
+  const runId = snapshot.run.id;
+  const localSessionId = crypto.randomUUID();
+  let attemptId: string | null = null;
+  try {
+    attemptId = await runStartAttempt(
+      runId,
+      task.id,
+      assignment.id,
+      localSessionId,
+    );
+    const sessionId = await agentStore.spawnSession(
+      snapshot.run.root_path ?? fileTreeState.rootPath ?? ".",
+      assignment.agent_type as AgentType,
+      { localSessionId, conversationTitle: task.title },
+    );
+    if (!sessionId) throw new Error("agent session failed to start");
+    ownedSessionIds.set(sessionId, runId);
+    agentStore.markSessionRunOwned(sessionId, runId);
+    await agentStore.sendPrompt(
+      buildTaskPrompt(snapshot.run.objective, task),
+      undefined,
+      undefined,
+      sessionId,
+    );
+    await waitForTurn(sessionId);
+    const response = finalAssistantMessage(sessionId);
+    const parsed = response ? parseAgentFindings(response) : null;
+    if (!parsed) {
+      await recordGap(
+        runId,
+        task.id,
+        "unparseable",
+        task.title,
+        "agent response did not contain a valid seren-findings block",
+      );
+      await runFinishAttempt(runId, attemptId, "parse_failed");
+      await runVerifyTask(runId, task.id);
+      return;
+    }
+    for (const finding of parsed.findings) {
+      await runRecordFinding(toFinding(runId, task.id, attemptId, finding));
+    }
+    for (const gap of parsed.coverage_gaps) {
+      await runAddCoverageGap(toCoverageGap(runId, task.id, gap));
+    }
+    await runFinishAttempt(runId, attemptId, "completed");
+    await runVerifyTask(runId, task.id);
+    await runCompleteTask(runId, task.id);
+  } catch (error) {
+    if (attemptId) {
+      const detail = error instanceof Error ? error.message : String(error);
+      try {
+        await recordGap(runId, task.id, "other", task.title, detail);
+        await runFinishAttempt(runId, attemptId, "failed");
+      } catch {
+        // Preserve the original dispatch failure; the durable event loop may be stopping.
+      }
+    }
+  }
+}
+
+let disposeDispatcher: (() => void) | null = null;
+let assignmentCursor = 0;
+const inFlightTasks = new Set<string>();
+const ownedSessionIds = new Map<string, string>();
+
+function releaseTerminalOwnership(snapshot: RunSnapshot | null): void {
+  if (!isTerminalRun(snapshot)) return;
+  for (const [sessionId, runId] of ownedSessionIds) {
+    if (runId === snapshot?.run.id) {
+      agentStore.releaseSessionRunOwnership(sessionId);
+      ownedSessionIds.delete(sessionId);
+    }
+  }
+}
+
+export function startRunDispatcher(): void {
+  if (disposeDispatcher) return;
+  createRoot((dispose) => {
+    disposeDispatcher = dispose;
+    createEffect(() => {
+      const snapshot = runState.snapshot;
+      const runId = runState.activeRunId;
+      releaseTerminalOwnership(snapshot);
+      if (
+        !snapshot ||
+        !runId ||
+        snapshot.run.status === "interrupted" ||
+        isTerminalRun(snapshot)
+      ) {
+        return;
+      }
+      const plans = selectDispatchPlan(
+        snapshot.tasks,
+        snapshot.assignments,
+        inFlightTasks,
+        MAX_CONCURRENT_TASKS,
+        assignmentCursor,
+      );
+      assignmentCursor += plans.length;
+      for (const plan of plans) {
+        inFlightTasks.add(plan.task.id);
+        void dispatchTask(
+          snapshot,
+          plan.task,
+          plan.assignment,
+          ownedSessionIds,
+        ).finally(() => inFlightTasks.delete(plan.task.id));
+      }
+    });
+  });
+}
+
+export function stopRunDispatcher(): void {
+  disposeDispatcher?.();
+  disposeDispatcher = null;
+  for (const sessionId of ownedSessionIds.keys()) {
+    agentStore.releaseSessionRunOwnership(sessionId);
+  }
+  ownedSessionIds.clear();
+  inFlightTasks.clear();
+  assignmentCursor = 0;
+}

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -18,6 +18,7 @@ export type TaskState =
 
 export type RunStatus =
   | "running"
+  | "interrupted"
   | "completed"
   | "partial"
   | "failed"
@@ -51,6 +52,8 @@ export type RunEventType =
   | "evidence_attached"
   | "approval_requested"
   | "run_cancel_requested"
+  | "run_interrupted"
+  | "run_relaunched"
   | "run_finalized"
   | "lease_state_changed"
   | "check_declared"
@@ -66,6 +69,7 @@ export interface Run {
   root_path: string | null;
   status: RunStatus;
   cancel_requested: boolean;
+  interrupted_at: number | null;
   created_at: number;
   updated_at: number;
   completed_at: number | null;
@@ -329,6 +333,38 @@ export async function runUpdateFindingStatus(
     finding_id: findingId,
     status,
   }) as Promise<void>;
+}
+
+export type AttemptOutcome = "completed" | "failed" | "parse_failed";
+
+export async function runStartAttempt(
+  runId: string,
+  taskId: string,
+  agentAssignmentId?: string | null,
+  agentSessionId?: string | null,
+): Promise<string> {
+  return invoke("run_start_attempt", {
+    run_id: runId,
+    task_id: taskId,
+    agent_assignment_id: agentAssignmentId ?? null,
+    agent_session_id: agentSessionId ?? null,
+  }) as Promise<string>;
+}
+
+export async function runFinishAttempt(
+  runId: string,
+  attemptId: string,
+  outcome: AttemptOutcome,
+): Promise<void> {
+  return invoke("run_finish_attempt", {
+    run_id: runId,
+    attempt_id: attemptId,
+    outcome,
+  }) as Promise<void>;
+}
+
+export async function runRelaunch(runId: string): Promise<Run> {
+  return invoke("run_relaunch", { run_id: runId }) as Promise<Run>;
 }
 
 export function subscribeRunEvents(

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -9,6 +9,7 @@ import {
   runCancel,
   runCreate,
   runGetState,
+  runRelaunch,
   runUpdateFindingStatus,
   type Task,
 } from "@/services/run";
@@ -114,6 +115,13 @@ async function applyEvent(event: RunEvent): Promise<void> {
     event.event_type === "assignment_added"
   ) {
     await hydrate(event.run_id);
+  } else if (
+    event.event_type === "run_interrupted" ||
+    event.event_type === "run_relaunched" ||
+    event.event_type === "attempt_started" ||
+    event.event_type === "attempt_finished"
+  ) {
+    await hydrate(event.run_id);
   }
   setState("lastSequence", event.sequence);
 }
@@ -143,6 +151,16 @@ async function cancel(): Promise<void> {
   if (!state.activeRunId) return;
   try {
     const run = await runCancel(state.activeRunId);
+    setState("snapshot", "run", run);
+  } catch (error) {
+    setState("error", errorMessage(error));
+  }
+}
+
+async function relaunch(): Promise<void> {
+  if (!state.activeRunId) return;
+  try {
+    const run = await runRelaunch(state.activeRunId);
     setState("snapshot", "run", run);
   } catch (error) {
     setState("error", errorMessage(error));
@@ -212,6 +230,7 @@ export const runStore = {
   applyEvent,
   launch,
   cancel,
+  relaunch,
   approveFinding: (findingId: string) =>
     setFindingStatus(findingId, "accepted"),
   rejectFinding: (findingId: string) => setFindingStatus(findingId, "rejected"),
@@ -219,6 +238,7 @@ export const runStore = {
   lanes,
   findingsCount: () => state.snapshot?.findings.length ?? 0,
   coverageGaps: () => state.snapshot?.coverage_gaps ?? [],
+  isInterrupted: () => state.snapshot?.run.status === "interrupted",
 };
 
 export async function launchMission(objective: string): Promise<void> {

--- a/tests/unit/run-dispatcher-parse.test.ts
+++ b/tests/unit/run-dispatcher-parse.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Verifies the strict agent findings output contract.
+// ABOUTME: Covers fenced JSON extraction, defaults, inferred approvals, and parse failures.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/run", () => ({
+  runAddCoverageGap: vi.fn(),
+  runCompleteTask: vi.fn(),
+  runFinishAttempt: vi.fn(),
+  runRecordFinding: vi.fn(),
+  runStartAttempt: vi.fn(),
+  runVerifyTask: vi.fn(),
+}));
+vi.mock("@/stores/agent.store", () => ({ agentStore: {} }));
+vi.mock("@/stores/fileTree", () => ({ fileTreeState: { rootPath: null } }));
+vi.mock("@/stores/run.store", () => ({
+  runState: { snapshot: null, activeRunId: null },
+}));
+
+import { parseAgentFindings } from "@/services/run-dispatcher";
+
+describe("parseAgentFindings", () => {
+  it("parses the last seren-findings block and applies confidence and approval defaults", () => {
+    const text = [
+      "The first draft was superseded.",
+      "```seren-findings",
+      '{"findings":[],"coverage_gaps":[]}',
+      "```",
+      "Final answer:",
+      "```seren-findings",
+      JSON.stringify({
+        findings: [
+          {
+            claim: "The report is ready.",
+            evidence: [
+              {
+                kind: "file_range",
+                locator: "report.md:1-4",
+                excerpt: "ready",
+              },
+            ],
+            proposed_artifact: { kind: "email", uri: "draft:report" },
+          },
+        ],
+      }),
+      "```",
+    ].join("\n");
+
+    const parsed = parseAgentFindings(text);
+    expect(parsed?.findings).toEqual([
+      {
+        claim: "The report is ready.",
+        confidence: "asserted",
+        evidence: [
+          {
+            kind: "file_range",
+            locator: "report.md:1-4",
+            excerpt: "ready",
+          },
+        ],
+        proposed_artifact: { kind: "email", uri: "draft:report" },
+        needs_approval: true,
+      },
+    ]);
+    expect(parsed?.coverage_gaps).toEqual([]);
+  });
+
+  it("parses a trailing bare JSON object after prose", () => {
+    const parsed = parseAgentFindings(
+      'I checked the source. {"findings":[{"claim":"A fact","confidence":"verified","evidence":[]}],"coverage_gaps":[]}',
+    );
+    expect(parsed?.findings[0].confidence).toBe("verified");
+    expect(parsed?.findings[0].needs_approval).toBe(false);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseAgentFindings("```seren-findings\n{bad json}\n```"))
+      .toBeNull();
+  });
+
+  it("returns null when the findings block is missing or has invalid evidence", () => {
+    expect(parseAgentFindings("No structured result was produced.")).toBeNull();
+    expect(
+      parseAgentFindings(
+        '```seren-findings\n{"findings":[{"claim":"bad","evidence":[{"kind":"unknown","locator":"x","excerpt":"y"}]}]}\n```',
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/run-dispatcher-selection.test.ts
+++ b/tests/unit/run-dispatcher-selection.test.ts
@@ -1,0 +1,79 @@
+// ABOUTME: Tests deterministic ready-task admission for the run dispatcher.
+// ABOUTME: Protects the three-task cap, in-flight exclusion, and assignment round robin.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/run", () => ({}));
+vi.mock("@/stores/agent.store", () => ({ agentStore: {} }));
+vi.mock("@/stores/fileTree", () => ({ fileTreeState: { rootPath: null } }));
+vi.mock("@/stores/run.store", () => ({
+  runState: { snapshot: null, activeRunId: null },
+}));
+
+import {
+  selectDispatchPlan,
+  selectReadyTasks,
+} from "@/services/run-dispatcher";
+import type { AgentAssignment, Task } from "@/services/run";
+
+function task(id: string, state: Task["state"] = "ready"): Task {
+  return {
+    id,
+    run_id: "run-1",
+    title: id,
+    brief: `Brief ${id}`,
+    state,
+    blocked_reason: null,
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+function assignment(id: string): AgentAssignment {
+  return {
+    id,
+    run_id: "run-1",
+    agent_type: "codex",
+    model_id: null,
+    role_label: id,
+    created_at: 1,
+  };
+}
+
+describe("run dispatcher selection", () => {
+  it("excludes in-flight tasks and caps admission at three", () => {
+    const tasks = [task("one"), task("two"), task("three"), task("four")];
+    expect(selectReadyTasks(tasks, new Set(["two"]), 3).map((item) => item.id)).toEqual([
+      "one",
+      "three",
+      "four",
+    ]);
+    expect(selectReadyTasks(tasks, new Set(), 2).map((item) => item.id)).toEqual([
+      "one",
+      "two",
+    ]);
+  });
+
+  it("round-robins assignments in the selected plan", () => {
+    const plans = selectDispatchPlan(
+      [task("one"), task("two"), task("three")],
+      [assignment("a"), assignment("b")],
+      new Set(),
+      3,
+    );
+    expect(plans.map((plan) => [plan.task.id, plan.assignment.id])).toEqual([
+      ["one", "a"],
+      ["two", "b"],
+      ["three", "a"],
+    ]);
+    expect(
+      selectDispatchPlan(
+        [task("four")],
+        [assignment("a"), assignment("b")],
+        new Set(),
+        3,
+        1,
+      )[0].assignment.id,
+    ).toBe("b");
+  });
+});

--- a/tests/unit/run-store-events.test.ts
+++ b/tests/unit/run-store-events.test.ts
@@ -32,6 +32,7 @@ function snapshot(): RunSnapshot {
       root_path: null,
       status: "running",
       cancel_requested: false,
+      interrupted_at: null,
       created_at: 1,
       updated_at: 1,
       completed_at: null,


### PR DESCRIPTION
## Summary

- Adds attempt lifecycle commands: run_start_attempt, run_finish_attempt, and run_relaunch, with attempt_started and attempt_finished events.
- Reconciles in-flight runs at scheduler startup by marking them interrupted and emitting run_interrupted.
- Adds a one-action relaunch that clears interrupted_at, returns every non-terminal task to ready, emits run_relaunched, and recomputes run status.
- Adds the interrupted_at column through add_column_if_missing so existing databases migrate safely.
- Adds a deterministic frontend dispatcher with a three-task concurrency cap, run-owned agent sessions, a 30-minute turn timeout, and a strict seren-findings output contract.
- Parse failures become an unparseable coverage gap and review state; no task completes silently.

## Verification

- Focused Rust run suite: 39/39 passed, exit 0.
- Full cargo test: exit 0.
- Vitest: 2,868 passed and 15 skipped, exit 0.
- Biome check: exit 0 with existing repository warnings.
- Frontend build: exit 0.

The live slice walkthrough with a real three-agent run, a non-git target, an approval gate, and the restart cycle is the next phase.

Part of #3511
