### PR TITLE
fix(happy): hide routine mobile tool calls

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -11,7 +11,6 @@ import nacl from "tweetnacl";
 import {
   composeApprovalNotification,
   createAssistantMessageCoalescer,
-  createFileReadSummarizer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "./translate.mjs";
@@ -701,7 +700,6 @@ export function createHappyLayer({
   const liveSessions = new Set();
   const turnCorrelator = createTurnCorrelator();
   const assistantMessageCoalescer = createAssistantMessageCoalescer();
-  const fileReadSummarizer = createFileReadSummarizer();
 
   const sessionSummaries = new Map();
   const sessionSummaryRevisions = new Map();
@@ -2110,8 +2108,7 @@ export function createHappyLayer({
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     const correlatedEvent = turnCorrelator.correlate(event);
     for (const publishableEvent of assistantMessageCoalescer.consume(correlatedEvent)) {
-      const summarizedEvent = fileReadSummarizer.annotate(publishableEvent);
-      for (const message of translateNeutralEvent(summarizedEvent, { provider })) {
+      for (const message of translateNeutralEvent(publishableEvent, { provider })) {
         if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
         if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
       }
@@ -2686,7 +2683,6 @@ export function createHappyLayer({
       await promptQueue.close();
       turnCorrelator.close();
       assistantMessageCoalescer.close();
-      fileReadSummarizer.close();
       cancelPairing();
       await pairingAuthorizationPromise;
       // A remote spawn may already own a persisted relay row while provider

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -6,17 +6,8 @@ import { randomUUID } from "node:crypto";
 import { createEnvelope } from "@slopus/happy-wire";
 
 const AGENT_PROVIDER = "codex";
-const TOOL_OUTPUT_MAX_CHARS = 1_200;
-const TOOL_ERROR_MAX_CHARS = 6_000;
 const FILE_DIFF_MAX_CHARS = 2_000;
-const TOOL_INPUT_MAX_CHARS = 2_000;
 const MOBILE_TRUNCATION_MARKER = "\n… [truncated for Happy Mobile]";
-// A file read streams the whole file body to the phone. Provider runtimes label
-// that read differently: claude-code emits the semantic kind `fileRead`, while
-// ACP surfaces the ToolKind `read`. Either one identifies a read whose result
-// body should be summarized rather than forwarded. lmstudio labels calls by
-// transport (`local`/`mcp`), so its reads fall back to the character cap below.
-const FILE_READ_TOOL_KINDS = new Set(["fileRead", "read"]);
 
 function stringValue(value, fallback = "") {
   return typeof value === "string" ? value : fallback;
@@ -43,21 +34,6 @@ function boundedMobileText(value, maxChars) {
     prefix = prefix.slice(0, -1);
   }
   return `${prefix}${MOBILE_TRUNCATION_MARKER}`;
-}
-
-// Tool parameters carry whole file bodies — a `Write` call's content arrives
-// here in full. Every string is bounded in place so the argument shape the
-// phone renders survives, matching the limit already applied to the diff the
-// same write produces.
-function boundedToolInput(value) {
-  if (typeof value === "string") return boundedMobileText(value, TOOL_INPUT_MAX_CHARS);
-  if (Array.isArray(value)) return value.map(boundedToolInput);
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [key, boundedToolInput(entry)]),
-    );
-  }
-  return value;
 }
 
 function summarizeFileContent(value) {
@@ -233,57 +209,6 @@ export function createAssistantMessageCoalescer({ createMessageId = randomUUID }
 }
 
 /**
- * A file `Read` streams its whole result to the phone, and an agent that reads
- * many files buries the conversation. `tool-end` carries only the call id and
- * body, while the read kind arrives on the earlier `tool-start`, so remember
- * which calls are reads and replace a completed read's body with a line-count
- * summary — the same elision `summarizeFileContent` already applies to diffs.
- * Errors are never elided; a truncated failure is worse than useless.
- *
- * @param {{maxPending?: number}} options
- */
-export function createFileReadSummarizer({ maxPending = 512 } = {}) {
-  const fileReadCallIds = new Set();
-
-  function annotate(event) {
-    if (!event || typeof event !== "object" || typeof event.kind !== "string") {
-      return event;
-    }
-    const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
-    const callId = stringValue(payload.toolCallId);
-    if (event.kind === "tool-start") {
-      if (callId && FILE_READ_TOOL_KINDS.has(stringValue(payload.kind))) {
-        // A read whose `tool-end` never arrives (e.g. a cancelled turn) would
-        // otherwise pin its call id forever; evict the oldest to bound growth.
-        if (fileReadCallIds.size >= maxPending) {
-          const oldest = fileReadCallIds.values().next().value;
-          if (oldest !== undefined) fileReadCallIds.delete(oldest);
-        }
-        fileReadCallIds.add(callId);
-      }
-      return event;
-    }
-    if (event.kind === "tool-end" && callId && fileReadCallIds.has(callId)) {
-      fileReadCallIds.delete(callId);
-      if (!payload.error && typeof payload.result === "string") {
-        return {
-          ...event,
-          payload: { ...payload, result: summarizeFileContent(payload.result) },
-        };
-      }
-    }
-    return event;
-  }
-
-  return {
-    annotate,
-    close() {
-      fileReadCallIds.clear();
-    },
-  };
-}
-
-/**
  * Convert exactly one neutral event. The returned list is deliberate: a
  * completion can carry both a turn boundary and usage metadata.
  *
@@ -315,24 +240,10 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
       if (!text) return [];
       return [eventEnvelope("user", { t: "text", text }, payload, "user")];
     case "tool-start":
-      return [{ ...acp({
-        type: "tool-call",
-        callId: stringValue(payload.toolCallId, "unknown-call"),
-        name: stringValue(payload.name, stringValue(payload.kind, "tool")),
-        input: boundedToolInput(payload.parameters ?? {}),
-        id: stringValue(payload.toolCallId, "unknown-call"),
-      }), provider }];
     case "tool-end":
-      return [{ ...acp({
-        type: "tool-result",
-        callId: stringValue(payload.toolCallId, "unknown-call"),
-        output: boundedMobileText(
-          payload.error ?? payload.result ?? "",
-          payload.error ? TOOL_ERROR_MAX_CHARS : TOOL_OUTPUT_MAX_CHARS,
-        ),
-        id: stringValue(payload.toolCallId, "unknown-call"),
-        ...(payload.error ? { isError: true } : {}),
-      }), provider }];
+      // Happy has no working global visibility control for routine tool cards.
+      // Permission requests use their own message type below and stay actionable.
+      return [];
     case "file-diff":
       return [{ ...acp({
         type: "file-edit",

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -7,14 +7,9 @@ import { describe, expect, it } from "vitest";
 import {
   composeApprovalNotification,
   createAssistantMessageCoalescer,
-  createFileReadSummarizer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "../../bin/happy-bridge/translate.mjs";
-// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
-import { translateProviderEvent } from "../../bin/happy-bridge/provider-source.mjs";
-// @ts-expect-error — the browser-local runtime is plain ESM without declarations.
-import { _emitAcpToolCallUpdate } from "../../bin/browser-local/acp-runtime.mjs";
 
 const payload = {
   text: "assistant text",
@@ -43,8 +38,6 @@ describe("neutral-to-Happy session translation", () => {
   it.each([
     ["assistant-delta", "session"],
     ["user-message", "session"],
-    ["tool-start", "agent"],
-    ["tool-end", "agent"],
     ["file-diff", "agent"],
     ["diff-proposal", "agent"],
     ["diff-proposal-resolved", "session"],
@@ -62,6 +55,46 @@ describe("neutral-to-Happy session translation", () => {
 
   it("drops an unknown neutral event", () => {
     expect(translateNeutralEvent({ kind: "unknown", sessionId: "session-1", payload })).toEqual([]);
+  });
+
+  it.each(["tool-start", "tool-end"])(
+    "does not forward routine %s payloads to Happy",
+    (kind) => {
+      expect(
+        translateNeutralEvent({
+          kind,
+          sessionId: "session-1",
+          payload: {
+            toolCallId: "call-private",
+            name: "mcpToolCall",
+            parameters: { value: "do-not-forward" },
+            result: "do-not-forward",
+          },
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it("keeps permission requests actionable while routine tool events are hidden", () => {
+    const [message] = translateNeutralEvent({
+      kind: "permission-request",
+      sessionId: "session-1",
+      payload: {
+        requestId: "request-1",
+        toolName: "mcpToolCall",
+        description: "Approval required",
+        options: [{ optionId: "allow-once" }, { optionId: "deny" }],
+      },
+    });
+
+    expect(message).toMatchObject({
+      transport: "agent",
+      body: {
+        type: "permission-request",
+        permissionId: "request-1",
+        toolName: "mcpToolCall",
+      },
+    });
   });
 
   it("does not republish a Happy-originated user message back to Happy", () => {
@@ -114,151 +147,6 @@ describe("neutral-to-Happy session translation", () => {
     expect(assistant.envelope.id).toBe("message-remote-1");
     expect(assistant.envelope.ev.text).toBe("TURN3157FIXED");
     expect(turnEnd.envelope.turn).toBe("turn-remote-1");
-  });
-
-  it("bounds tool output for mobile while retaining more error context", () => {
-    const success = translateNeutralEvent({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "call-success", result: "x".repeat(6_000) },
-    })[0].body;
-    const error = translateNeutralEvent({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "call-error", error: "e".repeat(3_000) },
-    })[0].body;
-
-    expect(success).toMatchObject({ callId: "call-success", id: "call-success" });
-    expect(success.output).toHaveLength(1_200);
-    expect(success.output).toContain("[truncated for Happy Mobile]");
-    expect(error).toMatchObject({
-      callId: "call-error",
-      id: "call-error",
-      isError: true,
-      output: "e".repeat(3_000),
-    });
-  });
-
-  it("summarizes a completed file read body while keeping the read visible", () => {
-    const summarizer = createFileReadSummarizer();
-    const body = "line one\nline two\nline three";
-
-    // The read announces itself on tool-start (claude-code emits kind "fileRead").
-    const startEvent = summarizer.annotate({
-      kind: "tool-start",
-      sessionId: "session-1",
-      payload: {
-        toolCallId: "read-1",
-        kind: "fileRead",
-        title: "Read: /workspace/project/app.ts",
-        parameters: { file_path: "/workspace/project/app.ts" },
-      },
-    });
-    const [startMessage] = translateNeutralEvent(startEvent);
-    expect(startMessage.body).toMatchObject({ type: "tool-call", callId: "read-1" });
-
-    // tool-end carries only the body; it is replaced with a line-count summary.
-    const endEvent = summarizer.annotate({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "read-1", result: body },
-    });
-    const [endMessage] = translateNeutralEvent(endEvent);
-    expect(endMessage.body.output).toBe("[3 lines hidden on Happy Mobile]");
-    expect(endMessage.body.output).not.toContain("line two");
-  });
-
-  it("summarizes an ACP `read` result emitted by the real runtime pipeline", () => {
-    // The ACP wire carries the tool category on `kind` and has no `name`
-    // field, so a hand-built payload can pass while the runtime emits
-    // something else (#3454). Drive the fixture through the runtime's own
-    // emitter and the provider event mapping instead.
-    const summarizer = createFileReadSummarizer();
-    const session = { id: "session-1" };
-    const neutralEvents: Array<Record<string, unknown>> = [];
-    const emit = (method: string, params: Record<string, unknown>) => {
-      const event = translateProviderEvent(method, params);
-      if (event) neutralEvents.push(summarizer.annotate(event));
-    };
-
-    _emitAcpToolCallUpdate(emit, session, {
-      sessionUpdate: "tool_call",
-      toolCallId: "read-2",
-      title: "Read app.ts",
-      kind: "read",
-      status: "pending",
-    });
-    _emitAcpToolCallUpdate(emit, session, {
-      sessionUpdate: "tool_call_update",
-      toolCallId: "read-2",
-      status: "completed",
-      content: [{ type: "text", text: "only one line" }],
-    });
-
-    const toolStart = neutralEvents.find((event) => event.kind === "tool-start");
-    expect(toolStart).toMatchObject({ payload: { kind: "read" } });
-    const toolEnd = neutralEvents.find((event) => event.kind === "tool-end");
-    expect(toolEnd).toBeDefined();
-    expect(translateNeutralEvent(toolEnd)[0].body.output).toBe(
-      "[1 line hidden on Happy Mobile]",
-    );
-  });
-
-  it("leaves a failed read and a non-read result untouched", () => {
-    const summarizer = createFileReadSummarizer();
-    // A read that errored keeps its short, diagnostic failure text.
-    summarizer.annotate({
-      kind: "tool-start",
-      sessionId: "session-1",
-      payload: { toolCallId: "read-err", kind: "fileRead" },
-    });
-    const failed = summarizer.annotate({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "read-err", error: "ENOENT: no such file" },
-    });
-    expect(translateNeutralEvent(failed)[0].body).toMatchObject({
-      isError: true,
-      output: "ENOENT: no such file",
-    });
-
-    // A shell command's output is not a read and stays on the character-cap path.
-    summarizer.annotate({
-      kind: "tool-start",
-      sessionId: "session-1",
-      payload: { toolCallId: "run-1", kind: "shell" },
-    });
-    const command = summarizer.annotate({
-      kind: "tool-end",
-      sessionId: "session-1",
-      payload: { toolCallId: "run-1", result: "build succeeded" },
-    });
-    expect(translateNeutralEvent(command)[0].body.output).toBe("build succeeded");
-  });
-
-  it("bounds tool input without flattening its shape", () => {
-    // A `Write` call carries the whole file body in its parameters. Left
-    // unbounded it went to the relay and onto the phone in full, while the
-    // diff the same write produces was capped.
-    const [message] = translateNeutralEvent({
-      kind: "tool-start",
-      sessionId: "session-1",
-      payload: {
-        toolCallId: "call-write",
-        name: "Write",
-        parameters: {
-          file_path: "/workspace/project/file.ts",
-          content: "x".repeat(2_000_000),
-          replacements: [{ old: "y".repeat(5_000), count: 3 }],
-        },
-      },
-    });
-
-    expect(message.body.input.file_path).toBe("/workspace/project/file.ts");
-    expect(message.body.input.content).toHaveLength(2_000);
-    expect(message.body.input.content).toContain("[truncated for Happy Mobile]");
-    expect(message.body.input.replacements[0].old).toHaveLength(2_000);
-    expect(message.body.input.replacements[0].count).toBe(3);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- hide routine provider tool starts and results from Happy Mobile by default;
- keep assistant text, turn state, file-change messages, and actionable permission requests available;
- remove the obsolete Happy-only file-read summarizer and its superseded coverage.

Closes #3527.

## Audit

The private reproduction screenshot showed raw `mcpToolCall` cards dominating the Happy mobile stream. It is intentionally not attached to this public repository.

The affected path is isolated to `translateNeutralEvent`, whose only production caller is the Happy relay adapter. Seren Desktop's local tool-call renderer does not pass through it.

Happy's current app source exposes an “Inline Tool Calls” setting, but the value is not consumed by its chat renderer. Its separate “Group Tool Calls” setting is opt-in, defaults off, and collapses groups rather than hiding routine events. Earlier fixes #3125 and #3426 reduced payload size while deliberately retaining the cards, so they do not resolve this behavior.

## Safety

Happy permission prompts use their own `permission-request` message. Focused coverage verifies that routine `tool-start` / `tool-end` payloads are dropped while permission requests remain publishable and actionable.

## Network path

`provider://tool-call|tool-result`
→ local provider-runtime WebSocket
→ `publishEvent`
→ `translateNeutralEvent`
→ Happy client encrypted outbox
→ `POST /v3/sessions/{sessionId}/messages` on the configured Happy relay.

This path calls the Happy API directly and contains no Seren publisher slug. The method and route were verified against the installed official `happy@1.2.0` client source. The change suppresses two payload types and does not alter the relay host, method, route, authentication, or encryption.

## Validation

- `pnpm exec vitest run tests/unit/happy-bridge-translate-happy.test.ts tests/unit/happy-bridge-translate-provider.test.ts` — 47 passed
- `pnpm test` — 2,864 passed, 15 skipped
- `node --check bin/happy-bridge/translate.mjs`
- `node --check bin/happy-bridge/happy-layer.mjs`
- `git diff --check`
- `pnpm build`

A live paired-client walkthrough will be recorded after the PR is raised, before merge.