### PR TITLE
fix(run): walkthrough follow-up - dispatcher fallbacks and no-build mode

### DIFF
--- a/docs/20260801_Mission_Control_Slice_Walkthrough.md
+++ b/docs/20260801_Mission_Control_Slice_Walkthrough.md
@@ -56,6 +56,53 @@ The corresponding earlier issue evidence is recorded in [the #3529 validation-hi
 
 The earlier same-slot prompt was caused by rebuilding an unsigned development binary. The dialog asked for the scratch keychain's generated `login` password, not Taariq's macOS password. The `--no-build` mode records the per-rebuild bound: a rebuild may require a fresh operator authorization, while relaunching the same already-authorized binary does not. The local-only screenshot and the generated slot password are not committed.
 
+## Final no-build evidence pass — 2026-08-01
+
+The first phase-27 no-build launcher attempt exited 143 before creating a fresh control discovery file. The repository's full Cargo gate from the preceding phase had overwritten `src-tauri/target/debug/Seren` with the default-feature binary: its fingerprint recorded `features=["default"]`, while the existing `src-tauri/target/debug/deps/Seren-7ab2b1a71896a2bd` executable recorded `features=["validation"]` and contained the validation control server. I restored that existing validation-feature executable to the launcher path with a recoverable copy of the default binary outside the worktree. No source file was changed and no validation rebuild was run. This derived-artifact repair is the phase deviation from the strict no-rebuild assumption.
+
+The repaired no-build launch at 12:24:08 used control server `http://127.0.0.1:59105`. Its health response was `{"ok":true,"frontendReady":true}` and `dumpText` showed `Employees`, `Approval inbox`, `Bounties`, `$1.67`, and `Mission control`; the process log showed slot-keychain reads and `Token refreshed successfully`. No Keychain prompt appeared.
+
+For the required restart attempt, the process was stopped at 12:24:12 while `cf306239-d710-4301-aff6-335b4a3ebe02` still had non-terminal tasks. The same binary relaunched at 12:25:26 on control server `http://127.0.0.1:59231`. Its health response was again `{"ok":true,"frontendReady":true}` and `dumpText` again showed `Employees`, `Approval inbox`, `Bounties`, and `Mission control`, with no Keychain prompt. The fresh frontend showed the launch box rather than an interrupted banner: `runStore` starts with no active run and does not hydrate an existing database run on mount. Read-only SQL confirmed that the `cf306239…` row remained `running`, with no new `run_interrupted` or `run_relaunched` event and no attempt 2. I therefore did not click a nonexistent `run-relaunch` control and did not create a duplicate run.
+
+The final read-only excerpts from the validation slot database were:
+
+```text
+runs:
+  a9c83443-d70a-4f5d-a9aa-a05d41caa5d6  interrupted  interrupted_at=1785584239863
+  cf306239-d710-4301-aff6-335b4a3ebe02  running       interrupted_at=NULL
+
+cf306239-d710-4301-aff6-335b4a3ebe02 events:
+  sequence 1 run_created
+  sequence 10 attempt_started
+  sequence 12 attempt_started
+  sequence 16 attempt_started
+  sequence 17 coverage_gap_recorded
+  sequence 18 attempt_finished
+
+cf306239-d710-4301-aff6-335b4a3ebe02 attempts:
+  cc7a2696-6d4a-4891-86e8-11e1595c20c7  attempt=1  session=47fee3e1-8efc-45fc-9c27-78ec6fa8b1ab
+  2d772e75-c087-4b63-872e-3c5f35e52f21  attempt=1  session=05b7bd2a-a757-4040-961b-811d6f1db7c4  outcome=parse_failed
+  999911d2-b397-4a82-8f6d-221c1c945376  attempt=1  session=ceb0b07d-d0f4-4ab5-8b49-3cd0aded3316
+
+coverage gap:
+  d0447d07-880f-4aad-bc0b-987aab166b8a  unparseable  Summarize non-git release documents
+```
+
+## Proven / not proven
+
+| Area | Result | Evidence and bound |
+| --- | --- | --- |
+| Slot keychain store/read across relaunch | Proven | One repaired no-build launch plus the following same-binary restart restored the authenticated shell with no Keychain dialog; process logs show keyring reads and token refresh. |
+| Three-way dispatcher start / concurrency observation | Partially proven | `cf306239…` has three real agent sessions and three attempt-1 rows; the run did not produce complete parseable output. |
+| Run-owned sessions | Not proven | Session IDs are present in readonly SQL, but the restart pass did not expose a durable UI state from which ownership could be independently verified. |
+| Startup interruption | Proven for prior run | `a9c83443…` has `run_interrupted` at sequence 27 and `interrupted_at=1785584239863`; the fresh process-kill pass did not add an interruption event for `cf306239…`. |
+| Relaunch and attempt numbering across restart | Not proven | No `run_relaunched` row or attempt number 2 exists; no interrupted banner was rendered after restart because the frontend did not hydrate the existing run. |
+| Coverage-gap honesty | Proven | The parse failure created the `unparseable` coverage-gap row and left the task in `review`; no finding was synthesized. |
+| Evidence findings and email approval | Not proven | `run_findings` is empty, so there is no `evidence_json`, email artifact, `open → accepted` transition, or `finding_status_changed` event. |
+| Leases and worktree provisioning | Not proven | Outside the dispatcher exercised by this walkthrough. |
+
+The final bounds are: validation used the existing signed-in slot and the no-build binary-reuse path; rebuilding may require fresh operator keychain authorization; the current run was not duplicated; no live email was sent; screenshots were local-only; MCP/provider availability and model output were not treated as evidence; and no credential or generated slot password is part of this artifact.
+
 ## Partial real run evidence
 
 The current no-build session created one fresh real run after the keychain proof. The scheduler also reconciled the previous in-flight run when this command path started. Read-only SQL from the slot database confirmed:

--- a/docs/20260801_Mission_Control_Slice_Walkthrough.md
+++ b/docs/20260801_Mission_Control_Slice_Walkthrough.md
@@ -5,7 +5,7 @@ ABOUTME: Separates the authenticated partial run from the incomplete restart wal
 
 ## Outcome
 
-The offline launch-box slice is committed in `5c314258`. A real validation instance reached the authenticated shell once, and a real three-task dispatch was started in slot 1422. The full restart/relaunch walkthrough is not complete: later same-slot launches stopped before publishing a fresh validation-control endpoint while macOS Keychain authorization was pending.
+The offline launch-box slice is committed in `5c314258`. A real validation instance reached the authenticated shell, and two same-slot restarts restored it without a visible prompt. The verification is not complete: the next relaunch displayed a fresh macOS Keychain authorization dialog before publishing a fresh validation-control endpoint, so issue #3529 remains open and the run walkthrough is blocked.
 
 This report is part of #3511. Issue [#3529](https://github.com/serenorg/seren-desktop/issues/3529) records the validation sign-in history.
 
@@ -41,7 +41,7 @@ The launcher prints the generated slot password locally for an assisted prompt; 
 
 ## Definitive sign-in evidence
 
-The second instrumented sign-in attempt in this phase reached the signed-in shell without a human answering a prompt. The validation control response for `waitFor button[aria-label^="SerenBucks balance"]` was:
+The instrumented sign-in and the next two same-slot restarts reached the signed-in shell without a human answering a prompt. The validation control response for `waitFor button[aria-label^="SerenBucks balance"]` was:
 
 ```json
 {"found":"button[aria-label^=\"SerenBucks balance\"]"}
@@ -49,9 +49,9 @@ The second instrumented sign-in attempt in this phase reached the signed-in shel
 
 The following `dumpText` then included `$3.07`, `Employees`, `New employee`, `Approval inbox`, and `Bounties`, with no sign-in form. This proves the API login and local token persistence path succeeded at least once in the slot.
 
-The corresponding issue evidence is recorded in [the #3529 resolution-history comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151085576).
+The corresponding earlier issue evidence is recorded in [the #3529 validation-history comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151085576).
 
-A later same-slot launch visibly displayed the Keychain dialog asking for the `login` keychain password. At the time of capture it had not been answered; the app log then ended with a keyring lookup followed by `tauri_runtime_wry: web content process terminated`, and the discovery file still contained the prior PID. The local-only screenshot is `/tmp/seren-validation-slot1422-current.png`; it is not committed.
+A later same-slot launch visibly displayed the Keychain dialog asking for the `login` keychain password. At the time of capture it had not been answered; the app log then ended with a keyring lookup followed by `tauri_runtime_wry: web content process terminated`, and the discovery file still contained the prior PID. The validation wrapper rebuilt the app during this relaunch, which is a deviation from the requested no-rebuild restart and means this attempt cannot prove promptless access for the rebuilt binary. The local-only capture is not committed. The new evidence is recorded in [the latest #3529 comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151176397), and the issue remains open.
 
 ## Partial real run evidence
 
@@ -72,7 +72,7 @@ attempt_number=1 for each of the three attempts
 
 Read-only SQL from the slot database (`.../chat.db`) confirmed the rows above. It also recorded three coverage gaps: an unknown `seren` native agent type, a failed local agent session, and an unparseable agent response. No finding was inserted, so this partial run does not satisfy the evidence or approval portion of the walkthrough.
 
-The dispatcher now treats `seren` as a signed-in cloud-chat fallback, falls back to that path when a native provider cannot start, records a provider-boundary coverage gap, and keeps parse failures in review. The titlebar now has the missing Mission Control trigger needed to open the launch box.
+The dispatcher now treats `seren` as a signed-in cloud-chat fallback, resolves the live Seren model catalog when the stored model is `auto`, falls back to that path when a native provider cannot start, records a provider-boundary coverage gap, and keeps parse failures in review. The titlebar now has the missing Mission Control trigger needed to open the launch box. The catalog fix was verified by the focused dispatcher tests but could not be exercised in the live UI because the validation control endpoint was blocked by the Keychain dialog.
 
 ## Walkthrough bounds and remaining gap
 
@@ -85,6 +85,6 @@ The following required live proof remains absent and is intentionally not synthe
 - screenshots remain local-only; provider behavior and model output remain potentially flaky;
 - the current restart failure is limited to the validation process/control path after the Keychain prompt, not established as a production fresh-sign-in defect.
 
-The next run must reuse slot 1422, confirm a fresh discovery PID, complete the launch-box run, approve the email artifact, interrupt a non-terminal task, click `run-relaunch`, and capture all SQL with `sqlite3 -readonly`.
+The next run must reuse slot 1422 after the operator completes the visible Keychain authorization, confirm a fresh discovery PID, complete the launch-box run, approve the email artifact, interrupt a non-terminal task, click `run-relaunch`, and capture all SQL with `sqlite3 -readonly`.
 
 Part of #3511

--- a/docs/20260801_Mission_Control_Slice_Walkthrough.md
+++ b/docs/20260801_Mission_Control_Slice_Walkthrough.md
@@ -1,68 +1,90 @@
-<!-- ABOUTME: Records the validation sign-in investigation for the Mission Control vertical slice.
-ABOUTME: The live run was not started because macOS secure-storage authorization remained blocked. -->
+<!-- ABOUTME: Records the validation sign-in investigation and Mission Control slice evidence.
+ABOUTME: Separates the authenticated partial run from the incomplete restart walkthrough. -->
 
 # Mission Control slice walkthrough
 
 ## Outcome
 
-The offline launch-box slice is committed in `5c314258`. The live walkthrough stopped at sign-in after one instrumented attempt and one retry after the launcher fix. No live run, task, agent session, finding, approval transition, or validation-instance SQL evidence was produced.
+The offline launch-box slice is committed in `5c314258`. A real validation instance reached the authenticated shell once, and a real three-task dispatch was started in slot 1422. The full restart/relaunch walkthrough is not complete: later same-slot launches stopped before publishing a fresh validation-control endpoint while macOS Keychain authorization was pending.
 
-The validation sign-in blocker is tracked in [issue #3529](https://github.com/serenorg/seren-desktop/issues/3529). This report is part of #3511.
+This report is part of #3511. Issue [#3529](https://github.com/serenorg/seren-desktop/issues/3529) records the validation sign-in history.
 
-## Root cause and evidence
+## Root-cause history
 
-Root cause: the validation launcher set `HOME` to the per-slot scratch directory in `scripts/validation-env.ts:23-25`, but that scratch HOME had no macOS default User keychain. The fresh-session OS-keychain path introduced by commit `e5617753` therefore failed before a token could be stored. The configured login endpoint remained `https://api.serendb.com/auth/login`; an exact-method, exact-body-shape shell request returned HTTP 200, so the gateway and authentication response were not the failing layer.
+### Layer 1: scratch HOME had no default keychain
 
-Captured evidence before the launcher change:
+The validation launcher set `HOME` to the per-slot scratch directory in `scripts/validation-env.ts`, but that HOME initially had no macOS default User keychain. The fresh-session OS-keychain path introduced by commit `e5617753` therefore failed before a token could be stored. The configured login endpoint remained `https://api.serendb.com/auth/login`; an exact-method, exact-body-shape shell request returned HTTP 200, so the gateway and authentication response were not the failing layer.
+
+Captured evidence:
 
 ```text
 POST https://api.serendb.com/auth/login
 HTTP_STATUS=200
 
-HOME=/Users/taariqlewis/Projects/Seren_Projects/seren-desktop/.worktrees/slice-walkthrough/artifacts/validation-home/slot1422 security default-keychain
+HOME=.../artifacts/validation-home/slot1422 security default-keychain
 security: SecKeychainCopyDefault: A default keychain could not be found.
 
 UI: OS credential store could not store Seren access token: Platform secure storage failure: A default keychain could not be found.
 ```
 
-The launcher was changed to provision and unlock a persistent keychain inside the validation slot before starting Tauri. This is the smallest validation-environment fix for the missing default-keychain condition. The single retry reached token persistence, but macOS then returned an interactive authorization failure:
+The launcher now provisions a persistent keychain in the slot, disables automatic locking, unlocks it, makes it the default keychain, and restricts the security-tool search list to that slot. Every mutation is guarded so it can run only under `artifacts/validation-home/`.
+
+### Layer 2: per-slot application authorization
+
+After the first layer was provisioned, one instrumented sign-in reached token persistence but macOS returned an interactive authorization failure. The prompt was for the generated slot keychain's `login` password, not Taariq's macOS account password. The earlier UI error was:
 
 ```text
-UI screenshot: OS credential store could not store Seren access token: Platform secure storage failure: User canceled the operation.
-validation stdout: keyring set-password reached access-token.v1, but no successful token write or signed-in shell followed
+OS credential store could not store Seren access token: Platform secure storage failure: User canceled the operation.
 ```
 
-The shell check and the UI error together bound the failure to macOS Keychain authorization for the validation binary, rather than the API route. No authorization bypass was attempted. The screenshot was retained locally at `/tmp/seren-slice-signin-stall.png` and is not committed because screenshots from the signed-in validation environment are local-only.
+The launcher prints the generated slot password locally for an assisted prompt; it is deliberately absent from source, commits, this document, and the PR. The current launcher additionally configures the slot keychain's partition list and keeps the slot HOME explicit.
 
-Relevant configuration and history:
+## Definitive sign-in evidence
 
-- `src/lib/config.ts:9-10` resolves the API root to `https://api.serendb.com` when no Vite override is supplied.
-- `scripts/validation-dev.ts` passes the slot HOME and does not replace the API root with another host.
-- `src/lib/tauri-fetch.ts` routes the login request through the gateway bridge; the observed failure occurs later while storing the returned access token.
-- `src-tauri/capabilities/default.json` permits the API origin, and no validation-specific capability file narrows that HTTP scope.
-- `e5617753` moved desktop access and refresh tokens into the native OS keychain, which is why a fresh scratch HOME exposes this validation-only condition.
-- `078ba82a` changed desktop API-key scope handling but did not change the login transport or token-storage path.
+The second instrumented sign-in attempt in this phase reached the signed-in shell without a human answering a prompt. The validation control response for `waitFor button[aria-label^="SerenBucks balance"]` was:
 
-## Diagnostic code change
+```json
+{"found":"button[aria-label^=\"SerenBucks balance\"]"}
+```
 
-`src/services/auth.ts` now includes the resolved login URL and either the HTTP status or a short transport error in failed-login diagnostics. The tests cover an HTTP 503 response and a no-response gateway failure. The console diagnostic contains only URL/status/error metadata; no credential is logged.
+The following `dumpText` then included `$3.07`, `Employees`, `New employee`, `Approval inbox`, and `Bounties`, with no sign-in form. This proves the API login and local token persistence path succeeded at least once in the slot.
 
-Focused verification:
+The corresponding issue evidence is recorded in [the #3529 resolution-history comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151085576).
+
+A later same-slot launch visibly displayed the Keychain dialog asking for the `login` keychain password. At the time of capture it had not been answered; the app log then ended with a keyring lookup followed by `tauri_runtime_wry: web content process terminated`, and the discovery file still contained the prior PID. The local-only screenshot is `/tmp/seren-validation-slot1422-current.png`; it is not committed.
+
+## Partial real run evidence
+
+Before the restart-only control failure, slot 1422 created two real runs. The first stopped after `run_create` because the original renderer bridge used snake_case Tauri argument names. The second used the corrected camelCase bridge and created three assignments, three tasks, and three dispatcher attempts:
 
 ```text
-pnpm vitest run tests/unit/auth-service-refresh-login.test.ts tests/unit/validation-env.test.ts
-8 tests passed; 5 tests passed; exit 0
+run 7696ed9d-e978-480b-bfa5-26924cad6fb9  status=running
+tasks:
+  e848877d-c5f6-418b-ab7a-7073bbf07fab  failed
+  38633e7c-fc1e-4897-ae05-7eeae90c3ce2  review
+  7d81ed6a-4b63-46a0-a71b-741ea5f3a416  failed
+agent sessions:
+  b699874e-b427-4567-9a5f-864d5c1adfa0
+  aa581134-e01f-42db-b358-a166729e48a7
+  3dff59f9-b214-499b-8e0f-448a15cbd21f
+attempt_number=1 for each of the three attempts
 ```
 
-## Walkthrough coverage
+Read-only SQL from the slot database (`.../chat.db`) confirmed the rows above. It also recorded three coverage gaps: an unknown `seren` native agent type, a failed local agent session, and an unparseable agent response. No finding was inserted, so this partial run does not satisfy the evidence or approval portion of the walkthrough.
 
-Because the signed-in shell was never reached, the following evidence is intentionally absent rather than synthesized:
+The dispatcher now treats `seren` as a signed-in cloud-chat fallback, falls back to that path when a native provider cannot start, records a provider-boundary coverage gap, and keeps parse failures in review. The titlebar now has the missing Mission Control trigger needed to open the launch box.
 
-- no real run id, task ids, agent session ids, attempt numbering, or restart/relaunch cycle;
-- no `interrupted` status history, `run_events` sequence dump, `run_tasks` dump, or `run_attempts` dump from a validation database;
-- no findings with git or non-git evidence, coverage-gap row, email artifact, or `finding_status_changed` approval event;
-- no proof of dispatcher concurrency, model fallback behavior, leases, or worktree provisioning.
+## Walkthrough bounds and remaining gap
 
-The non-git target preparation and offline UI tests are separate from this blocked live proof. If macOS Keychain access is authorized for the validation binary, the next walkthrough must reuse the slot database, run the three declared tasks, approve the email artifact, interrupt a non-terminal run, relaunch it, and capture the required `sqlite3 -readonly` evidence. Local screenshots remain outside the repository.
+The following required live proof remains absent and is intentionally not synthesized:
+
+- no run has yet completed the three requested tasks with two evidenced findings and an email artifact;
+- no `open → accepted` email finding or `finding_status_changed` approval event was produced;
+- no restart cycle has produced `run_interrupted`, a fresh attempt number, `run_relaunched`, or a terminal post-relaunch status;
+- leases and worktree provisioning were not exercised by the dispatcher;
+- screenshots remain local-only; provider behavior and model output remain potentially flaky;
+- the current restart failure is limited to the validation process/control path after the Keychain prompt, not established as a production fresh-sign-in defect.
+
+The next run must reuse slot 1422, confirm a fresh discovery PID, complete the launch-box run, approve the email artifact, interrupt a non-terminal task, click `run-relaunch`, and capture all SQL with `sqlite3 -readonly`.
 
 Part of #3511

--- a/docs/20260801_Mission_Control_Slice_Walkthrough.md
+++ b/docs/20260801_Mission_Control_Slice_Walkthrough.md
@@ -1,13 +1,13 @@
 <!-- ABOUTME: Records the validation sign-in investigation and Mission Control slice evidence.
-ABOUTME: Separates the authenticated partial run from the incomplete restart walkthrough. -->
+ABOUTME: Separates resolved slot-keychain access from the externally blocked run. -->
 
 # Mission Control slice walkthrough
 
 ## Outcome
 
-The offline launch-box slice is committed in `5c314258`. A real validation instance reached the authenticated shell, and two same-slot restarts restored it without a visible prompt. The verification is not complete: the next relaunch displayed a fresh macOS Keychain authorization dialog before publishing a fresh validation-control endpoint, so issue #3529 remains open and the run walkthrough is blocked.
+The offline launch-box slice is committed in `5c314258`. A rebuilt validation instance reached the authenticated shell, and two consecutive `--no-build` relaunches restored it without a visible prompt. The slot-keychain verification is resolved for the authorized binary. The later Mission Control run remains incomplete because the external MCP gateway returned HTTP 503 and native provider fallbacks were unavailable; those are run-coverage bounds, not keychain failures.
 
-This report is part of #3511. Issue [#3529](https://github.com/serenorg/seren-desktop/issues/3529) records the validation sign-in history.
+This report is part of #3511. Issue [#3529](https://github.com/serenorg/seren-desktop/issues/3529) records the validation sign-in history; its closure evidence is in [the closing comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151275967).
 
 ## Root-cause history
 
@@ -39,40 +39,45 @@ OS credential store could not store Seren access token: Platform secure storage 
 
 The launcher prints the generated slot password locally for an assisted prompt; it is deliberately absent from source, commits, this document, and the PR. The current launcher additionally configures the slot keychain's partition list and keeps the slot HOME explicit.
 
-## Definitive sign-in evidence
+## Keychain verification — RESOLVED
 
-The instrumented sign-in and the next two same-slot restarts reached the signed-in shell without a human answering a prompt. The validation control response for `waitFor button[aria-label^="SerenBucks balance"]` was:
+The rebuilt binary launched on slot 1422 at 11:34:51 and reached the signed-in shell. It was then stopped and relaunched twice with `SEREN_VALIDATION_DEV_PORT=1422 pnpm tauri:validation:dev -- --no-build`; the direct binary path reused the already-authorized build. Both no-build launches reached the signed-in shell without a human answering a Keychain prompt. The validation control responses for the two no-build launches contained these authenticated-shell rows:
 
 ```json
-{"found":"button[aria-label^=\"SerenBucks balance\"]"}
+{"selector":"span:nth-visible(9)","text":"Employees"}
+{"selector":"div:nth-visible(12)","text":"Approval inbox"}
+{"selector":"span:nth-visible(14)","text":"Bounties"}
+{"selector":"div:nth-visible(652)","text":"Mission control"}
 ```
 
-The following `dumpText` then included `$3.07`, `Employees`, `New employee`, `Approval inbox`, and `Bounties`, with no sign-in form. This proves the API login and local token persistence path succeeded at least once in the slot.
+The first no-build control server was `http://127.0.0.1:57784` at 11:35:28; the second was `http://127.0.0.1:57844` at 11:35:53. Their logs each showed reads of the slot access-token entry and successful token refresh, and neither log contained a Keychain prompt. The initial built launch's `dumpText` also included `$3.07`, `Employees`, `New employee`, `Approval inbox`, and `Bounties`, with no sign-in form. This proves store and read-back for the slot keychain across the built launch plus two no-build relaunches.
 
 The corresponding earlier issue evidence is recorded in [the #3529 validation-history comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151085576).
 
-A later same-slot launch visibly displayed the Keychain dialog asking for the `login` keychain password. At the time of capture it had not been answered; the app log then ended with a keyring lookup followed by `tauri_runtime_wry: web content process terminated`, and the discovery file still contained the prior PID. The validation wrapper rebuilt the app during this relaunch, which is a deviation from the requested no-rebuild restart and means this attempt cannot prove promptless access for the rebuilt binary. The local-only capture is not committed. The new evidence is recorded in [the latest #3529 comment](https://github.com/serenorg/seren-desktop/issues/3529#issuecomment-5151176397), and the issue remains open.
+The earlier same-slot prompt was caused by rebuilding an unsigned development binary. The dialog asked for the scratch keychain's generated `login` password, not Taariq's macOS password. The `--no-build` mode records the per-rebuild bound: a rebuild may require a fresh operator authorization, while relaunching the same already-authorized binary does not. The local-only screenshot and the generated slot password are not committed.
 
 ## Partial real run evidence
 
-Before the restart-only control failure, slot 1422 created two real runs. The first stopped after `run_create` because the original renderer bridge used snake_case Tauri argument names. The second used the corrected camelCase bridge and created three assignments, three tasks, and three dispatcher attempts:
+The current no-build session created one fresh real run after the keychain proof. The scheduler also reconciled the previous in-flight run when this command path started. Read-only SQL from the slot database confirmed:
 
 ```text
-run 7696ed9d-e978-480b-bfa5-26924cad6fb9  status=running
+run cf306239-d710-4301-aff6-335b4a3ebe02  status=running
 tasks:
-  e848877d-c5f6-418b-ab7a-7073bbf07fab  failed
-  38633e7c-fc1e-4897-ae05-7eeae90c3ce2  review
-  7d81ed6a-4b63-46a0-a71b-741ea5f3a416  failed
+  cc7a2696-6d4a-4891-86e8-11e1595c20c7  running
+  2d772e75-c087-4b63-872e-3c5f35e52f21  review
+  999911d2-b397-4a82-8f6d-221c1c945376  running
 agent sessions:
-  b699874e-b427-4567-9a5f-864d5c1adfa0
-  aa581134-e01f-42db-b358-a166729e48a7
-  3dff59f9-b214-499b-8e0f-448a15cbd21f
+  47fee3e1-8efc-45fc-9c27-78ec6fa8b1ab
+  05b7bd2a-a757-4040-961b-811d6f1db7c4
+  ceb0b07d-d0f4-4ab5-8b49-3cd0aded3316
 attempt_number=1 for each of the three attempts
+coverage gap:
+  d0447d07-880f-4aad-bc0b-987aab166b8a  unparseable  Summarize non-git release documents
 ```
 
-Read-only SQL from the slot database (`.../chat.db`) confirmed the rows above. It also recorded three coverage gaps: an unknown `seren` native agent type, a failed local agent session, and an unparseable agent response. No finding was inserted, so this partial run does not satisfy the evidence or approval portion of the walkthrough.
+The previous in-flight run `a9c83443-d70a-4f5d-a9aa-a05d41caa5d6` has a `run_interrupted` event at sequence 27 and `interrupted_at=1785584239863`, proving startup reconciliation. The new run's three sessions were real, but no attempt completed with a parseable `seren-findings` block. No finding was inserted, so this real run does not satisfy the evidence or approval portion of the walkthrough.
 
-The dispatcher now treats `seren` as a signed-in cloud-chat fallback, resolves the live Seren model catalog when the stored model is `auto`, falls back to that path when a native provider cannot start, records a provider-boundary coverage gap, and keeps parse failures in review. The titlebar now has the missing Mission Control trigger needed to open the launch box. The catalog fix was verified by the focused dispatcher tests but could not be exercised in the live UI because the validation control endpoint was blocked by the Keychain dialog.
+The dispatcher now treats `seren` as a signed-in cloud-chat fallback, resolves the live Seren model catalog when the stored model is `auto`, falls back to that path when a native provider cannot start, records a provider-boundary coverage gap, and keeps parse failures in review. The titlebar now has the missing Mission Control trigger needed to open the launch box. The catalog fix was verified by focused dispatcher tests. The live run instead encountered a transient MCP gateway HTTP 503, a Codex HTTP 401, and local shell approvals; no evidence was synthesized from those blocked attempts.
 
 ## Walkthrough bounds and remaining gap
 
@@ -80,11 +85,11 @@ The following required live proof remains absent and is intentionally not synthe
 
 - no run has yet completed the three requested tasks with two evidenced findings and an email artifact;
 - no `open → accepted` email finding or `finding_status_changed` approval event was produced;
-- no restart cycle has produced `run_interrupted`, a fresh attempt number, `run_relaunched`, or a terminal post-relaunch status;
+- the new run has not completed a restart/relaunch cycle with `run_relaunched`, attempt number 2, and a terminal post-relaunch status; startup reconciliation did produce `run_interrupted` for the prior in-flight run when the new run command started;
 - leases and worktree provisioning were not exercised by the dispatcher;
 - screenshots remain local-only; provider behavior and model output remain potentially flaky;
-- the current restart failure is limited to the validation process/control path after the Keychain prompt, not established as a production fresh-sign-in defect.
+- the current run gap is the external MCP gateway/provider path; keychain access is not the failing layer.
 
-The next run must reuse slot 1422 after the operator completes the visible Keychain authorization, confirm a fresh discovery PID, complete the launch-box run, approve the email artifact, interrupt a non-terminal task, click `run-relaunch`, and capture all SQL with `sqlite3 -readonly`.
+The remaining work is the external-provider run path: restore the MCP gateway, rerun the three tasks without duplicating the run, approve an actual email artifact, and capture the relaunch rows with `sqlite3 -readonly`. Keychain access itself is resolved for the reused binary and issue #3529 can be closed on that evidence.
 
 Part of #3511

--- a/scripts/validation-dev-args.ts
+++ b/scripts/validation-dev-args.ts
@@ -4,3 +4,17 @@
 export function validationDevArgs(args: string[]): string[] {
   return args[0] === "--" ? args.slice(1) : [...args];
 }
+
+export function shouldSkipValidationBuild(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    args.includes("--no-build") ||
+    env.SEREN_VALIDATION_SKIP_BUILD === "1"
+  );
+}
+
+export function removeValidationBuildFlag(args: string[]): string[] {
+  return args.filter((argument) => argument !== "--no-build");
+}

--- a/scripts/validation-dev.ts
+++ b/scripts/validation-dev.ts
@@ -1,9 +1,16 @@
 // ABOUTME: Starts a manual validation Tauri app in an automatically leased slot.
 // ABOUTME: Releases the slot after the Tauri process and its dev server exit.
 
-import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { spawn, type ChildProcess } from "node:child_process";
 import os from "node:os";
-import { validationDevArgs } from "./validation-dev-args";
+import path from "node:path";
+import {
+  removeValidationBuildFlag,
+  shouldSkipValidationBuild,
+  validationDevArgs,
+} from "./validation-dev-args";
 import {
   ensureValidationHome,
   resolvePnpmStoreDir,
@@ -13,7 +20,11 @@ import { acquireValidationSlot } from "./validation-slots";
 
 async function main(): Promise<void> {
   const slot = await acquireValidationSlot();
-  const forwardedArgs = validationDevArgs(process.argv.slice(2));
+  const rawArgs = validationDevArgs(process.argv.slice(2));
+  // --no-build is the human-facing flag; SEREN_VALIDATION_SKIP_BUILD=1 is
+  // the first-class escape hatch for scripted relaunches.
+  const skipBuild = shouldSkipValidationBuild(rawArgs, process.env);
+  const forwardedArgs = removeValidationBuildFlag(rawArgs);
 
   try {
     const validationHome = await ensureValidationHome(process.cwd(), slot.port);
@@ -34,47 +45,141 @@ async function main(): Promise<void> {
       `[validation] leased port ${slot.port} with identifier ${slot.identifier}; scratch home ${validationHome}`,
     );
 
-    const child = spawn(
-      "pnpm",
-      [
-        "tauri",
-        "dev",
-        "--features",
-        "validation",
-        "--config",
-        "src-tauri/tauri.validation.conf.json",
-        "--config",
-        JSON.stringify(slot.tauriConfig),
-        ...forwardedArgs,
-      ],
-      {
-        cwd: process.cwd(),
-        stdio: "inherit",
-        env: childEnv,
-      },
+    const children: ChildProcess[] = [];
+    const repoRoot = process.cwd();
+    const validationBinary = path.join(
+      repoRoot,
+      "src-tauri",
+      "target",
+      "debug",
+      process.platform === "win32" ? "Seren.exe" : "Seren",
     );
+
+    if (skipBuild) {
+      await assertValidationBinary(validationBinary);
+      const vite = spawn(
+        "pnpm",
+        [
+          "dev",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          String(slot.port),
+          "--strictPort",
+        ],
+        {
+          cwd: repoRoot,
+          stdio: "inherit",
+          env: childEnv,
+        },
+      );
+      children.push(vite);
+      await waitForDevServer(`http://127.0.0.1:${slot.port}`, vite);
+      children.push(
+        spawn(validationBinary, forwardedArgs, {
+          cwd: path.join(repoRoot, "src-tauri"),
+          stdio: "inherit",
+          env: childEnv,
+        }),
+      );
+    } else {
+      children.push(
+        spawn(
+          "pnpm",
+          [
+            "tauri",
+            "dev",
+            "--features",
+            "validation",
+            "--config",
+            "src-tauri/tauri.validation.conf.json",
+            "--config",
+            JSON.stringify(slot.tauriConfig),
+            ...forwardedArgs,
+          ],
+          {
+            cwd: repoRoot,
+            stdio: "inherit",
+            env: childEnv,
+          },
+        ),
+      );
+    }
+
+    const child = children.at(-1);
+    if (!child) throw new Error("validation launcher did not start a child");
 
     const forwardedSignals = ["SIGINT", "SIGTERM"] as const;
     for (const signal of forwardedSignals) {
-      process.once(signal, () => child.kill(signal));
+      process.once(signal, () => {
+        for (const runningChild of children) {
+          if (runningChild.exitCode === null) runningChild.kill(signal);
+        }
+      });
     }
 
-    const result = await new Promise<{
-      code: number | null;
-      signal: NodeJS.Signals | null;
-    }>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code, signal) => resolve({ code, signal }));
-    });
+    const result = await waitForChild(child);
 
     if (result.signal) {
       process.exitCode = result.signal === "SIGINT" ? 130 : 143;
     } else {
       process.exitCode = result.code ?? 1;
     }
+
+    for (const runningChild of children) {
+      if (runningChild !== child && runningChild.exitCode === null) {
+        runningChild.kill("SIGTERM");
+      }
+    }
   } finally {
     await slot.release();
   }
+}
+
+async function assertValidationBinary(binaryPath: string): Promise<void> {
+  try {
+    await access(binaryPath, constants.X_OK);
+  } catch {
+    throw new Error(
+      `Validation binary not found at ${binaryPath}; run pnpm tauri:validation:dev once without --no-build first`,
+    );
+  }
+}
+
+async function waitForDevServer(
+  baseUrl: string,
+  child: ChildProcess,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error("validation Vite server exited before becoming ready");
+    }
+    try {
+      const response = await Promise.race([
+        fetch(`${baseUrl}/`),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), 1_000),
+        ),
+      ]);
+      if (response instanceof Response && response.ok) return;
+    } catch {
+      // The dev server may need several polls while pnpm starts Vite.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`timed out waiting for validation Vite at ${baseUrl}`);
+}
+
+function waitForChild(child: ChildProcess): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
 }
 
 main().catch((error) => {

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -53,17 +53,31 @@ export async function ensureValidationHome(
   const validationHome = validationHomeForSlot(repoRoot, port);
   await mkdir(validationHome, { recursive: true, mode: 0o700 });
   if (process.platform === "darwin") {
-    await ensureValidationKeychain(validationHome);
+    await ensureValidationKeychain(validationHome, repoRoot);
   }
   return validationHome;
 }
 
-async function ensureValidationKeychain(validationHome: string): Promise<void> {
-  const keychainDirectory = path.join(validationHome, "Library", "Keychains");
+export async function ensureValidationKeychain(
+  validationHome: string,
+  repoRoot: string,
+): Promise<void> {
+  const resolvedHome = assertValidationHome(validationHome, repoRoot);
+  const keychainDirectory = path.join(
+    resolvedHome,
+    "Library",
+    "Keychains",
+  );
   const keychainPath = path.join(keychainDirectory, "login.keychain-db");
   await mkdir(keychainDirectory, { recursive: true, mode: 0o700 });
 
-  const keychainPassword = `seren-validation-keychain-${path.basename(validationHome)}`;
+  const keychainPassword = `seren-validation-keychain-${path.basename(resolvedHome)}`;
+  const securityEnv = {
+    ...process.env,
+    HOME: resolvedHome,
+  };
+  const security = (args: string[]) =>
+    execFileAsync("security", args, { env: securityEnv });
   let keychainExists = true;
   try {
     await stat(keychainPath);
@@ -72,7 +86,7 @@ async function ensureValidationKeychain(validationHome: string): Promise<void> {
   }
 
   if (!keychainExists) {
-    await execFileAsync("security", [
+    await security([
       "create-keychain",
       "-p",
       keychainPassword,
@@ -80,14 +94,37 @@ async function ensureValidationKeychain(validationHome: string): Promise<void> {
     ]);
   }
 
-  // macOS resolves the User keychain from HOME. Keep validation's app data
-  // hermetic while giving the slot its own persistent, unlocked keychain.
-  await execFileAsync("security", [
-    "unlock-keychain",
-    "-p",
-    keychainPassword,
-    keychainPath,
-  ]);
+  // Keep validation's app data hermetic while making the slot keychain the
+  // only user keychain visible to its security-tool mutations and the app.
+  await security(["set-keychain-settings", keychainPath]);
+  await security(["unlock-keychain", "-p", keychainPassword, keychainPath]);
+  await security(["default-keychain", "-d", "user", "-s", keychainPath]);
+  await security(["list-keychains", "-d", "user", "-s", keychainPath]);
+
+  const slot = path.basename(resolvedHome).replace(/^slot/, "");
+  console.log(
+    `[validation] scratch keychain password for slot ${slot} (safe to type into a Keychain prompt for login.keychain-db under artifacts/validation-home): ${keychainPassword}`,
+  );
+}
+
+function assertValidationHome(validationHome: string, repoRoot: string): string {
+  const resolvedHome = path.resolve(validationHome);
+  const validationRoot = path.resolve(
+    repoRoot,
+    "artifacts",
+    "validation-home",
+  );
+  const relativeHome = path.relative(validationRoot, resolvedHome);
+  if (
+    relativeHome.length === 0 ||
+    relativeHome.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeHome)
+  ) {
+    throw new Error(
+      `refusing security mutation outside validation HOME: ${resolvedHome}`,
+    );
+  }
+  return resolvedHome;
 }
 
 function assertValidPort(port: number): void {

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -100,10 +100,45 @@ export async function ensureValidationKeychain(
 
   // Keep validation's app data hermetic while making the slot keychain the
   // only user keychain visible to its security-tool mutations and the app.
-  await security(["set-keychain-settings", keychainPath]);
-  await security(["unlock-keychain", "-p", keychainPassword, keychainPath]);
-  await security(["default-keychain", "-d", "user", "-s", keychainPath]);
-  await security(["list-keychains", "-d", "user", "-s", keychainPath]);
+  await bestEffortSecurity(
+    security,
+    ["set-keychain-settings", keychainPath],
+  );
+  await bestEffortSecurity(security, [
+    "unlock-keychain",
+    "-p",
+    keychainPassword,
+    keychainPath,
+  ]);
+  await bestEffortSecurity(security, [
+    "default-keychain",
+    "-d",
+    "user",
+    "-s",
+    keychainPath,
+  ]);
+  await bestEffortSecurity(security, [
+    "list-keychains",
+    "-d",
+    "user",
+    "-s",
+    keychainPath,
+  ]);
+}
+
+async function bestEffortSecurity(
+  security: (args: string[]) => Promise<unknown>,
+  args: string[],
+): Promise<void> {
+  try {
+    await security(args);
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message.split("\n", 1)[0] : String(error);
+    console.warn(
+      `[validation] security ${args[0]} did not complete; continuing for interactive keychain authorization: ${detail}`,
+    );
+  }
 }
 
 function assertValidationHome(validationHome: string, repoRoot: string): string {

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -20,14 +20,30 @@ export function validationChildEnv(inputs: {
   realHome: string;
   pnpmStoreDir?: string | null;
 }): NodeJS.ProcessEnv {
+  const validationHome = validationHomeForSlot(inputs.repoRoot, inputs.port);
+  const validationIdentifier = `com.serendb.desktop.validation.slot${inputs.port}`;
   const env: NodeJS.ProcessEnv = {
     ...inputs.baseEnv,
-    HOME: validationHomeForSlot(inputs.repoRoot, inputs.port),
+    HOME: validationHome,
     CARGO_HOME:
       inputs.baseEnv.CARGO_HOME ?? path.join(inputs.realHome, ".cargo"),
     RUSTUP_HOME:
       inputs.baseEnv.RUSTUP_HOME ?? path.join(inputs.realHome, ".rustup"),
+    SEREN_VALIDATION_DISCOVERY_PATH: path.join(
+      validationHome,
+      "Library",
+      "Application Support",
+      validationIdentifier,
+      "validation-control.json",
+    ),
   };
+
+  // macOS Foundation resolves Tauri's app-data directory from
+  // CFFIXED_USER_HOME rather than HOME. Keep the validation app's database,
+  // discovery token, and keychain in the same per-slot sandbox after a restart.
+  if (process.platform === "darwin") {
+    env.CFFIXED_USER_HOME = validationHome;
+  }
 
   if (inputs.pnpmStoreDir != null) {
     env.npm_config_store_dir = inputs.pnpmStoreDir;

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -78,6 +78,10 @@ export async function ensureValidationKeychain(
   };
   const security = (args: string[]) =>
     execFileAsync("security", args, { env: securityEnv });
+  const slot = path.basename(resolvedHome).replace(/^slot/, "");
+  console.log(
+    `[validation] scratch keychain password for slot ${slot} (safe to type into a Keychain prompt for login.keychain-db under artifacts/validation-home): ${keychainPassword}`,
+  );
   let keychainExists = true;
   try {
     await stat(keychainPath);
@@ -100,11 +104,6 @@ export async function ensureValidationKeychain(
   await security(["unlock-keychain", "-p", keychainPassword, keychainPath]);
   await security(["default-keychain", "-d", "user", "-s", keychainPath]);
   await security(["list-keychains", "-d", "user", "-s", keychainPath]);
-
-  const slot = path.basename(resolvedHome).replace(/^slot/, "");
-  console.log(
-    `[validation] scratch keychain password for slot ${slot} (safe to type into a Keychain prompt for login.keychain-db under artifacts/validation-home): ${keychainPassword}`,
-  );
 }
 
 function assertValidationHome(validationHome: string, repoRoot: string): string {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -599,6 +599,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
     setSlidePanel((v) => (v === "meetings" ? null : "meetings"));
   };
 
+  const handleToggleMissionControl = () => {
+    setSlidePanel((v) => (v === "missioncontrol" ? null : "missioncontrol"));
+  };
+
   const handleToggleSkills = () => {
     setSlidePanel((v) => (v === "skills" ? null : "skills"));
   };
@@ -1031,6 +1035,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
         <Titlebar
           onSignInClick={handleSignInClick}
           onToggleMeetings={handleToggleMeetings}
+          onToggleMissionControl={handleToggleMissionControl}
           onToggleSkills={handleToggleSkills}
           onToggleSettings={handleToggleSettings}
           meetingRecording={meetingRecording()}

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -14,6 +14,7 @@ import { updaterStore } from "@/stores/updater.store";
 interface TitlebarProps {
   onSignInClick: () => void;
   onToggleMeetings: () => void;
+  onToggleMissionControl: () => void;
   onToggleSkills: () => void;
   onToggleSettings: () => void;
   /** A meeting capture is live; show the recording indicator on the button. */
@@ -224,6 +225,32 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
               }}
             />
           </Show>
+        </button>
+
+        <button
+          type="button"
+          data-testid="titlebar-mission-control-button"
+          class="flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-muted-foreground cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95"
+          onClick={props.onToggleMissionControl}
+          title="Mission Control"
+          aria-label="Mission Control"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            role="img"
+            aria-label="Mission Control"
+          >
+            <circle cx="12" cy="12" r="7" />
+            <circle cx="12" cy="12" r="2" />
+            <path d="M12 2v3M12 19v3M2 12h3M19 12h3" />
+          </svg>
         </button>
 
         <button

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -2,6 +2,11 @@
 // ABOUTME: It turns agent replies into durable findings, coverage gaps, and attempt results.
 
 import { createEffect, createRoot } from "solid-js";
+import {
+  continueToolIteration,
+  getActiveModel,
+  streamMessageWithTools,
+} from "@/services/chat";
 import type { AgentType } from "@/services/providers";
 import {
   type AgentAssignment,
@@ -42,6 +47,14 @@ const CONFIDENCES = new Set<FindingConfidence>([
   "refuted",
 ]);
 const ARTIFACT_KINDS = new Set(["diff", "document", "email", "comment"]);
+const NATIVE_AGENT_TYPES = new Set<AgentType>([
+  "claude-code",
+  "codex",
+  "gemini",
+  "grok",
+  "claude-codex",
+  "lmstudio",
+]);
 
 export interface ParsedEvidence {
   kind: EvidenceKind;
@@ -233,6 +246,7 @@ export function buildTaskPrompt(
     "",
     "Investigate the task using the available tools and workspace.",
     "Report only claims you can support. State what you could not check as coverage_gaps.",
+    "Include a coverage_gaps entry for every material boundary you did not exercise, such as leases or worktree provisioning.",
     "End your reply with a fenced JSON block tagged seren-findings using this shape:",
     "```seren-findings",
     '{"findings":[{"claim":"...","confidence":"asserted|verified|refuted","evidence":[{"kind":"command_result|file_range|email|document|url|log_excerpt|publisher_result","locator":"...","excerpt":"..."}],"proposed_artifact":{"kind":"diff|document|email|comment","uri":"...","digest":"..."},"needs_approval":false}],"coverage_gaps":[{"kind":"other","subject":"...","detail":"..."}]}',
@@ -378,6 +392,44 @@ async function recordGap(
   );
 }
 
+function isNativeAgentType(agentType: string): agentType is AgentType {
+  return NATIVE_AGENT_TYPES.has(agentType as AgentType);
+}
+
+/**
+ * Use the signed-in Seren model when a launch-box assignment is not backed by
+ * a local CLI, or when a local CLI cannot start. The assignment remains the
+ * durable source of truth; this fallback keeps a run honest by recording the
+ * provider boundary as a coverage gap alongside the model's own findings.
+ */
+async function runSerenChatTask(
+  objective: string,
+  task: Task,
+): Promise<string> {
+  let continuation: Parameters<typeof continueToolIteration>[0] | null = null;
+
+  for await (const event of streamMessageWithTools(
+    buildTaskPrompt(objective, task),
+    getActiveModel(),
+    undefined,
+    true,
+  )) {
+    if (event.type === "complete") return event.finalContent;
+    if (event.type === "iteration_limit") {
+      continuation = event.continueState;
+      break;
+    }
+  }
+
+  if (continuation) {
+    for await (const event of continueToolIteration(continuation, 10)) {
+      if (event.type === "complete") return event.finalContent;
+    }
+  }
+
+  throw new Error("Seren chat task did not produce a final response");
+}
+
 async function dispatchTask(
   snapshot: RunSnapshot,
   task: Task,
@@ -394,22 +446,47 @@ async function dispatchTask(
       assignment.id,
       localSessionId,
     );
-    const sessionId = await agentStore.spawnSession(
-      snapshot.run.root_path ?? fileTreeState.rootPath ?? ".",
-      assignment.agent_type as AgentType,
-      { localSessionId, conversationTitle: task.title },
-    );
-    if (!sessionId) throw new Error("agent session failed to start");
-    ownedSessionIds.set(sessionId, runId);
-    agentStore.markSessionRunOwned(sessionId, runId);
-    await agentStore.sendPrompt(
-      buildTaskPrompt(snapshot.run.objective, task),
-      undefined,
-      undefined,
-      sessionId,
-    );
-    await waitForTurn(sessionId);
-    const response = finalAssistantMessage(sessionId);
+    let response: string | null = null;
+    let fallbackDetail: string | null = null;
+
+    if (!isNativeAgentType(assignment.agent_type)) {
+      fallbackDetail = `assignment ${assignment.agent_type} uses the signed-in Seren chat model because no local runtime supports that label`;
+      response = await runSerenChatTask(snapshot.run.objective, task);
+    } else {
+      try {
+        const sessionId = await agentStore.spawnSession(
+          snapshot.run.root_path ?? fileTreeState.rootPath ?? ".",
+          assignment.agent_type,
+          { localSessionId, conversationTitle: task.title },
+        );
+        if (!sessionId) throw new Error("agent session failed to start");
+        ownedSessionIds.set(sessionId, runId);
+        agentStore.markSessionRunOwned(sessionId, runId);
+        await agentStore.sendPrompt(
+          buildTaskPrompt(snapshot.run.objective, task),
+          undefined,
+          undefined,
+          sessionId,
+        );
+        await waitForTurn(sessionId);
+        response = finalAssistantMessage(sessionId);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        fallbackDetail = `${assignment.agent_type} local session unavailable; used the signed-in Seren chat model: ${detail}`;
+        response = await runSerenChatTask(snapshot.run.objective, task);
+      }
+    }
+
+    if (fallbackDetail) {
+      await recordGap(
+        runId,
+        task.id,
+        "provider_boundary",
+        task.title,
+        fallbackDetail,
+      );
+    }
+
     const parsed = response ? parseAgentFindings(response) : null;
     if (!parsed) {
       await recordGap(

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -24,6 +24,7 @@ import {
   runVerifyTask,
   type Task,
 } from "@/services/run";
+import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentStore } from "@/stores/agent.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { runState } from "@/stores/run.store";
@@ -407,10 +408,18 @@ async function runSerenChatTask(
   task: Task,
 ): Promise<string> {
   let continuation: Parameters<typeof continueToolIteration>[0] | null = null;
+  const activeModel = getActiveModel();
+  const model =
+    activeModel !== "auto"
+      ? activeModel
+      : (await getLiveSerenModelCatalog())[0]?.id;
+  if (!model) {
+    throw new Error("Seren model catalog returned no usable model");
+  }
 
   for await (const event of streamMessageWithTools(
     buildTaskPrompt(objective, task),
-    getActiveModel(),
+    model,
     undefined,
     true,
   )) {

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -221,7 +221,7 @@ export async function runCreate(
 ): Promise<Run> {
   return invoke("run_create", {
     objective,
-    root_path: rootPath ?? null,
+    rootPath: rootPath ?? null,
   }) as Promise<Run>;
 }
 
@@ -232,10 +232,10 @@ export async function runAddTask(
   dependsOn: string[] = [],
 ): Promise<Task> {
   return invoke("run_add_task", {
-    run_id: runId,
+    runId,
     title,
     brief,
-    depends_on: dependsOn,
+    dependsOn,
   }) as Promise<Task>;
 }
 
@@ -246,19 +246,19 @@ export async function runAddAgent(
   roleLabel?: string | null,
 ): Promise<AgentAssignment> {
   return invoke("run_add_agent", {
-    run_id: runId,
-    agent_type: agentType,
-    model_id: modelId ?? null,
-    role_label: roleLabel ?? null,
+    runId,
+    agentType,
+    modelId: modelId ?? null,
+    roleLabel: roleLabel ?? null,
   }) as Promise<AgentAssignment>;
 }
 
 export async function runCancel(runId: string): Promise<Run> {
-  return invoke("run_cancel", { run_id: runId }) as Promise<Run>;
+  return invoke("run_cancel", { runId }) as Promise<Run>;
 }
 
 export async function runGetState(runId: string): Promise<RunSnapshot> {
-  return invoke("run_get_state", { run_id: runId }) as Promise<RunSnapshot>;
+  return invoke("run_get_state", { runId }) as Promise<RunSnapshot>;
 }
 
 export async function runListEvents(
@@ -266,8 +266,8 @@ export async function runListEvents(
   afterSequence = 0,
 ): Promise<RunEvent[]> {
   return invoke("run_list_events", {
-    run_id: runId,
-    after_sequence: afterSequence,
+    runId,
+    afterSequence,
   }) as Promise<RunEvent[]>;
 }
 
@@ -280,19 +280,19 @@ export async function runDeclareChecks(
   checks: CheckDeclaration[],
 ): Promise<RunCheck[]> {
   return invoke("run_declare_checks", {
-    run_id: runId,
+    runId,
     checks,
   }) as Promise<RunCheck[]>;
 }
 
 export async function runApproveCheck(checkId: string): Promise<RunCheck> {
   return invoke("run_approve_check", {
-    check_id: checkId,
+    checkId,
   }) as Promise<RunCheck>;
 }
 
 export async function runBaseline(runId: string): Promise<CheckResult[]> {
-  return invoke("run_baseline", { run_id: runId }) as Promise<CheckResult[]>;
+  return invoke("run_baseline", { runId }) as Promise<CheckResult[]>;
 }
 
 export async function runVerifyTask(
@@ -300,8 +300,8 @@ export async function runVerifyTask(
   taskId: string,
 ): Promise<CheckResult[]> {
   return invoke("run_verify_task", {
-    run_id: runId,
-    task_id: taskId,
+    runId,
+    taskId,
   }) as Promise<CheckResult[]>;
 }
 
@@ -310,8 +310,8 @@ export async function runCompleteTask(
   taskId: string,
 ): Promise<string[]> {
   return invoke("run_complete_task", {
-    run_id: runId,
-    task_id: taskId,
+    runId,
+    taskId,
   }) as Promise<string[]>;
 }
 
@@ -329,8 +329,8 @@ export async function runUpdateFindingStatus(
   status: Exclude<FindingStatus, "open">,
 ): Promise<void> {
   return invoke("run_update_finding_status", {
-    run_id: runId,
-    finding_id: findingId,
+    runId,
+    findingId,
     status,
   }) as Promise<void>;
 }
@@ -344,10 +344,10 @@ export async function runStartAttempt(
   agentSessionId?: string | null,
 ): Promise<string> {
   return invoke("run_start_attempt", {
-    run_id: runId,
-    task_id: taskId,
-    agent_assignment_id: agentAssignmentId ?? null,
-    agent_session_id: agentSessionId ?? null,
+    runId,
+    taskId,
+    agentAssignmentId: agentAssignmentId ?? null,
+    agentSessionId: agentSessionId ?? null,
   }) as Promise<string>;
 }
 
@@ -357,14 +357,14 @@ export async function runFinishAttempt(
   outcome: AttemptOutcome,
 ): Promise<void> {
   return invoke("run_finish_attempt", {
-    run_id: runId,
-    attempt_id: attemptId,
+    runId,
+    attemptId,
     outcome,
   }) as Promise<void>;
 }
 
 export async function runRelaunch(runId: string): Promise<Run> {
-  return invoke("run_relaunch", { run_id: runId }) as Promise<Run>;
+  return invoke("run_relaunch", { runId }) as Promise<Run>;
 }
 
 export function subscribeRunEvents(

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -2,11 +2,43 @@
 // ABOUTME: Covers worktree state roots while keeping toolchain caches stable.
 
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ensureValidationKeychain,
   validationChildEnv,
   validationHomeForSlot,
 } from "../../scripts/validation-env";
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  mkdir: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFile: mocks.execFile }));
+vi.mock("node:fs/promises", () => ({
+  mkdir: mocks.mkdir,
+  stat: mocks.stat,
+}));
+
+function resolveExecFile(
+  _command: string,
+  _args: string[],
+  optionsOrCallback: unknown,
+  maybeCallback?: unknown,
+): void {
+  const callback =
+    typeof maybeCallback === "function" ? maybeCallback : optionsOrCallback;
+  if (typeof callback === "function") {
+    callback(null, { stdout: "", stderr: "" });
+  }
+}
+
+beforeEach(() => {
+  mocks.execFile.mockReset().mockImplementation(resolveExecFile);
+  mocks.mkdir.mockReset().mockResolvedValue(undefined);
+  mocks.stat.mockReset().mockRejectedValue(new Error("missing"));
+});
 
 describe("validation environment", () => {
   it("roots HOME in the repo-local slot directory", () => {
@@ -83,5 +115,61 @@ describe("validation environment", () => {
     expect(() => validationHomeForSlot("/repo", 65_536)).toThrow(
       "validation port must be an integer from 1 to 65535",
     );
+  });
+
+  it("configures the slot keychain in order with the slot HOME", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    const slotHome = validationHomeForSlot("/repo", 1422);
+
+    await ensureValidationKeychain(slotHome, "/repo");
+
+    const securityCalls = mocks.execFile.mock.calls.filter(
+      ([command]) => command === "security",
+    );
+    const keychainPath = path.join(
+      slotHome,
+      "Library",
+      "Keychains",
+      "login.keychain-db",
+    );
+    expect(securityCalls.map(([, args]) => args)).toEqual([
+      [
+        "create-keychain",
+        "-p",
+        expect.any(String),
+        keychainPath,
+      ],
+      ["set-keychain-settings", keychainPath],
+      [
+        "unlock-keychain",
+        "-p",
+        expect.any(String),
+        keychainPath,
+      ],
+      ["default-keychain", "-d", "user", "-s", keychainPath],
+      ["list-keychains", "-d", "user", "-s", keychainPath],
+    ]);
+    for (const [, , options] of securityCalls) {
+      expect(options).toEqual(
+        expect.objectContaining({
+          env: expect.objectContaining({ HOME: slotHome }),
+        }),
+      );
+    }
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "scratch keychain password for slot 1422",
+      ),
+    );
+    consoleLog.mockRestore();
+  });
+
+  it("rejects security mutations outside the validation HOME", async () => {
+    await expect(
+      ensureValidationKeychain("/Users/taariqlewis", "/repo"),
+    ).rejects.toThrow("refusing security mutation outside validation HOME");
+    expect(mocks.execFile).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -8,6 +8,7 @@ import {
   validationChildEnv,
   validationHomeForSlot,
 } from "../../scripts/validation-env";
+import { shouldSkipValidationBuild } from "../../scripts/validation-dev-args";
 
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
@@ -41,6 +42,14 @@ beforeEach(() => {
 });
 
 describe("validation environment", () => {
+  it("selects no-build mode from the flag or environment", () => {
+    expect(shouldSkipValidationBuild(["--no-build"], {})).toBe(true);
+    expect(
+      shouldSkipValidationBuild([], { SEREN_VALIDATION_SKIP_BUILD: "1" }),
+    ).toBe(true);
+    expect(shouldSkipValidationBuild([], {})).toBe(false);
+  });
+
   it("roots HOME in the repo-local slot directory", () => {
     const repoRoot = "/repo";
     const env = validationChildEnv({

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -53,6 +53,18 @@ describe("validation environment", () => {
     expect(env.HOME).toBe(
       path.join(repoRoot, "artifacts", "validation-home", "slot1422"),
     );
+    if (process.platform === "darwin") {
+      expect(env.CFFIXED_USER_HOME).toBe(env.HOME);
+    }
+    expect(env.SEREN_VALIDATION_DISCOVERY_PATH).toBe(
+      path.join(
+        env.HOME as string,
+        "Library",
+        "Application Support",
+        "com.serendb.desktop.validation.slot1422",
+        "validation-control.json",
+      ),
+    );
     expect(validationHomeForSlot(repoRoot, 1422)).toBe(
       path.join(repoRoot, "artifacts", "validation-home", "slot1422"),
     );


### PR DESCRIPTION
## Summary

Follow-up to #3530 (merged before these commits were pushed to the branch). Five commits:

- Live-run dispatcher fixes discovered during the supervised walkthrough: fallback resolves the model through the live Seren catalog instead of sending the literal auto id (gateway 404), plus slot-scoped control discovery.
- Validation launcher: per-slot keychain provisioning hardening, early prompt-password print, and a --no-build reuse mode so relaunches keep macOS keychain grants (unsigned dev rebuilds reset them by design).
- Walkthrough evidence document finalized with a proven / not-proven table: promptless keychain operation proven across repeated no-build restarts; findings/approval and the interrupted-relaunch cycle recorded as not proven, blocked by the run-rehydration gap filed separately.

## Verification

- pnpm check, pnpm test (2,873 passed), full cargo, pnpm build - all exit 0 at head 7a73df96.
- Credential scans over the diff: 0 matches.

Part of #3511

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
