### PR TITLE
fix(approvals): align inbox badge with pending decisions (#3533)

### DIFF
--- a/src/components/inbox/InboxList.tsx
+++ b/src/components/inbox/InboxList.tsx
@@ -13,7 +13,7 @@ import {
 } from "solid-js";
 import { LocalApprovalsSection } from "@/components/approvals/LocalApprovalsSection";
 import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
-import { groupInboxEntries } from "@/components/inbox/grouping";
+import { groupInboxEntries, inboxIsEmpty } from "@/components/inbox/grouping";
 import { getDefaultOrganizationId } from "@/lib/tauri-bridge";
 import {
   type ApprovalDecisionState,
@@ -24,6 +24,7 @@ import {
   type ApprovalInboxToolCallEntry,
   approvalInbox,
 } from "@/services/approval-inbox";
+import { pendingApprovalCount } from "@/stores/approvals.store";
 
 function intendedTerminalState(
   decision: ApprovalDecisionVerb,
@@ -415,7 +416,7 @@ export const InboxList: Component = () => {
               : String(initialPage.error)}
           </div>
         </Match>
-        <Match when={allEntries().length === 0}>
+        <Match when={inboxIsEmpty(allEntries(), pendingApprovalCount())}>
           <EmptyState />
         </Match>
         <Match when={allEntries().length > 0}>

--- a/src/components/inbox/grouping.ts
+++ b/src/components/inbox/grouping.ts
@@ -38,3 +38,11 @@ export function groupInboxEntries(
 export function entryAllowsDecision(entry: ApprovalInboxEntry): boolean {
   return entry.decision_state === "pending";
 }
+
+/** The all-clear state is valid only when neither inbox source has work. */
+export function inboxIsEmpty(
+  cloudEntries: readonly ApprovalInboxEntry[],
+  localPendingCount: number,
+): boolean {
+  return cloudEntries.length === 0 && localPendingCount === 0;
+}

--- a/src/components/sidebar/EmployeesSection.tsx
+++ b/src/components/sidebar/EmployeesSection.tsx
@@ -24,6 +24,7 @@ import type {
   EmployeeSummary,
 } from "@/lib/employees/types";
 import {
+  countPendingDecisions,
   employeeApprovals,
   type OrgPendingApprovalRun,
 } from "@/services/employee-approvals";
@@ -210,6 +211,14 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
     for (const [key, rows] of left) {
       const other = right.get(key);
       if (!other || other.length !== rows.length) return false;
+      for (let index = 0; index < rows.length; index += 1) {
+        if (
+          rows[index].runId !== other[index].runId ||
+          rows[index].pendingCount !== other[index].pendingCount
+        ) {
+          return false;
+        }
+      }
     }
     return true;
   };
@@ -238,7 +247,7 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
   };
 
   const pendingCountFor = (deploymentId: string): number =>
-    pendingByDeployment().get(deploymentId)?.length ?? 0;
+    countPendingDecisions(pendingByDeployment().get(deploymentId) ?? []);
 
   // The global inbox badge: local-gate blocks (this device) + cloud operator
   // approvals. Stays visible wherever the sidebar is, i.e. after navigating
@@ -246,7 +255,7 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
   const inboxPendingTotal = createMemo(() => {
     let cloud = 0;
     for (const rows of pendingByDeployment().values()) {
-      cloud += rows.length;
+      cloud += countPendingDecisions(rows);
     }
     return cloud + pendingApprovalCount();
   });

--- a/src/services/employee-approvals.ts
+++ b/src/services/employee-approvals.ts
@@ -18,6 +18,13 @@ export type OrgPendingApprovalRun = {
   pendingCount: number;
 };
 
+/** Count operator decisions, rather than the runs that contain them. */
+export function countPendingDecisions(
+  rows: readonly Pick<OrgPendingApprovalRun, "pendingCount">[],
+): number {
+  return rows.reduce((total, row) => total + row.pendingCount, 0);
+}
+
 function fromCloud(row: CloudPendingApprovalRun): OrgPendingApprovalRun {
   return {
     runId: row.run_id,

--- a/tests/unit/employee-approval-count.test.ts
+++ b/tests/unit/employee-approval-count.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Protects approval badges from counting awaiting runs instead of decisions.
+// ABOUTME: Covers zero, single, and multi-decision cloud run responses.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/seren-cloud", () => ({
+  serenCloudPendingApprovals: vi.fn(),
+}));
+
+import { countPendingDecisions } from "@/services/employee-approvals";
+
+describe("countPendingDecisions", () => {
+  it("sums decisions without treating empty runs as pending items", () => {
+    expect(countPendingDecisions([{ pendingCount: 0 }])).toBe(0);
+    expect(countPendingDecisions([{ pendingCount: 1 }])).toBe(1);
+    expect(
+      countPendingDecisions([{ pendingCount: 0 }, { pendingCount: 2 }]),
+    ).toBe(2);
+  });
+});

--- a/tests/unit/inbox-list-grouping.test.ts
+++ b/tests/unit/inbox-list-grouping.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   entryAllowsDecision,
   groupInboxEntries,
+  inboxIsEmpty,
 } from "@/components/inbox/grouping";
 import type {
   ApprovalDecisionState,
@@ -126,5 +127,13 @@ describe("entryAllowsDecision", () => {
     expect(
       entryAllowsDecision(blockedEgress({ decision_state: "approved" })),
     ).toBe(false);
+  });
+});
+
+describe("inboxIsEmpty", () => {
+  it("does not report all clear while a local approval is pending", () => {
+    expect(inboxIsEmpty([], 1)).toBe(false);
+    expect(inboxIsEmpty([], 0)).toBe(true);
+    expect(inboxIsEmpty([toolCall()], 0)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #3533.

## What changed

- Count cloud approval decisions from each pending run instead of counting run rows.
- Reconcile sidebar state when a run's pending-decision count changes without changing the number of runs.
- Suppress the inbox **All clear** state while a device-local approval remains pending.
- Add focused regression coverage for zero, one, and multiple cloud decisions and for the local-pending empty-state guard.

## Network path trace

No new outbound path is introduced. The existing paths remain:

- `GET https://api.serendb.com/pending_approvals?limit=100` for cloud run summaries used by sidebar badges.
- `GET https://api.serendb.com/inbox/approvals?limit=50` for cloud decision entries rendered by Approval inbox.
- Tauri IPC `list_pending_approvals` for device-local continuations.

These methods and paths were verified against the generated Seren Cloud API metadata. The repair changes only frontend counting and empty-state interpretation.

## Validation

- `pnpm test` — 407 files passed, 3 skipped; 2,871 tests passed, 15 skipped.
- Focused approval tests — 15 passed.
- `pnpm build` — passed.
- Biome check on all changed files — passed.

User-provided screenshots and logs were reviewed locally and are intentionally omitted because they contain account-specific data.