### PR TITLE
fix(run): rehydrate nonterminal runs and reconcile at startup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -665,6 +665,14 @@ pub fn run() {
                     .await;
             });
 
+            let run_engine_app = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let run_engine = run_engine_app.state::<run::scheduler::RunEngineState>();
+                if let Err(error) = run_engine.ensure_started(&run_engine_app).await {
+                    log::warn!("[run-engine] Startup reconciliation deferred: {error}");
+                }
+            });
+
             // Create the configured windows here rather than letting Tauri
             // auto-create them (the window is marked "create": false in
             // tauri.conf.json) so the Windows e2e release gate can enable

--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -192,6 +192,10 @@ impl RunEngineState {
         Ok(sender)
     }
 
+    pub async fn ensure_started(&self, app: &AppHandle) -> Result<(), String> {
+        self.sender(app).await.map(|_| ())
+    }
+
     pub async fn create_run(
         &self,
         app: &AppHandle,

--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -29,6 +29,7 @@ export const MissionControlPanel: Component = () => {
   let disposed = false;
 
   onMount(() => {
+    void runStore.hydrateLatest();
     startRunDispatcher();
     const subscription = subscribeRunEvents((event) => {
       void runStore.applyEvent(event);

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -4,6 +4,7 @@
 import { createStore } from "solid-js/store";
 import {
   type FindingStatus,
+  type Run,
   type RunEvent,
   type RunSnapshot,
   runAddAgent,
@@ -11,6 +12,7 @@ import {
   runCancel,
   runCreate,
   runGetState,
+  runList,
   runRelaunch,
   runUpdateFindingStatus,
   type Task,
@@ -96,6 +98,30 @@ async function hydrate(runId: string): Promise<void> {
       snapshot,
       lastSequence: 0,
     });
+  } catch (error) {
+    setState("error", errorMessage(error));
+  }
+}
+
+async function hydrateLatest(): Promise<void> {
+  setState("error", null);
+  try {
+    const latest = (await runList())
+      .filter((run) => run.status === "running" || run.status === "interrupted")
+      .reduce<Run | null>(
+        (current, candidate) =>
+          current === null || candidate.created_at > current.created_at
+            ? candidate
+            : current,
+        null,
+      );
+
+    if (latest) {
+      await hydrate(latest.id);
+      return;
+    }
+
+    setState({ activeRunId: null, snapshot: null, lastSequence: 0 });
   } catch (error) {
     setState("error", errorMessage(error));
   }
@@ -246,6 +272,7 @@ export const runStore = {
     return state.error;
   },
   hydrate,
+  hydrateLatest,
   applyEvent,
   launch,
   cancel,

--- a/tests/unit/run-store-hydrate.test.ts
+++ b/tests/unit/run-store-hydrate.test.ts
@@ -1,0 +1,132 @@
+// ABOUTME: Tests persisted Mission Control run selection after app startup.
+// ABOUTME: Protects newest non-terminal hydration, interrupted recovery, and errors.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/run", async () => {
+  const actual = await vi.importActual<typeof import("@/services/run")>(
+    "@/services/run",
+  );
+  return {
+    ...actual,
+    runGetState: vi.fn(),
+    runList: vi.fn(),
+  };
+});
+
+import {
+  runGetState,
+  runList,
+  type Run,
+  type RunSnapshot,
+} from "@/services/run";
+import {
+  runState,
+  runStore,
+  setRunState,
+} from "@/stores/run.store";
+
+const getStateMock = vi.mocked(runGetState);
+const listMock = vi.mocked(runList);
+
+function run(
+  id: string,
+  status: Run["status"],
+  createdAt: number,
+): Run {
+  return {
+    id,
+    objective: `Objective ${id}`,
+    root_path: null,
+    status,
+    cancel_requested: false,
+    interrupted_at: status === "interrupted" ? createdAt + 1 : null,
+    created_at: createdAt,
+    updated_at: createdAt,
+    completed_at: status === "completed" ? createdAt + 1 : null,
+  };
+}
+
+function snapshot(runRecord: Run): RunSnapshot {
+  return {
+    run: runRecord,
+    tasks: [],
+    dependencies: [],
+    assignments: [],
+    attempts: [],
+    findings: [],
+    checks: [],
+    check_results: [],
+    coverage_gaps: [],
+  };
+}
+
+describe("run store startup hydration", () => {
+  beforeEach(() => {
+    setRunState({
+      activeRunId: null,
+      snapshot: null,
+      lastSequence: 0,
+      launchPending: false,
+      error: null,
+    });
+    getStateMock.mockReset();
+    listMock.mockReset();
+  });
+
+  it("hydrates the newest non-terminal run", async () => {
+    const olderRunning = run("run-old", "running", 10);
+    const newestInterrupted = run("run-new", "interrupted", 30);
+    listMock.mockResolvedValue([
+      run("run-complete", "completed", 40),
+      newestInterrupted,
+      olderRunning,
+    ]);
+    getStateMock.mockResolvedValue(snapshot(newestInterrupted));
+
+    await runStore.hydrateLatest();
+
+    expect(getStateMock).toHaveBeenCalledWith("run-new");
+    expect(runState.activeRunId).toBe("run-new");
+    expect(runState.snapshot?.run.status).toBe("interrupted");
+  });
+
+  it("leaves the store empty when all runs are terminal", async () => {
+    setRunState({
+      activeRunId: "stale-run",
+      snapshot: snapshot(run("stale-run", "running", 1)),
+      lastSequence: 4,
+    });
+    listMock.mockResolvedValue([
+      run("run-complete", "completed", 10),
+      run("run-failed", "failed", 20),
+      run("run-cancelled", "cancelled", 30),
+    ]);
+
+    await runStore.hydrateLatest();
+
+    expect(runState.activeRunId).toBeNull();
+    expect(runState.snapshot).toBeNull();
+    expect(runState.lastSequence).toBe(0);
+  });
+
+  it("hydrates an interrupted run for the recovery banner", async () => {
+    const interrupted = run("run-interrupted", "interrupted", 20);
+    listMock.mockResolvedValue([interrupted]);
+    getStateMock.mockResolvedValue(snapshot(interrupted));
+
+    await runStore.hydrateLatest();
+
+    expect(runStore.isInterrupted()).toBe(true);
+    expect(runState.snapshot?.run.interrupted_at).not.toBeNull();
+  });
+
+  it("stores run-list failures without throwing", async () => {
+    listMock.mockRejectedValue(new Error("run list unavailable"));
+
+    await expect(runStore.hydrateLatest()).resolves.toBeUndefined();
+
+    expect(runState.error).toBe("run list unavailable");
+    expect(runState.snapshot).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Rehydrates persisted non-terminal runs after app restart and starts the run scheduler eagerly during Tauri setup.

- Adds RunEngineState::ensure_started so startup reconciliation runs before UI actions.
- Adds runStore.hydrateLatest to select and hydrate the newest running or interrupted run, with an explicit empty state when all runs are terminal and error handling for list failures.
- Calls hydrateLatest from Mission Control onMount so interrupted runs render their existing recovery banner and Relaunch action.

## Verification

- pnpm check — exit 0 (48 pre-existing warnings).
- pnpm vitest run tests/unit/run-store-hydrate.test.ts — exit 0, 4 tests passed.
- pnpm vitest run tests/unit/run-store-hydrate.test.ts tests/unit/run-store-events.test.ts — exit 0, 7 tests passed.
- pnpm test — exit 0, 2,873 tests passed and 15 skipped.
- cargo test --manifest-path src-tauri/Cargo.toml --lib run:: — exit 0, 39 tests passed.
- Full cargo test — exit 0.
- pnpm build — exit 0.

Fixes #3532
Part of #3511
