### PR TITLE
fix(employees): present readiness responses as chat prose

### DIFF
--- a/packages/employees-core/src/index.ts
+++ b/packages/employees-core/src/index.ts
@@ -787,7 +787,9 @@ export function createEmployeeRunManager(
       if (registered) registered.runId = runId;
 
       if (!runId) {
-        const text = fallbackTextFromResult(invocation.result);
+        const text = employeeAssistantDisplayText(
+          fallbackTextFromResult(invocation.result),
+        );
         const status = invocation.status ?? "completed";
         if (isFailureStatus(status) && !text) {
           throw new Error(`Run ${status} with no output`);
@@ -901,7 +903,9 @@ export function createEmployeeRunManager(
         Date.now(),
       );
 
-      const text = state.text || final.output || "";
+      const text = employeeAssistantDisplayText(
+        state.text || final.output || "",
+      );
       const errorMessage = state.errorMessage ?? final.statusMessage ?? null;
       if (isFailureStatus(final.status)) {
         throw new Error(
@@ -1018,8 +1022,7 @@ export function messageFromInvocationPayload(payload: unknown): string {
 
 export function assistantTextFromRun(run: EmployeeRunEventLike): string {
   const fromEvents = textFromOutputEvents(run.output_events);
-  if (fromEvents) return fromEvents;
-  return run.output?.trim() ?? "";
+  return employeeAssistantDisplayText(fromEvents || run.output?.trim() || "");
 }
 
 export function textFromOutputEvents(value: unknown): string {
@@ -1027,6 +1030,53 @@ export function textFromOutputEvents(value: unknown): string {
     .map((event) => (event.type === "text" ? event.text : ""))
     .join("")
     .trim();
+}
+
+const EMPLOYEE_READINESS_KEYS = new Set([
+  "artifact_url",
+  "employee",
+  "scheduled_at",
+  "skill",
+  "status",
+  "verification",
+]);
+
+/**
+ * Converts the employee runtime's readiness acknowledgement into chat prose.
+ * The key allowlist keeps arbitrary JSON answers byte-for-byte unchanged.
+ */
+export function employeeAssistantDisplayText(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return value;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return value;
+  }
+
+  const acknowledgement = parsed as Record<string, unknown>;
+  const keys = Object.keys(acknowledgement);
+  if (
+    acknowledgement.status !== "ready" ||
+    !keys.every((key) => EMPLOYEE_READINESS_KEYS.has(key)) ||
+    !keys.some((key) =>
+      ["artifact_url", "scheduled_at", "verification"].includes(key),
+    )
+  ) {
+    return value;
+  }
+
+  const rawName =
+    stringValue(acknowledgement.employee) ?? stringValue(acknowledgement.skill);
+  if (!rawName) return value;
+  const name = rawName.replace(/\s+/g, " ").trim();
+  if (!name || name.length > 120) return value;
+  return `I'm ${name}. I'm ready to help.`;
 }
 
 export function errorTextFromOutputEvents(value: unknown): string {
@@ -1263,7 +1313,9 @@ export function employeeTextFromConversationMessage(
     message.run?.status_message?.trim() ||
     assistantTextFromRunOutput(message.run) ||
     "";
-  return isFailureStatus(status) ? sanitizeEmployeeErrorText(text) : text;
+  return isFailureStatus(status)
+    ? sanitizeEmployeeErrorText(text)
+    : employeeAssistantDisplayText(text);
 }
 
 function looksLikeStructuredError(value: string): boolean {
@@ -1283,8 +1335,7 @@ function assistantTextFromRunOutput(
 ): string {
   if (!run) return "";
   const fromEvents = textFromOutputEvents(run.output_events);
-  if (fromEvents) return fromEvents;
-  return run.output?.trim() ?? "";
+  return employeeAssistantDisplayText(fromEvents || run.output?.trim() || "");
 }
 
 export function outputEventEnvelopes(

--- a/src/services/employee-chat-sync.ts
+++ b/src/services/employee-chat-sync.ts
@@ -3,6 +3,7 @@
 
 import {
   type EmployeeOutputEventEnvelope,
+  employeeAssistantDisplayText,
   formatToolAuditEvent,
   isFailureStatus,
   outputEventEnvelopes,
@@ -514,7 +515,9 @@ function buildAssistantMessageDrafts(
     }),
   );
 
-  const assistantText = textParts.join("").trim() || message.content.trim();
+  const assistantText = employeeAssistantDisplayText(
+    textParts.join("").trim() || message.content.trim(),
+  );
   if (assistantText || statusMessage || thinkingParts.length > 0) {
     messages.push(
       draftFromUnifiedMessage(

--- a/tests/unit/employees-core-run-stream.test.ts
+++ b/tests/unit/employees-core-run-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createEmployeeRunManager,
+  employeeAssistantDisplayText,
   employeeErrorTextFromCode,
   employeeCapabilityGuidanceForError,
   employeeErrorCodeFromConversationMessage,
@@ -75,6 +76,38 @@ function runtimeApi(frames: unknown[], terminal: EmployeeRunEventLike) {
 }
 
 describe("employees-core sequenced run stream", () => {
+  it("presents readiness acknowledgements as chat prose", () => {
+    const acknowledgement = JSON.stringify({
+      skill: "Operations Assistant",
+      status: "ready",
+      scheduled_at: null,
+      artifact_url: null,
+      verification: { status: "not_applicable" },
+      employee: "Operations Assistant",
+    });
+
+    expect(employeeAssistantDisplayText(acknowledgement)).toBe(
+      "I'm Operations Assistant. I'm ready to help.",
+    );
+    expect(
+      employeeTextFromConversationMessage({
+        role: "assistant",
+        content: acknowledgement,
+        run_summary: { status: "completed" },
+      }),
+    ).toBe("I'm Operations Assistant. I'm ready to help.");
+  });
+
+  it("preserves JSON that is not the readiness contract", () => {
+    const jsonAnswer = JSON.stringify({
+      employee: "Operations Assistant",
+      status: "ready",
+      answer: { queue_depth: 3 },
+    });
+
+    expect(employeeAssistantDisplayText(jsonAnswer)).toBe(jsonAnswer);
+  });
+
   it("selects assistant conversation text from typed events before raw content", () => {
     const text = employeeTextFromConversationMessage({
       role: "assistant",
@@ -716,6 +749,29 @@ describe("employees-core sequenced run stream", () => {
     expect(getRun).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("completed");
     expect(result.text).toBe("final");
+  });
+
+  it("presents a terminal readiness envelope as chat prose", async () => {
+    const acknowledgement = JSON.stringify({
+      employee: "Operations Assistant",
+      status: "ready",
+      scheduled_at: null,
+      artifact_url: null,
+      verification: { status: "not_applicable" },
+    });
+    const { api } = runtimeApi(
+      [control("end")],
+      runEvent("completed", undefined, { output: acknowledgement }),
+    );
+
+    const result = await createEmployeeRunManager(api).runEmployeeMessage(
+      "dep_1",
+      "Who are you?",
+    );
+
+    expect(result.text).toBe(
+      "I'm Operations Assistant. I'm ready to help.",
+    );
   });
 
   it("does not append divergent terminal snapshots as text chunks", async () => {


### PR DESCRIPTION
Closes #3536

## Summary
- recognize the employee runtime's structured `ready` acknowledgement and present it as concise chat prose
- apply the same normalization to live terminal output and cloud-synced conversation history
- preserve arbitrary JSON answers unless they match the narrow readiness contract

## Validation
- `pnpm vitest run tests/unit/employees-core-run-stream.test.ts tests/unit/employee-runtime-startup.test.ts` (40 passed)
- `pnpm test` (408 files passed, 2,878 tests passed)
- `pnpm build`
- `pnpm exec biome check packages/employees-core/src/index.ts src/services/employee-chat-sync.ts tests/unit/employees-core-run-stream.test.ts`
- `git diff --check`

## Network path audit
No new outbound path is introduced. Employee chat continues to use the live `seren-cloud` publisher through the generated client: session resolution/creation, `POST /deployments/{id}/sessions/{session_id}/messages` (with `POST /deployments/{id}/runs` fallback), run stream/status reads, and conversation-history reads. The live publisher list confirms the `seren-cloud` slug; the deployment/session/run routes are defined by the checked-in generated Seren Cloud OpenAPI client.

## Privacy
The issue, tests, and this PR use synthetic employee names only. Local screenshots and console logs were not uploaded.