### PR TITLE
fix(happy): map Seren agents and report compat version

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -24,6 +24,7 @@ import { createHappySessionKeyStore } from "./session-key-store.mjs";
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const SESSION_KEEP_ALIVE_MS = 2000;
+const HAPPY_CLI_COMPAT_VERSION = "1.2.0";
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
 const HAPPY_CONTEXT_RESET_NOTICE =
   "Provider context reset: the original native session was unavailable, so Seren started a new provider context for this existing Happy thread.";
@@ -219,7 +220,7 @@ function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
   return {
     host: config.machineName,
     platform: `${process.platform}-${process.arch}`,
-    happyCliVersion: "1.2.0",
+    happyCliVersion: HAPPY_CLI_COMPAT_VERSION,
     homeDir: os.homedir(),
     happyHomeDir: os.homedir(),
     happyLibDir: "seren-desktop",
@@ -233,8 +234,10 @@ function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
 const HAPPY_AGENT_TYPES = new Map([
   ["claude", "claude-code"],
   ["claude-code", "claude-code"],
+  ["claude-codex", "claude-codex"],
   ["gemini", "gemini"],
   ["grok", "grok"],
+  ["lmstudio", "lmstudio"],
   ["codex", "codex"],
 ]);
 const RESTORABLE_HAPPY_AGENT_TYPES = new Set(HAPPY_AGENT_TYPES.values());
@@ -247,8 +250,8 @@ function happyAgentType(agent) {
 
 function defaultApprovalPolicy(agentType) {
   // Match the desktop's fresh-session defaults. Codex is explicitly
-  // on-failure; Claude, Gemini, and Grok resolve their normal defaults in their
-  // runtimes when no stricter policy is supplied.
+  // on-failure; every other runtime resolves its normal default when no
+  // stricter policy is supplied.
   return agentType === "codex" ? DEFAULT_CODEX_APPROVAL_POLICY : undefined;
 }
 
@@ -285,7 +288,7 @@ function sessionMetadata(config, summary, machineId) {
     path: cwd,
     host: config.machineName,
     name: summary.title ?? `${summary.agentType ?? "Agent"} session`,
-    version: "seren-desktop",
+    version: HAPPY_CLI_COMPAT_VERSION,
     os: process.platform,
     machineId,
     homeDir: os.homedir(),

--- a/scripts/smoke-local-provider-runtime.mjs
+++ b/scripts/smoke-local-provider-runtime.mjs
@@ -117,6 +117,19 @@ async function smokeRuntime({ label, wsUrl, token }) {
     if (!Array.isArray(agents)) {
       throw new Error(`${label}: provider_get_available_agents did not return an array`);
     }
+    const advertisedAgentTypes = new Set(agents.map((agent) => agent?.type));
+    for (const agentType of [
+      "codex",
+      "claude-code",
+      "claude-codex",
+      "gemini",
+      "grok",
+      "lmstudio",
+    ]) {
+      if (!advertisedAgentTypes.has(agentType)) {
+        throw new Error(`${label}: provider_get_available_agents omitted ${agentType}`);
+      }
+    }
 
     const sessions = await rpcCall(ws, "provider_list_sessions");
     if (!Array.isArray(sessions)) {

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -349,6 +349,31 @@ function createLayerHarness({
 }
 
 describe("Happy session liveness", () => {
+  it("uses one Happy compatibility semver for machine and session metadata", async () => {
+    const summary = {
+      sessionId: "compat-version-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+
+    await harness.layer.start();
+
+    expect(harness.api.getOrCreateMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ happyCliVersion: "1.2.0" }),
+      }),
+    );
+    expect(harness.api.getOrCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ version: "1.2.0" }),
+      }),
+    );
+
+    await harness.layer.close();
+  });
+
   it("publishes one first-prompt summary so Happy threads receive distinct titles", async () => {
     const summary = {
       sessionId: "title-session",
@@ -2946,6 +2971,32 @@ describe("Happy session liveness", () => {
       expectedAgentPermissionMode: null,
       agentSessionId: "synthetic-native-session",
     });
+
+    await harness.layer.close();
+  });
+
+  it.each([
+    ["claude-codex", "claude-codex"],
+    ["lmstudio", "lmstudio"],
+  ])("forwards the advertised %s agent to the provider runtime", async (mobileAgent, providerAgent) => {
+    const harness = createLayerHarness();
+    harness.source.spawn.mockImplementation(async (spec) => ({
+      sessionId: String(spec.localSessionId),
+      agentType: String(spec.agentType),
+      agentSessionId: "synthetic-native-session",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+      reused: false,
+      owned: true,
+    }));
+    await harness.layer.start();
+
+    await expect(harness.spawn({ directory: SYNTHETIC_ROOT, agent: mobileAgent })).resolves.toMatchObject({
+      type: "success",
+    });
+    expect(harness.source.spawn).toHaveBeenCalledWith(expect.objectContaining({
+      agentType: providerAgent,
+    }));
 
     await harness.layer.close();
   });


### PR DESCRIPTION
## Summary

- forward `claude-codex` and `lmstudio` through the Happy bridge to their canonical Seren provider runtimes
- retain fail-closed rejection for unknown Happy agent identifiers
- use one `1.2.0` Happy compatibility constant for both machine and session metadata, removing the false “CLI Update Required” warning
- require all six canonical Seren agents in the live provider-runtime smoke

This is limited to Seren-owned bridge/runtime code; it does not change Happy Mobile or any upstream repository.

## Validation

- `pnpm check` (passes; existing repository warnings only)
- `pnpm test` — 2,881 passed, 15 skipped
- `pnpm build`
- `pnpm test:runtime-smoke`
- prior cold-worktree Rust/integration run — 1,289 passed after `pnpm prepare:mcp-servers`

Fixes #3540