### PR TITLE
fix(happy): advertise Gemini to mobile clients

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -240,6 +240,26 @@ const HAPPY_AGENT_TYPES = new Map([
 const RESTORABLE_HAPPY_AGENT_TYPES = new Set(HAPPY_AGENT_TYPES.values());
 const EXACT_RESUME_HAPPY_AGENT_TYPES = new Set(["claude-code", "codex"]);
 
+function happyCliAvailability(agents) {
+  const availableAgentTypes = new Set(
+    (Array.isArray(agents) ? agents : [])
+      .filter((agent) => agent?.available !== false)
+      .map((agent) => agent?.type)
+      .filter((type) => typeof type === "string"),
+  );
+  const supports = (happyType) => {
+    const serenType = HAPPY_AGENT_TYPES.get(happyType);
+    return typeof serenType === "string" && availableAgentTypes.has(serenType);
+  };
+  return {
+    claude: supports("claude"),
+    codex: supports("codex"),
+    gemini: supports("gemini"),
+    openclaw: supports("openclaw"),
+    detectedAt: Date.now(),
+  };
+}
+
 function happyAgentType(agent) {
   if (agent === undefined || agent === null) return "claude-code";
   return HAPPY_AGENT_TYPES.get(agent) ?? null;
@@ -2139,6 +2159,7 @@ export function createHappyLayer({
     advertisedAgents = Array.isArray(advertised.agents) ? advertised.agents : [];
     await machineClient.updateMachineMetadata((metadata) => ({
       ...(metadata ?? machineMetadata(config)),
+      cliAvailability: happyCliAvailability(advertisedAgents),
       remoteCapabilities: { agents: advertisedAgents, roots: advertisedRoots },
     }));
   }

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -321,6 +321,7 @@ function createLayerHarness({
     api,
     client,
     layer,
+    machineClient,
     async processUserMessage(message: Record<string, unknown>, seq: number) {
       await client.dispatchUserMessage(message);
       await onMessageProcessed?.(seq);
@@ -349,6 +350,40 @@ function createLayerHarness({
 }
 
 describe("Happy session liveness", () => {
+  it("publishes Gemini in Happy's legacy picker metadata from live Seren capabilities", async () => {
+    const harness = createLayerHarness();
+    const agents = [
+      { type: "claude-code", available: true },
+      { type: "codex", available: true },
+      { type: "gemini", available: true },
+      { type: "grok", available: true },
+      { type: "openclaw", available: true },
+    ];
+    harness.source.advertise.mockResolvedValue({ agents });
+
+    await harness.layer.start();
+
+    const update = harness.machineClient.updateMachineMetadata.mock.calls.at(-1)?.[0];
+    expect(update).toBeTypeOf("function");
+    const metadata = update?.({ existing: "preserved" });
+    expect(metadata).toMatchObject({
+      existing: "preserved",
+      cliAvailability: {
+        claude: true,
+        codex: true,
+        gemini: true,
+        openclaw: false,
+        detectedAt: expect.any(Number),
+      },
+      remoteCapabilities: {
+        agents,
+        roots: [SYNTHETIC_ROOT],
+      },
+    });
+
+    await harness.layer.close();
+  });
+
   it("publishes one first-prompt summary so Happy threads receive distinct titles", async () => {
     const summary = {
       sessionId: "title-session",


### PR DESCRIPTION
Fixes #3542

## Summary

Happy Mobile's built-in Gemini picker row is gated by `machine.metadata.cliAvailability.gemini`. Seren already advertises Gemini in `remoteCapabilities.agents`, but the Happy bridge never populated the legacy availability object, so a paired phone hid Gemini despite the runtime supporting it.

## Audited code path

`provider_get_available_agents`
→ `provider-source.mjs::advertise`
→ `happy-layer.mjs::updateCapabilities`
→ encrypted machine metadata
→ Happy Mobile's built-in availability filter
→ `spawn-happy-session`
→ Seren's existing `gemini` runtime.

The audit reviewed PRs #2984, #2986, #3116, and #3131 plus issues #3537 and #3540. No existing issue or PR covered Gemini's missing legacy availability metadata.

## Change

- Derive Happy's legacy Claude, Codex, Gemini, and OpenClaw flags from the same live provider records used for `remoteCapabilities.agents`.
- Mark only agent types that are both advertised and accepted by Seren's Happy spawn allowlist.
- Preserve the complete dynamic capability catalog unchanged.
- Add one focused regression case at the machine-metadata update boundary.

This makes Gemini visible while keeping OpenClaw false because the Seren bridge cannot spawn it.

## Validation

- Focused Happy bridge test: 52 passed.
- Full frontend suite: 2,879 passed, 15 skipped.
- Rust and integration tests: 1,289 passed, 3 ignored.
- Production build: passed.
- Local provider-runtime smoke: passed.
- `pnpm check`: passed with the repository's existing 48 warnings; no changed-file diagnostics.
- `git diff --check`: passed.

## Network path

No Seren publisher slug or Gateway API participates in the runtime feature. The existing direct Happy relay path is unchanged:

- `POST /v1/machines` registers encrypted machine metadata.
- Socket.IO/WebSocket `/v1/updates` event `machine-update-metadata` refreshes encrypted metadata.
- The phone invokes `spawn-happy-session` over `/v1/updates` after selection.

No host, method, path, or authentication scope changes.

## Functional walkthrough

The required post-PR hosted-relay walkthrough will use the real Happy client and Seren provider runtime with no local relay or mocked metadata. Public evidence will exclude pairing material, credentials, machine identifiers, and local paths.