### PR TITLE
fix(happy): route Agy sessions to Gemini

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -235,6 +235,9 @@ const HAPPY_AGENT_TYPES = new Map([
   ["claude", "claude-code"],
   ["claude-code", "claude-code"],
   ["claude-codex", "claude-codex"],
+  // Current Happy clients offer Agy instead of their deprecated Gemini row.
+  // Seren keeps its supported Google runtime canonical as `gemini`.
+  ["agy", "gemini"],
   ["gemini", "gemini"],
   ["grok", "grok"],
   ["lmstudio", "lmstudio"],
@@ -257,6 +260,7 @@ function happyCliAvailability(agents) {
   return {
     claude: supports("claude"),
     codex: supports("codex"),
+    agy: supports("agy"),
     gemini: supports("gemini"),
     openclaw: supports("openclaw"),
     detectedAt: Date.now(),

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -350,7 +350,7 @@ function createLayerHarness({
 }
 
 describe("Happy session liveness", () => {
-  it("publishes Gemini in Happy's legacy picker metadata from live Seren capabilities", async () => {
+  it("publishes Agy and legacy Gemini picker metadata from live Seren capabilities", async () => {
     const harness = createLayerHarness();
     const agents = [
       { type: "claude-code", available: true },
@@ -371,6 +371,7 @@ describe("Happy session liveness", () => {
       cliAvailability: {
         claude: true,
         codex: true,
+        agy: true,
         gemini: true,
         openclaw: false,
         detectedAt: expect.any(Number),
@@ -3011,6 +3012,7 @@ describe("Happy session liveness", () => {
   });
 
   it.each([
+    ["agy", "gemini"],
     ["claude-codex", "claude-codex"],
     ["lmstudio", "lmstudio"],
   ])("forwards the advertised %s agent to the provider runtime", async (mobileAgent, providerAgent) => {


### PR DESCRIPTION
Fixes #3542

## Summary

- advertise Happy's supported Agy picker row when Seren's live Gemini provider is available
- translate inbound `spawn-happy-session({ agent: "agy" })` to Seren's canonical `provider_spawn({ agentType: "gemini" })`
- preserve the legacy Gemini alias, the complete dynamic capability catalog, and fail-closed rejection for unknown identifiers
- change only Seren-owned bridge code; no upstream Happy source or dependency is modified

## Audited code path

`provider_get_available_agents`
→ `provider-source.mjs::advertise`
→ `happy-layer.mjs::updateCapabilities`
→ encrypted `cliAvailability.agy`
→ Happy's built-in Agy picker
→ `spawn-happy-session({ agent: "agy" })`
→ `happyAgentType`
→ Seren `provider_spawn({ agentType: "gemini" })`.

The audit covered Seren issues #3537, #3540, #3542; Seren PRs #2986, #3541, #3543; Happy PRs slopus/happy#1430 and #1541; Happy issue slopus/happy#1540; the current Happy picker, storage schema, and spawn RPC; and the pinned Happy SDK metadata transport. No duplicate Seren issue or implementation was found.

## Change

- add one explicit Agy→Gemini compatibility alias to the existing Happy agent allowlist
- derive `cliAvailability.agy` from the same live Gemini record that powers `remoteCapabilities.agents`
- extend the existing focused metadata and forwarding regression cases

## Validation

- focused Happy bridge suite: 56 passed
- full frontend suite: 2,883 passed, 15 skipped
- Rust/integration: 1,289 passed, 3 ignored
- production build: passed
- real local provider-runtime smoke: passed
- `pnpm check`: passed with the repository's existing 48 warnings; no changed-file diagnostics
- `git diff --check`: passed

## Network path

No Seren publisher slug or Gateway API participates in the runtime feature. Existing direct Happy traffic is unchanged:

- `POST /v1/machines` registers encrypted machine metadata
- Socket.IO/WebSocket `/v1/updates`, event `machine-update-metadata`, refreshes `cliAvailability.agy`
- the phone invokes `spawn-happy-session({ agent: "agy" })` over `/v1/updates`
- the bridge calls the local provider runtime's `provider_spawn({ agentType: "gemini" })`
- existing session creation continues through `POST /v1/sessions`

No host, method, path, credential, or authorization scope changes.

## Functional walkthrough

The required post-PR walkthrough will use the current Happy client, hosted relay, and real Seren provider runtime with no mocked metadata or spawn calls. Public evidence will exclude pairing material, credentials, machine identifiers, and local paths.
