### PR TITLE
fix(runtime): bound and cancel admission waits (#3548, #3549)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2620,6 +2620,7 @@ function attachProcessListeners(
   session,
   exitPromises,
   admissionGate,
+  respawningSessions,
 ) {
   const logPrefix = session.logPrefix ?? providerLogPrefix("claude");
   session.output.on("line", (line) => handleLine(emit, session, line));
@@ -2682,7 +2683,12 @@ function attachProcessListeners(
     // to reuse this session ID.
     const finish = () => {
       exitPromises.delete(session.id);
-      admissionGate.release(session.id);
+      // A wedged process being replaced keeps its slot: the respawn reuses the
+      // same session id without re-acquiring, so releasing here would let a
+      // queued session in alongside it and exceed the concurrency limit.
+      if (!respawningSessions?.has(session.id)) {
+        admissionGate.release(session.id);
+      }
       resolveExit();
     };
 
@@ -2753,6 +2759,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
   // this to prevent the old exit handler from deleting the new session.
   const exitPromises = new Map();
   const admissionMetadata = new Map();
+  // Session ids whose process is being replaced by the initialize-handshake
+  // respawn. Their exit must not hand the admission slot back.
+  const respawningSessions = new Set();
   const admissionGate = createAdmissionGate({
     limit: resolveClaudeSessionLimit(),
     onQueued(sessionId, position) {
@@ -2900,9 +2909,12 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       currentModelId: preferredModel,
       reasoningEffort: effectiveEffort,
     });
-    await admissionGate.acquire(sessionId);
+    try {
+      await admissionGate.acquire(sessionId);
+    } finally {
+      admissionMetadata.delete(sessionId);
+    }
     admissionAcquired = true;
-    admissionMetadata.delete(sessionId);
     let serenMcpProxy = null;
     let mcpConfig;
     let claudeArgs;
@@ -2938,6 +2950,13 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       });
     } catch (error) {
       await serenMcpProxy?.close();
+      // Session setup failed before the process exists, so no exit handler will
+      // ever hand this slot back. Release it here or the gate loses capacity
+      // permanently.
+      if (admissionAcquired) {
+        admissionAcquired = false;
+        admissionGate.release(sessionId);
+      }
       throw error;
     }
     // Surface the resolved --model value at every spawn so UI/runtime model
@@ -3090,6 +3109,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         launchedSession,
         exitPromises,
         admissionGate,
+        respawningSessions,
       );
       return { processHandle, session: launchedSession };
     };
@@ -3125,9 +3145,14 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
           // down with it, mirroring terminateSession's cleanup.
           session.output.close();
           const pendingExit = exitPromises.get(sessionId);
-          killChildTree(processHandle);
-          if (pendingExit) await pendingExit;
-          ({ processHandle, session } = launchClaudeProcess());
+          respawningSessions.add(sessionId);
+          try {
+            killChildTree(processHandle);
+            if (pendingExit) await pendingExit;
+            ({ processHandle, session } = launchClaudeProcess());
+          } finally {
+            respawningSessions.delete(sessionId);
+          }
         }
       }
 

--- a/bin/browser-local/session-admission.mjs
+++ b/bin/browser-local/session-admission.mjs
@@ -1,17 +1,37 @@
 // ABOUTME: Provides FIFO admission control for concurrent local Claude sessions.
 // ABOUTME: Keeps active capacity bounded and exposes queue state for runtime status events.
 
-export function createAdmissionGate({ limit, onQueued } = {}) {
+// A queued request must give up before its caller does. Otherwise the caller
+// abandons the spawn, capacity frees later, and the queue admits a session
+// nobody owns — an invisible CLI process holding a slot until app restart.
+// The provider_spawn RPC gives up at 120s (src/services/providers.ts).
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 110_000;
+
+export function createAdmissionGate({ limit, onQueued, acquireTimeoutMs } = {}) {
   const normalizedLimit = Number.isFinite(Number(limit)) && Number(limit) > 0
     ? Math.floor(Number(limit))
     : 1;
+  const normalizedTimeout =
+    Number.isFinite(Number(acquireTimeoutMs)) && Number(acquireTimeoutMs) > 0
+      ? Math.floor(Number(acquireTimeoutMs))
+      : DEFAULT_ACQUIRE_TIMEOUT_MS;
   const active = new Set();
   const pending = [];
+
+  function takePending(sessionId) {
+    const index = pending.findIndex(
+      (request) => request.sessionId === sessionId,
+    );
+    if (index === -1) return null;
+    const [request] = pending.splice(index, 1);
+    return request ?? null;
+  }
 
   function drain() {
     while (active.size < normalizedLimit && pending.length > 0) {
       const request = pending.shift();
       if (!request) return;
+      request.clearTimer();
       if (active.has(request.sessionId)) {
         request.resolve();
         continue;
@@ -37,14 +57,34 @@ export function createAdmissionGate({ limit, onQueued } = {}) {
     }
 
     let resolveRequest;
-    const promise = new Promise((resolve) => {
+    let rejectRequest;
+    const promise = new Promise((resolve, reject) => {
       resolveRequest = resolve;
+      rejectRequest = reject;
     });
+    let timer = null;
     const request = {
       sessionId,
       promise,
-      resolve: resolveRequest,
+      resolve: () => resolveRequest(),
+      reject: (error) => rejectRequest(error),
+      clearTimer() {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      },
     };
+    timer = setTimeout(() => {
+      timer = null;
+      if (!takePending(sessionId)) return;
+      request.reject(
+        new Error(
+          `Timed out after ${normalizedTimeout}ms waiting for a local Claude session slot`,
+        ),
+      );
+    }, normalizedTimeout);
+    if (typeof timer.unref === "function") timer.unref();
     pending.push(request);
     try {
       onQueued?.(sessionId, pending.length);
@@ -54,7 +94,18 @@ export function createAdmissionGate({ limit, onQueued } = {}) {
     return promise;
   }
 
+  // Releases an admitted session. A session that is still queued is cancelled
+  // instead, so an abandoned spawn can never be admitted after the fact.
   function release(sessionId) {
+    const queued = takePending(sessionId);
+    if (queued) {
+      queued.clearTimer();
+      queued.reject(
+        new Error(`Admission request cancelled for session ${sessionId}`),
+      );
+      drain();
+      return true;
+    }
     if (!active.delete(sessionId)) {
       return false;
     }

--- a/tests/unit/session-admission.test.ts
+++ b/tests/unit/session-admission.test.ts
@@ -75,6 +75,55 @@ describe("session admission gate", () => {
     expect(gate.activeCount()).toBe(0);
   });
 
+  it("gives up on a queued session once its acquire deadline passes", async () => {
+    const gate = createAdmissionGate({ limit: 1, acquireTimeoutMs: 20 });
+    await gate.acquire("a");
+    const queued = gate.acquire("b");
+
+    await expect(queued).rejects.toThrow(
+      /Timed out after 20ms waiting for a local Claude session slot/,
+    );
+    expect(gate.pendingCount()).toBe(0);
+
+    // Capacity freeing afterwards must not admit the abandoned session.
+    gate.release("a");
+    expect(gate.activeCount()).toBe(0);
+  });
+
+  it("cancels a queued session when its caller releases it", async () => {
+    const gate = createAdmissionGate({ limit: 1 });
+    await gate.acquire("a");
+    const queued = gate.acquire("b");
+
+    expect(gate.release("b")).toBe(true);
+    await expect(queued).rejects.toThrow(
+      /Admission request cancelled for session b/,
+    );
+    expect(gate.pendingCount()).toBe(0);
+
+    gate.release("a");
+    expect(gate.activeCount()).toBe(0);
+  });
+
+  it("keeps serving later waiters after one is cancelled", async () => {
+    const gate = createAdmissionGate({ limit: 1 });
+    await gate.acquire("a");
+    const b = gate.acquire("b");
+    let cResolved = false;
+    const c = gate.acquire("c").then(() => {
+      cResolved = true;
+    });
+
+    expect(gate.release("b")).toBe(true);
+    await expect(b).rejects.toThrow(/cancelled/);
+    expect(gate.pendingCount()).toBe(1);
+
+    gate.release("a");
+    await c;
+    expect(cResolved).toBe(true);
+    expect(gate.activeCount()).toBe(1);
+  });
+
   it("reports queued positions", async () => {
     const queued: Array<[string, number]> = [];
     const gate = createAdmissionGate({


### PR DESCRIPTION
Closes #3548. Closes #3549.

## What was broken

**#3548 (P0)** — `release()` only touched the `active` set, so a queued admission request could not be removed. When the frontend's `provider_spawn` RPC gave up at 120s, the queue entry survived; the next freed slot admitted a session nobody owned, spawning a real Claude CLI process whose events the UI discards and whose slot is held until app restart. Three of those = total Claude-agent outage.

**#3549 (P1)** — `admissionGate.acquire()` is followed by a try/catch that closes the MCP proxy and rethrows without releasing the slot; the only releasing catch guards a later try block. An MCP proxy port-bind failure or the Windows temp-file write failing permanently consumed a slot.

Also fixed while in the same lifecycle: the wedged-initialize respawn detaches the session before killing it, so the exit handler saw `wasTracked=false` and released the slot mid-retry — letting a queued session in alongside the respawned one and exceeding the concurrency limit.

## The fix

- `acquire()` now bounds its wait at 110s (just under the caller's 120s RPC timeout) and removes itself from the queue on expiry, so an abandoned spawn can never be admitted after the fact.
- `release()` on a queued session cancels it instead of being a no-op, and drains the queue so later waiters still progress.
- The setup catch releases the slot it holds.
- The respawn marks the session id so its intentional kill does not hand the slot back; the replacement keeps the same slot.
- Spawn metadata is cleaned up via `finally` so a rejected acquire cannot leak it.

No behavior change for spawns that would have succeeded before the caller gave up — the bound sits inside the existing 120s window.

## Verification

- 3 new tests in `tests/unit/session-admission.test.ts` cover deadline expiry, caller cancellation, and that a cancelled waiter does not block the ones behind it.
- Full worktree unit suite: **2820 passed, 3 skipped, 0 failed**.
- Biome clean on all three files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com