### PR TITLE
fix(run): retire agent sessions when tasks and runs end (#3550, #3560)

### DIFF
--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -260,9 +260,12 @@ export function selectReadyTasks(
   inFlight: ReadonlySet<string>,
   cap = MAX_CONCURRENT_TASKS,
 ): Task[] {
+  // The cap bounds total concurrency, so tasks already running count against
+  // it. The dispatch effect re-runs on every snapshot change; without this,
+  // each re-run would admit a fresh capful on top of the in-flight ones.
   return tasks
     .filter((task) => task.state === "ready" && !inFlight.has(task.id))
-    .slice(0, Math.max(0, cap));
+    .slice(0, Math.max(0, cap - inFlight.size));
 }
 
 export interface DispatchPlan {
@@ -448,6 +451,7 @@ async function dispatchTask(
   const runId = snapshot.run.id;
   const localSessionId = crypto.randomUUID();
   let attemptId: string | null = null;
+  let spawnedSessionId: string | null = null;
   try {
     attemptId = await runStartAttempt(
       runId,
@@ -469,6 +473,7 @@ async function dispatchTask(
           { localSessionId, conversationTitle: task.title },
         );
         if (!sessionId) throw new Error("agent session failed to start");
+        spawnedSessionId = sessionId;
         ownedSessionIds.set(sessionId, runId);
         agentStore.markSessionRunOwned(sessionId, runId);
         await agentStore.sendPrompt(
@@ -528,6 +533,28 @@ async function dispatchTask(
         // Preserve the original dispatch failure; the durable event loop may be stopping.
       }
     }
+  } finally {
+    // A task owns its agent session for the length of the task. Holding it
+    // open afterwards would keep an admission slot and a live CLI process for
+    // work that is already finished, starving the next task and any chat the
+    // user starts while the run is going.
+    if (spawnedSessionId) {
+      ownedSessionIds.delete(spawnedSessionId);
+      await retireRunSession(spawnedSessionId);
+    }
+  }
+}
+
+async function retireRunSession(sessionId: string): Promise<void> {
+  agentStore.releaseSessionRunOwnership(sessionId);
+  try {
+    await agentStore.terminateSession(sessionId);
+  } catch (error) {
+    console.warn(
+      "[RunDispatcher] Failed to terminate run-owned session:",
+      sessionId,
+      error,
+    );
   }
 }
 
@@ -540,8 +567,11 @@ function releaseTerminalOwnership(snapshot: RunSnapshot | null): void {
   if (!isTerminalRun(snapshot)) return;
   for (const [sessionId, runId] of ownedSessionIds) {
     if (runId === snapshot?.run.id) {
-      agentStore.releaseSessionRunOwnership(sessionId);
       ownedSessionIds.delete(sessionId);
+      // Stopping a run must stop its agents. Leaving them alive lets a
+      // cancelled run keep spending tokens and appending findings to a record
+      // the user already closed.
+      void retireRunSession(sessionId);
     }
   }
 }
@@ -587,7 +617,7 @@ export function stopRunDispatcher(): void {
   disposeDispatcher?.();
   disposeDispatcher = null;
   for (const sessionId of ownedSessionIds.keys()) {
-    agentStore.releaseSessionRunOwnership(sessionId);
+    void retireRunSession(sessionId);
   }
   ownedSessionIds.clear();
   inFlightTasks.clear();

--- a/tests/unit/run-dispatcher-selection.test.ts
+++ b/tests/unit/run-dispatcher-selection.test.ts
@@ -46,12 +46,22 @@ describe("run dispatcher selection", () => {
     expect(selectReadyTasks(tasks, new Set(["two"]), 3).map((item) => item.id)).toEqual([
       "one",
       "three",
-      "four",
     ]);
     expect(selectReadyTasks(tasks, new Set(), 2).map((item) => item.id)).toEqual([
       "one",
       "two",
     ]);
+  });
+
+  it("counts in-flight tasks against the concurrency cap", () => {
+    const tasks = [task("one"), task("two"), task("three"), task("four")];
+    expect(
+      selectReadyTasks(tasks, new Set(["one", "two", "three"]), 3),
+    ).toEqual([]);
+    expect(
+      selectReadyTasks(tasks, new Set(["one"]), 3).map((item) => item.id),
+    ).toEqual(["two", "three"]);
+    expect(selectReadyTasks(tasks, new Set(["one", "two"]), 3)).toHaveLength(1);
   });
 
   it("round-robins assignments in the selected plan", () => {


### PR DESCRIPTION
Closes #3550. Closes #3560.

## What was broken

**#3550 (P1)** — `run-dispatcher.ts` contained zero `terminateSession` calls. Each task spawned a session, marked it run-owned, and left it alive; `ownedByRunId` fences those sessions out of idle reclaim (agent.store.ts:2180-2181). Since `MAX_CONCURRENT_TASKS` (3) equals the admission limit (3), a run's finished-but-alive sessions held every slot: task 4 queued, timed out, and silently fell back to the signed-in chat model — the user asked for Claude Code and got something else. While a run was active the user also could not open a new Claude chat, and after the run 3 stale processes lingered.

**#3560 (P2)** — `releaseTerminalOwnership` only cleared the ownership flag. Nothing terminated the session or aborted `waitForTurn` (30-minute deadline), so after Stop up to 3 agents kept spending tokens and appending findings to a cancelled run.

## The fix

- `dispatchTask` records the session it spawns and retires it in a `finally`, so a task owns its session for exactly the length of the task.
- `releaseTerminalOwnership` and `stopRunDispatcher` retire sessions rather than just un-flagging them. `waitForTurn` already throws "agent session disappeared before completion" when its session is gone, so Stop unwinds in-flight work within one poll interval.
- `retireRunSession` releases ownership then terminates, tolerating an already-gone session (`terminateSession` no-ops on unknown ids).
- `selectReadyTasks` subtracts `inFlight.size` from the cap. The dispatch effect re-runs on every snapshot change, so slicing to the raw cap admitted a fresh capful per re-run instead of bounding total concurrency.

**UI/UX unchanged.** Run sessions are background sessions; `spawnSession` only sets `activeSessionId` when nothing is active, and `terminateSession` only reassigns the active session if the terminated one was active. Conversation rows and their transcripts persist — only the live CLI process is retired.

## Test change worth reviewing

`run-dispatcher-selection.test.ts` asserted `selectReadyTasks(tasks, new Set(["two"]), 3)` returns **three** tasks — it encoded the uncapped behavior. Corrected to two, plus a new test pinning in-flight tasks against the cap.

## Verification

- Full worktree unit suite: **2821 passed, 3 skipped, 0 failed**.
- Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com