### PR TITLE
fix(run): announce terminal runs and protect settled records (#3551, #3556, #3558)

### DIFF
--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -669,7 +669,9 @@ fn process_command(
             let _ = reply.send(approve_check(app, conn, check_id));
         }
         SchedulerCommand::RunBaseline { run_id, reply } => {
-            if let Err(error) = start_baseline(app, conn, sender, run_id, reply) {
+            let mut reply = Some(reply);
+            if let Err(error) = start_baseline(app, conn, sender, run_id, &mut reply) {
+                send_check_reply(&mut reply, Err(error.clone()));
                 log::error!("[run-engine] baseline dispatch failed: {error}");
             }
         }
@@ -685,7 +687,9 @@ fn process_command(
             task_id,
             reply,
         } => {
-            if let Err(error) = start_verify(app, conn, sender, run_id, task_id, reply) {
+            let mut reply = Some(reply);
+            if let Err(error) = start_verify(app, conn, sender, run_id, task_id, &mut reply) {
+                send_check_reply(&mut reply, Err(error.clone()));
                 log::error!("[run-engine] verify dispatch failed: {error}");
             }
         }
@@ -1062,12 +1066,24 @@ fn run_check_commands(
         .collect()
 }
 
+/// Answers a check request exactly once. Dropping the sender instead would
+/// reach the caller as a bare channel-closed message, hiding the real reason
+/// the request failed.
+fn send_check_reply(
+    reply: &mut Option<oneshot::Sender<Result<Vec<CheckResult>, String>>>,
+    result: Result<Vec<CheckResult>, String>,
+) {
+    if let Some(sender) = reply.take() {
+        let _ = sender.send(result);
+    }
+}
+
 fn start_baseline(
     app: &AppHandle,
     conn: &Connection,
     sender: &mpsc::Sender<SchedulerCommand>,
     run_id: String,
-    reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    reply: &mut Option<oneshot::Sender<Result<Vec<CheckResult>, String>>>,
 ) -> Result<(), String> {
     let checks = store::list_checks(conn, &run_id).map_err(|error| error.to_string())?;
     let root_path = approved_check_root(conn, &run_id)?;
@@ -1103,12 +1119,15 @@ fn start_baseline(
             }
         }
         let result = finish_baseline(app, conn, run_id, Vec::new());
-        let _ = reply.send(result);
+        send_check_reply(reply, result);
         return Ok(());
     }
 
     let root_path = PathBuf::from(root_path.expect("checked above"));
     let finish_sender = sender.clone();
+    let Some(reply) = reply.take() else {
+        return Err("baseline reply channel already used".to_string());
+    };
     tauri::async_runtime::spawn(async move {
         let worker = tauri::async_runtime::spawn_blocking(move || {
             run_check_commands(&root_path, &approved, "baseline", None)
@@ -1167,7 +1186,7 @@ fn start_verify(
     sender: &mpsc::Sender<SchedulerCommand>,
     run_id: String,
     task_id: String,
-    reply: oneshot::Sender<Result<Vec<CheckResult>, String>>,
+    reply: &mut Option<oneshot::Sender<Result<Vec<CheckResult>, String>>>,
 ) -> Result<(), String> {
     let state: String = conn
         .query_row(
@@ -1207,7 +1226,7 @@ fn start_verify(
             }
         }
         let result = finish_verify(app, conn, run_id, task_id, Vec::new());
-        let _ = reply.send(result);
+        send_check_reply(reply, result);
         return Ok(());
     }
 
@@ -1216,6 +1235,9 @@ fn start_verify(
     let finish_run_id = run_id.clone();
     let finish_task_id = task_id.clone();
     let worker_task_id = finish_task_id.clone();
+    let Some(reply) = reply.take() else {
+        return Err("verify reply channel already used".to_string());
+    };
     tauri::async_runtime::spawn(async move {
         let worker = tauri::async_runtime::spawn_blocking(move || {
             run_check_commands(
@@ -1601,7 +1623,10 @@ fn prepare_relaunch(conn: &Connection, run_id: &str) -> Result<Vec<NewRunEvent>,
     let mut events = Vec::new();
     for (task_id, state) in tasks {
         let state = TaskState::parse(&state).ok_or_else(|| format!("invalid task state: {state}"))?;
-        if state.is_terminal() || state == TaskState::Ready {
+        // Pending tasks are waiting on a prerequisite, so they are already in
+        // the right state; promoting them here would run them ahead of the work
+        // they depend on. Promotion happens once their dependencies are done.
+        if state.is_terminal() || state == TaskState::Ready || state == TaskState::Pending {
             continue;
         }
         store::transition_task(conn, &task_id, TaskState::Ready, None)
@@ -1902,6 +1927,12 @@ fn add_assignment(
 }
 
 fn request_cancel(app: &AppHandle, conn: &Connection, run_id: String) -> Result<Run, String> {
+    // Cancelling a run that already settled would rewrite its outcome —
+    // a completed run would be recorded as cancelled and lose its
+    // completion timestamp. Report the settled run as-is instead.
+    if load_run_status(conn, &run_id)?.is_terminal() {
+        return load_run(conn, &run_id);
+    }
     let updated = conn
         .execute(
             "UPDATE runs SET cancel_requested = 1, updated_at = ?1 WHERE id = ?2",
@@ -1961,22 +1992,9 @@ fn request_cancel(app: &AppHandle, conn: &Connection, run_id: String) -> Result<
             },
         )?;
     }
+    // recompute_ready_and_status emits RunFinalized for the terminal
+    // transition this cancel just caused.
     recompute_ready_and_status(app, conn, &run_id)?;
-    append_and_emit(
-        app,
-        conn,
-        NewRunEvent {
-            id: Uuid::new_v4().to_string(),
-            run_id: run_id.clone(),
-            task_id: None,
-            attempt_id: None,
-            agent_id: None,
-            event_type: RunEventType::RunFinalized,
-            payload: json!({"status": RunStatus::Cancelled}),
-            provider_event_id: None,
-            created_at: now_ms(),
-        },
-    )?;
     load_run(conn, &run_id)
 }
 
@@ -2035,26 +2053,45 @@ fn recompute_ready_and_status(
     conn: &Connection,
     run_id: &str,
 ) -> Result<(), String> {
+    for event in promote_ready_tasks(conn, run_id)? {
+        append_and_emit(app, conn, event)?;
+    }
+
+    if let Some(event) = settle_run_status(conn, run_id)? {
+        append_and_emit(app, conn, event)?;
+    }
+    Ok(())
+}
+
+/// Promotes pending tasks whose dependencies are all done. This is the only
+/// place a task becomes ready, so dependency order holds no matter what put
+/// the task back into pending.
+fn promote_ready_tasks(conn: &Connection, run_id: &str) -> Result<Vec<NewRunEvent>, String> {
+    let mut events = Vec::new();
     for task_id in store::ready_task_ids(conn, run_id).map_err(|error| error.to_string())? {
         store::transition_task(conn, &task_id, TaskState::Ready, None)
             .map_err(|error| error.to_string())?;
-        append_and_emit(
-            app,
-            conn,
-            NewRunEvent {
-                id: Uuid::new_v4().to_string(),
-                run_id: run_id.to_string(),
-                task_id: Some(task_id),
-                attempt_id: None,
-                agent_id: None,
-                event_type: RunEventType::TaskStateChanged,
-                payload: json!({"state": TaskState::Ready}),
-                provider_event_id: None,
-                created_at: now_ms(),
-            },
-        )?;
+        events.push(NewRunEvent {
+            id: Uuid::new_v4().to_string(),
+            run_id: run_id.to_string(),
+            task_id: Some(task_id),
+            attempt_id: None,
+            agent_id: None,
+            event_type: RunEventType::TaskStateChanged,
+            payload: json!({"state": TaskState::Ready}),
+            provider_event_id: None,
+            created_at: now_ms(),
+        });
     }
+    Ok(events)
+}
 
+/// Persists the run's derived status. Returns the event announcing a terminal
+/// outcome when this call is what settled the run — that transition is the one
+/// status change nothing else announces, so without it the UI keeps showing a
+/// finished run as working with its Stop control still live.
+fn settle_run_status(conn: &Connection, run_id: &str) -> Result<Option<NewRunEvent>, String> {
+    let previous_status = load_run_status(conn, run_id)?;
     let (cancel_requested, interrupted, task_states) = load_status_inputs(conn, run_id)?;
     let status = derive_run_status(&task_states, cancel_requested, interrupted);
     let completed_at = status.is_terminal().then_some(now_ms());
@@ -2069,7 +2106,31 @@ fn recompute_ready_and_status(
     if updated == 0 {
         return Err("run not found".to_string());
     }
-    Ok(())
+    if !status.is_terminal() || previous_status.is_terminal() {
+        return Ok(None);
+    }
+    Ok(Some(NewRunEvent {
+        id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        task_id: None,
+        attempt_id: None,
+        agent_id: None,
+        event_type: RunEventType::RunFinalized,
+        payload: json!({"status": status}),
+        provider_event_id: None,
+        created_at: now_ms(),
+    }))
+}
+
+fn load_run_status(conn: &Connection, run_id: &str) -> Result<RunStatus, String> {
+    let raw: String = conn
+        .query_row(
+            "SELECT status FROM runs WHERE id = ?1",
+            params![run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    RunStatus::parse(&raw).ok_or_else(|| format!("invalid run status in database: {raw}"))
 }
 
 fn load_status_inputs(
@@ -2202,6 +2263,9 @@ mod tests {
         for event in prepare_relaunch(&conn, "run-relaunch").unwrap() {
             store::append_event(&conn, &event).unwrap();
         }
+        for event in promote_ready_tasks(&conn, "run-relaunch").unwrap() {
+            store::append_event(&conn, &event).unwrap();
+        }
         let snapshot = store::load_run_snapshot(&conn, "run-relaunch")
             .unwrap()
             .unwrap();
@@ -2212,6 +2276,171 @@ mod tests {
             .unwrap()
             .iter()
             .any(|event| event.event_type == RunEventType::RunRelaunched));
+    }
+
+    #[test]
+    fn relaunch_keeps_a_task_waiting_on_its_unfinished_prerequisite() {
+        let conn = connection();
+        store::create_run(
+            &conn,
+            &Run {
+                id: "run-deps".to_string(),
+                objective: "respect dependencies on relaunch".to_string(),
+                root_path: None,
+                status: RunStatus::Interrupted,
+                cancel_requested: false,
+                interrupted_at: Some(5),
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+        // task-first was interrupted mid-run; task-second has never been
+        // promoted because task-first has not finished.
+        for (task_id, state, dependencies) in [
+            ("task-first", "running", Vec::new()),
+            ("task-second", "pending", vec!["task-first".to_string()]),
+        ] {
+            store::add_task(
+                &conn,
+                &Task {
+                    id: task_id.to_string(),
+                    run_id: "run-deps".to_string(),
+                    title: task_id.to_string(),
+                    brief: "ordered work".to_string(),
+                    state: TaskState::Ready,
+                    blocked_reason: None,
+                    created_at: 1,
+                    updated_at: 1,
+                },
+                &dependencies,
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE run_tasks SET state = ?1 WHERE id = ?2",
+                params![state, task_id],
+            )
+            .unwrap();
+        }
+
+        for event in prepare_relaunch(&conn, "run-deps").unwrap() {
+            store::append_event(&conn, &event).unwrap();
+        }
+        for event in promote_ready_tasks(&conn, "run-deps").unwrap() {
+            store::append_event(&conn, &event).unwrap();
+        }
+
+        let snapshot = store::load_run_snapshot(&conn, "run-deps").unwrap().unwrap();
+        let state_of = |id: &str| {
+            snapshot
+                .tasks
+                .iter()
+                .find(|task| task.id == id)
+                .expect("task present")
+                .state
+        };
+        assert_eq!(state_of("task-first"), TaskState::Ready);
+        assert_eq!(state_of("task-second"), TaskState::Pending);
+    }
+
+    fn seed_run(conn: &Connection, run_id: &str) {
+        store::create_run(
+            conn,
+            &Run {
+                id: run_id.to_string(),
+                objective: "settle status".to_string(),
+                root_path: None,
+                status: RunStatus::Running,
+                cancel_requested: false,
+                interrupted_at: None,
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+            },
+        )
+        .unwrap();
+    }
+
+    fn seed_done_task(conn: &Connection, run_id: &str, task_id: &str) {
+        store::add_task(
+            conn,
+            &Task {
+                id: task_id.to_string(),
+                run_id: run_id.to_string(),
+                title: task_id.to_string(),
+                brief: "finished work".to_string(),
+                state: TaskState::Ready,
+                blocked_reason: None,
+                created_at: 1,
+                updated_at: 1,
+            },
+            &[],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE run_tasks SET state = 'done' WHERE id = ?1",
+            params![task_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn settling_a_run_announces_its_terminal_outcome_once() {
+        let conn = connection();
+        seed_run(&conn, "run-settle");
+        seed_done_task(&conn, "run-settle", "task-done");
+
+        let event = settle_run_status(&conn, "run-settle")
+            .unwrap()
+            .expect("completing the last task settles the run");
+        assert_eq!(event.event_type, RunEventType::RunFinalized);
+        assert_eq!(event.payload["status"], json!("completed"));
+        assert_eq!(load_run_status(&conn, "run-settle").unwrap(), RunStatus::Completed);
+
+        // Later recomputes must not re-announce an outcome already reported.
+        assert!(settle_run_status(&conn, "run-settle").unwrap().is_none());
+    }
+
+    #[test]
+    fn settling_a_working_run_announces_nothing() {
+        let conn = connection();
+        seed_run(&conn, "run-working");
+        store::add_task(
+            &conn,
+            &Task {
+                id: "task-open".to_string(),
+                run_id: "run-working".to_string(),
+                title: "task-open".to_string(),
+                brief: "still going".to_string(),
+                state: TaskState::Ready,
+                blocked_reason: None,
+                created_at: 1,
+                updated_at: 1,
+            },
+            &[],
+        )
+        .unwrap();
+
+        assert!(settle_run_status(&conn, "run-working").unwrap().is_none());
+        assert_eq!(load_run_status(&conn, "run-working").unwrap(), RunStatus::Running);
+    }
+
+    #[test]
+    fn a_settled_run_reads_as_terminal_so_cancel_leaves_it_alone() {
+        let conn = connection();
+        seed_run(&conn, "run-settled");
+        seed_done_task(&conn, "run-settled", "task-done");
+        settle_run_status(&conn, "run-settled").unwrap();
+
+        // request_cancel consults exactly this before touching the record; a
+        // completed run must never be rewritten as cancelled.
+        assert!(load_run_status(&conn, "run-settled").unwrap().is_terminal());
+        let snapshot = store::load_run_snapshot(&conn, "run-settled")
+            .unwrap()
+            .unwrap();
+        assert_eq!(snapshot.run.status, RunStatus::Completed);
+        assert!(snapshot.run.completed_at.is_some());
     }
 
     #[test]

--- a/src-tauri/src/run/store.rs
+++ b/src-tauri/src/run/store.rs
@@ -173,12 +173,21 @@ pub fn finish_attempt(
     if !matches!(outcome, "completed" | "failed" | "parse_failed") {
         return Err(invalid_value("attempt outcome", outcome));
     }
+    // An attempt records its outcome once. A late failure on the way out of a
+    // finished attempt must not rewrite a completed one as failed.
     let updated = conn.execute(
-        "UPDATE run_attempts SET outcome = ?1, ended_at = ?2 WHERE id = ?3",
+        "UPDATE run_attempts SET outcome = ?1, ended_at = ?2 WHERE id = ?3 AND outcome IS NULL",
         params![outcome, ended_at, attempt_id],
     )?;
     if updated == 0 {
-        return Err(rusqlite::Error::QueryReturnedNoRows);
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM run_attempts WHERE id = ?1)",
+            params![attempt_id],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -12,6 +12,20 @@ use std::time::{Duration, Instant};
 
 const SETUP_OUTPUT_LIMIT: usize = 2_000;
 
+/// Every child this module spawns is background work for a run. Without this
+/// flag Windows opens a console window for each one — setup scripts, evidence
+/// checks, and every git call during provisioning.
+fn hidden_command(program: &str) -> Command {
+    #[allow(unused_mut)]
+    let mut command = Command::new(program);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    command
+}
+
 #[derive(Debug, Clone)]
 pub struct ProvisionRequest {
     pub run_id: String,
@@ -186,7 +200,7 @@ fn provision_worktree(request: &ProvisionRequest) -> Result<ProvisionedWorkspace
             continue;
         }
 
-        let output = Command::new("git")
+        let output = hidden_command("git")
             .current_dir(source_path)
             .args(["worktree", "add"])
             .arg(&root_path)
@@ -203,9 +217,11 @@ fn provision_worktree(request: &ProvisionRequest) -> Result<ProvisionedWorkspace
             });
         }
 
-        // A concurrent provisioner may have claimed the branch between the
-        // existence check and git worktree add; retry with the next suffix.
-        if root_path.exists() {
+        // A concurrent provisioner may have claimed the path or branch between
+        // the existence check and git worktree add. A live worktree there is
+        // theirs and holds real work, so only clear a leftover that is not one
+        // before retrying with the next suffix.
+        if root_path.exists() && !root_path.join(".git").exists() {
             let _ = fs::remove_dir_all(&root_path);
         }
         if !git_branch_exists(source_path, &branch_name)? {
@@ -231,7 +247,7 @@ fn provision_worktree(request: &ProvisionRequest) -> Result<ProvisionedWorkspace
 }
 
 fn ensure_git_repository(source_path: &Path) -> Result<(), ProvisionError> {
-    let output = Command::new("git")
+    let output = hidden_command("git")
         .args(["-C"])
         .arg(source_path)
         .args(["rev-parse", "--git-dir"])
@@ -245,7 +261,7 @@ fn ensure_git_repository(source_path: &Path) -> Result<(), ProvisionError> {
 }
 
 fn git_stdout(source_path: &Path, arguments: &[&str]) -> Result<String, ProvisionError> {
-    let output = Command::new("git")
+    let output = hidden_command("git")
         .current_dir(source_path)
         .args(arguments)
         .output()
@@ -260,7 +276,7 @@ fn git_stdout(source_path: &Path, arguments: &[&str]) -> Result<String, Provisio
 }
 
 fn git_branch_exists(source_path: &Path, branch_name: &str) -> Result<bool, ProvisionError> {
-    let status = Command::new("git")
+    let status = hidden_command("git")
         .current_dir(source_path)
         .args(["show-ref", "--verify", "--quiet"])
         .arg(format!("refs/heads/{branch_name}"))
@@ -425,13 +441,13 @@ pub fn run_setup_script(
 fn setup_command(script: &str) -> Command {
     #[cfg(target_os = "windows")]
     {
-        let mut command = Command::new("cmd");
+        let mut command = hidden_command("cmd");
         command.args(["/C", script]);
         command
     }
     #[cfg(not(target_os = "windows"))]
     {
-        let mut command = Command::new("/bin/sh");
+        let mut command = hidden_command("/bin/sh");
         command.args(["-c", script]);
         #[cfg(unix)]
         {
@@ -453,7 +469,7 @@ fn kill_setup_process_group(pid: u32) {
 
 #[cfg(windows)]
 fn kill_setup_process_group(pid: u32) {
-    let _ = Command::new("taskkill")
+    let _ = hidden_command("taskkill")
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status();
 }
@@ -500,7 +516,7 @@ pub fn release(
             }
             let source_repo = source_repo
                 .ok_or_else(|| "worktree release requires source repository".to_string())?;
-            let output = Command::new("git")
+            let output = hidden_command("git")
                 .current_dir(source_repo)
                 .args(["worktree", "remove", "--force"])
                 .arg(root)
@@ -548,7 +564,7 @@ mod tests {
     }
 
     fn git_command(cwd: &Path, arguments: &[&str]) {
-        let output = Command::new("git")
+        let output = hidden_command("git")
             .current_dir(cwd)
             .args(arguments)
             .output()
@@ -562,7 +578,7 @@ mod tests {
     }
 
     fn git_output(cwd: &Path, arguments: &[&str]) -> String {
-        let output = Command::new("git")
+        let output = hidden_command("git")
             .current_dir(cwd)
             .args(arguments)
             .output()

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::panic::PanicHookInfo;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use hmac::{Hmac, Mac};
 use regex::Regex;
@@ -29,6 +29,11 @@ const MAX_BUNDLE_BYTES: usize = 5 * 1024 * 1024;
 const MAX_SWEEP_PER_LAUNCH: usize = 5;
 // Retry-After ceiling so a misconfigured server cannot hang us indefinitely.
 const MAX_RETRY_AFTER_SECONDS: u64 = 60;
+// Sidecars arrive faster than the per-launch replay budget drains them, so the
+// directory is pruned to a bounded, recent window. Beyond these limits a report
+// is stale enough that keeping it costs disk without buying diagnostics.
+const MAX_RETAINED_SIDECARS: usize = 60;
+const MAX_SIDECAR_AGE_SECONDS: u64 = 14 * 24 * 60 * 60;
 // Bound the native runtime-error dedup set so a long-running session with many
 // distinct native failures cannot grow it unbounded. Native reports are rare
 // (catastrophic events), so clearing on overflow is acceptable.
@@ -170,14 +175,9 @@ pub async fn sweep_support_crash_reports(app: AppHandle) -> Result<(), String> {
     let client = build_http_client();
     let mut processed = 0usize;
 
-    for entry in entries {
+    for path in prune_sidecars(entries)? {
         if processed >= MAX_SWEEP_PER_LAUNCH {
             break;
-        }
-        let entry = entry.map_err(|err| format!("failed to read crash entry: {err}"))?;
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-            continue;
         }
 
         let is_pending = path
@@ -229,6 +229,69 @@ pub async fn sweep_support_crash_reports(app: AppHandle) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Returns the sidecars worth replaying, oldest first, after deleting the ones
+/// that are too old or too far beyond the retention window. Reports arrive
+/// faster than the per-launch replay budget drains them, so without pruning the
+/// directory grows without bound and the oldest reports are never reached.
+fn prune_sidecars(entries: fs::ReadDir) -> Result<Vec<PathBuf>, String> {
+    let now = SystemTime::now();
+    let mut sidecars: Vec<(SystemTime, PathBuf)> = Vec::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|err| format!("failed to read crash entry: {err}"))?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(now);
+        sidecars.push((modified, path));
+    }
+
+    let (keep, discard) = partition_sidecars(sidecars, now);
+    for path in discard {
+        if let Err(err) = fs::remove_file(&path) {
+            log::warn!(
+                "[support-report] failed to delete stale sidecar {}: {err}",
+                path.display()
+            );
+        }
+    }
+    Ok(keep)
+}
+
+/// Splits sidecars into the ones worth replaying (oldest first, so the sweep
+/// drains the longest-waiting reports) and the ones to delete for being too old
+/// or beyond the retention window.
+fn partition_sidecars(
+    mut sidecars: Vec<(SystemTime, PathBuf)>,
+    now: SystemTime,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let mut discard = Vec::new();
+    sidecars.retain(|(modified, path)| {
+        let expired = now
+            .duration_since(*modified)
+            .is_ok_and(|age| age.as_secs() > MAX_SIDECAR_AGE_SECONDS);
+        if expired {
+            discard.push(path.clone());
+        }
+        !expired
+    });
+
+    sidecars.sort_by(|left, right| left.0.cmp(&right.0));
+    while sidecars.len() > MAX_RETAINED_SIDECARS {
+        let (_, path) = sidecars.remove(0);
+        discard.push(path);
+    }
+
+    (
+        sidecars.into_iter().map(|(_, path)| path).collect(),
+        discard,
+    )
 }
 
 fn install_panic_hook(app: AppHandle) {
@@ -625,6 +688,50 @@ fn windows_home_pattern() -> &'static Regex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pruning_discards_expired_sidecars() {
+        let now = SystemTime::now();
+        let fresh = PathBuf::from("pending-fresh.json");
+        let expired = PathBuf::from("pending-expired.json");
+
+        let (keep, discard) = partition_sidecars(
+            vec![
+                (now - Duration::from_secs(60), fresh.clone()),
+                (
+                    now - Duration::from_secs(MAX_SIDECAR_AGE_SECONDS + 60),
+                    expired.clone(),
+                ),
+            ],
+            now,
+        );
+
+        assert_eq!(keep, vec![fresh]);
+        assert_eq!(discard, vec![expired]);
+    }
+
+    #[test]
+    fn pruning_keeps_the_newest_sidecars_within_the_retention_limit() {
+        let now = SystemTime::now();
+        let total = MAX_RETAINED_SIDECARS + 5;
+        // Highest index is the most recent.
+        let sidecars: Vec<(SystemTime, PathBuf)> = (0..total)
+            .map(|index| {
+                (
+                    now - Duration::from_secs((total - index) as u64 * 60),
+                    PathBuf::from(format!("pending-{index}.json")),
+                )
+            })
+            .collect();
+
+        let (keep, discard) = partition_sidecars(sidecars, now);
+
+        assert_eq!(keep.len(), MAX_RETAINED_SIDECARS);
+        assert_eq!(discard.len(), 5);
+        // Oldest survivor first, so the sweep drains the longest-waiting report.
+        assert_eq!(keep[0], PathBuf::from("pending-5.json"));
+        assert_eq!(discard[0], PathBuf::from("pending-0.json"));
+    }
 
     #[test]
     fn redacts_tokens_and_home_paths() {

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -158,6 +158,7 @@ async function applyEvent(event: RunEvent): Promise<void> {
   } else if (
     event.event_type === "run_interrupted" ||
     event.event_type === "run_relaunched" ||
+    event.event_type === "run_finalized" ||
     event.event_type === "attempt_started" ||
     event.event_type === "attempt_finished"
   ) {


### PR DESCRIPTION
Closes #3551. Closes #3556. Closes #3558. Also fixes four of the eight items in #3559 (the Rust-side ones).

## #3551 (P1) — completed runs looked like they were still working, and Stop corrupted them

`recompute_ready_and_status` persisted the terminal status but emitted nothing; `RunFinalized` was emitted only by `request_cancel`. So the last event of a natural completion was `task_state_changed(done)`, which the store applies in place without touching `snapshot.run.status`. The header stayed "Run · running" with Stop enabled, and clicking Stop set `cancel_requested=1` — permanently rewriting a **completed** run as `cancelled` and overwriting `completed_at`, with no record anywhere that it had succeeded.

- The status recompute is now `settle_run_status`, which returns a `RunFinalized` event when *this* call is what settled the run (guarded on the previous status, so it announces once).
- `request_cancel` returns a settled run untouched instead of rewriting it.
- The cancel path's hand-rolled `RunFinalized` is gone — the same transition now produces it.
- `run.store.ts` hydrates on `run_finalized` (it previously had no branch for it at all, so even the cancel event was inert).

## #3556 (P1, Windows) — console windows during runs

Zero of the run module's spawns set `CREATE_NO_WINDOW`, while every other spawn site in the codebase does. All ten now go through a `hidden_command` helper: `cmd /C` setup scripts and checks (up to 300s with a visible window each), every `git` call during provisioning, and `taskkill`.

## #3558 (P2) — unbounded sidecar growth

The sweep replays 5 per launch with no pruning; reports arrive faster than that. **Measured: 88 files, oldest 3 days back, some 52KB.** Sidecars are now pruned by age (14 days) and count (60, oldest discarded), and the survivors are handed to the sweep **oldest first** so the longest-waiting reports actually get sent. The decision is a pure function (`partition_sidecars`) so it is tested without touching the filesystem or adding a dependency.

## From #3559

- **Attempt outcome overwrite**: `finish_attempt` now has `WHERE outcome IS NULL`, so a late failure cannot rewrite a completed attempt (a missing attempt still errors).
- **Dropped oneshot replies**: `start_verify`/`start_baseline` take the reply as an `Option` slot; any early error is now sent to the caller instead of dropping the sender, which surfaced as "run scheduler dropped verify response" instead of the real reason.
- **Relaunch dependency ordering**: relaunch skipped terminal and ready tasks but force-promoted **pending** ones — including tasks never promoted because a prerequisite was unfinished. Pending tasks are now left alone; `promote_ready_tasks` (extracted, dependency-aware, the single place a task becomes ready) picks them up when their dependencies finish. Note I first tried rewinding to `Pending`; the state machine deliberately rewinds to `Ready` and rejected it, which is what pointed at the real bug.
- **Worktree provisioning race**: the retry path called `remove_dir_all` on a path a concurrent provisioner may have just won, deleting a live worktree. It now only clears a leftover that is not a worktree (no `.git` entry). Verified against real git 2.50 that an existing empty directory is accepted, so the retry contract is unchanged.

## Verification

- Full Rust lib suite in the worktree: **1283 passed, 0 failed, 2 ignored**.
- 4 new tests: terminal announcement fires once, a working run announces nothing, a settled run reads terminal (exactly what the cancel guard consults), relaunch leaves a dependent task pending.
- Run-store vitest files pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com