### PR TITLE
fix(happy): keep the bridge authoritative over advertised agents (#3554, #3561)

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -330,7 +330,14 @@ export function deriveHappySessionTitle(text) {
   if (trimmed.length <= HAPPY_SESSION_TITLE_MAX_CHARS) return trimmed;
   const prefix = trimmed.slice(0, HAPPY_SESSION_TITLE_MAX_CHARS);
   const lastSpace = prefix.lastIndexOf(" ");
-  return `${lastSpace > 10 ? prefix.slice(0, lastSpace) : prefix}\u2026`;
+  let head = lastSpace > 10 ? prefix.slice(0, lastSpace) : prefix;
+  // Cutting by code unit can split an emoji or other astral character, leaving
+  // a lone surrogate that renders as a replacement glyph on the phone.
+  const finalCodeUnit = head.charCodeAt(head.length - 1);
+  if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+    head = head.slice(0, -1);
+  }
+  return `${head}\u2026`;
 }
 
 // Modes the provider runtimes accept. A remote peer may only move a session
@@ -2160,6 +2167,24 @@ export function createHappyLayer({
     }
   }
 
+  // The machine keep-alive rewrites cliAvailability from PATH probing when it
+  // connects and on every tick. Seren's agents are run by the desktop, not
+  // installed as PATH binaries, so that probe erases what the bridge
+  // advertises and the phone stops offering agents that work. The bridge is
+  // the authority on which agents exist, so its values survive every write.
+  function keepAdvertisedCliAvailability(client) {
+    const applyUpdate = client.updateMachineMetadata.bind(client);
+    client.updateMachineMetadata = (updater) =>
+      applyUpdate((metadata) => {
+        const next = updater(metadata);
+        if (!next || advertisedAgents.length === 0) return next;
+        return {
+          ...next,
+          cliAvailability: happyCliAvailability(advertisedAgents),
+        };
+      });
+  }
+
   async function updateCapabilities() {
     if (!machineClient || !source) return;
     const advertised = await source.advertise();
@@ -2549,6 +2574,7 @@ export function createHappyLayer({
       daemonState: { status: "running", pid: process.pid, startedAt: Date.now() },
     });
     machineClient = api.machineSyncClient(machine);
+    keepAdvertisedCliAvailability(machineClient);
     setupMachineHandlers();
     machineClient.connect();
     return true;

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -232,6 +232,10 @@ function normalizeSession(session) {
 // "ask" so approval prompts are never dropped silently.
 const CODEX_UNATTENDED_MODES = new Set(["auto", "bypassPermissions", "safe-yolo", "yolo"]);
 
+// Every mode the bridge accepts from mobile maps to one the target runtime
+// accepts. A mode that reaches a runtime it does not know throws, and the
+// bridge treats that throw as fatal — one mismatched value from a phone would
+// otherwise close the session's relay socket until the bridge restarts.
 export function providerPermissionMode(mode, agentType) {
   if (agentType === "codex") {
     return CODEX_UNATTENDED_MODES.has(mode) ? "auto" : "ask";
@@ -239,17 +243,21 @@ export function providerPermissionMode(mode, agentType) {
   if (agentType === "gemini") {
     return {
       default: "default",
+      ask: "default",
+      auto: "auto_edit",
       acceptEdits: "auto_edit",
       bypassPermissions: "yolo",
       plan: "plan",
       "read-only": "plan",
       "safe-yolo": "yolo",
       yolo: "yolo",
-    }[mode] ?? mode;
+    }[mode] ?? "default";
   }
   if (agentType === "grok") {
     return {
       default: "default",
+      ask: "default",
+      auto: "acceptEdits",
       auto_edit: "acceptEdits",
       acceptEdits: "acceptEdits",
       dontAsk: "dontAsk",
@@ -258,7 +266,20 @@ export function providerPermissionMode(mode, agentType) {
       "read-only": "plan",
       "safe-yolo": "bypassPermissions",
       yolo: "bypassPermissions",
-    }[mode] ?? mode;
+    }[mode] ?? "default";
+  }
+  if (agentType === "claude-code" || agentType === "claude-codex") {
+    return {
+      default: "default",
+      ask: "default",
+      auto: "acceptEdits",
+      acceptEdits: "acceptEdits",
+      plan: "plan",
+      "read-only": "plan",
+      "safe-yolo": "acceptEdits",
+      yolo: "bypassPermissions",
+      bypassPermissions: "bypassPermissions",
+    }[mode] ?? "default";
   }
   return mode;
 }

--- a/tests/unit/happy-bridge-permission-mode.test.ts
+++ b/tests/unit/happy-bridge-permission-mode.test.ts
@@ -63,4 +63,41 @@ describe("codex permission mode mapping", () => {
     }
     expect(isSupportedPermissionMode("nope")).toBe(false);
   });
+
+  it("maps every remote mode to one the target runtime accepts", () => {
+    // The modes each runtime will accept; anything else throws and the bridge
+    // treats that throw as fatal for the session.
+    const runtimeModes: Record<string, Set<string>> = {
+      "claude-code": new Set([
+        "default",
+        "acceptEdits",
+        "plan",
+        "bypassPermissions",
+      ]),
+      "claude-codex": new Set([
+        "default",
+        "acceptEdits",
+        "plan",
+        "bypassPermissions",
+      ]),
+      gemini: new Set(["default", "auto_edit", "yolo", "plan"]),
+      codex: new Set(["ask", "auto"]),
+    };
+
+    for (const [agentType, accepted] of Object.entries(runtimeModes)) {
+      for (const mode of REMOTE_MODES) {
+        expect(
+          accepted.has(providerPermissionMode(mode, agentType)),
+          `${agentType} rejects ${mode} -> ${providerPermissionMode(mode, agentType)}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("never leaves a read-only request able to edit", () => {
+    expect(providerPermissionMode("read-only", "claude-code")).toBe("plan");
+    expect(providerPermissionMode("read-only", "gemini")).toBe("plan");
+    expect(providerPermissionMode("read-only", "grok")).toBe("plan");
+    expect(providerPermissionMode("read-only", "codex")).toBe("ask");
+  });
 });

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -338,6 +338,9 @@ function createLayerHarness({
       if (!machineHandlers) throw new Error("machine handlers are not ready");
       return machineHandlers.spawnSession(options);
     },
+    // Captured before start() so it survives the layer wrapping the client's
+    // metadata writer to keep the bridge authoritative over cliAvailability.
+    machineMetadataWrites: machineClient.updateMachineMetadata,
     source,
     supervisorCall,
     supervisorNotify,
@@ -363,7 +366,7 @@ describe("Happy session liveness", () => {
 
     await harness.layer.start();
 
-    const update = harness.machineClient.updateMachineMetadata.mock.calls.at(-1)?.[0];
+    const update = harness.machineMetadataWrites.mock.calls.at(-1)?.[0];
     expect(update).toBeTypeOf("function");
     const metadata = update?.({ existing: "preserved" });
     expect(metadata).toMatchObject({
@@ -380,6 +383,28 @@ describe("Happy session liveness", () => {
         agents,
         roots: [SYNTHETIC_ROOT],
       },
+    });
+
+    // The relay client's own keep-alive rewrites cliAvailability from PATH
+    // probing, which never finds Seren's desktop-managed agents. The bridge
+    // stays authoritative no matter who writes.
+    await harness.machineClient.updateMachineMetadata(() => ({
+      cliAvailability: {
+        claude: false,
+        codex: false,
+        gemini: false,
+        openclaw: false,
+        agy: false,
+        detectedAt: 1,
+      },
+    }));
+    const probeWrite = harness.machineMetadataWrites.mock.calls.at(-1)?.[0];
+    expect(probeWrite?.({}).cliAvailability).toMatchObject({
+      claude: true,
+      codex: true,
+      agy: true,
+      gemini: true,
+      openclaw: false,
     });
 
     await harness.layer.close();

--- a/tests/unit/happy-session-title.test.ts
+++ b/tests/unit/happy-session-title.test.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Verifies mobile thread titles derived from a first prompt stay renderable.
+// ABOUTME: Protects word-boundary truncation and astral characters from being split.
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — the happy bridge layer is plain ESM without declarations.
+import { deriveHappySessionTitle } from "../../bin/happy-bridge/happy-layer.mjs";
+
+describe("happy session title", () => {
+  it("keeps a short prompt as-is and collapses whitespace", () => {
+    expect(deriveHappySessionTitle("  check\n the  ledger ")).toBe(
+      "check the ledger",
+    );
+  });
+
+  it("ignores non-string and empty input", () => {
+    expect(deriveHappySessionTitle(null)).toBeNull();
+    expect(deriveHappySessionTitle("   ")).toBeNull();
+  });
+
+  it("truncates on a word boundary", () => {
+    const title = deriveHappySessionTitle(
+      "investigate every unpaid invoice across the billing system",
+    );
+    expect(title.endsWith("…")).toBe(true);
+    expect(title).not.toMatch(/ …$/);
+  });
+
+  it("never leaves a lone surrogate before the ellipsis", () => {
+    // The 30th code unit lands inside the emoji's surrogate pair.
+    const title = deriveHappySessionTitle(`${"の".repeat(29)}🚀tail`);
+    expect(title.endsWith("…")).toBe(true);
+    expect(title).not.toContain("�");
+    for (const codeUnit of [...title].map((char) => char.codePointAt(0))) {
+      expect(codeUnit >= 0xd800 && codeUnit <= 0xdfff).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #3554. Closes #3561.

## #3554 (P1) — the root cause of #3542 was still live

The vendored relay SDK's `machineSyncClient` runs a keep-alive on connect and every 20s. On its first tick `lastKnownCLIAvailability` is null, so `cliAvailabilityChanged` is unconditionally true and it writes `cliAvailability` from PATH probing (`commandExists("agy")` — a binary that never exists on a Seren machine, since agents are run by the desktop). The bridge writes its own values once at startup and on roots changes; the SDK's write starts inside the connect handler and typically lands last, so the phone stopped offering Agy and Gemini again. `patches/happy@1.2.0.patch` does not touch this path (grep count: 0), and the existing tests mock `machineClient`, so nothing could see it.

**Fix:** the bridge wraps the client's metadata writer, so whoever initiates a write, the advertised agent list wins. That is the invariant #3541/#3543/#3545 assume — the desktop knows which agents exist, PATH does not. When nothing has been advertised yet the SDK's value passes through unchanged.

## #3561 (P2) — one bad permission mode killed a mobile thread permanently

The bridge gate accepts the union of every runtime's modes (`default, acceptEdits, plan, bypassPermissions, read-only, safe-yolo, yolo, ask, auto`) but `providerPermissionMode` fell through to `?? mode` for anything unmapped — `ask`/`auto` for gemini and grok, and everything non-Claude for claude-code. The runtime then throws, the queue treats that throw as fatal, adds the session to `failedSessions` (never cleared except by retirement), and the SDK permanently closes that session's relay socket.

**Fix:** the maps are total per agent, with the closest-meaning target. `read-only` maps to a mode that cannot edit on every agent (`plan`/`ask`), and unknown input falls back to `default` rather than passing through. No mode becomes more permissive than it was.

Also: `deriveHappySessionTitle` no longer leaves a lone high surrogate before the ellipsis (the sibling truncator `boundedMobileText` already guarded this; the title helper did not).

## Verification

- New test asserts every remote mode maps into each runtime's accepted set, and that `read-only` never becomes editable.
- The liveness test now also asserts an SDK-style PATH-derived write is overridden with the bridge's values — the regression guard the original bug lacked.
- New `happy-session-title` tests cover word-boundary truncation and astral characters.
- Full unit suite: **2827 passed, 3 skipped, 0 failed** (404 files).

## Not fixed here — needs your call

The vendored SDK auto-registers relay-invokable `bash`/`readFile`/`writeFile` RPC handlers on the machine client with **no path restriction** (`registerCommonHandlers(this.rpcHandlerManager, null)`). A paired phone can run arbitrary shell commands on the desktop, outside the ActionConfirmation flow. This shipped in v3.75.0 and earlier — it is not a regression — and it matches upstream Happy's design where the paired device is the user's own. Flagging it rather than silently accepting it.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com