### PR TITLE
fix(run): settle tasks the completion gate rejects (#3552, #3553)

### DIFF
--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -1548,7 +1548,11 @@ fn finish_attempt(
             json!({"outcome": outcome}),
         ),
     )?;
-    if outcome == "failed" && TaskState::parse(&task_state) == Some(TaskState::Running) {
+    // An attempt that did not complete leaves its task failed from whatever
+    // stage it reached. Without this a task whose agent produced nothing usable
+    // rests in review forever and its run never reaches a terminal state.
+    let task_settled = TaskState::parse(&task_state).is_some_and(TaskState::is_terminal);
+    if outcome != "completed" && !task_settled {
         store::transition_task(conn, &task_id, TaskState::Failed, None)
             .map_err(|error| error.to_string())?;
         append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Failed))?;

--- a/src-tauri/src/run/status.rs
+++ b/src-tauri/src/run/status.rs
@@ -34,9 +34,16 @@ pub fn is_legal_transition(from: TaskState, to: TaskState) -> bool {
                 | TaskState::Failed
                 | TaskState::Cancelled
         ),
+        // Failed is reachable from review: an attempt can satisfy verification
+        // and still miss the completion gate (no evidence-bearing finding), and
+        // that task has to be able to end rather than rest in review forever.
         TaskState::Review => matches!(
             to,
-            TaskState::Done | TaskState::Running | TaskState::Ready | TaskState::Cancelled
+            TaskState::Done
+                | TaskState::Running
+                | TaskState::Ready
+                | TaskState::Failed
+                | TaskState::Cancelled
         ),
         TaskState::Done | TaskState::Failed | TaskState::Cancelled => false,
     }

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -2,6 +2,7 @@
 // ABOUTME: It turns agent replies into durable findings, coverage gaps, and attempt results.
 
 import { createEffect, createRoot } from "solid-js";
+import { reportError } from "@/lib/support/hook";
 import {
   continueToolIteration,
   getActiveModel,
@@ -510,8 +511,9 @@ async function dispatchTask(
         task.title,
         "agent response did not contain a valid seren-findings block",
       );
+      // Nothing was produced, so there is nothing to verify. Ending the attempt
+      // here settles the task instead of parking it in the review lane.
       await runFinishAttempt(runId, attemptId, "parse_failed");
-      await runVerifyTask(runId, task.id);
       return;
     }
     for (const finding of parsed.findings) {
@@ -520,19 +522,38 @@ async function dispatchTask(
     for (const gap of parsed.coverage_gaps) {
       await runAddCoverageGap(toCoverageGap(runId, task.id, gap));
     }
-    await runFinishAttempt(runId, attemptId, "completed");
     await runVerifyTask(runId, task.id);
-    await runCompleteTask(runId, task.id);
-  } catch (error) {
-    if (attemptId) {
-      const detail = error instanceof Error ? error.message : String(error);
-      try {
-        await recordGap(runId, task.id, "other", task.title, detail);
-        await runFinishAttempt(runId, attemptId, "failed");
-      } catch {
-        // Preserve the original dispatch failure; the durable event loop may be stopping.
-      }
+    // The completion gate decides the attempt's outcome. Recording "completed"
+    // before asking would leave a rejected task sitting in review with its
+    // reasons discarded and its run unable to finish.
+    const blockers = await runCompleteTask(runId, task.id);
+    if (blockers.length > 0) {
+      await recordGap(
+        runId,
+        task.id,
+        "incomplete_evidence",
+        task.title,
+        `task did not meet the completion gate: ${blockers.join("; ")}`,
+      );
+      await runFinishAttempt(runId, attemptId, "failed");
+      return;
     }
+    await runFinishAttempt(runId, attemptId, "completed");
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    try {
+      await recordGap(runId, task.id, "other", task.title, detail);
+      if (attemptId) {
+        await runFinishAttempt(runId, attemptId, "failed");
+      }
+    } catch {
+      // Preserve the original dispatch failure; the durable event loop may be stopping.
+    }
+    // A failure before the attempt exists used to disappear entirely, leaving
+    // the task ready and the effect retrying it on every snapshot change.
+    reportError("run.task_dispatch_failed", `task ${task.id}: ${detail}`, {
+      cause: error,
+    });
   } finally {
     // A task owns its agent session for the length of the task. Holding it
     // open afterwards would keep an admission slot and a live CLI process for

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -127,6 +127,16 @@ async function hydrateLatest(): Promise<void> {
   }
 }
 
+// Events are applied one at a time. Each handler may await a hydrate, and two
+// interleaved hydrates can finish out of order — writing back a lower sequence
+// and an older snapshot over a newer one.
+let applyQueue: Promise<void> = Promise.resolve();
+
+function enqueueEvent(event: RunEvent): Promise<void> {
+  applyQueue = applyQueue.then(() => applyEvent(event)).catch(() => {});
+  return applyQueue;
+}
+
 async function applyEvent(event: RunEvent): Promise<void> {
   if (state.activeRunId && event.run_id !== state.activeRunId) return;
   if (event.sequence <= state.lastSequence) return;
@@ -167,6 +177,16 @@ async function applyEvent(event: RunEvent): Promise<void> {
   setState("lastSequence", event.sequence);
 }
 
+const OBJECTIVE_TASK_TITLE_MAX = 80;
+
+export function objectiveTaskTitle(objective: string): string {
+  const collapsed = objective.trim().replace(/\s+/g, " ");
+  if (collapsed.length <= OBJECTIVE_TASK_TITLE_MAX) return collapsed;
+  const head = collapsed.slice(0, OBJECTIVE_TASK_TITLE_MAX);
+  const lastSpace = head.lastIndexOf(" ");
+  return `${lastSpace > 20 ? head.slice(0, lastSpace) : head}…`;
+}
+
 async function launch(options: LaunchOptions): Promise<void> {
   const trimmedObjective = options.objective.trim();
   if (!trimmedObjective) {
@@ -179,10 +199,19 @@ async function launch(options: LaunchOptions): Promise<void> {
     for (const agentType of options.agents) {
       await runAddAgent(run.id, agentType);
     }
+    let taskCount = 0;
     for (const task of options.tasks) {
       const title = task.title.trim();
       if (!title) continue;
       await runAddTask(run.id, title, task.brief.trim());
+      taskCount += 1;
+    }
+    // Task slots live behind Advanced controls, so the primary flow is an
+    // objective on its own. Without a task there is nothing to dispatch and the
+    // run sits at "running" with empty lanes forever, so the objective itself
+    // becomes the work.
+    if (taskCount === 0) {
+      await runAddTask(run.id, objectiveTaskTitle(trimmedObjective), trimmedObjective);
     }
     setState("activeRunId", run.id);
     await hydrate(run.id);
@@ -274,7 +303,7 @@ export const runStore = {
   },
   hydrate,
   hydrateLatest,
-  applyEvent,
+  applyEvent: enqueueEvent,
   launch,
   cancel,
   relaunch,

--- a/tests/unit/run-launch-objective-task.test.ts
+++ b/tests/unit/run-launch-objective-task.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Verifies the objective-only launch path still produces dispatchable work.
+// ABOUTME: Protects the primary Mission Control flow where task slots stay collapsed.
+
+import { describe, expect, it } from "vitest";
+import { objectiveTaskTitle } from "@/stores/run.store";
+
+describe("objective task title", () => {
+  it("keeps a short objective intact", () => {
+    expect(objectiveTaskTitle("  Find every stalled invoice  ")).toBe(
+      "Find every stalled invoice",
+    );
+  });
+
+  it("collapses whitespace", () => {
+    expect(objectiveTaskTitle("Find\n  every\tstalled invoice")).toBe(
+      "Find every stalled invoice",
+    );
+  });
+
+  it("truncates a long objective on a word boundary", () => {
+    const objective =
+      "Investigate every unpaid invoice across the billing system and the ledger exports and report which customers are affected";
+    const title = objectiveTaskTitle(objective);
+    expect(title.length).toBeLessThanOrEqual(81);
+    expect(title.endsWith("…")).toBe(true);
+    expect(title).not.toContain("  ");
+    expect(objective.startsWith(title.slice(0, -1))).toBe(true);
+  });
+
+  it("truncates a single long word without leaving an empty title", () => {
+    const title = objectiveTaskTitle("x".repeat(200));
+    expect(title).toBe(`${"x".repeat(80)}…`);
+  });
+});

--- a/tests/unit/run-store-events.test.ts
+++ b/tests/unit/run-store-events.test.ts
@@ -158,6 +158,34 @@ describe("run store event handling", () => {
     expect(runState.lastSequence).toBe(3);
   });
 
+  it("applies concurrent events in order without regressing the sequence", async () => {
+    const first = snapshot();
+    first.tasks[0].state = "verifying";
+    const second = snapshot();
+    second.tasks[0].state = "review";
+    // The earlier event's hydrate resolves last, mimicking two interleaved
+    // in-flight hydrates.
+    getStateMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(first), 20)),
+      )
+      .mockResolvedValueOnce(second);
+    setRunState({
+      activeRunId: "run-1",
+      snapshot: snapshot(),
+      lastSequence: 1,
+    });
+
+    await Promise.all([
+      runStore.applyEvent(event(3, "task_state_changed")),
+      runStore.applyEvent(event(5, "task_state_changed")),
+    ]);
+
+    expect(runState.lastSequence).toBe(5);
+    expect(runState.snapshot?.tasks[0].state).toBe("review");
+  });
+
   it("groups lanes and exposes findings that need operator review", () => {
     setRunState({
       activeRunId: "run-1",


### PR DESCRIPTION
Closes #3552. Closes #3553. Also fixes two more items from #3559.

## #3552 (P1) — tasks stranded in review, runs that could never finish

Two paths parked a task in the review lane with no way out:

1. **Unparseable reply** — the dispatcher recorded a gap, finished the attempt `parse_failed`, then called `runVerifyTask`, moving the task Running → Verifying → Review and returning.
2. **Rejected completion** — it finished the attempt `"completed"`, verified, then called `runCompleteTask` and **discarded its returned blockers**. The backend recorded `TaskCompletionRejected`, but `run.store.ts` has no branch for that event and no UI renders it, so the reasons were invisible.

`Review` is non-terminal, so the run stayed `running` forever and `hydrateLatest` re-selected it on every startup.

**Root cause, once I looked at the state machine:** `Review` had no edge to `Failed` — Done, Running, Ready, Cancelled only. There was literally no way for a reviewed task to end unsuccessfully. That missing edge is why these runs strand, so I added it rather than working around it.

With that in place:
- The unparseable path stops calling verify — nothing was produced, so there is nothing to verify — and the finished attempt settles the task.
- The happy path verifies, then asks the gate, and **the gate decides the outcome**: blockers → a coverage gap naming them plus a `failed` attempt; otherwise `completed`.
- `finish_attempt` fails its task from any non-terminal state when the outcome is not `completed` (previously only from `Running`).

A failed task is skipped by relaunch, consistent with how lease failures and attempt failures already behave.

## #3553 (P1) — objective-only launches did nothing

Task slots live inside a collapsed `<details>` "Advanced controls", and `runAddTask` was only called from that slot loop — no decomposer is wired to the run engine. So the primary flow (type objective → Start mission) created a run with agent assignments, **zero tasks**, empty lanes, and `running` forever, despite launch copy promising to break the objective into observable work. Now the objective becomes the task when no slot is filled, with a word-boundary-truncated title.

## From #3559

- **Event ordering**: `applyEvent` calls are serialized through a queue. Two interleaved handlers that both awaited a hydrate could resolve out of order, writing back a lower `lastSequence` and an older snapshot.
- **Silent dispatch swallow**: a failure before the attempt existed was dropped entirely — no log, no gap, no UI signal — while the effect retried on every snapshot change. It now reports through the support pipeline. (Worth noting: my first attempt used a plain `console.error` and the #2864 invariant test caught it, which is the test doing exactly its job.)

## Verification

- Full unit suite: **2825 passed, 3 skipped, 0 failed**, including the #2864 console-error invariant.
- Rust run-module tests: **43 passed, 0 failed**.
- New tests: concurrent out-of-order hydrates settle on the newest snapshot; objective-title truncation (word boundary, whitespace collapse, single-long-word).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com