### PR TITLE
fix(windows): quote cmd.exe launches and point the block somewhere (#3555, #3557, #3571)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -399,13 +399,14 @@ async function ensureGlobalNpmPackage({ emit, command, packageName, label }) {
       );
     });
   } else {
-    // Fallback: try npm directly (works in dev where symlinks are intact,
-    // and on Windows where npm.cmd is a valid batch file).
+    // Fallback: try npm directly, for a dev checkout where symlinks are intact.
+    // Node refuses to exec a .cmd shim without a shell, so Windows needs one.
     const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
     await new Promise((resolvePromise, rejectPromise) => {
       execFile(
         npmCommand,
         ["install", "-g", packageName],
+        { shell: process.platform === "win32" },
         (error, stdout, stderr) => {
           if (error) {
             rejectPromise(new Error(stderr || error.message));

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -23,6 +23,7 @@ import {
   DEFAULT_CLAUDE_EFFORT,
 } from "./effort.mjs";
 import { updatePeakInputTokens } from "./usage.mjs";
+import { composeWindowsShellCommand } from "./windows-shell-args.mjs";
 import { binaryRunsOnHost } from "./agent-registry.mjs";
 import { chooseUpdatedModelId, inferCurrentModelId } from "./model-resolution.mjs";
 import {
@@ -243,10 +244,23 @@ function buildClaudeSpawnInvocation({
     };
   }
 
+  const shell = resolveSpawnShell(claudeBin);
+  if (shell) {
+    // cmd.exe joins the command line with spaces and no per-argument quoting,
+    // so an unquoted path containing a space — a Windows username in the temp
+    // directory is enough — splits one argument into two and the launch fails
+    // or silently drops its MCP config.
+    return {
+      command: composeWindowsShellCommand(claudeBin, claudeArgs),
+      args: [],
+      shell,
+    };
+  }
+
   return {
     command: claudeBin,
     args: claudeArgs,
-    shell: resolveSpawnShell(claudeBin),
+    shell: false,
   };
 }
 

--- a/bin/browser-local/cli-scanner.mjs
+++ b/bin/browser-local/cli-scanner.mjs
@@ -100,6 +100,8 @@ export async function npmPackToDirectory({
       : "npm";
   const { stdout } = await execFileAsync(exec, args, {
     timeout: NPM_PACK_TIMEOUT_MS,
+    // Node refuses to exec a .cmd shim without a shell.
+    shell: !npmCliScript && process.platform === "win32",
   });
   // npm pack prints the tarball filename on the last non-empty stdout line.
   const filename = stdout

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -236,7 +236,8 @@ export async function runNpmView(packageName, { npmCliScript } = {}) {
     const { stdout } = await execFileAsync(
       npmCommand,
       ["view", packageName, "version"],
-      { timeout: NPM_VIEW_TIMEOUT_MS },
+      // Node refuses to exec a .cmd shim without a shell.
+      { timeout: NPM_VIEW_TIMEOUT_MS, shell: process.platform === "win32" },
     );
     return stdout.trim();
   } catch {
@@ -262,7 +263,8 @@ async function runNpmInstallLatest(packageName, { npmCliScript } = {}) {
   await execFileAsync(
     npmCommand,
     ["install", "-g", `${packageName}@latest`],
-    { timeout: NPM_INSTALL_TIMEOUT_MS },
+    // Node refuses to exec a .cmd shim without a shell.
+    { timeout: NPM_INSTALL_TIMEOUT_MS, shell: process.platform === "win32" },
   );
 }
 
@@ -284,7 +286,8 @@ async function runNpmInstallFromTarball(tarballPath, { npmCliScript } = {}) {
   await execFileAsync(
     npmCommand,
     ["install", "-g", tarballPath],
-    { timeout: NPM_INSTALL_TIMEOUT_MS },
+    // Node refuses to exec a .cmd shim without a shell.
+    { timeout: NPM_INSTALL_TIMEOUT_MS, shell: process.platform === "win32" },
   );
 }
 
@@ -394,6 +397,8 @@ export async function runNpmViewIntegrity(
         : "npm";
     const { stdout } = await execFileAsync(command, args, {
       timeout: NPM_VIEW_TIMEOUT_MS,
+      // Node refuses to exec a .cmd shim without a shell.
+      shell: !npmCliScript && process.platform === "win32",
     });
     const trimmed = stdout.trim();
     if (!trimmed) return null;

--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -33,7 +33,7 @@ const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
 const SEREN_APP_IDENTIFIER: &str = "com.serendb.desktop";
 
 #[cfg(target_os = "windows")]
-const WINDOWS_BOUNDED_UNAVAILABLE: &str = "Bounded local Claude Code sessions are blocked on native Windows because the current restricted-token backend cannot prevent reads outside the selected project. Select Full Access only if you accept unconfined file and network access.";
+const WINDOWS_BOUNDED_UNAVAILABLE: &str = "Bounded local Claude Code sessions are blocked on native Windows because the current restricted-token backend cannot prevent reads outside the selected project. Open Settings > Agent > Sandbox Mode and select Full Access only if you accept unconfined file and network access. Codex, Gemini, and Grok are unaffected and launch normally.";
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind")]

--- a/tests/unit/claude-sandbox-spawn.test.ts
+++ b/tests/unit/claude-sandbox-spawn.test.ts
@@ -186,4 +186,47 @@ describe("Claude bounded spawn boundary (#3192)", () => {
       });
     });
   });
+
+  it("quotes every argument when Windows launches a .cmd shim through cmd.exe", () => {
+    withWindows(() => {
+      const invocation = buildClaudeSpawnInvocation({
+        claudeBin: "C:\\Users\\First Last\\AppData\\Roaming\\npm\\claude.cmd",
+        claudeArgs: [
+          "--mcp-config",
+          "C:\\Users\\First Last\\AppData\\Local\\Temp\\seren-mcp-1.json",
+          "--strict-mcp-config",
+        ],
+        sandboxMode: "full-access",
+        sandboxProfile: null,
+      });
+
+      expect(invocation.shell).toBe("cmd.exe");
+      expect(invocation.args).toEqual([]);
+      // cmd.exe joins on spaces, so each argument carries its own quotes or a
+      // path containing a space splits into two arguments.
+      expect(invocation.command).toBe(
+        '"C:\\Users\\First Last\\AppData\\Roaming\\npm\\claude.cmd" ' +
+          '"--mcp-config" ' +
+          '"C:\\Users\\First Last\\AppData\\Local\\Temp\\seren-mcp-1.json" ' +
+          '"--strict-mcp-config"',
+      );
+    });
+  });
+
+  it("launches a native Windows executable without a shell", () => {
+    withWindows(() => {
+      expect(
+        buildClaudeSpawnInvocation({
+          claudeBin: "C:\\Program Files\\claude\\claude.exe",
+          claudeArgs: ["--version"],
+          sandboxMode: "full-access",
+          sandboxProfile: null,
+        }),
+      ).toEqual({
+        command: "C:\\Program Files\\claude\\claude.exe",
+        args: ["--version"],
+        shell: false,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #3557. Closes #3571. Closes #3555.

## #3557 (P1) — Windows paths with spaces broke the Claude launch

`resolveSpawnShell` returns `"cmd.exe"` for a `.cmd` shim, and Node's shell mode joins command + args with spaces and **no per-argument quoting**. `os.tmpdir()` on a machine whose username contains a space is `C:\Users\First Last\AppData\Local\Temp`, so `--mcp-config <that path>` split into two arguments — the launch breaks or silently drops its MCP config.

The repo already had the right helper (`composeWindowsShellCommand`), wired only to the Codex spawn. It now covers the Claude `.cmd` path too. Native `claude.exe` still spawns with `shell: false` and is untouched, which is why the e2e never caught this.

Verified the real output before relying on it:
```
"C:\Users\First Last\...\claude.cmd" "--mcp-config" "C:\Users\First Last\...\seren-mcp-1.json" "--strict-mcp-config"
```

## #3571 (P2) — npm .cmd fallbacks threw EINVAL

Node has refused to `execFile` a `.cmd`/`.bat` without `shell: true` since the CVE-2024-27980 release. Five call sites in `agent-registry.mjs`, `cli-scanner.mjs`, and `cli-updater.mjs` passed `npm.cmd` with no shell; these are exactly the fallbacks used when the embedded `npm-cli.js` is missing, so a broken runtime produced `EINVAL` instead of a diagnosable npm error. (`agent-registry.mjs:810` already did this correctly and is untouched.)

## #3555 (P0-Windows) — read this one carefully

**I did not change the default sandbox mode and did not weaken the block.** Bounded really is unsafe on the current Windows backend, and `scripts/windows-e2e-app.mjs` asserts the bounded spawn fails. What changed is that the dead end is now navigable: the message names the exact path (Settings > Agent > Sandbox Mode > Full Access) and states that Codex, Gemini, and Grok are unaffected.

I **appended** to the message rather than rewriting it, because the Windows e2e greps for `"Agent launch blocked: the trusted sandbox launch spec failed"` and `"cannot prevent reads outside the selected project"`, and per our own operating notes that harness can only be validated by a real tag-driven release. Both substrings are intact, verified by grep; the existing Rust assertion at `sandbox.rs:365` still passes.

**This makes the failure actionable, not absent.** A fresh Windows user's first "New Agent → Claude Code" still fails; they are now told exactly what to do about it. If you want a launch-time prompt offering the switch instead, that is new UI on a security-consent flow and I'd rather you choose it deliberately than have me add it unasked.

## Verification

- Full unit suite: **2834 passed, 3 skipped, 0 failed** (405 files).
- Rust sandbox tests pass.
- 2 new tests: every argument quoted for a `.cmd` launch with spaces in both the binary and the temp path; a native `.exe` still launches with no shell.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com