### PR TITLE
fix(auth): keep session tokens on the Gateway and repairs consistent (#3562, #3563, #3564, #3565, #3559)

### DIFF
--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -866,6 +866,14 @@ async fn execute_single_task(
                                 if let WorkerEvent::Error { ref message } = worker_event {
                                     captured_error = Some(message.clone());
                                 }
+                                // A worker that goes on to complete has
+                                // recovered: some forward intermediate errors
+                                // and keep streaming. Holding the earlier error
+                                // would reject a turn that produced a real
+                                // answer, blanking it in the conversation.
+                                if matches!(worker_event, WorkerEvent::Complete { .. }) {
+                                    captured_error = None;
+                                }
                                 let worker_event =
                                     guard_completion(&app_for_events, &conv_id, worker_event);
                                 if matches!(worker_event, WorkerEvent::Complete { .. }) {

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -504,6 +504,25 @@ fn tail_output(output: Vec<u8>) -> String {
     String::from_utf8_lossy(&output[start..]).to_string()
 }
 
+/// The repository a worktree belongs to, read from the worktree itself. The
+/// run's recorded root can differ from where the worktree was provisioned, and
+/// removing from the wrong repository fails and leaks the directory.
+fn worktree_owner(root: &Path) -> Option<PathBuf> {
+    let output = hidden_command("git")
+        .current_dir(root)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let common_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if common_dir.is_empty() {
+        return None;
+    }
+    PathBuf::from(common_dir).parent().map(Path::to_path_buf)
+}
+
 pub fn release(
     root: &Path,
     source_repo: Option<&Path>,
@@ -514,7 +533,10 @@ pub fn release(
             if !root.exists() {
                 return Ok(());
             }
-            let source_repo = source_repo
+            let owner = worktree_owner(root);
+            let source_repo = owner
+                .as_deref()
+                .or(source_repo)
                 .ok_or_else(|| "worktree release requires source repository".to_string())?;
             let output = hidden_command("git")
                 .current_dir(source_repo)
@@ -594,6 +616,39 @@ mod tests {
         fs::write(root.join("tracked.txt"), "initial\n").unwrap();
         git_command(root, &["add", "tracked.txt"]);
         git_command(root, &["commit", "-m", "initial"]);
+    }
+
+    #[test]
+    fn releasing_a_worktree_finds_its_own_repository() {
+        let source = tempfile::tempdir().unwrap();
+        let workspaces = tempfile::tempdir().unwrap();
+        make_git_repo(source.path());
+
+        let provisioned = provision(&request(
+            "run-release",
+            "task-release",
+            "release me",
+            LeaseMode::Worktree,
+            Some(source.path().to_path_buf()),
+            workspaces.path(),
+        ))
+        .unwrap();
+        assert!(provisioned.root_path.exists());
+
+        // A run whose recorded root is not the provisioning repository — the
+        // lease never stored where it actually came from. Releasing must still
+        // remove the worktree rather than fail and leak it.
+        let unrelated = tempfile::tempdir().unwrap();
+        make_git_repo(unrelated.path());
+
+        release(
+            &provisioned.root_path,
+            Some(unrelated.path()),
+            LeaseMode::Worktree,
+        )
+        .unwrap();
+
+        assert!(!provisioned.root_path.exists());
     }
 
     fn test_db() -> Connection {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -2,7 +2,11 @@
 // ABOUTME: Uses Tauri HTTP plugin when available, falls back to browser fetch.
 
 import { getToken } from "./tauri-bridge";
-import { getTauriFetch, shouldSkipRefresh } from "./tauri-fetch";
+import {
+  getTauriFetch,
+  isGatewayApiRequest,
+  shouldSkipRefresh,
+} from "./tauri-fetch";
 
 /**
  * Make an HTTP request using the appropriate fetch for the environment.
@@ -23,8 +27,12 @@ export async function appFetch(
     const request = baseRequest.clone();
     const response = await fetchFn(request);
 
+    // Only the Seren Gateway gets a refreshed Seren session token. A 401 from
+    // a third-party host must never cause the user's token to be attached to a
+    // retry aimed at that host.
     if (
       response.status === 401 &&
+      isGatewayApiRequest(request) &&
       !shouldSkipRefresh(request) &&
       !refreshedForRequest
     ) {

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -92,6 +92,11 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
         if (repaired.warning) {
           console.warn(`[Auth Store] ${repaired.warning}`);
         }
+        // Repair revokes the old key. The gateway caches its authenticated
+        // connection and tool list for ten minutes, so without reconnecting
+        // here a mid-session repair leaves every MCP tool call answering 401
+        // until that cache expires.
+        await resetGateway();
       } else {
         verboseRuntimeConsole.debug(
           "[Auth Store] Stored API key scopes are current",

--- a/tests/unit/fetch-retry.test.ts
+++ b/tests/unit/fetch-retry.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getToken: vi.fn<() => Promise<string | null>>(),
   getTauriFetch: vi.fn<() => Promise<typeof globalThis.fetch>>(),
   shouldSkipRefresh: vi.fn<(input: RequestInfo | URL) => boolean>(),
+  isGatewayApiRequest: vi.fn<(input: RequestInfo | URL) => boolean>(),
   refreshAccessToken: vi.fn<() => Promise<boolean>>(),
 }));
 
@@ -17,6 +18,7 @@ vi.mock("@/lib/tauri-bridge", () => ({
 vi.mock("@/lib/tauri-fetch", () => ({
   getTauriFetch: mocks.getTauriFetch,
   shouldSkipRefresh: mocks.shouldSkipRefresh,
+  isGatewayApiRequest: mocks.isGatewayApiRequest,
 }));
 
 vi.mock("@/services/auth", () => ({
@@ -29,9 +31,11 @@ describe("fetch retry behavior", () => {
     mocks.getToken.mockReset();
     mocks.getTauriFetch.mockReset();
     mocks.shouldSkipRefresh.mockReset();
+    mocks.isGatewayApiRequest.mockReset();
     mocks.refreshAccessToken.mockReset();
 
     mocks.shouldSkipRefresh.mockReturnValue(false);
+    mocks.isGatewayApiRequest.mockReturnValue(true);
   });
 
   it("appFetch retries once with refreshed bearer token", async () => {
@@ -57,6 +61,27 @@ describe("fetch retry behavior", () => {
     expect(firstRequest.headers.get("Authorization")).toBe("Bearer old-token");
     expect(secondRequest.headers.get("Authorization")).toBe("Bearer new-token");
     expect(response.status).toBe(200);
+  });
+
+  it("never sends a refreshed Seren token to a third-party host", async () => {
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+    mocks.getTauriFetch.mockResolvedValue(fetchMock);
+    mocks.isGatewayApiRequest.mockReturnValue(false);
+    mocks.refreshAccessToken.mockResolvedValue(true);
+    mocks.getToken.mockResolvedValue("seren-session-token");
+
+    const { appFetch } = await import("@/lib/fetch");
+    const response = await appFetch("https://openrouter.ai/api/v1/models");
+
+    // No refresh, no retry, and nothing carrying the user's session token.
+    expect(mocks.refreshAccessToken).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(request.headers.get("Authorization")).toBeNull();
+    expect(response.status).toBe(401);
   });
 
   it("appFetch does not retry when endpoint is in refresh skip list", async () => {

--- a/tests/unit/validation-app-ready.test.ts
+++ b/tests/unit/validation-app-ready.test.ts
@@ -30,6 +30,7 @@ describe("validation app-ready scenario", () => {
     await runAppReady({
       client,
       artifactsDir: "/unused",
+      validationHome: "/unused",
       writeArtifact,
     });
 


### PR DESCRIPTION
Closes #3562. Closes #3563. Closes #3564. Closes #3565. Closes #3559.

## #3564 (P2, security) — a third-party 401 could receive the user's Seren token

`appFetch` retried **any** 401 after refreshing the Seren session, setting `Authorization: Bearer <seren token>` on the retry. `shouldSkipRefresh` only inspects the path (`/auth/login`, `/auth/refresh`, `/auth/signup`), never the host. #3483 routed `openrouter.ai/api/v1/models` through `appFetch`, adding a third-party host to that path.

The refresh-retry is now gated on `isGatewayApiRequest` — a helper that already existed and was already exported. New test: a 401 from `openrouter.ai` triggers no refresh, no retry, and carries no Authorization header.

## #3562 (P2) — Desktop API key repair left the gateway on a revoked key

The Settings-panel repair calls `resetGateway()`; the automatic repair in `ensureApiKey` did not. `initializeGateway` short-circuits on a valid cache (10-minute TTL), so a mid-session repair — which revokes the old key — left every MCP tool call answering 401 until expiry. The auto-repair now resets the gateway too. Startup-path upgraders were never affected, since repair completes before the first connect.

The other two items in #3562 are recorded as accepted rather than fixed:
- **Downgrade/re-upgrade precedence**: needs a value comparison across storage backends; the blast radius is a rollback-then-upgrade, and I did not want to change credential precedence rules under release pressure without your call.
- **Startup revocation sweep serialization**: real, but the ledger on this machine holds 11 records and the stall only appears on a degraded network. Changing reaper concurrency touches revocation ordering — deliberately out of scope for a release-blocking fix.

Say the word and I'll take either on.

## #3563 (P2) — a recovered turn had its answer blanked

`execute_single_task` captured any `WorkerEvent::Error` and never cleared it. #3497 changed the non-transient exit from `break` to `return Err`, so a worker that forwarded an intermediate error and then completed successfully (both `cloud_agent_worker` and `provider_worker` do this) had its turn rejected — the answer rendered, then `handleError` patched the completed row to `status: "error"` with empty content. A `Complete` event now clears the captured error, since a worker that completes has recovered.

## #3559 final item — releasing a worktree from the wrong repository

`run_release_workspace` derived the git repo from `run.root_path`; the lease never stored where it was actually provisioned. If they differed, `git worktree remove` ran in the wrong repo, errored, and left the lease active with the directory leaked. Release now asks the worktree which repository owns it (`rev-parse --path-format=absolute --git-common-dir`), falling back to the passed path. Verified against real git 2.50 before relying on it. New test provisions a real worktree, passes a **different** repo as the source, and asserts it is still removed.

With this, all eight items in #3559 are fixed.

## #3565 (P2) — tsc drift

`validation-app-ready.test.ts` was missing `validationHome` after #3510 added it to `ScenarioContext`. Confirmed clean with `tsc --noEmit`.

## Verification

- Rust: orchestrator **322 passed**, workspace **8 passed**, both 0 failed.
- Full unit suite green; `fetch-retry` and `validation-app-ready` pass.
- Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com