### PR TITLE
chore(lint): keep scratch artifacts out of the lint scope (#3574)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "**/index.html",
       "**/vite.config.ts",
       "!**/.worktrees/**/*",
+      "!**/artifacts/**/*",
       "!**/src/api/generated/**/*",
       "!**/src-tauri/target/**/*",
       "!**/mcp-servers"


### PR DESCRIPTION
Closes #3574.

`biome.json` includes `**/src/**/*`, which matches **any** nested `src` directory — including `artifacts/validation-home/slot1422/.codex/.tmp/plugins/plugins/plugin-eval/src/`, dependency code a validation walkthrough drops there. `artifacts/` is gitignored, so CI never sees it, but locally `pnpm check` exits 1 against third-party scratch.

## What this actually uncovered

Biome caps diagnostics. The scratch noise was **filling that budget**, so `pnpm check` reported only `artifacts/` paths and nothing else. With `artifacts/` excluded, 20 real diagnostics appear in tracked files: 17 `lint/style/noNonNullAssertion` and 3 `lint/complexity/useOptionalChain` in `src/components/{chat,employees,session}`.

**Being precise about what that does and does not mean:**
- Those files were **not** touched by this release. `SessionContent.tsx`'s last change is #1468.
- **CI runs `pnpm lint`, not `pnpm check`** (`.github/workflows/ci.yml:81`), and I verified `pnpm lint` exits **0** on current main. The release gate is green and always was.
- So this PR does not turn `pnpm check` green — it makes the remaining red *real and actionable* instead of scratch noise.

I deliberately did **not** run `biome check --fix` over those 20. They are all auto-fixable, but rewriting three untouched component files hours before a tag is exactly the kind of unrelated churn that turns a clean release into a bisect. Worth its own PR after v3.76.0.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com