### PR TITLE
fix(windows): launch the agent on first run instead of refusing (#3577)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -99,7 +99,11 @@ import { openExternalLink } from "@/lib/external-link";
 import { runtimeHasCapability } from "@/lib/runtime";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { estimateTokens } from "@/lib/token-counter";
-import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
+import {
+  getEnabledMcpServers,
+  resolveAgentSandboxMode,
+  settingsStore,
+} from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 // @ts-expect-error — shared provider-runtime ESM has no generated declaration.
 import { serenMcpToolName } from "../../bin/browser-local/seren-mcp-contract.mjs";
@@ -3472,7 +3476,9 @@ export const agentStore = {
         const info = await providerService.spawnAgent(
           resolvedAgentType,
           cwd,
-          settingsStore.settings.agentSandboxMode,
+          // Resolved at spawn so the agent starts on every platform, including
+          // one where the stored mode has no working containment backend.
+          resolveAgentSandboxMode(settingsStore.settings.agentSandboxMode),
           serenCredential,
           approvalPolicy,
           settingsStore.settings.agentSearchEnabled,

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -3,6 +3,7 @@
 
 import { createStore } from "solid-js/store";
 import type { McpServerConfig, McpSettings } from "@/lib/mcp/types";
+import { isWindowsPlatform } from "@/lib/platform";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 
 const SETTINGS_STORE = "settings.json";
@@ -230,6 +231,32 @@ export interface ToolsetSettings {
 }
 
 /**
+ * The sandbox mode an agent can actually launch under on this platform.
+ *
+ * Windows has no working bounded backend — the restricted token cannot prevent
+ * reads outside the selected project, so every bounded mode is refused at the
+ * launch-spec boundary. Defaulting Windows to a bounded mode therefore does not
+ * produce a contained agent, it produces an agent that will not start. Full
+ * access is the only mode that runs there. macOS (Seatbelt) and Linux
+ * (Landlock) keep real containment as their default.
+ */
+export function defaultAgentSandboxMode(): Settings["agentSandboxMode"] {
+  return isWindowsPlatform() ? "full-access" : "workspace-write";
+}
+
+/**
+ * Resolves a stored preference to one this platform can launch. A Windows
+ * install carrying a bounded mode — the old default, or a choice made before
+ * this build — cannot start any agent, so it resolves to the mode that works.
+ */
+export function resolveAgentSandboxMode(
+  mode: Settings["agentSandboxMode"],
+): Settings["agentSandboxMode"] {
+  if (isWindowsPlatform() && mode !== "full-access") return "full-access";
+  return mode;
+}
+
+/**
  * Default settings values.
  */
 const DEFAULT_SETTINGS: Settings = {
@@ -286,7 +313,7 @@ const DEFAULT_SETTINGS: Settings = {
   historySyncDatabaseName: null,
   historySyncLastSyncedAt: null,
   // Agent
-  agentSandboxMode: "workspace-write",
+  agentSandboxMode: defaultAgentSandboxMode(),
   agentApprovalPolicy: "on-request",
   agentSearchEnabled: true,
   agentNetworkEnabled: true,
@@ -375,7 +402,11 @@ async function loadAppSettings(): Promise<void> {
 
     if (stored) {
       const parsed = JSON.parse(stored) as Partial<Settings>;
-      setSettingsState("app", { ...DEFAULT_SETTINGS, ...parsed });
+      const merged = { ...DEFAULT_SETTINGS, ...parsed };
+      merged.agentSandboxMode = resolveAgentSandboxMode(
+        merged.agentSandboxMode,
+      );
+      setSettingsState("app", merged);
     }
   } catch {
     // Use defaults if loading fails

--- a/tests/unit/agent-credential-lease-wiring.test.ts
+++ b/tests/unit/agent-credential-lease-wiring.test.ts
@@ -43,7 +43,7 @@ describe("agent session credential leases (#3194, #3504)", () => {
     // providerService.spawnAgent takes the brokered credential in the slot the
     // raw key used to occupy.
     expect(bodyAfter("async spawnSession(", 30_000)).toMatch(
-      /agentSandboxMode,\s*\n\s*serenCredential,/,
+      /agentSandboxMode\),\s*\n\s*serenCredential,/,
     );
   });
 

--- a/tests/unit/windows-sandbox-default.test.ts
+++ b/tests/unit/windows-sandbox-default.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Guards that a Windows install can always launch an agent on first run.
+// ABOUTME: Bounded modes have no working backend there, so they must resolve to one that runs.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function withPlatform<T>(
+  platform: string,
+  run: (mod: typeof import("@/stores/settings.store")) => T | Promise<T>,
+): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(navigator, "platform");
+  Object.defineProperty(navigator, "platform", {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    vi.resetModules();
+    const mod = await import("@/stores/settings.store");
+    return await run(mod);
+  } finally {
+    if (original) Object.defineProperty(navigator, "platform", original);
+  }
+}
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("agent sandbox mode per platform", () => {
+  it("defaults Windows to the only mode that can launch", async () => {
+    await withPlatform("Win32", ({ defaultAgentSandboxMode }) => {
+      expect(defaultAgentSandboxMode()).toBe("full-access");
+    });
+  });
+
+  it("keeps real containment as the default off Windows", async () => {
+    for (const platform of ["MacIntel", "Linux x86_64"]) {
+      await withPlatform(platform, ({ defaultAgentSandboxMode }) => {
+        expect(defaultAgentSandboxMode()).toBe("workspace-write");
+      });
+    }
+  });
+
+  it("resolves an unlaunchable stored Windows preference to one that runs", async () => {
+    await withPlatform("Win32", ({ resolveAgentSandboxMode }) => {
+      // These are the values an upgrader carries in from an older build.
+      expect(resolveAgentSandboxMode("workspace-write")).toBe("full-access");
+      expect(resolveAgentSandboxMode("read-only")).toBe("full-access");
+      expect(resolveAgentSandboxMode("full-access")).toBe("full-access");
+    });
+  });
+
+  it("never rewrites a bounded preference where containment works", async () => {
+    for (const platform of ["MacIntel", "Linux x86_64"]) {
+      await withPlatform(platform, ({ resolveAgentSandboxMode }) => {
+        expect(resolveAgentSandboxMode("workspace-write")).toBe(
+          "workspace-write",
+        );
+        expect(resolveAgentSandboxMode("read-only")).toBe("read-only");
+      });
+    }
+  });
+});


### PR DESCRIPTION
Closes #3577. Supersedes the approach in #3555.

## What changes

Windows has no working bounded backend. The restricted token cannot prevent reads outside the selected project, so `build_launch_spec` refuses every bounded mode (`sandbox.rs:256-260`). Defaulting Windows to `workspace-write` therefore never produced a contained agent — it produced an agent that would not start, and a fresh install's first "New Agent → Claude Code" failed at the launch-spec boundary.

- `defaultAgentSandboxMode()` — Windows defaults to `full-access`; macOS (Seatbelt) and Linux (Landlock) keep `workspace-write`, because their containment is real.
- `resolveAgentSandboxMode()` — applied when loading stored settings, so a Windows upgrader carrying the old bounded default is not left with a permanently broken launch, and again at spawn, so no stored or mid-session preference can refuse a launch the platform can never honor.

**No new UI.** No dialogs, no prompts, no components. The existing Settings notice about the Windows containment gap is unchanged.

## Security posture, stated plainly

This grants unconfined file and network access by default on Windows. On Windows the alternative was never "contained" — it was "does not run." macOS and Linux containment is untouched, and the Rust block itself is untouched, so nothing can silently launch bounded-but-unenforced.

## The Windows e2e still asserts the block

`scripts/windows-e2e-app.mjs` passes `sandboxMode: "workspace-write"` **explicitly** at lines 999, 1108, and 1190 — it never reads the app default. `runBlockedWindowsBoundedJourney` continues to assert that a bounded spawn is refused, so the containment guarantee stays under test.

## Test change worth reviewing

`agent-credential-lease-wiring.test.ts` pins the spawn **argument order** by matching source text, to prove a credential never lands in the wrong slot. Wrapping the mode in `resolveAgentSandboxMode(...)` changed the expression text but not the order, so the pattern moved from `agentSandboxMode,` to `agentSandboxMode),`. The invariant it guards is intact.

## Verification

- 4 new tests: Windows defaults to a launchable mode; macOS/Linux keep containment; a stored bounded Windows preference resolves; a bounded preference is never rewritten where containment works.
- Full unit suite: **2839 passed, 3 skipped, 0 failed**.
- Biome clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
