### PR TITLE
fix(happy): revoke unscoped shell and filesystem RPC from the relay (#3578)

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -1903,6 +1903,7 @@ export function createHappyLayer({
           }
         },
       });
+      revokeUnscopedRpc(client, UNSCOPED_SESSION_RPC);
     } catch (error) {
       if (!resumedBinding) await sessionApi.deactivateSession(session.id);
       throw error;
@@ -2164,6 +2165,38 @@ export function createHappyLayer({
     if (event.kind === "permission-request" && api) {
       const notification = composeApprovalNotification();
       api.push().sendToAllDevices(notification.title, notification.body, notification.data);
+    }
+  }
+
+  // The relay client registers these on every client it builds. On the machine
+  // client they carry no path restriction at all, so a paired device could read
+  // or write any absolute path and run arbitrary shell commands — none of it
+  // through the approval flow that governs every other tool call, and none of
+  // it bounded by the advertised roots. Revoked before the socket connects, so
+  // the relay is never told they exist.
+  const UNSCOPED_MACHINE_RPC = [
+    "bash",
+    "readFile",
+    "writeFile",
+    "listDirectory",
+    "getDirectoryTree",
+    "ripgrep",
+  ];
+  // A session's path scoping never applied to a command string, so a
+  // session-scoped shell is still an unscoped shell. Its file handlers stay:
+  // they are confined to the session directory and mobile file browsing uses
+  // them.
+  const UNSCOPED_SESSION_RPC = ["bash"];
+
+  function revokeUnscopedRpc(client, methods) {
+    const manager = client?.rpcHandlerManager;
+    if (!manager?.unregisterHandler) return;
+    for (const method of methods) {
+      try {
+        manager.unregisterHandler(method);
+      } catch (error) {
+        debug(`failed to revoke Happy RPC handler ${method}: ${error}`);
+      }
     }
   }
 
@@ -2574,6 +2607,7 @@ export function createHappyLayer({
       daemonState: { status: "running", pid: process.pid, startedAt: Date.now() },
     });
     machineClient = api.machineSyncClient(machine);
+    revokeUnscopedRpc(machineClient, UNSCOPED_MACHINE_RPC);
     keepAdvertisedCliAvailability(machineClient);
     setupMachineHandlers();
     machineClient.connect();

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -82,6 +82,9 @@ function createClient() {
           rpcHandlers.set(name, handler);
         },
       ),
+      unregisterHandler: vi.fn((name: string) => {
+        rpcHandlers.delete(name);
+      }),
     },
     sendAgentMessage: vi.fn(),
     sendClaudeSessionMessage: vi.fn(),
@@ -90,6 +93,8 @@ function createClient() {
     sendSessionProtocolMessage: vi.fn(),
     suppressNextArchiveSignal: vi.fn(),
     updateMetadata: vi.fn(),
+    // Exposed so tests can observe which RPC handlers survive construction.
+    rpcHandlers,
   };
 }
 
@@ -224,6 +229,17 @@ function createLayerHarness({
   let machineHandlers:
     | { spawnSession(options: Record<string, unknown>): Promise<Record<string, unknown>> }
     | undefined;
+  // The relay SDK auto-registers these on every client it builds; the bridge is
+  // expected to revoke the unscoped ones before the socket connects.
+  const machineRpcHandlers = new Set([
+    "bash",
+    "readFile",
+    "writeFile",
+    "listDirectory",
+    "getDirectoryTree",
+    "ripgrep",
+    "difftastic",
+  ]);
   const machineClient = {
     connect: vi.fn(),
     setRPCHandlers: vi.fn((handlers) => {
@@ -231,6 +247,14 @@ function createLayerHarness({
     }),
     shutdown: vi.fn(),
     updateMachineMetadata: vi.fn(async () => {}),
+    rpcHandlerManager: {
+      registerHandler: vi.fn((name: string) => {
+        machineRpcHandlers.add(name);
+      }),
+      unregisterHandler: vi.fn((name: string) => {
+        machineRpcHandlers.delete(name);
+      }),
+    },
   };
   const api = {
     deactivateSession: vi.fn(async () => true),
@@ -341,6 +365,10 @@ function createLayerHarness({
     // Captured before start() so it survives the layer wrapping the client's
     // metadata writer to keep the bridge authoritative over cliAvailability.
     machineMetadataWrites: machineClient.updateMachineMetadata,
+    machineRpcHandlers,
+    get sessionRpcHandlers() {
+      return client.rpcHandlers;
+    },
     source,
     supervisorCall,
     supervisorNotify,
@@ -406,6 +434,62 @@ describe("Happy session liveness", () => {
       gemini: true,
       openclaw: false,
     });
+
+    await harness.layer.close();
+  });
+
+  it("revokes the relay SDK's unscoped shell and filesystem RPC on the machine", async () => {
+    const harness = createLayerHarness();
+
+    await harness.layer.start();
+
+    // These carry no path restriction on the machine client, so a paired
+    // device could read or write any absolute path and run arbitrary shell
+    // commands outside the approval flow.
+    for (const method of [
+      "bash",
+      "readFile",
+      "writeFile",
+      "listDirectory",
+      "getDirectoryTree",
+      "ripgrep",
+    ]) {
+      expect(
+        harness.machineRpcHandlers.has(method),
+        `machine RPC ${method} was left registered`,
+      ).toBe(false);
+    }
+    // Revoked before the socket is told about them.
+    const revokeCalls =
+      harness.machineClient.rpcHandlerManager.unregisterHandler.mock
+        .invocationCallOrder;
+    const connectCall = harness.machineClient.connect.mock.invocationCallOrder;
+    expect(Math.max(...revokeCalls)).toBeLessThan(connectCall[0]);
+
+    await harness.layer.close();
+  });
+
+  it("revokes the relay SDK's shell RPC on a session client", async () => {
+    const summary = {
+      sessionId: "shell-revocation-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+    // The SDK registers this in the session client constructor.
+    harness.sessionRpcHandlers.set("bash", async () => ({ stdout: "" }));
+
+    await harness.layer.start();
+
+    // A session's path scoping never applied to the command string, so a
+    // session-scoped shell is still an unscoped shell.
+    expect(harness.sessionRpcHandlers.has("bash")).toBe(false);
+    // Session-scoped file access stays: mobile file browsing uses it and it is
+    // confined to the session directory.
+    expect(
+      harness.client.rpcHandlerManager.unregisterHandler,
+    ).not.toHaveBeenCalledWith("readFile");
 
     await harness.layer.close();
   });


### PR DESCRIPTION
Closes #3578.

## The exposure

`happy@1.2.0` auto-registers relay-invokable RPC handlers on every client it builds, via `registerCommonHandlers`: `bash`, `readFile`, `writeFile`, `listDirectory`, `getDirectoryTree`, `ripgrep`.

On the **machine** client the scope argument is `null`, and the path check short-circuits to valid for every path when the working directory is null. So a paired device could read or write **any absolute path** and execute **arbitrary shell commands** — none of it through the ActionConfirmation approval flow that governs every other tool call in this product, and none of it bounded by the advertised roots that `bin/happy-bridge/validate.mjs` exists to enforce.

Not a regression: this shipped in v3.75.0 and earlier. Upstream's model is that the paired device is the user's own phone holding the E2E keys, which is defensible for their product but not against this project's stated security model — and "your own phone" stops holding the moment a device is lost or a client pairs one.

## The fix

The SDK exposes `RpcHandlerManager.unregisterHandler(method)`, so the bridge revokes them directly — no surgery on the 53KB vendored patch file, and nothing to re-apply when the patch is regenerated.

- **Machine client** — all six revoked, before `connect()`. `unregisterHandler` emits `rpc-unregister` only when a socket exists, so revoking pre-connect means the relay is never told they existed in the first place.
- **Session clients** — `bash` only. Its path scoping never applied to the command string, so a session-scoped shell was still an unscoped shell.

**Deliberately kept:** session-scoped `readFile`/`listDirectory`/`getDirectoryTree`/`ripgrep`. Those are confined to the session directory and mobile file browsing uses them, so revoking them would break working functionality to no security benefit.

## Verification

Two new tests, both asserting observable behavior rather than the call:

- Every unscoped machine handler is gone after `start()`, **and** the last revocation happens before `connect()` — proven by comparing `invocationCallOrder`, so the ordering guarantee can't silently regress.
- A session client loses `bash` while `readFile` is explicitly never revoked.

The harness previously mocked `machineClient` without an `rpcHandlerManager`, which is why nothing could observe this; it now seeds the SDK's auto-registered set so revocation is measurable.

Full unit suite: **2841 passed, 3 skipped, 0 failed**. `bin/` is outside Biome's configured scope, so no lint applies to the bridge file.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
