### PR TITLE
fix(run): move a task off an agent type that already failed it (#3544)

### DIFF
--- a/src-tauri/src/run/scheduler.rs
+++ b/src-tauri/src/run/scheduler.rs
@@ -1549,15 +1549,45 @@ fn finish_attempt(
         ),
     )?;
     // An attempt that did not complete leaves its task failed from whatever
-    // stage it reached. Without this a task whose agent produced nothing usable
-    // rests in review forever and its run never reaches a terminal state.
+    // stage it reached, so a task whose agent produced nothing usable cannot
+    // rest in review and hold its run open — unless another agent type has not
+    // been tried yet, in which case the task goes back to ready so the next
+    // dispatch reaches for one that has not already failed here.
     let task_settled = TaskState::parse(&task_state).is_some_and(TaskState::is_terminal);
     if outcome != "completed" && !task_settled {
-        store::transition_task(conn, &task_id, TaskState::Failed, None)
+        let next_state = if untried_assignment_exists(conn, &run_id, &task_id)? {
+            TaskState::Ready
+        } else {
+            TaskState::Failed
+        };
+        store::transition_task(conn, &task_id, next_state, None)
             .map_err(|error| error.to_string())?;
-        append_and_emit(app, conn, task_state_event(&run_id, &task_id, TaskState::Failed))?;
+        append_and_emit(app, conn, task_state_event(&run_id, &task_id, next_state))?;
     }
     recompute_ready_and_status(app, conn, &run_id)
+}
+
+/// True when the run has an agent assignment this task has never been attempted
+/// with. An unhealthy agent type otherwise keeps the task, because dispatch
+/// round-robins without consulting what already failed for it.
+fn untried_assignment_exists(
+    conn: &Connection,
+    run_id: &str,
+    task_id: &str,
+) -> Result<bool, String> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM run_agent_assignments g
+             WHERE g.run_id = ?1
+               AND NOT EXISTS (
+                   SELECT 1 FROM run_attempts a
+                   WHERE a.task_id = ?2 AND a.agent_assignment_id = g.id
+               )
+         )",
+        params![run_id, task_id],
+        |row| row.get(0),
+    )
+    .map_err(|error| error.to_string())
 }
 
 fn reconcile_interrupted(conn: &Connection) -> Result<Vec<NewRunEvent>, String> {
@@ -2346,6 +2376,79 @@ mod tests {
         };
         assert_eq!(state_of("task-first"), TaskState::Ready);
         assert_eq!(state_of("task-second"), TaskState::Pending);
+    }
+
+    #[test]
+    fn a_task_is_only_out_of_agents_once_every_assignment_was_attempted() {
+        use crate::run::types::{AgentAssignment, Attempt};
+        let conn = connection();
+        seed_run(&conn, "run-reroute");
+        store::add_task(
+            &conn,
+            &Task {
+                id: "task-reroute".to_string(),
+                run_id: "run-reroute".to_string(),
+                title: "task-reroute".to_string(),
+                brief: "needs a healthy agent".to_string(),
+                state: TaskState::Ready,
+                blocked_reason: None,
+                created_at: 1,
+                updated_at: 1,
+            },
+            &[],
+        )
+        .unwrap();
+        for id in ["assignment-a", "assignment-b"] {
+            store::add_assignment(
+                &conn,
+                &AgentAssignment {
+                    id: id.to_string(),
+                    run_id: "run-reroute".to_string(),
+                    agent_type: "codex".to_string(),
+                    model_id: None,
+                    role_label: None,
+                    created_at: 1,
+                },
+            )
+            .unwrap();
+        }
+
+        // Nothing attempted yet: both agents are still available.
+        assert!(untried_assignment_exists(&conn, "run-reroute", "task-reroute").unwrap());
+
+        store::insert_attempt(
+            &conn,
+            &Attempt {
+                id: "attempt-a".to_string(),
+                task_id: "task-reroute".to_string(),
+                agent_assignment_id: Some("assignment-a".to_string()),
+                agent_session_id: None,
+                attempt_number: 1,
+                outcome: Some("failed".to_string()),
+                started_at: 1,
+                ended_at: Some(2),
+            },
+        )
+        .unwrap();
+        // One agent burned, one still untried — the task must be retried, not failed.
+        assert!(untried_assignment_exists(&conn, "run-reroute", "task-reroute").unwrap());
+
+        store::insert_attempt(
+            &conn,
+            &Attempt {
+                id: "attempt-b".to_string(),
+                task_id: "task-reroute".to_string(),
+                agent_assignment_id: Some("assignment-b".to_string()),
+                agent_session_id: None,
+                attempt_number: 2,
+                outcome: Some("failed".to_string()),
+                started_at: 3,
+                ended_at: Some(4),
+            },
+        )
+        .unwrap();
+        // Every agent has now had the task; it has nowhere left to go.
+        assert!(!untried_assignment_exists(&conn, "run-reroute", "task-reroute").unwrap());
     }
 
     fn seed_run(conn: &Connection, run_id: &str) {

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -11,6 +11,7 @@ import {
 import type { AgentType } from "@/services/providers";
 import {
   type AgentAssignment,
+  type Attempt,
   type CoverageGap,
   type Evidence,
   type EvidenceKind,
@@ -49,6 +50,12 @@ const CONFIDENCES = new Set<FindingConfidence>([
   "refuted",
 ]);
 const ARTIFACT_KINDS = new Set(["diff", "document", "email", "comment"]);
+// The CLIs that can raise an action-required state, and the agent types each
+// one blocks. claude-codex drives both, so either blocks it.
+const AGENTS_BLOCKED_BY_CLI: Record<"claude" | "codex", AgentType[]> = {
+  claude: ["claude-code", "claude-codex"],
+  codex: ["codex", "claude-codex"],
+};
 const NATIVE_AGENT_TYPES = new Set<AgentType>([
   "claude-code",
   "codex",
@@ -280,12 +287,32 @@ export function selectDispatchPlan(
   inFlight: ReadonlySet<string>,
   cap = MAX_CONCURRENT_TASKS,
   assignmentOffset = 0,
+  attempts: readonly Attempt[] = [],
 ): DispatchPlan[] {
   if (assignments.length === 0) return [];
-  return selectReadyTasks(tasks, inFlight, cap).map((task, index) => ({
-    task,
-    assignment: assignments[(assignmentOffset + index) % assignments.length],
-  }));
+  const attemptedByTask = new Map<string, Set<string>>();
+  for (const attempt of attempts) {
+    if (!attempt.agent_assignment_id) continue;
+    const attempted =
+      attemptedByTask.get(attempt.task_id) ?? new Set<string>();
+    attempted.add(attempt.agent_assignment_id);
+    attemptedByTask.set(attempt.task_id, attempted);
+  }
+
+  return selectReadyTasks(tasks, inFlight, cap).map((task, index) => {
+    const attempted = attemptedByTask.get(task.id);
+    // Round-robin picks the next agent in rotation, which for a retry can be
+    // the one that just failed this task. Prefer any agent it has not been
+    // through yet, so an unhealthy agent type cannot keep the task.
+    const untried = attempted
+      ? assignments.filter((candidate) => !attempted.has(candidate.id))
+      : assignments;
+    const pool = untried.length > 0 ? untried : assignments;
+    return {
+      task,
+      assignment: pool[(assignmentOffset + index) % pool.length],
+    };
+  });
 }
 
 function toFinding(
@@ -354,6 +381,19 @@ async function waitForTurn(sessionId: string): Promise<void> {
     const session = agentStore.sessions[sessionId];
     if (!session)
       throw new Error("agent session disappeared before completion");
+    // A runtime whose CLI needs repair or installation will never produce a
+    // turn, so waiting out the full timeout only delays the reroute.
+    const blocked = agentStore.cliUpdateActionRequired;
+    if (
+      blocked &&
+      AGENTS_BLOCKED_BY_CLI[blocked.bareCommand]?.includes(
+        session.info.agentType,
+      )
+    ) {
+      throw new Error(
+        `${session.info.agentType} cannot run until its CLI is repaired (${blocked.reason})`,
+      );
+    }
     const threadId = session.conversationId;
     const active =
       agentStore.isTurnInFlight(threadId) ||
@@ -619,6 +659,7 @@ export function startRunDispatcher(): void {
         inFlightTasks,
         MAX_CONCURRENT_TASKS,
         assignmentCursor,
+        snapshot.attempts,
       );
       assignmentCursor += plans.length;
       for (const plan of plans) {

--- a/tests/unit/run-dispatcher-selection.test.ts
+++ b/tests/unit/run-dispatcher-selection.test.ts
@@ -86,4 +86,61 @@ describe("run dispatcher selection", () => {
       )[0].assignment.id,
     ).toBe("b");
   });
+
+  function attempt(
+    taskId: string,
+    assignmentId: string | null,
+    outcome: string | null = "failed",
+  ) {
+    return {
+      id: `attempt-${taskId}-${assignmentId}`,
+      task_id: taskId,
+      agent_assignment_id: assignmentId,
+      agent_session_id: null,
+      attempt_number: 1,
+      outcome,
+      started_at: 1,
+      ended_at: 2,
+    };
+  }
+
+  it("routes a retry to an agent the task has not already been through", () => {
+    const plans = selectDispatchPlan(
+      [task("one")],
+      [assignment("a"), assignment("b")],
+      new Set(),
+      3,
+      0,
+      [attempt("one", "a")],
+    );
+    // Round-robin would hand it back to "a"; the failed agent is skipped.
+    expect(plans[0].assignment.id).toBe("b");
+  });
+
+  it("falls back to the full rotation once every agent has been tried", () => {
+    const plans = selectDispatchPlan(
+      [task("one")],
+      [assignment("a"), assignment("b")],
+      new Set(),
+      3,
+      0,
+      [attempt("one", "a"), attempt("one", "b")],
+    );
+    expect(["a", "b"]).toContain(plans[0].assignment.id);
+  });
+
+  it("keeps one task's history from steering another task", () => {
+    const plans = selectDispatchPlan(
+      [task("one"), task("two")],
+      [assignment("a"), assignment("b")],
+      new Set(),
+      3,
+      0,
+      [attempt("one", "a")],
+    );
+    const byTask = new Map(plans.map((plan) => [plan.task.id, plan.assignment.id]));
+    expect(byTask.get("one")).toBe("b");
+    // "two" has no history, so it keeps its place in the rotation.
+    expect(byTask.get("two")).toBe("b");
+  });
 });


### PR DESCRIPTION
Closes #3544.

## Item 1 — reroute away from an agent type that already failed the task

Two halves, because the decision and the selection live in different places:

**Backend (`finish_attempt`).** A failed attempt sent its task straight to terminal, so an unhealthy agent type kept the task even with a healthy assignment idle on the same run. The task now returns to `ready` while any assignment has never been attempted for it, and only fails once every one has had a turn. The check reads the durable attempts table (`untried_assignment_exists`), so it survives restart rather than living in dispatcher memory.

**Dispatcher (`selectDispatchPlan`).** Round-robin picks the next agent in rotation, which for a retry is often the one that just failed. It now prefers an assignment the task has not been through, falling back to the full rotation once all are exhausted. One task's history never steers another's.

Note this issue's original framing — "attempt 2 after relaunch reused the SAME agent type" — no longer describes the code: since #3570 a failed task is terminal and relaunch skips it, so there was no retry left to intercept. Fixing it properly meant restoring a retry path first, which is what the backend half does.

## Item 2 — wedge guard

`waitForTurn` now ends the attempt as soon as the agent's CLI is in an action-required state, instead of holding the task for the full 30-minute turn timeout. That failure can never produce a turn, so waiting only delays the reroute that item 1 now makes possible.

**Worth flagging:** my first version of this guard tested `blocked.agentType`, a field that does not exist on that payload — it would have type-checked as `undefined === string` and silently never fired. The real payload carries `bareCommand`, whose type is the two-value union `"claude" | "codex"`, so the mapping to affected agent types is small, exhaustive, and grounded in the actual type rather than invented. `claude-codex` drives both CLIs, so either one blocks it.

## Verification

- Rust: `run::` **45 passed, 0 failed**, including a new test that walks a task from "both agents available" through "one burned" to "every agent tried" and asserts the decision flips only at the end. Verified by name (`a_task_is_only_out_of_agents_once_every_assignment_was_attempted ... ok`) after confirming it was actually compiled into the binary — the run counts were briefly ambiguous due to cargo lock contention, so I checked `--list` rather than trusting the totals.
- Frontend: **2844 passed, 3 skipped, 0 failed**, with three new selection tests (retry avoids the failed agent; falls back when all are exhausted; one task's history does not steer another).

Also caught during implementation: my first query used `run_agents` / `agent_id`; the real schema is `run_agent_assignments` / `agent_assignment_id`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
