### PR TITLE
ci(release): publish a tag when Windows signing is unavailable (#3582)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,14 @@ env:
   HAS_GH_PAT: ${{ secrets.GH_PAT != '' }}
   # SSL.com eSigner cloud signing for Windows EV code signing
   HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' }}
+  # Set the repository variable WINDOWS_SIGNING_UNAVAILABLE to "true" when the
+  # signing service itself cannot be reached — an expired or suspended SSL.com
+  # account, a provider outage — so a tag still publishes through the
+  # transparently unsigned path (#2929) instead of failing the whole release at
+  # the bundler. Windows installers are then unsigned and raise SmartScreen
+  # warnings; the Tauri updater is unaffected because its signature is a
+  # separate key. Remove the variable to restore signing.
+  WINDOWS_SIGNING_UNAVAILABLE: ${{ vars.WINDOWS_SIGNING_UNAVAILABLE }}
   # Fail-closed ceiling for billable SSL.com cloud hash-signing operations in one
   # Windows release job. Normal releases spend roughly 0-10; 100 leaves ample
   # drift while a cold/full cache reseed requires an explicit audited repo override.
@@ -420,7 +428,11 @@ jobs:
           "WINDOWS_SIGN_TELEMETRY_FILE=$telemetry" >> $env:GITHUB_ENV
           "WINDOWS_SIGNING_BLOCK_FILE=$blockFile" >> $env:GITHUB_ENV
           "WINDOWS_SIGNING_MONTHLY_STATE_FILE=$monthlyState" >> $env:GITHUB_ENV
-          "WINDOWS_SIGNING_BLOCKED=false" >> $env:GITHUB_ENV
+          $signingUnavailable = "$env:WINDOWS_SIGNING_UNAVAILABLE" -eq "true"
+          if ($signingUnavailable) {
+            Write-Host "::warning::WINDOWS_SIGNING_UNAVAILABLE is set; this release publishes unsigned Windows artifacts."
+          }
+          "WINDOWS_SIGNING_BLOCKED=$($signingUnavailable.ToString().ToLower())" >> $env:GITHUB_ENV
           "WINDOWS_SIGNING_MONTHLY_BLOCKED=false" >> $env:GITHUB_ENV
           "AWS_ACCESS_KEY_ID=$env:MONTHLY_R2_ACCESS_KEY_ID" >> $env:GITHUB_ENV
           "AWS_SECRET_ACCESS_KEY=$env:MONTHLY_R2_SECRET_ACCESS_KEY" >> $env:GITHUB_ENV
@@ -615,7 +627,7 @@ jobs:
           aws --version
 
       - name: Restore Windows signature cache from R2
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -653,7 +665,7 @@ jobs:
       # signing, so steady-state releases only spend signatures on changed files
       # while the signer keeps its existing Valid-signature skip and telemetry.
       - name: Sign embedded runtime (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           pnpm tsx scripts/print-windows-signables.ts `
@@ -738,7 +750,7 @@ jobs:
       # The cache dir was already restored from R2 above; the save step below
       # pushes any freshly signed plugins back for the next release to reuse.
       - name: Stage signed NSIS toolset (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           ./scripts/stage-signed-nsis-toolset.ps1 `
@@ -811,7 +823,7 @@ jobs:
       # builds never attempt to sign. The wrapper reads WINDOWS_SIGN_THUMBPRINT
       # from the eSigner CKA step via GITHUB_ENV.
       - name: Build Tauri app (budget-aware, Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         env:
           # The embedded runtime was already staged and EV-signed above; skip
           # re-preparation so the build does not overwrite the signed binaries
@@ -833,7 +845,7 @@ jobs:
           Get-Content sign-overlay.json
           pnpm tauri build --target ${{ matrix.target }} --config sign-overlay.json
       - name: Build Tauri app (unsigned, other)
-        if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu') && !(matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true')
+        if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu') && !(matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true')
         run: pnpm tauri build --target ${{ matrix.target }}
       - name: Build Tauri app (unsigned, macOS without signing)
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING != 'true'


### PR DESCRIPTION
Closes #3582.

## Why the release died

v3.76.0 compiled and linked on every platform and passed the Windows e2e gate, then failed at signing with `failed to bundle project: 'failed to run pwsh'`.

**It was not the signing budget**, which was my first hypothesis and the one the workflow's own comment points at. The budget summary reported:

```
WINDOWS_SIGNING_BLOCKED: false
WINDOWS_SIGNING_MONTHLY_BLOCKED: false
status=within_budget  projected=0  signed=0  max=100
```

Zero signatures consumed — the signer never ran once. And `git diff v3.75.0..HEAD` over `release.yml` and all four signing scripts is **empty**, so this is the same code that signed successfully on July 29. That points at the SSL.com account being unavailable, most likely billing.

## The design hole this exposed

The workflow already has a transparently unsigned fallback for blocked signing (#2929), and **25 downstream steps** correctly gate on `env.WINDOWS_SIGNING_BLOCKED != 'true'`.

Four steps did not — and they are precisely the ones that reach for the signing service:

| Step | What it does when signing is dead |
|---|---|
| `Build Tauri app (budget-aware, Windows)` | dies at the bundler — this is the failure |
| `Sign embedded runtime (Windows)` | calls SSL.com directly |
| `Stage signed NSIS toolset (Windows)` | stages a signed toolset that cannot exist |
| `Restore Windows signature cache from R2` | restores a cache nothing will populate |

So the fallback existed everywhere except where it was needed.

## The change

- `WINDOWS_SIGNING_UNAVAILABLE` repository variable declares the service unreachable and forces `WINDOWS_SIGNING_BLOCKED=true`, with a CI warning on every run so an unsigned release is never silent.
- The four steps above now honor `WINDOWS_SIGNING_BLOCKED`.
- The existing unsigned build path accepts Windows in that state.

Secrets are untouched, so `HAS_WINDOWS_SIGNING` stays true and the "refuse to publish an unsigned tag" guard keeps protecting against *accidentally* unconfigured signing. This mode is opt-in and reversible: delete the variable and signing resumes.

## Consequence, stated plainly

Windows installers from this release are **unsigned** and will raise SmartScreen warnings on download and first run. The Tauri updater is unaffected — its signature is a separate key (`TAURI_SIGNING_PRIVATE_KEY`), not Authenticode, so existing installs still update normally.

## Verification

YAML parses, no tabs introduced, 14 blocked-gates present (was 10), 5 references to the new variable. **This layer can only be validated by a real tagged release** — per our own rule I am not claiming it works until the next run proves it, and I will read that run's logs rather than assume.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
