### PR TITLE
ci(release): summarize a release that skipped signing (#3584)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -862,6 +862,28 @@ jobs:
           Add-Content -LiteralPath $summary -Value "- MAX_SIGNATURES: $env:MAX_SIGNATURES"
           Add-Content -LiteralPath $summary -Value "- Telemetry: ``$telemetry``"
           if (-not $telemetry -or -not (Test-Path -LiteralPath $telemetry)) {
+            # No telemetry is the expected, truthful outcome when signing was
+            # skipped: nothing signed, so nothing recorded. Absent telemetry
+            # while signing was expected is still an anomaly and still fails.
+            if ($env:WINDOWS_SIGNING_BLOCKED -eq "true") {
+              Add-Content -LiteralPath $summary -Value "- Status: signing skipped; no operations recorded"
+              # Downstream upload and release-notes steps consume this file and
+              # treat its absence as an error, so record the skip truthfully
+              # rather than leaving nothing behind.
+              $skippedState = [PSCustomObject]@{
+                schema_version = 1
+                status = "signing_skipped"
+                blocked = $true
+                max_signatures = [int]$env:MAX_SIGNATURES
+                projected_total = 0
+                actual_signed = 0
+                monthly = if (Test-Path -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE) { Get-Content -Raw -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE | ConvertFrom-Json } else { $null }
+                sources = @()
+              }
+              ($skippedState | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath "windows-signing-budget-state.json"
+              Write-Host "Windows signing budget summary: status=signing_skipped projected=0 signed=0 max=$env:MAX_SIGNATURES"
+              exit 0
+            }
             throw "No Windows signing telemetry found at: $telemetry"
           }
 


### PR DESCRIPTION
Closes #3584.

## Progress from #3583

With the switch set, the Windows build now takes the unsigned path and **succeeds**: `Build Tauri app (unsigned, other) [success]`, with all four signing steps correctly skipped and `WINDOWS_SIGNING_BLOCKED: true` propagating through the job. That part of the fallback works.

The job still failed one step later, in `Summarize Windows signing budget`:

```
Exception: No Windows signing telemetry found at: D:\a\_temp\windows-signing-telemetry.jsonl
```

The step treats missing telemetry as an anomaly, but a skipped-signing run produces exactly that — nothing signed, so nothing recorded.

## What the obvious fix would have broken

Simply exiting early there would have starved three downstream consumers, because the same step writes `windows-signing-budget-state.json` at its very end:

| Consumer | Behavior on a missing file |
|---|---|
| `Upload Windows signing budget state` | `if-no-files-found: error` |
| publish job | `jq -r '.blocked'` |
| release-notes generator | `JSON.parse(...).blocked === true` |

So the skip has to be **recorded**, not just tolerated. The step now writes a truthful `signing_skipped` state with `blocked: true`, `actual_signed: 0`, `projected_total: 0`. Both consumers key on `.blocked === true`, so the release still correctly identifies itself as unsigned and the notes disclose it.

Missing telemetry while signing was *expected* still throws — the anomaly check is preserved, just no longer misfiring on the legitimate case.

## Verification

YAML sane, no tabs, gate count unchanged at 14. I traced every consumer of the state file before changing the exit path rather than fixing the visible error alone — this is the second failure in this chain where the first plausible fix would have moved the break one step downstream instead of resolving it.

As with #3583, this can only be proven by a real tagged run. I'll read the logs.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
