### PR TITLE
ci(release): publish only the artifacts a user installs (#3586)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2145,6 +2145,28 @@ jobs:
               });
               const existingNames = new Set(existingAssets.data.map((asset) => asset.name));
 
+              // Default-deny. The publish job downloads every artifact any job
+              // produced, including internal diagnostics: the Windows e2e log
+              // bundle carries a real address and test-machine account paths,
+              // and the preflight installer carries a pre-stamp version. Only
+              // the artifacts a user installs or the updater reads belong on a
+              // public release, so a new diagnostic artifact is excluded until
+              // someone deliberately adds it here.
+              const releaseVersion = tagName.replace(/^v/, '');
+              const isPublishableAsset = (fileName) => {
+                if (fileName === 'latest.json') return true;
+                const named = /^SerenDesktop[._-].*\.(dmg|deb|AppImage|exe|msi)$/.test(fileName)
+                  || /^SerenDesktop[._-].*\.(tar\.gz|nsis\.zip)(\.sig)?$/.test(fileName);
+                if (!named) return false;
+                // The e2e preflight installer is built before the tag stamps the
+                // version, so it is named identically apart from carrying the
+                // stale conf version. Anything advertising a version other than
+                // this release's is not this release's artifact.
+                const stamped = fileName.match(/^SerenDesktop[._-](\d+\.\d+\.\d+)[._-]/);
+                if (stamped && stamped[1] !== releaseVersion) return false;
+                return true;
+              };
+
               const uploadAsset = async (filePath, fileName) => {
                 if (existingNames.has(fileName)) {
                   console.log(`Skipping ${fileName} on release ${releaseId} - already exists`);
@@ -2169,9 +2191,11 @@ jobs:
                   const stat = fs.statSync(filePath);
                   if (stat.isDirectory()) {
                     await walkDir(filePath);
-                  } else {
+                  } else if (isPublishableAsset(file)) {
                     console.log(`Uploading to release ${releaseId}: ${filePath}`);
                     await uploadAsset(filePath, file);
+                  } else {
+                    console.log(`Skipping non-published artifact: ${filePath}`);
                   }
                 }
               };


### PR DESCRIPTION
Closes #3586.

## The leak

The publish job uploaded **every** downloaded artifact to the public release with no filter. It downloads all artifacts, so internal diagnostics rode along.

`windows-e2e-logs.zip` was publicly downloadable on **43 releases**, containing a real email address and internal test-machine account paths (`C:\Users\SerenE2E…`). Verified independently on v3.76.0 and v3.75.0 — longstanding, not introduced by this release.

Two others leaked the same way: the unsigned e2e **preflight** installer (named like the real one but stamped with a stale version, sitting on the release page next to the genuine installer) and the internal signing-budget counters.

**Already remediated:** the log asset is deleted from all 43 releases and the stale installer from v3.76.0. This PR stops the workflow recreating it on the next tag.

## The fix

Uploads are default-deny. Only installers, update bundles, their signatures, and `latest.json` publish. A new diagnostic artifact is excluded automatically until someone deliberately adds it — the failure mode here was an allow-everything default, so an allow-everything-shaped fix would just wait to break again.

## Why a name allowlist alone was not enough

My first version passed a hand-written list of the leaked files but **kept the preflight installer**, because it shares the real installer's naming. I caught it by testing the predicate against v3.76.0's actual 21 asset names rather than reasoning about the regex.

The discriminator is the version: the preflight is built before the tag stamps `tauri.conf.json`, so it advertises a stale version. Anything whose stamped version is not this release's is rejected.

## Verification

Executed against the real v3.76.0 asset list: **18 user-facing assets kept, 3 internal dropped.** Unversioned bundles (`SerenDesktop_x64.app.tar.gz`) and `latest.json` are preserved, so macOS updates and the updater manifest are unaffected — I checked `latest.json` references none of the removed files before deleting anything.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
