### PR TITLE
fix(run): show Mission Control launch scrollbar

### DIFF
--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -52,7 +52,17 @@ export const MissionControlPanel: Component = () => {
 
   return (
     <div class="relative flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top_right,rgba(34,211,238,0.08),transparent_35%),#080d18] text-foreground">
-      <Show when={runStore.snapshot} fallback={<RunLaunchBox />}>
+      <Show
+        when={runStore.snapshot}
+        fallback={
+          <div
+            data-testid="mission-launch-scroll-region"
+            class="h-full min-h-0 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-slate-950/20 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-cyan-200/30 [&::-webkit-scrollbar-thumb:hover]:bg-cyan-200/45"
+          >
+            <RunLaunchBox />
+          </div>
+        }
+      >
         <div class="flex h-full min-h-0 flex-col">
           <header class="shrink-0 border-b border-border/70 px-5 pb-3 pt-5 lg:px-6">
             <div class="flex items-start justify-between gap-5">

--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -21,12 +21,52 @@ import {
 } from "@/services/run-dispatcher";
 import { runStore } from "@/stores/run.store";
 
+interface LaunchScrollMetrics {
+  visible: boolean;
+  thumbHeight: number;
+  thumbTop: number;
+}
+
+const EMPTY_LAUNCH_SCROLL_METRICS: LaunchScrollMetrics = {
+  visible: false,
+  thumbHeight: 0,
+  thumbTop: 0,
+};
+
 export const MissionControlPanel: Component = () => {
   const [tab, setTab] = createSignal<"overview" | "findings">("overview");
   const [reviewFinding, setReviewFinding] = createSignal<Finding | null>(null);
   const [selectedTask, setSelectedTask] = createSignal<Task | null>(null);
+  const [launchScroll, setLaunchScroll] = createSignal<LaunchScrollMetrics>(
+    EMPTY_LAUNCH_SCROLL_METRICS,
+  );
+  let launchScrollRegion: HTMLDivElement | undefined;
+  let launchResizeObserver: ResizeObserver | null = null;
   let unlisten: UnlistenFn | null = null;
   let disposed = false;
+
+  const updateLaunchScroll = () => {
+    const region = launchScrollRegion;
+    if (!region) return;
+
+    const maxScrollTop = Math.max(region.scrollHeight - region.clientHeight, 0);
+    if (maxScrollTop === 0) {
+      setLaunchScroll(EMPTY_LAUNCH_SCROLL_METRICS);
+      return;
+    }
+
+    const trackHeight = Math.max(region.clientHeight - 32, 0);
+    const thumbHeight = Math.min(
+      trackHeight,
+      Math.max(64, (region.clientHeight / region.scrollHeight) * trackHeight),
+    );
+    const availableTravel = Math.max(trackHeight - thumbHeight, 0);
+    setLaunchScroll({
+      visible: true,
+      thumbHeight,
+      thumbTop: (region.scrollTop / maxScrollTop) * availableTravel,
+    });
+  };
 
   onMount(() => {
     void runStore.hydrateLatest();
@@ -38,11 +78,22 @@ export const MissionControlPanel: Component = () => {
       if (disposed) cleanup();
       else unlisten = cleanup;
     });
+
+    queueMicrotask(() => {
+      const region = launchScrollRegion;
+      if (!region || disposed) return;
+      updateLaunchScroll();
+      launchResizeObserver = new ResizeObserver(updateLaunchScroll);
+      launchResizeObserver.observe(region);
+      const content = region.firstElementChild;
+      if (content) launchResizeObserver.observe(content);
+    });
   });
 
   onCleanup(() => {
     disposed = true;
     unlisten?.();
+    launchResizeObserver?.disconnect();
     stopRunDispatcher();
   });
 
@@ -55,11 +106,36 @@ export const MissionControlPanel: Component = () => {
       <Show
         when={runStore.snapshot}
         fallback={
-          <div
-            data-testid="mission-launch-scroll-region"
-            class="h-full min-h-0 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-slate-950/20 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-cyan-200/30 [&::-webkit-scrollbar-thumb:hover]:bg-cyan-200/45"
-          >
-            <RunLaunchBox />
+          <div class="relative h-full min-h-0">
+            <div
+              ref={launchScrollRegion}
+              data-testid="mission-launch-scroll-region"
+              data-scrollable={launchScroll().visible ? "true" : "false"}
+              tabindex="0"
+              aria-label="Mission launch form"
+              onScroll={updateLaunchScroll}
+              class="h-full min-h-0 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2 [&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-cyan-300/35 [&::-webkit-scrollbar-thumb]:bg-clip-padding [&::-webkit-scrollbar-thumb:hover]:bg-cyan-200/50"
+            >
+              <RunLaunchBox />
+            </div>
+            <div
+              data-testid="mission-launch-scrollbar"
+              aria-hidden="true"
+              class="pointer-events-none absolute bottom-4 right-1.5 top-4 z-20 w-1.5 rounded-full border border-cyan-200/15 bg-slate-950/35 transition-opacity"
+              classList={{
+                "opacity-100": launchScroll().visible,
+                "opacity-0": !launchScroll().visible,
+              }}
+            >
+              <div
+                data-testid="mission-launch-scrollbar-thumb"
+                class="absolute left-1/2 w-1 -translate-x-1/2 rounded-full bg-cyan-200/45"
+                style={{
+                  height: `${launchScroll().thumbHeight}px`,
+                  top: `${launchScroll().thumbTop}px`,
+                }}
+              />
+            </div>
           </div>
         }
       >

--- a/tests/unit/run-launchbox.test.ts
+++ b/tests/unit/run-launchbox.test.ts
@@ -46,6 +46,14 @@ describe("RunLaunchBox", () => {
     expect(missionControlSource).toContain("overflow-y-scroll");
     expect(missionControlSource).toContain("[scrollbar-gutter:stable]");
     expect(missionControlSource).toContain("[&::-webkit-scrollbar-thumb]");
+    expect(missionControlSource).toContain(
+      'data-testid="mission-launch-scrollbar"',
+    );
+    expect(missionControlSource).toContain(
+      'data-testid="mission-launch-scrollbar-thumb"',
+    );
+    expect(missionControlSource).toContain("new ResizeObserver");
+    expect(missionControlSource).toContain("onScroll={updateLaunchScroll}");
   });
 
   it("sends objective, tasks, agents, and workspace root to the store", async () => {

--- a/tests/unit/run-launchbox.test.ts
+++ b/tests/unit/run-launchbox.test.ts
@@ -15,6 +15,10 @@ const launchBoxSource = readFileSync(
   resolve("src/components/run/RunLaunchBox.tsx"),
   "utf8",
 );
+const missionControlSource = readFileSync(
+  resolve("src/components/run/MissionControlPanel.tsx"),
+  "utf8",
+);
 
 describe("RunLaunchBox", () => {
   beforeEach(() => {
@@ -33,6 +37,15 @@ describe("RunLaunchBox", () => {
     expect(launchBoxSource).toContain("run-agent-${agentType}");
     expect(launchBoxSource).toContain('data-testid="run-launch-start"');
     expect(launchBoxSource).toContain("await launchMission({");
+  });
+
+  it("keeps the launch form in a visible, stable scroll region", () => {
+    expect(missionControlSource).toContain(
+      'data-testid="mission-launch-scroll-region"',
+    );
+    expect(missionControlSource).toContain("overflow-y-scroll");
+    expect(missionControlSource).toContain("[scrollbar-gutter:stable]");
+    expect(missionControlSource).toContain("[&::-webkit-scrollbar-thumb]");
   });
 
   it("sends objective, tasks, agents, and workspace root to the store", async () => {


### PR DESCRIPTION
## Summary
- keep the Mission Control launch form inside a height-constrained scroll region
- show a proportional, persistent scrollbar only when the launch form overflows
- use a muted themed rail and thumb that remain visible without overpowering the form
- protect the scroll boundary and measurement behavior with focused regression coverage

## Validation
- `pnpm exec vitest run tests/unit/run-launchbox.test.ts` — 3 passed
- `pnpm test` — 2,911 passed, 15 skipped
- targeted Biome check for both changed files — passed
- `pnpm build` — passed
- isolated macOS Tauri walkthrough at 1200×800 — passed
- operator visually confirmed collapsed Advanced controls, overflow-only scrollbar visibility, thumb movement, full-form reachability, and final muted styling
- validation-feature Rust app build completed; three existing run-module warnings remain unchanged

No publisher/API path is involved; this is renderer-only layout behavior.

Closes #3588