### PR TITLE
fix(sidebar): add New Mission entry

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -603,6 +603,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
     setSlidePanel((v) => (v === "missioncontrol" ? null : "missioncontrol"));
   };
 
+  const handleOpenMissionControl = () => {
+    setSlidePanel("missioncontrol");
+  };
+
   const handleToggleSkills = () => {
     setSlidePanel((v) => (v === "skills" ? null : "skills"));
   };
@@ -1074,6 +1078,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
           <ThreadSidebar
             collapsed={sidebarCollapsed()}
             onToggle={() => setSidebarCollapsed((v) => !v)}
+            onCreateMission={handleOpenMissionControl}
             onOpenCatalog={handleOpenCatalog}
             onOpenInbox={handleOpenInbox}
           />

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -54,6 +54,7 @@ import { type WorkspaceWindow, workspaceStore } from "@/stores/workspace.store";
 interface ThreadSidebarProps {
   collapsed: boolean;
   onToggle?: () => void;
+  onCreateMission: () => void;
   onOpenCatalog?: () => void;
   onOpenInbox?: () => void;
 }
@@ -930,6 +931,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
         >
           <EmployeesSection
             onCreateEmployee={handleNewEmployee}
+            onCreateMission={props.onCreateMission}
             onOpenCatalog={props.onOpenCatalog}
             onOpenInbox={props.onOpenInbox}
           />

--- a/src/components/sidebar/EmployeesSection.tsx
+++ b/src/components/sidebar/EmployeesSection.tsx
@@ -46,6 +46,7 @@ export type EmployeeDetailEventDetail = { employeeId: string };
 
 interface EmployeesSectionProps {
   onCreateEmployee: () => void;
+  onCreateMission: () => void;
   onOpenCatalog?: () => void;
   onOpenInbox?: () => void;
 }
@@ -525,6 +526,42 @@ export const EmployeesSection: Component<EmployeesSectionProps> = (props) => {
                 </div>
                 <div class="thread-list-meta text-muted-foreground/70 truncate">
                   Persistent cloud worker
+                </div>
+              </div>
+            </button>
+            <button
+              type="button"
+              data-testid="sidebar-new-mission"
+              class="thread-list-row group flex items-center gap-2.5 w-full px-2 py-1.5 rounded-md bg-transparent border-none text-left cursor-pointer transition-colors duration-100 hover:bg-cyan-400/5 focus-visible:outline-none focus-visible:bg-cyan-400/5 focus-visible:ring-1 focus-visible:ring-cyan-300/40"
+              onClick={props.onCreateMission}
+              aria-label="New Mission"
+            >
+              <span
+                class="flex items-center justify-center w-[22px] h-[22px] rounded-md border border-cyan-300/25 text-cyan-300/75 transition-colors duration-100 group-hover:border-cyan-300/55 group-hover:text-cyan-200"
+                aria-hidden="true"
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.25"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="8" cy="8" r="4.5" />
+                  <circle cx="8" cy="8" r="1.25" />
+                  <path d="M8 1.5V3M8 13v1.5M1.5 8H3M13 8h1.5" />
+                </svg>
+              </span>
+              <div class="flex-1 min-w-0">
+                <div class="thread-list-title text-muted-foreground truncate transition-colors duration-100 group-hover:text-foreground">
+                  New Mission
+                </div>
+                <div class="thread-list-meta text-muted-foreground/70 truncate">
+                  Coordinate an agent team
                 </div>
               </div>
             </button>

--- a/tests/unit/mission-control-sidebar.test.ts
+++ b/tests/unit/mission-control-sidebar.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Protects the persistent Mission Control entry in the left sidebar.
+// ABOUTME: Confirms its placement and renderer-only open-panel callback path.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const employeeSectionSource = readFileSync(
+  resolve("src/components/sidebar/EmployeesSection.tsx"),
+  "utf8",
+);
+const threadSidebarSource = readFileSync(
+  resolve("src/components/layout/ThreadSidebar.tsx"),
+  "utf8",
+);
+const appShellSource = readFileSync(
+  resolve("src/components/layout/AppShell.tsx"),
+  "utf8",
+);
+
+describe("Mission Control sidebar entry", () => {
+  it("places New Mission below New employee and opens Mission Control", () => {
+    const newEmployee = employeeSectionSource.indexOf(
+      'aria-label="New employee"',
+    );
+    const newMission = employeeSectionSource.indexOf(
+      'data-testid="sidebar-new-mission"',
+    );
+    const approvalInbox = employeeSectionSource.indexOf(
+      'data-testid="sidebar-approval-inbox"',
+    );
+
+    expect(newEmployee).toBeGreaterThanOrEqual(0);
+    expect(newMission).toBeGreaterThan(newEmployee);
+    expect(approvalInbox).toBeGreaterThan(newMission);
+    expect(employeeSectionSource).toContain(
+      "onClick={props.onCreateMission}",
+    );
+    expect(employeeSectionSource).toContain('aria-label="New Mission"');
+    expect(threadSidebarSource).toContain(
+      "onCreateMission={props.onCreateMission}",
+    );
+
+    const openHandlerStart = appShellSource.indexOf(
+      "const handleOpenMissionControl",
+    );
+    const toggleSkillsStart = appShellSource.indexOf(
+      "const handleToggleSkills",
+      openHandlerStart,
+    );
+    expect(openHandlerStart).toBeGreaterThanOrEqual(0);
+    expect(appShellSource.slice(openHandlerStart, toggleSkillsStart)).toContain(
+      'setSlidePanel("missioncontrol")',
+    );
+    expect(appShellSource).toContain(
+      "onCreateMission={handleOpenMissionControl}",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a persistent **New Mission** row immediately below **New employee**
- reuse Mission Control compass language and restrained cyan emphasis for discoverability
- wire the row through the existing sidebar props to the renderer-owned Mission Control slide panel
- add one focused regression test for placement and callback continuity

## Validation
- `pnpm exec vitest run tests/unit/mission-control-sidebar.test.ts` — 1 passed
- `pnpm test` — 2,912 passed, 15 skipped
- staged source Biome check — passed
- `pnpm build` — passed

No outbound publisher/API path is involved. Clicking **New Mission** only sets the existing renderer slide-panel view to `missioncontrol`; network/IPC activity begins only if the user later submits the mission form.

Closes #3591