### PR TITLE
fix(employees): unwrap terminal response envelopes

### DIFF
--- a/packages/employees-core/src/index.ts
+++ b/packages/employees-core/src/index.ts
@@ -1032,7 +1032,8 @@ export function textFromOutputEvents(value: unknown): string {
     .trim();
 }
 
-const EMPLOYEE_READINESS_KEYS = new Set([
+const EMPLOYEE_RESPONSE_KEYS = new Set([
+  "answer",
   "artifact_url",
   "employee",
   "scheduled_at",
@@ -1040,9 +1041,15 @@ const EMPLOYEE_READINESS_KEYS = new Set([
   "status",
   "verification",
 ]);
+const EMPLOYEE_RESPONSE_STATUSES = new Set([
+  "complete",
+  "completed",
+  "ready",
+  "success",
+]);
 
 /**
- * Converts the employee runtime's readiness acknowledgement into chat prose.
+ * Extracts user-facing text from the employee runtime's response envelope.
  * The key allowlist keeps arbitrary JSON answers byte-for-byte unchanged.
  */
 export function employeeAssistantDisplayText(value: string): string {
@@ -1061,9 +1068,11 @@ export function employeeAssistantDisplayText(value: string): string {
 
   const acknowledgement = parsed as Record<string, unknown>;
   const keys = Object.keys(acknowledgement);
+  const status = stringValue(acknowledgement.status)?.toLowerCase();
   if (
-    acknowledgement.status !== "ready" ||
-    !keys.every((key) => EMPLOYEE_READINESS_KEYS.has(key)) ||
+    !status ||
+    !EMPLOYEE_RESPONSE_STATUSES.has(status) ||
+    !keys.every((key) => EMPLOYEE_RESPONSE_KEYS.has(key)) ||
     !keys.some((key) =>
       ["artifact_url", "scheduled_at", "verification"].includes(key),
     )
@@ -1071,8 +1080,14 @@ export function employeeAssistantDisplayText(value: string): string {
     return value;
   }
 
-  const rawName =
-    stringValue(acknowledgement.employee) ?? stringValue(acknowledgement.skill);
+  if (Object.hasOwn(acknowledgement, "answer")) {
+    return stringValue(acknowledgement.answer) ?? value;
+  }
+
+  const employee = stringValue(acknowledgement.employee);
+  if (status !== "ready" && employee) return employee;
+
+  const rawName = employee ?? stringValue(acknowledgement.skill);
   if (!rawName) return value;
   const name = rawName.replace(/\s+/g, " ").trim();
   if (!name || name.length > 120) return value;

--- a/tests/unit/employees-core-run-stream.test.ts
+++ b/tests/unit/employees-core-run-stream.test.ts
@@ -76,7 +76,7 @@ function runtimeApi(frames: unknown[], terminal: EmployeeRunEventLike) {
 }
 
 describe("employees-core sequenced run stream", () => {
-  it("presents readiness acknowledgements as chat prose", () => {
+  it("presents employee runtime envelopes as chat prose", () => {
     const acknowledgement = JSON.stringify({
       skill: "Operations Assistant",
       status: "ready",
@@ -89,13 +89,35 @@ describe("employees-core sequenced run stream", () => {
     expect(employeeAssistantDisplayText(acknowledgement)).toBe(
       "I'm Operations Assistant. I'm ready to help.",
     );
+
+    const successfulAnswer = JSON.stringify({
+      skill: "Operations Assistant",
+      status: "success",
+      scheduled_at: null,
+      artifact_url: null,
+      verification: { status: "not_applicable" },
+      answer: "The requested answer.",
+    });
     expect(
       employeeTextFromConversationMessage({
         role: "assistant",
-        content: acknowledgement,
+        content: successfulAnswer,
         run_summary: { status: "completed" },
       }),
-    ).toBe("I'm Operations Assistant. I'm ready to help.");
+    ).toBe("The requested answer.");
+
+    expect(
+      employeeAssistantDisplayText(
+        JSON.stringify({
+          skill: "Operations Assistant",
+          status: "success",
+          scheduled_at: null,
+          artifact_url: null,
+          verification: { status: "not_applicable" },
+          employee: "I am the operations assistant.",
+        }),
+      ),
+    ).toBe("I am the operations assistant.");
   });
 
   it("preserves JSON that is not the readiness contract", () => {
@@ -751,13 +773,14 @@ describe("employees-core sequenced run stream", () => {
     expect(result.text).toBe("final");
   });
 
-  it("presents a terminal readiness envelope as chat prose", async () => {
+  it("presents a terminal response envelope as chat prose", async () => {
     const acknowledgement = JSON.stringify({
-      employee: "Operations Assistant",
-      status: "ready",
+      skill: "Operations Assistant",
+      status: "complete",
       scheduled_at: null,
       artifact_url: null,
       verification: { status: "not_applicable" },
+      answer: "The terminal answer.",
     });
     const { api } = runtimeApi(
       [control("end")],
@@ -769,9 +792,7 @@ describe("employees-core sequenced run stream", () => {
       "Who are you?",
     );
 
-    expect(result.text).toBe(
-      "I'm Operations Assistant. I'm ready to help.",
-    );
+    expect(result.text).toBe("The terminal answer.");
   });
 
   it("does not append divergent terminal snapshots as text chunks", async () => {


### PR DESCRIPTION
Closes #3536

## Summary

- recognize live employee terminal envelopes with `success` / `complete` statuses
- extract the user-facing `answer` or `employee` response instead of rendering the whole runtime object
- retain the prior `ready` acknowledgement behavior and preserve arbitrary JSON outside the narrow runtime contract

## Root cause

The earlier fix only accepted `status: "ready"` and rejected the `answer` key. Live employee turns return additional successful terminal variants, so they bypassed the shared presentation helper even though the correct live and history consumers already called it.

## Validation

- `pnpm vitest run tests/unit/employees-core-run-stream.test.ts tests/unit/employee-runtime-startup.test.ts` — 40 passed
- `pnpm test` — 411 files passed, 2,911 tests passed
- `pnpm build`
- `pnpm exec biome check packages/employees-core/src/index.ts tests/unit/employees-core-run-stream.test.ts`
- `git diff --check`

## Network path audit

No new outbound path is introduced.

Employee-linked chat continues to call the live `seren-cloud` publisher through the generated Gateway client:

- `GET /deployments/{id}/sessions/{session_id}`
- `POST /deployments/{id}/sessions`
- `POST /deployments/{id}/sessions/{session_id}/messages`
- fallback: `POST /deployments/{id}/runs`
- `GET /deployments/{id}/runs/{run_id}/stream`
- `GET /deployments/{id}/runs/{run_id}`
- history: `GET /deployments/{id}/conversations`
- history: `GET /deployments/{id}/conversations/{conversation_id}/messages`

The live Seren publisher list confirms `seren-cloud`; the active route metadata is in the checked-in generated Seren Cloud OpenAPI client.

GitHub workflow calls use the live `github-api` publisher and its documented issue, pull, merge, and Actions endpoints.

## Privacy

All public examples and tests use synthetic names and content. The local screenshots were not uploaded because they contain personal desktop data.