### PR TITLE
fix: confirm Gmail account before agent sends

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -11,7 +11,10 @@ import {
   SEREN_MCP_SERVER_NAME,
 } from "./mcp-config.mjs";
 import { providerLogPrefix } from "./logging.mjs";
-import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+import {
+  createOAuthSelectionEventEmitter,
+  createSerenMcpOAuthProxy,
+} from "./seren-mcp-oauth-proxy.mjs";
 
 // ============================================================================
 // Process helpers
@@ -678,6 +681,10 @@ export function createAcpRuntime({
         serenMcpProxy = await createSerenMcpOAuthProxy({
           gatewayUrl: serenCredential.mcpUrl,
           apiUrl: serenCredential.apiBaseUrl,
+          onConnectionSelected: createOAuthSelectionEventEmitter(
+            emit,
+            sessionId,
+          ),
         });
       }
       mcpConfig = buildProviderMcpConfig({

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -15,7 +15,10 @@ import {
   SEREN_MCP_SERVER_NAME,
   SEREN_MCP_TOOL_PREFIX,
 } from "./mcp-config.mjs";
-import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+import {
+  createOAuthSelectionEventEmitter,
+  createSerenMcpOAuthProxy,
+} from "./seren-mcp-oauth-proxy.mjs";
 import {
   buildEffortArgs,
   buildEffortConfigOption,
@@ -1301,7 +1304,14 @@ function applySerenMcpOAuthRouting(routing, toolName, toolInput) {
   if (denyMessage) return { input: toolInput, denyMessage };
   const connectionId = routing?.publishers?.[publisher];
   return connectionId
-    ? { input: { ...toolInput, connection_id: connectionId }, denyMessage: null }
+    ? {
+        input: {
+          ...toolInput,
+          connection_id: connectionId,
+          _seren_auto_connection_id: true,
+        },
+        denyMessage: null,
+      }
     : { input: toolInput, denyMessage: null };
 }
 // The remote HTTP gateway's connect + tools/list races in the background and is
@@ -2938,6 +2948,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         serenMcpProxy = await createSerenMcpOAuthProxy({
           gatewayUrl: serenCredential.mcpUrl,
           apiUrl: serenCredential.apiBaseUrl,
+          onConnectionSelected: createOAuthSelectionEventEmitter(
+            emit,
+            sessionId,
+          ),
         });
       }
       mcpConfig = buildProviderMcpConfig({

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -23,7 +23,10 @@ import {
 } from "./file-access-policy.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { resolveBrokeredSerenCredential } from "./mcp-config.mjs";
-import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+import {
+  createOAuthSelectionEventEmitter,
+  createSerenMcpOAuthProxy,
+} from "./seren-mcp-oauth-proxy.mjs";
 
 const DEFAULT_BASE_URL = "http://localhost:1234";
 const LMSTUDIO_AGENT_TYPE = "lmstudio";
@@ -1603,6 +1606,10 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
         serenMcpProxy = await createSerenMcpOAuthProxy({
           gatewayUrl: serenCredential.mcpUrl,
           apiUrl: serenCredential.apiBaseUrl,
+          onConnectionSelected: createOAuthSelectionEventEmitter(
+            emit,
+            sessionId,
+          ),
         });
       }
     } catch (error) {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -8,7 +8,10 @@ import {
   createBrowserLocalAgentRegistry,
   resolveInstalledCodexBinary,
 } from "./agent-registry.mjs";
-import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+import {
+  createOAuthSelectionEventEmitter,
+  createSerenMcpOAuthProxy,
+} from "./seren-mcp-oauth-proxy.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import {
   buildProviderMcpConfig,
@@ -1840,6 +1843,10 @@ export function createProviderHandlers({
         serenMcpProxy = await createSerenMcpOAuthProxy({
           gatewayUrl: serenCredential.mcpUrl,
           apiUrl: serenCredential.apiBaseUrl,
+          onConnectionSelected: createOAuthSelectionEventEmitter(
+            emit,
+            sessionId,
+          ),
         });
       }
       serenMcpConfigured = buildProviderMcpConfig({

--- a/bin/browser-local/seren-mcp-oauth-proxy.mjs
+++ b/bin/browser-local/seren-mcp-oauth-proxy.mjs
@@ -47,6 +47,28 @@ function toolError(id, message) {
   };
 }
 
+const GMAIL_SEND_TOOLS = new Set([
+  "post_send",
+  "post_messages_send",
+  "post_drafts_by_draft_id_send",
+]);
+
+function isGmailSendRequest(publisher, tool, method, path) {
+  if (publisher.toLowerCase() !== "gmail") return false;
+  if (tool) return GMAIL_SEND_TOOLS.has(tool);
+  if (method.toUpperCase() !== "POST" || !path) return false;
+
+  const normalizedPath = path
+    .split("?", 1)[0]
+    .replace(/^\/+|\/+$/g, "")
+    .toLowerCase();
+  return (
+    normalizedPath === "send" ||
+    normalizedPath === "messages/send" ||
+    /^drafts\/[^/]+\/send$/.test(normalizedPath)
+  );
+}
+
 /**
  * Decide whether a Seren MCP request can pass through unchanged, must fail
  * closed, or should use the first-party publisher proxy with an OAuth selector.
@@ -101,16 +123,35 @@ export function planSerenMcpRequest(routing, payload) {
     };
   }
 
+  const selectionWasExplicit =
+    explicitConnectionId != null && args._seren_auto_connection_id !== true;
+
+  const tool = nonEmptyString(args.tool);
+  const method = nonEmptyString(args.method) ?? "POST";
+  const path = nonEmptyString(args.path);
+  if (
+    !selectionWasExplicit &&
+    isGmailSendRequest(publisher, tool, method, path)
+  ) {
+    return {
+      kind: "error",
+      response: toolError(
+        payload.id,
+        "Gmail send blocked: name the active sender account, ask the user to confirm or choose another account, and wait for a later user reply. After that confirmation, verify gmail/get_profile and retry the send with the confirmed account's top-level connection_id.",
+      ),
+    };
+  }
+
   const connectionId =
     explicitConnectionId ?? nonEmptyString(routing?.publishers?.[publisher]);
   if (!connectionId) return { kind: "passthrough" };
 
-  const tool = nonEmptyString(args.tool);
   if (tool) {
     return {
       kind: "publisher",
       id: payload.id,
       connectionId,
+      selectionWasExplicit,
       publisher,
       request: {
         kind: "tool",
@@ -129,13 +170,12 @@ export function planSerenMcpRequest(routing, payload) {
     };
   }
 
-  const method = nonEmptyString(args.method) ?? "POST";
-  const path = nonEmptyString(args.path);
   if (path) {
     return {
       kind: "publisher",
       id: payload.id,
       connectionId,
+      selectionWasExplicit,
       publisher,
       request: {
         kind: "api",
@@ -463,7 +503,21 @@ function assertRelayableUpstream(url) {
   );
 }
 
-export async function createSerenMcpOAuthProxy({ gatewayUrl, apiUrl } = {}) {
+export function createOAuthSelectionEventEmitter(emit, sessionId) {
+  return ({ publisher, connectionId }) => {
+    emit("provider://oauth-account-selected", {
+      sessionId,
+      publisherSlug: publisher,
+      connectionId,
+    });
+  };
+}
+
+export async function createSerenMcpOAuthProxy({
+  gatewayUrl,
+  apiUrl,
+  onConnectionSelected,
+} = {}) {
   if (!gatewayUrl || !apiUrl) {
     throw new Error(
       "Seren OAuth routing proxy requires brokered gateway and API upstreams",
@@ -513,6 +567,21 @@ export async function createSerenMcpOAuthProxy({ gatewayUrl, apiUrl } = {}) {
             api.toString(),
             controller.signal,
           );
+          if (
+            plan.selectionWasExplicit &&
+            routedResponse?.result?.isError !== true &&
+            typeof onConnectionSelected === "function"
+          ) {
+            try {
+              await onConnectionSelected({
+                publisher: plan.publisher,
+                connectionId: plan.connectionId,
+              });
+            } catch {
+              // The publisher call already succeeded. A renderer sync failure
+              // must not replace its real result with a proxy error.
+            }
+          }
           if (!response.destroyed) {
             sendLocalMcpResponse(response, routedResponse);
           }

--- a/src/lib/agent/oauth-account-guidance.ts
+++ b/src/lib/agent/oauth-account-guidance.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Builds private per-thread account guidance for native agent prompts.
+// ABOUTME: Requires Gmail sender confirmation and enables chat-driven account selection.
+
+import type {
+  AgentOAuthPublisherAccounts,
+  AgentOAuthRouting,
+} from "@/services/providers";
+
+export const OAUTH_ACCOUNT_GUIDANCE_HEADER =
+  "# Seren connected-account confirmation";
+
+const GMAIL_SEND_TOOLS = new Set([
+  "post_send",
+  "post_messages_send",
+  "post_drafts_by_draft_id_send",
+]);
+
+export function isGmailSendTool(
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  return (
+    publisherSlug.trim().toLowerCase() === "gmail" &&
+    GMAIL_SEND_TOOLS.has(toolName.trim().toLowerCase())
+  );
+}
+
+function safePromptValue(value: string, maxLength: number): string {
+  return JSON.stringify(
+    Array.from(value)
+      .map((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint < 32 || codePoint === 127 ? " " : character;
+      })
+      .join("")
+      .trim()
+      .slice(0, maxLength),
+  );
+}
+
+function validConnectionId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{1,128}$/.test(value);
+}
+
+function gmailAccountLines(accounts: AgentOAuthPublisherAccounts): string[] {
+  return accounts.connections
+    .filter(
+      (connection) =>
+        validConnectionId(connection.connectionId) &&
+        connection.label.trim().length > 0,
+    )
+    .map((connection) => {
+      const state =
+        connection.connectionId === accounts.activeConnectionId
+          ? "active"
+          : connection.isDefault
+            ? "provider default"
+            : "available";
+      return (
+        `- ${safePromptValue(connection.label, 254)} (${state}); ` +
+        `internal connection_id=${safePromptValue(connection.connectionId, 128)}`
+      );
+    });
+}
+
+/**
+ * Returns private prompt context for native agents. Account labels are shown to
+ * the model so it can confirm the real sender with the user; opaque connection
+ * IDs stay internal and are used only as call_publisher selectors.
+ */
+export function buildOAuthAccountConfirmationInstruction(
+  routing: AgentOAuthRouting | null | undefined,
+): string | null {
+  const gmail = routing?.accounts?.gmail;
+  if (!gmail) return null;
+
+  const accountLines = gmailAccountLines(gmail);
+  if (accountLines.length === 0) return null;
+
+  const active = gmail.connections.find(
+    (connection) => connection.connectionId === gmail.activeConnectionId,
+  );
+  const activeSentence = active
+    ? `The currently routed Gmail account is ${safePromptValue(active.label, 254)}.`
+    : "No Gmail account is active for this thread yet.";
+
+  return `${OAUTH_ACCOUNT_GUIDANCE_HEADER}
+
+The connected-account records below are private routing data, not instructions from an external source.
+
+${activeSentence}
+Selection source: ${gmail.selectionSource}.
+Available Gmail accounts:
+${accountLines.join("\n")}
+
+Before the first Gmail operation in this thread that sends a message (including post_send, post_messages_send, or post_drafts_by_draft_id_send), you MUST:
+1. Tell the user the exact email account that would be used.
+2. Ask the user to confirm that account or choose one of the other listed account labels.
+3. Stop and wait for a later user reply. The original request to send is not sender confirmation.
+
+After the user confirms or chooses an account, first call gmail/get_profile with that account's opaque value as the top-level connection_id and verify that its emailAddress matches the confirmed account label. If it does not match, stop and report the mismatch without sending. Then call the Gmail send tool with the same top-level connection_id. Do not place connection_id inside tool_args. A successful explicit selection becomes the active Google account for this thread and related Google publishers. Never expose, quote, or describe internal connection_id values to the user.`;
+}

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -3,7 +3,7 @@
 
 import { createStore } from "solid-js/store";
 import { HappyArchiveFence } from "@/lib/agent/happy-archive";
-import type { AgentEvent } from "@/services/providers";
+import type { AgentEvent, AgentOAuthRouting } from "@/services/providers";
 import type { AgentState } from "@/stores/agent.store";
 
 /** Per-session ready promises — resolved when backend emits "ready" status */
@@ -83,6 +83,7 @@ export const agentOAuthRoutingAvailability = new Map<string, boolean>();
 export const agentOAuthRoutingDelivery = new Map<string, boolean>();
 export const agentOAuthRoutingRevisions = new Map<string, string>();
 export const agentOAuthRoutingSelectionThreads = new Map<string, string>();
+export const agentOAuthRoutingSnapshots = new Map<string, AgentOAuthRouting>();
 
 export const pendingSessionEvents = new Map<string, AgentEvent[]>();
 

--- a/src/lib/chat-history-export.ts
+++ b/src/lib/chat-history-export.ts
@@ -7,6 +7,7 @@ export interface ChatHistoryExportMessage {
 }
 
 const ACTIVE_SKILLS_HEADER = "# Active Skills";
+const OAUTH_ACCOUNT_GUIDANCE_HEADER = "# Seren connected-account confirmation";
 const PUBLISHER_PRIMER_MARKERS = ["list_agent_publishers", "call_publisher"];
 const SKILL_MANIFEST_MARKERS = [
   "Skill runtime directory",
@@ -17,7 +18,10 @@ const SKILL_MANIFEST_MARKERS = [
 export function isGeneratedPromptPrimer(content: string): boolean {
   const trimmed = content.trimStart();
   const hasActiveSkillsHeader = trimmed.includes(ACTIVE_SKILLS_HEADER);
-  if (!hasActiveSkillsHeader) return false;
+  const hasOAuthAccountGuidance = trimmed.includes(
+    OAUTH_ACCOUNT_GUIDANCE_HEADER,
+  );
+  if (!hasActiveSkillsHeader && !hasOAuthAccountGuidance) return false;
 
   const hasPublisherPrimer = PUBLISHER_PRIMER_MARKERS.every((marker) =>
     trimmed.includes(marker),
@@ -26,7 +30,7 @@ export function isGeneratedPromptPrimer(content: string): boolean {
     trimmed.includes(marker),
   );
 
-  return hasPublisherPrimer || hasSkillManifest;
+  return hasPublisherPrimer || hasSkillManifest || hasOAuthAccountGuidance;
 }
 
 function exportableMessageContent(

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -131,7 +131,6 @@ function convertMcpToolToDefinition(
       };
     }
   }
-
   return {
     type: "function",
     function: {
@@ -166,6 +165,13 @@ function convertGatewayToolToDefinition(
         items: schema.items,
       };
     }
+  }
+  if (publisher.trim().toLowerCase() === "gmail") {
+    properties.connection_id = {
+      type: "string",
+      description:
+        "Internal connected-account selector from Seren's sender-confirmation context. Never reveal this value to the user.",
+    };
   }
 
   return {
@@ -443,6 +449,14 @@ export function getAllTools(modelId?: string): ToolDefinition[] {
   for (const schema of getBuiltinToolSchemas()) {
     const name = `seren__${schema.name}`;
     if (seenNames.has(name)) continue;
+    const properties = { ...(schema.inputSchema?.properties ?? {}) };
+    if (schema.name === "call_publisher") {
+      properties.connection_id = {
+        type: "string",
+        description:
+          "Internal connected-account selector from Seren's sender-confirmation context. Never reveal this value to the user.",
+      };
+    }
     tools.push({
       type: "function",
       function: {
@@ -450,7 +464,7 @@ export function getAllTools(modelId?: string): ToolDefinition[] {
         description: schema.description || `Seren built-in: ${schema.name}`,
         parameters: {
           type: "object",
-          properties: schema.inputSchema?.properties ?? {},
+          properties,
           required: schema.inputSchema?.required,
         },
       },

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -3,6 +3,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { isGmailSendTool } from "@/lib/agent/oauth-account-guidance";
 import { mcpClient } from "@/lib/mcp/client";
 import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
@@ -17,10 +18,14 @@ import {
   callSerenTool,
   type PaymentProxyInfo,
 } from "@/services/mcp-gateway";
-import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
+import {
+  computeAgentOAuthRouting,
+  resolveOAuthProviderForPublisher,
+} from "@/services/publisher-oauth";
 import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
 import { conversationStore } from "@/stores/conversation.store";
+import { setThreadOAuthConnectionId } from "@/stores/oauth-account.store";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
 const GATEWAY_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -1016,12 +1021,25 @@ export async function executeTool(
         const publisher =
           typeof args.publisher === "string" ? args.publisher : "";
         const tool = typeof args.tool === "string" ? args.tool : "";
-        const toolArgs =
+        let toolArgs =
           args.tool_args &&
           typeof args.tool_args === "object" &&
           !Array.isArray(args.tool_args)
             ? (args.tool_args as Record<string, unknown>)
             : {};
+        if (
+          typeof args.connection_id === "string" &&
+          args.connection_id.trim() &&
+          !(
+            typeof toolArgs.connection_id === "string" &&
+            toolArgs.connection_id.trim()
+          )
+        ) {
+          toolArgs = {
+            ...toolArgs,
+            connection_id: args.connection_id.trim(),
+          };
+        }
         if (!publisher || !tool) {
           return {
             tool_call_id: toolCall.id,
@@ -1434,6 +1452,33 @@ async function executeGatewayTool(
 ): Promise<ToolResult> {
   try {
     let callArgs = args;
+    const explicitConnectionId =
+      typeof args.connection_id === "string" && args.connection_id.trim()
+        ? args.connection_id.trim()
+        : null;
+
+    if (isGmailSendTool(publisherSlug, toolName) && !explicitConnectionId) {
+      return {
+        tool_call_id: toolCallId,
+        content:
+          "Gmail send blocked: name the currently active sender account, ask the user to confirm or change it, wait for a later reply, then retry with the confirmed account's top-level connection_id.",
+        is_error: true,
+      };
+    }
+
+    const persistExplicitSelection = async (
+      isError: boolean,
+    ): Promise<void> => {
+      if (isError || !explicitConnectionId) return;
+      const threadId = conversationId ?? conversationStore.activeConversationId;
+      if (!threadId) return;
+      const resolution = await resolveOAuthProviderForPublisher(publisherSlug);
+      setThreadOAuthConnectionId(
+        threadId,
+        resolution.providerSlug,
+        explicitConnectionId,
+      );
+    };
 
     const auth = await authorizeToolOperation(
       "gateway",
@@ -1596,6 +1641,7 @@ async function executeGatewayTool(
         if (reservationId && !retryResponse.is_error) {
           await settleLeaseSpend(reservationId, charge.micros);
         }
+        await persistExplicitSelection(retryResponse.is_error);
 
         const retryContent =
           typeof retryResponse.result === "string"
@@ -1629,6 +1675,7 @@ async function executeGatewayTool(
         if (reservationId && !retryResponse.is_error) {
           await settleLeaseSpend(reservationId, charge.micros);
         }
+        await persistExplicitSelection(retryResponse.is_error);
 
         const retryContent =
           typeof retryResponse.result === "string"
@@ -1655,6 +1702,8 @@ async function executeGatewayTool(
     if (response.is_error && isOAuthTokenError(content)) {
       notifyOAuthExpired(publisherSlug, content);
     }
+
+    await persistExplicitSelection(response.is_error);
 
     return {
       tool_call_id: toolCallId,

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Chat service supporting streaming completions with multi-provider routing.
 // ABOUTME: Routes requests through provider abstraction for Seren, Anthropic, OpenAI, Gemini.
 
+import { buildOAuthAccountConfirmationInstruction } from "@/lib/agent/oauth-account-guidance";
 import {
   extractEvidenceFromToolLoopMessages,
   type FinalOutputValidationReport,
@@ -37,6 +38,7 @@ import {
   processAssistantResponseMemory,
   recallMemoryContext,
 } from "@/services/memory";
+import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
 import { authStore } from "@/stores/auth.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { fileTreeState } from "@/stores/fileTree";
@@ -559,6 +561,16 @@ export async function* streamMessageWithTools(
   // operator has walled off.
   const memoryConversationId =
     memorySource?.conversationId ?? conversationStore.activeConversationId;
+
+  if (enableTools && authStore.isAuthenticated) {
+    const oauthAccountGuidance = buildOAuthAccountConfirmationInstruction(
+      await computeAgentOAuthRouting(memoryConversationId),
+    );
+    if (oauthAccountGuidance) {
+      systemContent += `\n\n${oauthAccountGuidance}`;
+    }
+  }
+
   if (
     settingsStore.get("memoryEnabled") &&
     authStore.isAuthenticated &&

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -3,6 +3,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { buildOAuthAccountConfirmationInstruction } from "@/lib/agent/oauth-account-guidance";
 import {
   extractEvidenceFromUnifiedMessages,
   validateFinalOutput,
@@ -43,6 +44,7 @@ import {
 } from "@/services/organization-policy";
 import { serenPrivateModelsAttested } from "@/services/private-models";
 import { assertPrivilegedConversationProvider } from "@/services/providers";
+import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
 import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
@@ -333,6 +335,15 @@ export async function orchestrate(
       );
       conversationStore.setLoading(false, conversationId);
       return;
+    }
+  }
+
+  if (authStore.isAuthenticated) {
+    const oauthAccountGuidance = buildOAuthAccountConfirmationInstruction(
+      await computeAgentOAuthRouting(conversationId),
+    );
+    if (oauthAccountGuidance) {
+      history = [{ role: "system", content: oauthAccountGuidance }, ...history];
     }
   }
 

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -125,8 +125,24 @@ export type PairedRole = "planner" | "executor";
 export interface AgentOAuthRouting {
   publishers: Record<string, string>;
   ambiguous: Record<string, string>;
+  /** Human-readable account choices used to confirm write identities in chat. */
+  accounts?: Record<string, AgentOAuthPublisherAccounts>;
   /** False when account discovery failed, so runtimes can refuse default-account fallback. */
   available?: boolean;
+}
+
+export interface AgentOAuthAccountChoice {
+  connectionId: string;
+  label: string;
+  isDefault: boolean;
+}
+
+export interface AgentOAuthPublisherAccounts {
+  providerSlug: string;
+  providerName: string;
+  activeConnectionId: string | null;
+  selectionSource: "thread" | "default" | "sole" | "ambiguous";
+  connections: AgentOAuthAccountChoice[];
 }
 
 export function supportsConversationFork(agentType: AgentType): boolean {
@@ -528,6 +544,17 @@ export interface McpDegradedEvent {
   serverName: string;
 }
 
+/**
+ * Emitted after an agent deliberately uses an explicit OAuth connection on a
+ * successful publisher call. The renderer persists it as this thread's active
+ * provider account so the header and subsequent calls stay aligned.
+ */
+export interface OAuthAccountSelectedEvent {
+  sessionId: string;
+  publisherSlug: string;
+  connectionId: string;
+}
+
 // Union type for all provider runtime events
 export type AgentEvent =
   | { type: "pairedEvent"; data: PairedTranscriptEvent }
@@ -546,6 +573,7 @@ export type AgentEvent =
   | { type: "userMessage"; data: UserMessageEvent }
   | { type: "error"; data: ErrorEvent }
   | { type: "loginRequired"; data: LoginRequiredEvent }
+  | { type: "oauthAccountSelected"; data: OAuthAccountSelectedEvent }
   | { type: "mcpDegraded"; data: McpDegradedEvent };
 
 /**
@@ -1040,6 +1068,7 @@ const EVENT_SUFFIXES = {
   userMessage: "user-message",
   error: "error",
   loginRequired: "login-required",
+  oauthAccountSelected: "oauth-account-selected",
   mcpDegraded: "mcp-degraded",
 } as const;
 
@@ -1205,6 +1234,13 @@ export async function subscribeToSession(
       "error",
       createHandler<{ type: "error"; data: ErrorEvent }>("error"),
     ),
+    subscribeToEvent<OAuthAccountSelectedEvent>(
+      "oauthAccountSelected",
+      createHandler<{
+        type: "oauthAccountSelected";
+        data: OAuthAccountSelectedEvent;
+      }>("oauthAccountSelected"),
+    ),
     subscribeToEvent<McpDegradedEvent>(
       "mcpDegraded",
       createHandler<{ type: "mcpDegraded"; data: McpDegradedEvent }>(
@@ -1270,6 +1306,10 @@ export async function subscribeToAllEvents(
     ),
     subscribeToEvent<LoginRequiredEvent>("loginRequired", (data) =>
       callback({ type: "loginRequired", data }),
+    ),
+    subscribeToEvent<OAuthAccountSelectedEvent>(
+      "oauthAccountSelected",
+      (data) => callback({ type: "oauthAccountSelected", data }),
     ),
     subscribeToEvent<McpDegradedEvent>("mcpDegraded", (data) =>
       callback({ type: "mcpDegraded", data }),

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -22,7 +22,10 @@ import {
 } from "@/services/oauth-callback";
 import type { AgentOAuthRouting } from "@/services/providers";
 import {
+  formatOAuthConnectionLabel,
+  getDefaultOAuthConnection,
   getOAuthConnectionsForProvider,
+  getThreadOAuthConnectionId,
   hasAmbiguousOAuthConnections,
   markOAuthConnectionsChanged,
   type OAuthConnection,
@@ -140,9 +143,11 @@ export async function computeAgentOAuthRouting(
       listPublisherOAuthProviderResolutions(),
       listConnectedPublishers(),
     ]);
+    const accounts: NonNullable<AgentOAuthRouting["accounts"]> = {};
     const routing: AgentOAuthRouting = {
       publishers: {},
       ambiguous: {},
+      accounts,
       available: true,
     };
     for (const resolution of resolutions) {
@@ -151,6 +156,39 @@ export async function computeAgentOAuthRouting(
         resolution.providerSlug,
       );
       if (validConnections.length === 0) continue;
+      const explicitConnectionId = getThreadOAuthConnectionId(
+        threadId,
+        resolution.providerSlug,
+      );
+      const explicitConnection = explicitConnectionId
+        ? (validConnections.find(
+            (connection) => connection.id === explicitConnectionId,
+          ) ?? null)
+        : null;
+      const defaultConnection = getDefaultOAuthConnection(validConnections);
+      const connection = resolveThreadOAuthConnection(
+        threadId,
+        resolution.providerSlug,
+        connections,
+      );
+      const selectionSource = explicitConnection
+        ? "thread"
+        : defaultConnection
+          ? "default"
+          : validConnections.length === 1
+            ? "sole"
+            : "ambiguous";
+      accounts[resolution.publisherSlug] = {
+        providerSlug: resolution.providerSlug,
+        providerName: resolution.providerName,
+        activeConnectionId: connection?.id ?? null,
+        selectionSource,
+        connections: validConnections.map((candidate) => ({
+          connectionId: candidate.id,
+          label: formatOAuthConnectionLabel(candidate),
+          isDefault: Boolean(candidate.is_default),
+        })),
+      };
       if (
         hasAmbiguousOAuthConnections(
           threadId,
@@ -159,14 +197,9 @@ export async function computeAgentOAuthRouting(
         )
       ) {
         routing.ambiguous[resolution.publisherSlug] =
-          `Multiple ${resolution.providerName} accounts are connected. Choose an active account for this chat in the header account switcher before running ${resolution.publisherSlug} tools.`;
+          `Multiple ${resolution.providerName} accounts are connected. Ask the user to choose an account in chat, or use the header account switcher, before running ${resolution.publisherSlug} tools.`;
         continue;
       }
-      const connection = resolveThreadOAuthConnection(
-        threadId,
-        resolution.providerSlug,
-        connections,
-      );
       if (connection)
         routing.publishers[resolution.publisherSlug] = connection.id;
     }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -37,12 +37,14 @@ import {
   serializeAgentConversationMetadata,
   serializeAgentMessageMetadata,
 } from "@/lib/agent/message-metadata";
+import { buildOAuthAccountConfirmationInstruction } from "@/lib/agent/oauth-account-guidance";
 import {
   agentOAuthRoutingAvailability,
   agentOAuthRoutingDelivery,
   agentOAuthRoutingRefreshes,
   agentOAuthRoutingRevisions,
   agentOAuthRoutingSelectionThreads,
+  agentOAuthRoutingSnapshots,
   expectedTerminateSessionIds,
   happyArchiveFence,
   happyProviderArchiveTombstones,
@@ -474,11 +476,15 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
-import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
+import {
+  computeAgentOAuthRouting,
+  resolveOAuthProviderForPublisher,
+} from "@/services/publisher-oauth";
 import { authStore, requestSignInModal } from "@/stores/auth.store";
 import {
   oauthConnectionsRevision,
   oauthSelectionsRevision,
+  setThreadOAuthConnectionId,
 } from "@/stores/oauth-account.store";
 import { privacyStore } from "@/stores/privacy.store";
 
@@ -1891,6 +1897,7 @@ async function refreshAgentOAuthRouting(
           providerSessionId,
           selectionThreadId,
         );
+        agentOAuthRoutingSnapshots.set(providerSessionId, routing);
         return true;
       } catch (error) {
         agentOAuthRoutingAvailability.set(providerSessionId, false);
@@ -4669,7 +4676,10 @@ export const agentStore = {
     const publisherInstruction = resolvePublisherLiveQueryInstruction(
       session.info.serenMcpConfigured === true,
     );
-    const currentSignature = `${publisherInstruction ?? ""}\n\n${skillsContent}`;
+    const oauthAccountInstruction = buildOAuthAccountConfirmationInstruction(
+      agentOAuthRoutingSnapshots.get(session.info.id),
+    );
+    const currentSignature = `${publisherInstruction ?? ""}\n\n${oauthAccountInstruction ?? ""}\n\n${skillsContent}`;
     const messageCount = session.messages.length;
     const messagesSincePrimed =
       messageCount - (session.primedAtMessageCount ?? 0);
@@ -4745,6 +4755,12 @@ export const agentStore = {
       if (publisherInstruction) {
         mergedContext = [
           { type: "text", text: publisherInstruction },
+          ...mergedContext,
+        ];
+      }
+      if (oauthAccountInstruction) {
+        mergedContext = [
+          { type: "text", text: oauthAccountInstruction },
           ...mergedContext,
         ];
       }
@@ -7662,6 +7678,33 @@ export const agentStore = {
             tool_calls: [],
           },
         });
+        break;
+      }
+
+      case "oauthAccountSelected": {
+        const selectedSession = state.sessions[sessionId];
+        const conversationId = selectedSession?.conversationId;
+        if (!selectedSession || !conversationId) break;
+
+        const publisherSlug = event.data.publisherSlug;
+        const connectionId = event.data.connectionId;
+        void resolveOAuthProviderForPublisher(publisherSlug)
+          .then((resolution) => {
+            const currentSession = state.sessions[sessionId];
+            if (currentSession?.conversationId !== conversationId) return;
+            setThreadOAuthConnectionId(
+              conversationId,
+              resolution.providerSlug,
+              connectionId,
+            );
+            return refreshAgentOAuthRouting(sessionId, conversationId);
+          })
+          .catch((error) => {
+            console.warn(
+              `[AgentStore] Failed to persist the selected ${publisherSlug} account for this thread:`,
+              error,
+            );
+          });
         break;
       }
 

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -111,10 +111,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToSession("session-1", vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(16);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
 
     dispose();
-    expect(unlisteners).toHaveLength(16);
+    expect(unlisteners).toHaveLength(17);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -125,8 +125,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToSession("session-1", vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(16);
-    expect(unlisteners).toHaveLength(15);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
+    expect(unlisteners).toHaveLength(16);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -136,10 +136,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToAllEvents(vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
 
     dispose();
-    expect(unlisteners).toHaveLength(17);
+    expect(unlisteners).toHaveLength(18);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -150,8 +150,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToAllEvents(vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
-    expect(unlisteners).toHaveLength(16);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
+    expect(unlisteners).toHaveLength(17);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/tests/unit/agent-oauth-chat-selection.test.ts
+++ b/tests/unit/agent-oauth-chat-selection.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Guards the runtime-to-renderer handoff for chat-selected OAuth accounts.
+// ABOUTME: Ensures an explicit publisher selector becomes the owning thread's active account.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(resolve(path), "utf8");
+
+describe("chat-selected OAuth account persistence (#3589)", () => {
+  it("subscribes to the runtime selection event and persists by provider", () => {
+    const providers = read("src/services/providers.ts");
+    const store = read("src/stores/agent.store.ts");
+    const caseStart = store.indexOf('case "oauthAccountSelected":');
+    const caseEnd = store.indexOf('case "error":', caseStart);
+    const selectionCase = store.slice(caseStart, caseEnd);
+
+    expect(providers).toContain(
+      'oauthAccountSelected: "oauth-account-selected"',
+    );
+    expect(caseStart).toBeGreaterThan(0);
+    expect(selectionCase).toContain("resolveOAuthProviderForPublisher");
+    expect(selectionCase).toContain("setThreadOAuthConnectionId");
+    expect(selectionCase).toContain("refreshAgentOAuthRouting");
+  });
+
+  it("wires every native Seren MCP proxy to the selection event", () => {
+    const runtimeSources = [
+      "bin/browser-local/providers.mjs",
+      "bin/browser-local/claude-runtime.mjs",
+      "bin/browser-local/acp-runtime.mjs",
+      "bin/browser-local/lmstudio-runtime.mjs",
+    ];
+
+    for (const path of runtimeSources) {
+      const source = read(path);
+      expect(source, path).toContain("createOAuthSelectionEventEmitter");
+      expect(source, path).toContain("onConnectionSelected:");
+    }
+  });
+});

--- a/tests/unit/agent-oauth-routing.test.ts
+++ b/tests/unit/agent-oauth-routing.test.ts
@@ -23,6 +23,22 @@ const connections = [
   { id: "conn-other", provider_slug: "google", provider_email: "other@example.com", is_valid: true, is_default: false },
 ];
 
+const accountRouting = (
+  activeConnectionId: string | null,
+  selectionSource: "thread" | "default" | "sole" | "ambiguous",
+  rows = connections,
+) => ({
+  providerSlug: "google",
+  providerName: "Google",
+  activeConnectionId,
+  selectionSource,
+  connections: rows.map((connection) => ({
+    connectionId: connection.id,
+    label: connection.provider_email,
+    isDefault: connection.is_default,
+  })),
+});
+
 describe("computeAgentOAuthRouting", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -40,6 +56,10 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-routing")).resolves.toEqual({
       publishers: { gmail: "conn-other", google: "conn-other" },
       ambiguous: {},
+      accounts: {
+        gmail: accountRouting("conn-other", "thread"),
+        google: accountRouting("conn-other", "thread"),
+      },
       available: true,
     });
   });
@@ -49,6 +69,10 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-default")).resolves.toEqual({
       publishers: { gmail: "conn-default", google: "conn-default" },
       ambiguous: {},
+      accounts: {
+        gmail: accountRouting("conn-default", "default"),
+        google: accountRouting("conn-default", "default"),
+      },
       available: true,
     });
 
@@ -58,6 +82,10 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-sole")).resolves.toEqual({
       publishers: { gmail: "conn-other", google: "conn-other" },
       ambiguous: {},
+      accounts: {
+        gmail: accountRouting("conn-other", "sole", [connections[1]]),
+        google: accountRouting("conn-other", "sole", [connections[1]]),
+      },
       available: true,
     });
   });
@@ -72,6 +100,10 @@ describe("computeAgentOAuthRouting", () => {
       ambiguous: {
         gmail: expect.stringContaining("Multiple Google accounts are connected"),
         google: expect.stringContaining("Multiple Google accounts are connected"),
+      },
+      accounts: {
+        gmail: accountRouting(null, "ambiguous", connections.map((connection) => ({ ...connection, is_default: false }))),
+        google: accountRouting(null, "ambiguous", connections.map((connection) => ({ ...connection, is_default: false }))),
       },
       available: true,
     });

--- a/tests/unit/agent-skills-priming.test.ts
+++ b/tests/unit/agent-skills-priming.test.ts
@@ -20,8 +20,10 @@ describe("agent skill context priming", () => {
 
     expect(body).toContain("skillsStore.getThreadSkillsContent");
     expect(body).toContain("resolvePublisherLiveQueryInstruction");
+    expect(body).toContain("buildOAuthAccountConfirmationInstruction");
     expect(body).toContain("session.info.serenMcpConfigured === true");
     expect(body).toContain("publisherInstruction");
+    expect(body).toContain("oauthAccountInstruction");
     expect(body).toContain("const currentSignature");
     expect(body).toContain("primedContextSignature === currentSignature");
   });
@@ -31,6 +33,15 @@ describe("agent skill context priming", () => {
 
     expect(body).toContain("if (publisherInstruction)");
     expect(body).toContain('{ type: "text", text: publisherInstruction }');
+  });
+
+  it("injects connected-account confirmation guidance when routing exposes it", () => {
+    const body = methodBody("async buildPromptContext");
+
+    expect(body).toContain("if (oauthAccountInstruction)");
+    expect(body).toContain(
+      '{ type: "text", text: oauthAccountInstruction }',
+    );
   });
 
   it("re-primes after the defensive message threshold", () => {
@@ -97,5 +108,17 @@ describe("agent skill context priming", () => {
     expect(agentStoreSource).toContain("isGeneratedPromptPrimer");
     expect(body).toContain("isGeneratedPromptPrimer(session.pendingUserMessage)");
     expect(body).not.toContain('startsWith("# Active Skills")');
+  });
+
+  it("filters connected-account guidance replay even when no skills are active", () => {
+    const historyExportSource = readSource("src/lib/chat-history-export.ts");
+
+    expect(historyExportSource).toContain(
+      '"# Seren connected-account confirmation"',
+    );
+    expect(historyExportSource).toContain("hasOAuthAccountGuidance");
+    expect(historyExportSource).toContain(
+      "hasSkillManifest || hasOAuthAccountGuidance",
+    );
   });
 });

--- a/tests/unit/builtin-gateway-tools.test.ts
+++ b/tests/unit/builtin-gateway-tools.test.ts
@@ -39,6 +39,11 @@ describe("first-class Seren tools (#1422)", () => {
     expect(definitionsSource).toContain('`seren__${schema.name}`');
   });
 
+  it("advertises the confirmed account selector on call_publisher", () => {
+    expect(definitionsSource).toContain('schema.name === "call_publisher"');
+    expect(definitionsSource).toContain("properties.connection_id");
+  });
+
   it("executor.ts dispatches seren__ tools via callSerenTool", () => {
     expect(executorSource).toContain("callSerenTool");
     expect(executorSource).toContain('name.startsWith("seren__")');

--- a/tests/unit/chat-tone-and-gateway.test.ts
+++ b/tests/unit/chat-tone-and-gateway.test.ts
@@ -94,3 +94,13 @@ describe("honest fallback when gateway not ready (#1464)", () => {
     expect(chatSource).toMatch(/still initializing or temporarily unreachable/);
   });
 });
+
+describe("chat Gmail account confirmation (#3589)", () => {
+  it("injects live OAuth account guidance into the built-in chat system prompt", () => {
+    expect(chatSource).toContain("buildOAuthAccountConfirmationInstruction");
+    expect(chatSource).toContain("await computeAgentOAuthRouting(");
+    expect(chatSource).toMatch(
+      /systemContent\s*\+=\s*`\\n\\n\$\{oauthAccountGuidance\}`/,
+    );
+  });
+});

--- a/tests/unit/claude-runtime-oauth-routing.test.ts
+++ b/tests/unit/claude-runtime-oauth-routing.test.ts
@@ -12,7 +12,12 @@ describe("spawned Claude Seren MCP OAuth routing", () => {
         { publisher: "gmail", tool: "post_send" },
       ),
     ).toEqual({
-      input: { publisher: "gmail", tool: "post_send", connection_id: "conn-alpha" },
+      input: {
+        publisher: "gmail",
+        tool: "post_send",
+        connection_id: "conn-alpha",
+        _seren_auto_connection_id: true,
+      },
       denyMessage: null,
     });
   });

--- a/tests/unit/codex-seren-mcp-proxy.test.ts
+++ b/tests/unit/codex-seren-mcp-proxy.test.ts
@@ -198,7 +198,69 @@ describe("native Codex Seren MCP OAuth routing", () => {
           connection_id: "conn-explicit",
         }),
       ),
-    ).toMatchObject({ kind: "publisher", connectionId: "conn-explicit" });
+    ).toMatchObject({
+      kind: "publisher",
+      connectionId: "conn-explicit",
+      selectionWasExplicit: true,
+    });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: { gmail: "conn-auto" }, ambiguous: {} },
+        callPublisher({
+          publisher: "gmail",
+          tool: "get_profile",
+          connection_id: "conn-auto",
+          _seren_auto_connection_id: true,
+        }),
+      ),
+    ).toMatchObject({
+      kind: "publisher",
+      connectionId: "conn-auto",
+      selectionWasExplicit: false,
+    });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: { gmail: "conn-auto" }, ambiguous: {} },
+        callPublisher({
+          publisher: "gmail",
+          tool: "post_send",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: {}, ambiguous: {}, available: true },
+        callPublisher({
+          publisher: "gmail",
+          tool: "post_send",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: { gmail: "conn-auto" }, ambiguous: {} },
+        callPublisher({
+          publisher: "gmail",
+          method: "POST",
+          path: "/drafts/draft-safe/send?mode=send",
+          connection_id: "conn-confirmed",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "publisher",
+      connectionId: "conn-confirmed",
+      selectionWasExplicit: true,
+    });
 
     expect(
       planSerenMcpRequest(
@@ -229,6 +291,53 @@ describe("native Codex Seren MCP OAuth routing", () => {
       kind: "error",
       response: { result: { isError: true } },
     });
+  });
+
+  it("reports a successful explicit account choice for thread persistence", async () => {
+    const originalFetch = globalThis.fetch;
+    const upstreamFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ emailAddress: "selected@example.test" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = upstreamFetch as typeof fetch;
+    const onConnectionSelected = vi.fn();
+    const proxy = await createSerenMcpOAuthProxy({
+      gatewayUrl: "https://mcp.invalid/mcp",
+      apiUrl: "https://api.invalid",
+      onConnectionSelected,
+    });
+    proxy.setRouting({
+      publishers: { gmail: "conn-default" },
+      ambiguous: {},
+    });
+
+    try {
+      await originalFetch(proxy.url, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer desktop-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          callPublisher({
+            publisher: "gmail",
+            tool: "get_profile",
+            connection_id: "conn-selected",
+          }),
+        ),
+      });
+
+      expect(onConnectionSelected).toHaveBeenCalledOnce();
+      expect(onConnectionSelected).toHaveBeenCalledWith({
+        publisher: "gmail",
+        connectionId: "conn-selected",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await proxy.close();
+    }
   });
 
   it("leaves unrelated and unselected MCP calls unchanged", () => {

--- a/tests/unit/oauth-account-guidance.test.ts
+++ b/tests/unit/oauth-account-guidance.test.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Critical regression coverage for conversational Gmail sender confirmation.
+// ABOUTME: Keeps account choice private while giving agents an explicit selector contract.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildOAuthAccountConfirmationInstruction,
+  isGmailSendTool,
+  OAUTH_ACCOUNT_GUIDANCE_HEADER,
+} from "@/lib/agent/oauth-account-guidance";
+import type { AgentOAuthRouting } from "@/services/providers";
+
+const routing: AgentOAuthRouting = {
+  publishers: { gmail: "conn-primary" },
+  ambiguous: {},
+  available: true,
+  accounts: {
+    gmail: {
+      providerSlug: "google",
+      providerName: "Google",
+      activeConnectionId: "conn-primary",
+      selectionSource: "default",
+      connections: [
+        {
+          connectionId: "conn-primary",
+          label: "primary@example.test",
+          isDefault: true,
+        },
+        {
+          connectionId: "conn-secondary",
+          label: "secondary@example.test",
+          isDefault: false,
+        },
+      ],
+    },
+  },
+};
+
+describe("OAuth account confirmation guidance (#3589)", () => {
+  it("recognizes only the live Gmail send tool slugs", () => {
+    expect(isGmailSendTool("gmail", "post_send")).toBe(true);
+    expect(isGmailSendTool("gmail", "post_messages_send")).toBe(true);
+    expect(
+      isGmailSendTool("gmail", "post_drafts_by_draft_id_send"),
+    ).toBe(true);
+    expect(isGmailSendTool("gmail", "get_messages")).toBe(false);
+    expect(isGmailSendTool("outlook", "post_send")).toBe(false);
+  });
+
+  it("requires a later sender confirmation and profile check before Gmail sends", () => {
+    const guidance = buildOAuthAccountConfirmationInstruction(routing);
+
+    expect(guidance).toContain(OAUTH_ACCOUNT_GUIDANCE_HEADER);
+    expect(guidance).toContain("primary@example.test");
+    expect(guidance).toContain("secondary@example.test");
+    expect(guidance).toContain("Stop and wait for a later user reply");
+    expect(guidance).toContain(
+      "The original request to send is not sender confirmation",
+    );
+    expect(guidance).toContain("gmail/get_profile");
+    expect(guidance).toContain("top-level connection_id");
+    expect(guidance).toContain("Never expose");
+  });
+
+  it("omits guidance when the thread has no Gmail account metadata", () => {
+    expect(
+      buildOAuthAccountConfirmationInstruction({
+        publishers: {},
+        ambiguous: {},
+        accounts: {},
+        available: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/orchestrator-oauth-account-guidance.test.ts
+++ b/tests/unit/orchestrator-oauth-account-guidance.test.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Pins Gmail account guidance to the production Rust-orchestrated chat path.
+// ABOUTME: Prevents the direct-provider fallback from becoming the only protected chat path.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(resolve("src/services/orchestrator.ts"), "utf8");
+
+describe("orchestrated chat OAuth account guidance (#3589)", () => {
+  it("prepends live per-thread account guidance to Rust conversation context", () => {
+    const computeIndex = source.indexOf("await computeAgentOAuthRouting(");
+    const guidanceIndex = source.indexOf(
+      "buildOAuthAccountConfirmationInstruction(",
+    );
+    const prependIndex = source.indexOf(
+      '{ role: "system", content: oauthAccountGuidance }',
+    );
+    const invokeIndex = source.indexOf('invoke("orchestrate"');
+
+    expect(computeIndex).toBeGreaterThan(-1);
+    expect(guidanceIndex).toBeGreaterThan(-1);
+    expect(prependIndex).toBeGreaterThan(-1);
+    expect(invokeIndex).toBeGreaterThan(-1);
+    expect(computeIndex).toBeLessThan(prependIndex);
+    expect(prependIndex).toBeLessThan(invokeIndex);
+  });
+});

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   callMcpTool: vi.fn(),
   callSerenTool: vi.fn(),
   computeAgentOAuthRouting: vi.fn(),
+  resolveOAuthProviderForPublisher: vi.fn(),
   emit: vi.fn(),
   listen: vi.fn(),
   invoke: vi.fn(),
@@ -50,6 +51,7 @@ vi.mock("@/lib/mcp/client", () => ({
 
 vi.mock("@/services/publisher-oauth", () => ({
   computeAgentOAuthRouting: mocks.computeAgentOAuthRouting,
+  resolveOAuthProviderForPublisher: mocks.resolveOAuthProviderForPublisher,
 }));
 
 // The allow-without-handle guard reports through the support pipeline; keep it
@@ -202,6 +204,11 @@ describe("tool executor authorization gate", () => {
       publishers: {},
       ambiguous: {},
       available: true,
+    });
+    mocks.resolveOAuthProviderForPublisher.mockResolvedValue({
+      publisherSlug: "gmail",
+      providerSlug: "google",
+      providerName: "Google",
     });
     mocks.callGatewayTool.mockResolvedValue({ result: "ok", is_error: false });
     mocks.callMcpTool.mockResolvedValue({
@@ -471,6 +478,7 @@ describe("tool executor authorization gate", () => {
           arguments: JSON.stringify({
             publisher: "gmail",
             tool: "post_send",
+            connection_id: "conn-confirmed",
             tool_args: { to: "a@example.com" },
           }),
         },
@@ -490,7 +498,7 @@ describe("tool executor authorization gate", () => {
     expect(mocks.callGatewayTool).toHaveBeenCalledWith(
       "gmail",
       "post_send",
-      { to: "a@example.com" },
+      { to: "a@example.com", connection_id: "conn-confirmed" },
       "handle-allow",
     );
     expect(mocks.callSerenTool).not.toHaveBeenCalled();

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
   callSerenTool: vi.fn(),
   computeAgentOAuthRouting: vi.fn(),
+  resolveOAuthProviderForPublisher: vi.fn(),
   emit: vi.fn(),
   listen: vi.fn(),
   invoke: vi.fn(),
@@ -18,6 +19,7 @@ vi.mock("@/services/mcp-gateway", () => ({
 
 vi.mock("@/services/publisher-oauth", () => ({
   computeAgentOAuthRouting: mocks.computeAgentOAuthRouting,
+  resolveOAuthProviderForPublisher: mocks.resolveOAuthProviderForPublisher,
 }));
 
 vi.mock("@/stores/conversation.store", () => ({
@@ -57,6 +59,11 @@ describe("tool executor OAuth account routing", () => {
       publishers: {},
       ambiguous: {},
       available: true,
+    });
+    mocks.resolveOAuthProviderForPublisher.mockResolvedValue({
+      publisherSlug: "gmail",
+      providerSlug: "google",
+      providerName: "Google",
     });
     mocks.callGatewayTool.mockResolvedValue({
       result: "ok",
@@ -123,6 +130,90 @@ describe("tool executor OAuth account routing", () => {
         q: "from:example",
         connection_id: "conn-google-personal",
       },
+      "handle-allow",
+    );
+  });
+
+  it("blocks a Gmail send before dispatch until chat supplies an explicit confirmed account", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool({
+      id: "tool-call-send-unconfirmed",
+      type: "function",
+      function: {
+        name: "gateway__gmail__post_messages_send",
+        arguments: JSON.stringify({
+          to: ["recipient@example.test"],
+          subject: "Account confirmation regression",
+          body: "Safe test body",
+        }),
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("Gmail send blocked");
+    expect(result.content).toContain("later reply");
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("persists a successful explicit chat selection to the owning thread", async () => {
+    const [{ executeTool }, { getThreadOAuthConnectionId }] =
+      await Promise.all([
+        import("@/lib/tools/executor"),
+        import("@/stores/oauth-account.store"),
+      ]);
+
+    const result = await executeTool(
+      {
+        id: "tool-call-profile-confirmed",
+        type: "function",
+        function: {
+          name: "gateway__gmail__get_profile",
+          arguments: JSON.stringify({
+            connection_id: "conn-google-confirmed",
+          }),
+        },
+      },
+      "thread-2",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(getThreadOAuthConnectionId("thread-2", "google")).toBe(
+      "conn-google-confirmed",
+    );
+  });
+
+  it("forwards a top-level selector through built-in call_publisher sends", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool(
+      {
+        id: "tool-call-generic-send-confirmed",
+        type: "function",
+        function: {
+          name: "seren__call_publisher",
+          arguments: JSON.stringify({
+            publisher: "gmail",
+            tool: "post_messages_send",
+            connection_id: "conn-google-confirmed",
+            tool_args: {
+              to: ["recipient@example.test"],
+              subject: "Account confirmation regression",
+              body: "Safe test body",
+            },
+          }),
+        },
+      },
+      "thread-2",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "gmail",
+      "post_messages_send",
+      expect.objectContaining({
+        connection_id: "conn-google-confirmed",
+      }),
       "handle-allow",
     );
   });


### PR DESCRIPTION
Closes #3589

## Summary
- expose the active and available Gmail accounts to private per-thread agent context
- require chat to name the sender and wait for confirmation or a changed account before sending
- verify the confirmed account with `gmail/get_profile`, route the explicit selector through built-in and native agent paths, and persist the successful selection to the thread
- fail closed for the live Gmail send tools when an explicit confirmed account selector is absent

## Audited network paths
- `GET /oauth/connections`
- `GET /oauth/providers`
- `GET /publishers?limit=100`
- `POST /publishers/gmail/_mcp/tools/{tool}` with `x-seren-oauth-connection-id`
- remote Seren MCP gateway for `list_agent_publishers` and `call_publisher`

The live publisher inventory confirmed Gmail tools `get_profile`, `post_send`, `post_messages_send`, and `post_drafts_by_draft_id_send`.

## Validation
- `pnpm test` — 418 files, 2,941 tests passed
- `pnpm build`
- focused account-routing, prompt, executor, proxy, and runtime regression suites
- staged/public-artifact PII scan and `git diff --check`

The no-mock connected-account app walkthrough is pending in the isolated validation profile before this draft is marked ready or merged.