### PR TITLE
fix(chat): reroute retryable SerenModels stream failures

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -208,9 +208,8 @@ enum StreamOutcome {
         accumulated_cost: f64,
     },
     /// Stream terminated with an upstream error (HTTP 4xx/5xx wrapped by the
-    /// gateway). The error event has already been forwarded to the UI; this
-    /// variant lets the orchestrator distinguish failure from empty completion
-    /// so it does not lie about the conversation being completed successfully.
+    /// gateway). This variant lets the worker attach structured retryability
+    /// and cost before orchestration decides whether the failure is terminal.
     Failed {
         error: String,
         cost: f64,
@@ -252,6 +251,24 @@ fn embedded_stream_error_is_retryable(code: Option<&serde_json::Value>) -> bool 
             | "server_error"
             | "service_unavailable"
     )
+}
+
+/// Preserve the provider's retry classification for orchestration, but never
+/// retry a whole model attempt after a tool has executed. Replaying that
+/// attempt could repeat an external side effect.
+fn stream_failure_event(
+    message: String,
+    retryable: bool,
+    cost: Option<f64>,
+    tool_call_count: usize,
+) -> WorkerEvent {
+    let retryable = tool_call_count == 0
+        && (retryable || super::router::is_context_overflow_error(&message));
+    WorkerEvent::Failure {
+        message,
+        retryable,
+        cost,
+    }
 }
 
 /// Extract only stable code/message fields from an embedded provider error.
@@ -769,9 +786,6 @@ created if missing.",
                     .and_then(|v| v.as_str())
                     .unwrap_or("Gateway API error");
                 let message = format!("HTTP {}: {}", status, error_msg);
-                result.events.push(WorkerEvent::Error {
-                    message: message.clone(),
-                });
                 result.stream_error = Some(ParsedStreamError {
                     message,
                     retryable: gateway_status_is_retryable(status),
@@ -783,9 +797,6 @@ created if missing.",
         let effective = unwrap_publisher_body(&parsed);
 
         if let Some(stream_error) = parse_embedded_stream_error(effective) {
-            result.events.push(WorkerEvent::Error {
-                message: stream_error.message.clone(),
-            });
             result.stream_error = Some(stream_error);
             return result;
         }
@@ -991,8 +1002,8 @@ created if missing.",
             *last_finish_reason = Some(reason.clone());
         }
 
-        // Forward per-chunk events (Content, Thinking, Error) to the
-        // frontend. ToolCall events are deferred to stream end — see
+        // Forward per-chunk content and thinking events to the frontend.
+        // ToolCall events are deferred to stream end — see
         // emit_accumulated_tool_calls.
         for event in &result.events {
             match event {
@@ -1181,12 +1192,6 @@ created if missing.",
                             full_error,
                             retryable,
                         );
-                        event_tx
-                            .send(WorkerEvent::Error {
-                                message: full_error.clone(),
-                            })
-                            .await
-                            .map_err(|e| format!("Failed to send error event: {}", e))?;
                         return Ok(StreamOutcome::Failed {
                             error: full_error,
                             cost: accumulated_cost,
@@ -2015,10 +2020,18 @@ impl Worker for ChatModelWorker {
                 }
                 log::error!("[ChatModelWorker] HTTP {} from Gateway", status);
                 let display_message = summarize_gateway_error(status, &body_text);
+                let failure_event = stream_failure_event(
+                    display_message.clone(),
+                    gateway_status_is_retryable(status.as_u16().into()),
+                    if total_cost > 0.0 {
+                        Some(total_cost)
+                    } else {
+                        None
+                    },
+                    tool_call_count,
+                );
                 if let Err(e) = event_tx
-                    .send(WorkerEvent::Error {
-                        message: display_message.clone(),
-                    })
+                    .send(failure_event)
                     .await
                 {
                     // Channel closed — likely cancelled while sending
@@ -2376,9 +2389,21 @@ impl Worker for ChatModelWorker {
                         "[ChatModelWorker] Execution failed, returning error (retryable={})",
                         retryable
                     );
-                    // stream_response already forwarded WorkerEvent::Error.
+                    let failure_event = stream_failure_event(
+                        error.clone(),
+                        retryable,
+                        total,
+                        tool_call_count,
+                    );
+                    if event_tx.send(failure_event).await.is_err() {
+                        log::debug!(
+                            "[ChatModelWorker] Channel closed, cannot send stream failure"
+                        );
+                        return Ok(());
+                    }
                     // Returning an error keeps the orchestrator from treating
-                    // this failed turn as a successful empty completion.
+                    // this failed turn as a successful empty completion. The
+                    // structured event above retains retryability and cost.
                     return Err(error);
                 }
             }
@@ -2788,14 +2813,13 @@ mod tests {
         let data =
             r#"{"status":402,"body":{"error":{"message":"Insufficient credits"}},"cost":"0"}"#;
         let result = ChatModelWorker::parse_sse_data(data);
-        assert_eq!(result.events.len(), 1);
-        match &result.events[0] {
-            WorkerEvent::Error { message } => {
-                assert!(message.contains("402"));
-                assert!(message.contains("Insufficient credits"));
-            }
-            _ => panic!("Expected Error event"),
-        }
+        assert!(result.events.is_empty());
+        let failure = result
+            .stream_error
+            .expect("gateway error should terminate the stream");
+        assert!(failure.message.contains("402"));
+        assert!(failure.message.contains("Insufficient credits"));
+        assert!(!failure.retryable);
     }
 
     #[tokio::test]
@@ -2835,13 +2859,43 @@ mod tests {
             other => panic!("Expected Failed outcome, got: {:?}", other),
         }
 
-        match rx.recv().await {
-            Some(WorkerEvent::Error { message }) => {
-                assert_eq!(message, "upstream_error: upstream request failed");
-                assert!(!message.contains("live/model"));
+        assert!(
+            rx.try_recv().is_err(),
+            "stream parsing must not render a failure before orchestration decides whether to recover"
+        );
+    }
+
+    #[test]
+    fn retryable_stream_failure_becomes_terminal_after_any_tool_executes() {
+        let retryable = stream_failure_event(
+            "upstream_error: upstream request failed".to_string(),
+            true,
+            Some(0.002),
+            0,
+        );
+        assert!(matches!(
+            retryable,
+            WorkerEvent::Failure {
+                retryable: true,
+                cost: Some(0.002),
+                ..
             }
-            other => panic!("Expected sanitized Error event, got: {:?}", other),
-        }
+        ));
+
+        let after_tool = stream_failure_event(
+            "upstream_error: upstream request failed".to_string(),
+            true,
+            Some(0.003),
+            1,
+        );
+        assert!(matches!(
+            after_tool,
+            WorkerEvent::Failure {
+                retryable: false,
+                cost: Some(0.003),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -4,11 +4,11 @@
 use log;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{mpsc, watch, Mutex};
 use uuid::Uuid;
 
 use super::chat_model_worker::ChatModelWorker;
@@ -19,7 +19,7 @@ use super::mcp_publisher_worker::McpPublisherWorker;
 use super::rlm;
 use super::router;
 use super::subtask_context::{
-    MAX_CONTEXT_SUBTASKS, MAX_SUBTASK_RESULT_BYTES, inject_dependency_results,
+    inject_dependency_results, MAX_CONTEXT_SUBTASKS, MAX_SUBTASK_RESULT_BYTES,
 };
 use super::tool_bridge::ToolResultBridge;
 use super::trust;
@@ -29,7 +29,7 @@ use super::types::{
 };
 use super::worker::Worker;
 use crate::services::database::{
-    DbPool, PersistedMessage, resolve_conversation_provider, save_message_record,
+    resolve_conversation_provider, save_message_record, DbPool, PersistedMessage,
 };
 
 const COMMUNITY_PRIOR_TIMEOUT_MS: u64 = 200;
@@ -725,6 +725,80 @@ pub async fn orchestrate(
 // Single-Task Execution (Fast Path)
 // =============================================================================
 
+#[derive(Debug, Clone, PartialEq)]
+struct AttemptFailure {
+    message: String,
+    /// `Some` is an authoritative worker classification. `None` preserves the
+    /// legacy message-based policy for workers that only emit `Error`.
+    retryable: Option<bool>,
+    cost: f64,
+}
+
+fn attempt_failure_from_event(event: &WorkerEvent) -> Option<AttemptFailure> {
+    match event {
+        WorkerEvent::Error { message } => Some(AttemptFailure {
+            message: message.clone(),
+            retryable: None,
+            cost: 0.0,
+        }),
+        WorkerEvent::Failure {
+            message,
+            retryable,
+            cost,
+        } => Some(AttemptFailure {
+            message: message.clone(),
+            retryable: Some(*retryable),
+            cost: cost.unwrap_or(0.0),
+        }),
+        _ => None,
+    }
+}
+
+fn attempt_is_reroutable(failure: &AttemptFailure) -> bool {
+    failure
+        .retryable
+        .unwrap_or_else(|| router::is_reroutable_error(&failure.message))
+}
+
+fn add_prior_attempt_cost(event: WorkerEvent, prior_attempt_cost: f64) -> WorkerEvent {
+    if prior_attempt_cost <= 0.0 {
+        return event;
+    }
+
+    match event {
+        WorkerEvent::Complete {
+            final_content,
+            thinking,
+            cost,
+            rlm_steps,
+        } => WorkerEvent::Complete {
+            final_content,
+            thinking,
+            cost: Some(prior_attempt_cost + cost.unwrap_or(0.0)),
+            rlm_steps,
+        },
+        event => event,
+    }
+}
+
+fn emit_terminal_failure(
+    app: &AppHandle,
+    conversation_id: &str,
+    message: &str,
+    total_failed_cost: f64,
+) {
+    let event = OrchestratorEvent {
+        conversation_id: conversation_id.to_string(),
+        worker_event: WorkerEvent::Failure {
+            message: message.to_string(),
+            retryable: false,
+            cost: (total_failed_cost > 0.0).then_some(total_failed_cost),
+        },
+        subtask_id: None,
+    };
+    let _ = app.emit("orchestrator://event", &event);
+}
+
 /// Execute a single subtask with automatic reroute on transient errors.
 ///
 /// When a worker hits a 408/429/5xx, the orchestrator queries eval_signals
@@ -788,6 +862,7 @@ async fn execute_single_task(
     let mut same_model_retry_count: usize = 0;
     const MAX_SAME_MODEL_RETRIES: usize = 1;
     let mut network_retry_count: usize = 0;
+    let mut failed_attempt_cost: f64 = 0.0;
 
     loop {
         // Bail out if cancellation arrived between iterations (e.g. during
@@ -847,12 +922,14 @@ async fn execute_single_task(
         let model_id_for_events = routing.model_id.clone();
         let task_type_for_events = subtask.classification.task_type.clone();
         let started_at_for_events = started_at_ms;
+        let prior_attempt_cost = failed_attempt_cost;
         let mut cancel_rx_forward = cancel_rx.clone();
 
-        // Returns (was_cancelled, captured_error).
-        let mut reroutable_error: Option<String> = None;
+        // Returns (was_cancelled, captured_failure). Worker failures are held
+        // here until the retry/reroute policy decides they are terminal.
+        let mut attempt_failure: Option<AttemptFailure> = None;
         let forward_handle = tokio::spawn(async move {
-            let mut captured_error: Option<String> = None;
+            let mut captured_failure: Option<AttemptFailure> = None;
             let mut cancelled = *cancel_rx_forward.borrow();
             let mut streamed_content = String::new();
             while !cancelled {
@@ -863,8 +940,9 @@ async fn execute_single_task(
                                 if let WorkerEvent::Content { text } = &worker_event {
                                     streamed_content.push_str(text);
                                 }
-                                if let WorkerEvent::Error { ref message } = worker_event {
-                                    captured_error = Some(message.clone());
+                                if let Some(failure) = attempt_failure_from_event(&worker_event) {
+                                    captured_failure = Some(failure);
+                                    continue;
                                 }
                                 // A worker that goes on to complete has
                                 // recovered: some forward intermediate errors
@@ -872,8 +950,10 @@ async fn execute_single_task(
                                 // would reject a turn that produced a real
                                 // answer, blanking it in the conversation.
                                 if matches!(worker_event, WorkerEvent::Complete { .. }) {
-                                    captured_error = None;
+                                    captured_failure = None;
                                 }
+                                let worker_event =
+                                    add_prior_attempt_cost(worker_event, prior_attempt_cost);
                                 let worker_event =
                                     guard_completion(&app_for_events, &conv_id, worker_event);
                                 if matches!(worker_event, WorkerEvent::Complete { .. }) {
@@ -912,13 +992,13 @@ async fn execute_single_task(
                     }
                 }
             }
-            (cancelled, captured_error)
+            (cancelled, captured_failure)
         });
 
         let forward_result = forward_handle.await;
         let was_cancelled = forward_result.as_ref().map(|(c, _)| *c).unwrap_or(false);
-        if let Ok((_, Some(ref error_msg))) = forward_result {
-            reroutable_error = Some(error_msg.clone());
+        if let Ok((_, Some(ref failure))) = forward_result {
+            attempt_failure = Some(failure.clone());
         }
 
         // If the forward loop exited due to cancellation, signal the worker
@@ -942,40 +1022,34 @@ async fn execute_single_task(
             }
             Ok(Err(e)) => {
                 log::error!("[Orchestrator] Worker error: {}", e);
-                if reroutable_error.is_none() {
-                    let error_message = e;
-                    let error_event = OrchestratorEvent {
-                        conversation_id: conversation_id.to_string(),
-                        worker_event: WorkerEvent::Error {
-                            message: error_message.clone(),
-                        },
-                        subtask_id: None,
-                    };
-                    let _ = app.emit("orchestrator://event", &error_event);
-                    reroutable_error = Some(error_message);
+                if attempt_failure.is_none() {
+                    attempt_failure = Some(AttemptFailure {
+                        message: e,
+                        retryable: None,
+                        cost: 0.0,
+                    });
                 }
             }
             Err(e) => {
                 log::error!("[Orchestrator] Worker task panicked: {}", e);
-                let error_message = "Internal error: worker task failed".to_string();
-                let error_event = OrchestratorEvent {
-                    conversation_id: conversation_id.to_string(),
-                    worker_event: WorkerEvent::Error {
-                        message: error_message.clone(),
-                    },
-                    subtask_id: None,
-                };
-                let _ = app.emit("orchestrator://event", &error_event);
-                reroutable_error = Some(error_message);
+                attempt_failure = Some(AttemptFailure {
+                    message: "Internal error: worker task failed".to_string(),
+                    retryable: Some(false),
+                    cost: 0.0,
+                });
             }
+        }
+
+        if let Some(failure) = &attempt_failure {
+            failed_attempt_cost += failure.cost;
         }
 
         // Network transport errors (connection refused, DNS, etc.) should be
         // retried on the same model with exponential backoff — rerouting to a
         // different model won't help since all models share the same gateway.
-        let is_network_error = reroutable_error
+        let is_network_error = attempt_failure
             .as_ref()
-            .is_some_and(|msg| router::is_network_transport_error(msg));
+            .is_some_and(|failure| router::is_network_transport_error(&failure.message));
 
         if is_network_error {
             network_retry_count += 1;
@@ -986,7 +1060,10 @@ async fn execute_single_task(
                     network_retry_count,
                     router::MAX_NETWORK_RETRIES,
                     backoff_secs,
-                    reroutable_error.as_deref().unwrap_or("unknown"),
+                    attempt_failure
+                        .as_ref()
+                        .map(|failure| failure.message.as_str())
+                        .unwrap_or("unknown"),
                 );
                 let mut cancel_sleep = cancel_rx.clone();
                 if !sleep_or_cancel(
@@ -1006,29 +1083,35 @@ async fn execute_single_task(
             log::error!(
                 "[Orchestrator] Network error persists after {} retries, giving up: {}",
                 router::MAX_NETWORK_RETRIES,
-                reroutable_error.as_deref().unwrap_or("unknown"),
+                attempt_failure
+                    .as_ref()
+                    .map(|failure| failure.message.as_str())
+                    .unwrap_or("unknown"),
             );
-            return Err(
-                reroutable_error.unwrap_or_else(|| "Network request failed".to_string()),
-            );
+            let message = attempt_failure
+                .map(|failure| failure.message)
+                .unwrap_or_else(|| "Network request failed".to_string());
+            emit_terminal_failure(app, conversation_id, &message, failed_attempt_cost);
+            return Err(message);
         }
 
         // Reset network retry counter on non-network outcomes (success or other errors)
         network_retry_count = 0;
 
         // Check if we got a transient error eligible for retry/reroute
-        let is_transient = reroutable_error
-            .as_ref()
-            .is_some_and(|msg| router::is_reroutable_error(msg));
+        let is_transient = attempt_failure.as_ref().is_some_and(attempt_is_reroutable);
 
         if !is_transient {
-            if let Some(error_message) = reroutable_error {
-                return Err(error_message);
+            if let Some(failure) = attempt_failure {
+                emit_terminal_failure(app, conversation_id, &failure.message, failed_attempt_cost);
+                return Err(failure.message);
             }
             break;
         }
 
-        let error_msg = reroutable_error.unwrap();
+        let error_msg = attempt_failure
+            .expect("transient failure must exist")
+            .message;
 
         // Context-overflow errors get special handling: reroute to a 1M-context
         // model regardless of whether the user explicitly selected a model.
@@ -1071,6 +1154,7 @@ async fn execute_single_task(
             }
             // All large-context models exhausted — fall through to give up
             log::warn!("[Orchestrator] Context overflow but all large-context fallbacks exhausted");
+            emit_terminal_failure(app, conversation_id, &error_msg, failed_attempt_cost);
             return Err(error_msg);
         }
 
@@ -1131,6 +1215,7 @@ async fn execute_single_task(
                     same_model_retry_count,
                     error_msg,
                 );
+                emit_terminal_failure(app, conversation_id, &error_msg, failed_attempt_cost);
                 return Err(error_msg);
             }
 
@@ -1161,6 +1246,7 @@ async fn execute_single_task(
                 "[Orchestrator] Giving up after {} reroute attempts",
                 reroute_count
             );
+            emit_terminal_failure(app, conversation_id, &error_msg, failed_attempt_cost);
             return Err(error_msg);
         }
 
@@ -1227,6 +1313,7 @@ async fn execute_single_task(
                     "[Orchestrator] No fallback model available, giving up after {} reroute attempts",
                     reroute_count
                 );
+                emit_terminal_failure(app, conversation_id, &error_msg, failed_attempt_cost);
                 return Err(error_msg);
             }
         }
@@ -1845,6 +1932,52 @@ pub fn strip_frontmatter(content: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // Structured worker failure recovery (GH #3599)
+    // =========================================================================
+
+    #[test]
+    fn structured_upstream_failure_enters_reroute_policy() {
+        let event = WorkerEvent::Failure {
+            message: "upstream_error: upstream request failed".to_string(),
+            retryable: true,
+            cost: Some(0.002),
+        };
+        let failure = attempt_failure_from_event(&event).expect("failure should be captured");
+
+        assert!(attempt_is_reroutable(&failure));
+        assert_eq!(failure.cost, 0.002);
+    }
+
+    #[test]
+    fn structured_nonretryable_failure_overrides_status_message_heuristic() {
+        let failure = AttemptFailure {
+            message: "HTTP 503 after a publisher tool executed".to_string(),
+            retryable: Some(false),
+            cost: 0.003,
+        };
+
+        assert!(!attempt_is_reroutable(&failure));
+    }
+
+    #[test]
+    fn successful_recovery_includes_failed_attempt_cost() {
+        let complete = WorkerEvent::Complete {
+            final_content: "Recovered".to_string(),
+            thinking: None,
+            cost: Some(0.004),
+            rlm_steps: None,
+        };
+
+        let event = add_prior_attempt_cost(complete, 0.002);
+        match event {
+            WorkerEvent::Complete {
+                cost: Some(cost), ..
+            } => assert!((cost - 0.006).abs() < f64::EPSILON),
+            other => panic!("Expected Complete event, got {other:?}"),
+        }
+    }
 
     // =========================================================================
     // Frontmatter Stripping

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -72,6 +72,15 @@ pub enum WorkerEvent {
     Error {
         message: String,
     },
+    /// A worker failure with an authoritative retry classification. The
+    /// single-task orchestrator holds this event until recovery is exhausted,
+    /// so a retryable intermediate attempt never renders as terminal.
+    Failure {
+        message: String,
+        retryable: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cost: Option<f64>,
+    },
     /// Emitted when a request is rerouted to a different model after a transient error.
     Reroute {
         from_model: String,
@@ -414,6 +423,16 @@ mod tests {
         assert_eq!(json["type"], "error");
         assert_eq!(json["message"], "oops");
 
+        let failure = WorkerEvent::Failure {
+            message: "upstream_error: upstream request failed".to_string(),
+            retryable: true,
+            cost: Some(0.002),
+        };
+        let json = serde_json::to_value(&failure).unwrap();
+        assert_eq!(json["type"], "failure");
+        assert_eq!(json["retryable"], true);
+        assert_eq!(json["cost"], 0.002);
+
         let reroute = WorkerEvent::Reroute {
             from_model: "moonshotai/kimi-k2.5".to_string(),
             to_model: "anthropic/claude-sonnet-4".to_string(),
@@ -440,6 +459,21 @@ mod tests {
         match event {
             WorkerEvent::Error { message } => assert_eq!(message, "something failed"),
             _ => panic!("Expected Error variant"),
+        }
+
+        let json = r#"{"type":"failure","message":"upstream_error","retryable":true,"cost":0.002}"#;
+        let event: WorkerEvent = serde_json::from_str(json).unwrap();
+        match event {
+            WorkerEvent::Failure {
+                message,
+                retryable,
+                cost,
+            } => {
+                assert_eq!(message, "upstream_error");
+                assert!(retryable);
+                assert_eq!(cost, Some(0.002));
+            }
+            _ => panic!("Expected Failure variant"),
         }
     }
 

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -104,6 +104,12 @@ type WorkerEvent =
     }
   | { type: "error"; message: string }
   | {
+      type: "failure";
+      message: string;
+      retryable: boolean;
+      cost?: number;
+    }
+  | {
       type: "reroute";
       from_model: string;
       to_model: string;
@@ -540,6 +546,14 @@ function handleWorkerEvent(event: OrchestratorEvent): void {
       break;
     case "error":
       handleError(workerEvent.message, event.conversation_id);
+      break;
+    case "failure":
+      handleError(
+        workerEvent.message,
+        event.conversation_id,
+        "orchestrator",
+        workerEvent.cost,
+      );
       break;
     case "reroute":
       handleReroute(event.conversation_id, workerEvent);
@@ -1199,9 +1213,13 @@ function handleError(
   message: string,
   conversationId?: string,
   workerType: WorkerType = "orchestrator",
+  cost?: number,
 ): void {
   const stream = conversationId ? activeStreams.get(conversationId) : null;
   if (conversationId && stream) {
+    const existing = conversationStore
+      .getMessagesFor(conversationId)
+      .find((message) => message.id === stream.messageId);
     const errorMessage: UnifiedMessage = {
       id: stream.messageId,
       type: "assistant",
@@ -1211,13 +1229,11 @@ function handleError(
       status: "error",
       error: message,
       workerType,
+      cost: cost ?? existing?.cost,
     };
     conversationStore.setRLMProcessing(false, conversationId);
     conversationStore.finalizeStreaming(conversationId);
-    const hasMessage = conversationStore
-      .getMessagesFor(conversationId)
-      .some((existing) => existing.id === stream.messageId);
-    if (hasMessage) {
+    if (existing) {
       conversationStore.updateMessage(
         stream.messageId,
         errorMessage,

--- a/tests/unit/orchestrator-error-handoff.test.ts
+++ b/tests/unit/orchestrator-error-handoff.test.ts
@@ -9,18 +9,20 @@ describe("#3493 terminal orchestrator error handoff", () => {
     const source = readSource("src-tauri/src/orchestrator/service.rs");
 
     expect(source).toContain(
-      "if let Some(error_message) = reroutable_error {\n                return Err(error_message);",
+      "emit_terminal_failure(app, conversation_id, &failure.message, failed_attempt_cost);",
     );
+    expect(source).toContain("return Err(failure.message);");
   });
 
   it("updates an existing assistant row instead of duplicating the error", () => {
     const source = readSource("src/services/orchestrator.ts");
 
     expect(source).toContain(
-      ".some((existing) => existing.id === stream.messageId);",
+      ".find((message) => message.id === stream.messageId);",
     );
     expect(source).toContain(
       "conversationStore.updateMessage(\n        stream.messageId,\n        errorMessage,\n        conversationId,",
     );
+    expect(source).toContain("cost: cost ?? existing?.cost,");
   });
 });


### PR DESCRIPTION
## Summary

- preserve retryability and cost metadata for embedded SerenModels stream failures
- hold intermediate attempt failures until explicit-model retry or Auto rerouting is exhausted
- prevent whole-turn retries after a tool has executed, avoiding duplicate side effects
- keep the frontend's terminal failure handoff idempotent

Closes #3599.

## Audited network path

`orchestrate()` → Tauri `orchestrate` → `execute_single_task` → `ChatModelWorker` → `POST /publishers/seren-models/chat/completions`

Auto model discovery remains `GET /publishers/seren-models/models`. This PR adds no publisher slug, method, or path.

## Validation

- `pnpm check` — passed (existing warnings only)
- `pnpm test` — 2,936 tests passed
- `pnpm build` — passed (existing bundler warnings only)
- `pnpm verify:frontend-build` — passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib orchestrator::` — 325 tests passed

Live macOS walkthrough evidence will be added before requesting human approval. The PR will not be merged without explicit walkthrough approval.