### PR TITLE
fix(models): hydrate picker from live Seren catalog

### DIFF
--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -36,6 +36,7 @@ import {
   type AgentType,
   isConfidentialSafeProvider,
 } from "@/services/providers";
+import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentDisplayName, agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import type { Conversation as ChatConversation } from "@/stores/chat.store";
@@ -143,7 +144,8 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
     return out;
   });
 
-  // Default models from provider store (curated list)
+  // Provider models from the store. Seren is hydrated from its live curated
+  // catalog below; the other providers retain their local defaults.
   const defaultModels = () => providerStore.getModels(currentProvider());
 
   // Load full model list from the Seren catalog or private models catalog.
@@ -193,8 +195,23 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
           return;
         }
 
-        const models = await modelsService.getAvailable();
-        setCatalogModels(models);
+        if (currentProvider() === "seren") {
+          try {
+            const models = await getLiveSerenModelCatalog();
+            providerStore.setProviderModels("seren", models);
+          } catch (error) {
+            // Fail closed instead of putting retired local model IDs back in
+            // the no-query picker when authoritative discovery is unavailable.
+            providerStore.setProviderModels("seren", []);
+            console.warn(
+              "[ModelSelector] SerenModels curated catalog unavailable:",
+              error,
+            );
+          }
+        }
+
+        const searchableModels = await modelsService.getAvailable();
+        setCatalogModels(searchableModels);
       } catch (err) {
         console.error("Failed to load available models:", err);
       } finally {

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -100,40 +100,6 @@ interface GatewayResponse<T> {
 }
 
 /**
- * Default models available through Seren Gateway.
- */
-const DEFAULT_MODELS: ProviderModel[] = [
-  // OpenAI
-  { id: "openai/gpt-5.5", name: "OpenAI GPT 5.5", contextWindow: 1050000 },
-  // Anthropic
-  {
-    id: "anthropic/claude-opus-4.6",
-    name: "Claude Opus 4.6",
-    contextWindow: 1000000,
-  },
-  {
-    id: "anthropic/claude-opus-4.5",
-    name: "Claude Opus 4.5",
-    contextWindow: 200000,
-  },
-  {
-    id: "anthropic/claude-sonnet-4.6",
-    name: "Claude Sonnet 4.6",
-    contextWindow: 1000000,
-  },
-  // Z.ai (formerly THUDM)
-  { id: "z-ai/glm-5.1", name: "GLM 5.1", contextWindow: 202752 },
-  // MoonshotAI
-  { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
-  // Arcee AI
-  {
-    id: "arcee-ai/trinity-large-thinking",
-    name: "Arcee-AI Trinity Large Thinking",
-    contextWindow: 262144,
-  },
-];
-
-/**
  * Fetch the authoritative SerenModels catalog without substituting local
  * defaults. Callers that must only send advertised IDs can treat failures or
  * an empty response as "no model" and use their own safe fallback.
@@ -477,12 +443,7 @@ export const serenProvider: ProviderAdapter = {
   },
 
   async getModels(_apiKey: string): Promise<ProviderModel[]> {
-    // Try to fetch from Seren's models endpoint
-    try {
-      return await fetchSerenModelCatalog();
-    } catch {
-      return DEFAULT_MODELS;
-    }
+    return fetchSerenModelCatalog();
   },
 };
 

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -76,36 +76,9 @@ interface ProviderState {
  * Default models for each provider (used before fetching or as fallback).
  */
 const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
-  seren: [
-    // OpenAI
-    { id: "openai/gpt-5.5", name: "OpenAI GPT 5.5", contextWindow: 1050000 },
-    // Anthropic
-    {
-      id: "anthropic/claude-opus-4.6",
-      name: "Claude Opus 4.6",
-      contextWindow: 1000000,
-    },
-    {
-      id: "anthropic/claude-opus-4.5",
-      name: "Claude Opus 4.5",
-      contextWindow: 200000,
-    },
-    {
-      id: "anthropic/claude-sonnet-4.6",
-      name: "Claude Sonnet 4.6",
-      contextWindow: 1000000,
-    },
-    // Z.ai (formerly THUDM)
-    { id: "z-ai/glm-5.1", name: "GLM 5.1", contextWindow: 202752 },
-    // MoonshotAI
-    { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
-    // Arcee AI
-    {
-      id: "arcee-ai/trinity-large-thinking",
-      name: "Arcee-AI Trinity Large Thinking",
-      contextWindow: 262144,
-    },
-  ],
+  // Seren's inference catalog is runtime-owned and must be hydrated from the
+  // publisher before it is shown or used as a concrete-model fallback.
+  seren: [],
   "seren-private": [],
   anthropic: [
     {

--- a/tests/unit/provider-picker-contract.test.ts
+++ b/tests/unit/provider-picker-contract.test.ts
@@ -5,6 +5,8 @@ import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
 const modelSelectorSource = readSource("src/components/chat/ModelSelector.tsx");
+const providerStoreSource = readSource("src/stores/provider.store.ts");
+const serenProviderSource = readSource("src/lib/providers/seren.ts");
 const threadProviderSwitcherSource = readSource("src/components/chat/ThreadProviderSwitcher.tsx");
 const chatContentSource = readSource("src/components/chat/ChatContent.tsx");
 
@@ -17,6 +19,26 @@ function sourceBetween(source: string, startNeedle: string, endNeedle: string) {
 }
 
 describe("provider picker switch contract", () => {
+  it("hydrates the empty Seren picker from the live curated catalog", () => {
+    const catalogLoading = sourceBetween(
+      modelSelectorSource,
+      "// Load full model list from the Seren catalog or private models catalog.",
+      "// Filter models: show defaults when no search, search full catalog when typing",
+    );
+
+    expect(catalogLoading).toContain("getLiveSerenModelCatalog()");
+    expect(catalogLoading).toContain(
+      'providerStore.setProviderModels("seren", models)',
+    );
+    expect(catalogLoading).toContain(
+      'providerStore.setProviderModels("seren", [])',
+    );
+    expect(catalogLoading).toContain("modelsService.getAvailable()");
+    expect(providerStoreSource).toMatch(/seren:\s*\[\]/);
+    expect(serenProviderSource).not.toContain("const DEFAULT_MODELS");
+    expect(serenProviderSource).toContain("return fetchSerenModelCatalog()");
+  });
+
   it("keeps ModelSelector provider chips as draft filters until a model commits", () => {
     const selectProvider = sourceBetween(
       modelSelectorSource,


### PR DESCRIPTION
## Summary

- hydrate the empty Seren Models picker from the existing live SerenModels catalog cache
- remove both stale hardcoded Seren model fallback lists
- fail closed to an empty catalog when live discovery fails, while preserving the existing retry/error state
- preserve typed search across the full OpenRouter catalog

Closes #3600

## Why

The empty model-picker view was reading a static provider-store snapshot, so it drifted from SerenModels' authoritative `GET /models` response. Typed search already used the full OpenRouter catalog and remains unchanged.

## Validation

- `pnpm check` — passes (existing repository warnings only)
- `pnpm test` — 2,937 tests pass
- `pnpm build` — passes
- `pnpm verify:frontend-build` — passes
- focused catalog/provider contracts — 14 tests pass
- live signed-in macOS walkthrough:
  - baseline: 7 stale hardcoded entries reproduced
  - fixed empty search: all 7 current SerenModels entries shown; 0 stale entries
  - selected newly hydrated `google/gemini-3.6-flash` successfully
  - typed `openai/gpt-4o` search still returns the full-catalog results

## Walkthrough

### Before — stale hardcoded picker

![Baseline model picker with stale entries](https://gist.githubusercontent.com/taariq/efa751385081cabe9c984f9daecb6e40/raw/seren-3600-before.svg)

### After — live curated SerenModels catalog

![Fixed picker with current live entries](https://gist.githubusercontent.com/taariq/9b809e312d122f5bcb3ba12913389a39/raw/seren-3600-after.svg)

### Full OpenRouter search preserved

![Typed GPT-4o search results](https://gist.githubusercontent.com/taariq/36b312585e75f68e3bdee3040c29c06d/raw/seren-3600-search.svg)
