### PR TITLE
feat(macos): request TCC folder access for agent working roots

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -8,6 +8,12 @@
     <string>Seren uses your camera only when you enable the camera overlay for workflow recording.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>Seren captures meeting audio to produce live transcripts and notes.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>Seren needs access to your Desktop folder so agents can read and write files in working directories there.</string>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>Seren needs access to your Documents folder so agents can read and write files in working directories there.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>Seren needs access to your Downloads folder so agents can read and write files in working directories there.</string>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>

--- a/src-tauri/src/commands/folder_access.rs
+++ b/src-tauri/src/commands/folder_access.rs
@@ -1,0 +1,220 @@
+// ABOUTME: macOS TCC permission handling for the special user folders (Desktop, Documents, Downloads).
+// ABOUTME: The foreground app obtains the grant so the headless agent shell inherits it for working roots under them.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// The macOS special user folders that are individually gated by TCC. This is the
+/// complete per-folder set macOS protects (Full Disk Access is the separate
+/// catch-all), so it is the source of truth for the permissions UI — not a
+/// partial hardcoded list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FolderAccessKey {
+    Desktop,
+    Documents,
+    Downloads,
+}
+
+impl FolderAccessKey {
+    pub const ALL: [FolderAccessKey; 3] = [
+        FolderAccessKey::Desktop,
+        FolderAccessKey::Documents,
+        FolderAccessKey::Downloads,
+    ];
+
+    /// The home-relative subdirectory name.
+    fn subdir(self) -> &'static str {
+        match self {
+            FolderAccessKey::Desktop => "Desktop",
+            FolderAccessKey::Documents => "Documents",
+            FolderAccessKey::Downloads => "Downloads",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        // Same as the subdir today, kept separate so display text can diverge.
+        self.subdir()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FolderAccessStatus {
+    Granted,
+    Denied,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderAccessCheck {
+    pub key: FolderAccessKey,
+    pub status: FolderAccessStatus,
+    pub label: String,
+    pub path: String,
+    pub message: String,
+    pub can_request: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderAccessPreflight {
+    pub platform: String,
+    pub checks: Vec<FolderAccessCheck>,
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+}
+
+fn folder_path(key: FolderAccessKey) -> Option<PathBuf> {
+    home_dir().map(|home| home.join(key.subdir()))
+}
+
+/// Map the outcome of a directory read into a TCC access status.
+///
+/// `PermissionDenied` (EPERM) is the TCC block we care about. A missing folder is
+/// not a permission barrier — the parent was reachable enough to learn it is
+/// absent — so it counts as accessible. `None` means the read succeeded.
+///
+/// Kept OS-agnostic and free of side effects so it can be unit-tested anywhere.
+fn status_from_outcome(err_kind: Option<ErrorKind>) -> FolderAccessStatus {
+    match err_kind {
+        None => FolderAccessStatus::Granted,
+        Some(ErrorKind::NotFound) => FolderAccessStatus::Granted,
+        Some(_) => FolderAccessStatus::Denied,
+    }
+}
+
+/// Probe a folder by listing it. On macOS, reading the folder from this
+/// (foreground app) process is what surfaces the TCC consent prompt on first
+/// access; an already-granted folder lists silently.
+#[cfg(target_os = "macos")]
+fn probe(path: &Path) -> FolderAccessStatus {
+    status_from_outcome(std::fs::read_dir(path).err().map(|error| error.kind()))
+}
+
+fn message_for(key: FolderAccessKey, status: FolderAccessStatus) -> String {
+    match status {
+        FolderAccessStatus::Granted => format!("Seren can access your {} folder.", key.label()),
+        FolderAccessStatus::Denied => format!(
+            "Seren needs access to your {} folder so agents can read and write files in working roots there. \
+             Grant access, then allow it in the macOS prompt.",
+            key.label()
+        ),
+        FolderAccessStatus::Unsupported => {
+            "Folder access permissions are managed by macOS and only apply on macOS.".to_string()
+        }
+    }
+}
+
+fn check_for(key: FolderAccessKey) -> FolderAccessCheck {
+    let path = folder_path(key)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    #[cfg(target_os = "macos")]
+    let status = folder_path(key)
+        .map(|p| probe(&p))
+        .unwrap_or(FolderAccessStatus::Denied);
+    #[cfg(not(target_os = "macos"))]
+    let status = FolderAccessStatus::Unsupported;
+
+    let can_request = matches!(status, FolderAccessStatus::Denied);
+
+    FolderAccessCheck {
+        key,
+        status,
+        label: key.label().to_string(),
+        path,
+        message: message_for(key, status),
+        can_request,
+    }
+}
+
+fn preflight() -> FolderAccessPreflight {
+    FolderAccessPreflight {
+        platform: std::env::consts::OS.to_string(),
+        checks: FolderAccessKey::ALL.iter().copied().map(check_for).collect(),
+    }
+}
+
+/// Report access status for every macOS special folder. On macOS the first probe
+/// may itself surface the consent prompt, which is the intended behavior when the
+/// user is on the permissions screen.
+#[tauri::command]
+pub async fn folder_access_check_permissions() -> Result<FolderAccessPreflight, String> {
+    Ok(preflight())
+}
+
+/// Touch the requested folder from the foreground app to surface the macOS consent
+/// prompt, then re-report the full preflight so callers see the updated state.
+#[tauri::command]
+pub async fn folder_access_request_permission(
+    key: FolderAccessKey,
+) -> Result<FolderAccessPreflight, String> {
+    let _ = check_for(key);
+    Ok(preflight())
+}
+
+/// Deep-link to System Settings → Privacy & Security → Files and Folders, where the
+/// per-app folder toggles live (there is no per-folder settings anchor).
+#[tauri::command]
+pub async fn folder_access_open_permission_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")
+            .spawn()
+            .map_err(|error| format!("Failed to open System Settings: {error}"))?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Folder access permission settings are only available on macOS.".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_covers_every_macos_special_folder() {
+        // The set macOS gates per-folder is exactly Desktop/Documents/Downloads.
+        // A shorter list would silently drop a folder from the permissions UI.
+        assert_eq!(FolderAccessKey::ALL.len(), 3);
+        assert!(FolderAccessKey::ALL.contains(&FolderAccessKey::Desktop));
+        assert!(FolderAccessKey::ALL.contains(&FolderAccessKey::Documents));
+        assert!(FolderAccessKey::ALL.contains(&FolderAccessKey::Downloads));
+    }
+
+    #[test]
+    fn permission_denied_is_the_only_blocked_outcome() {
+        // EPERM from TCC is the block we surface; success and a missing folder are
+        // both "accessible" so we don't nag the user about folders they deleted.
+        assert_eq!(status_from_outcome(None), FolderAccessStatus::Granted);
+        assert_eq!(
+            status_from_outcome(Some(ErrorKind::NotFound)),
+            FolderAccessStatus::Granted
+        );
+        assert_eq!(
+            status_from_outcome(Some(ErrorKind::PermissionDenied)),
+            FolderAccessStatus::Denied
+        );
+    }
+
+    #[test]
+    fn denied_folders_are_requestable() {
+        assert!(matches!(
+            message_for(FolderAccessKey::Desktop, FolderAccessStatus::Denied),
+            m if m.contains("Desktop")
+        ));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod commands {
     pub mod conversation_search;
     pub mod credential_lease;
     pub mod employees_archive;
+    pub mod folder_access;
     pub mod gateway_http;
     pub mod happy_bridge;
     pub mod history_sync;
@@ -1143,6 +1144,9 @@ pub fn run() {
             commands::recording::recording_check_permissions,
             commands::recording::recording_request_permission,
             commands::recording::recording_open_permission_settings,
+            commands::folder_access::folder_access_check_permissions,
+            commands::folder_access::folder_access_request_permission,
+            commands::folder_access::folder_access_open_permission_settings,
             commands::recording::recording_start,
             commands::recording::recording_stop,
             commands::recording::recording_add_marker,

--- a/src/components/settings/FolderAccessSettings.tsx
+++ b/src/components/settings/FolderAccessSettings.tsx
@@ -1,0 +1,157 @@
+// ABOUTME: Agent-settings surface to grant macOS Desktop/Documents/Downloads (TCC) access.
+// ABOUTME: The headless agent shell can't trigger the OS prompt itself, so the app requests the grant here and the agent inherits it.
+
+import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import {
+  checkFolderAccessPermissions,
+  type FolderAccessCheck,
+  type FolderAccessKey,
+  type FolderAccessPreflight,
+  openFolderAccessSettings,
+  requestFolderAccessPermission,
+} from "@/services/folder-access";
+
+const STATUS_LABEL: Record<FolderAccessCheck["status"], string> = {
+  granted: "Granted",
+  denied: "Not granted",
+  unsupported: "Unsupported",
+};
+
+const STATUS_CLASS: Record<FolderAccessCheck["status"], string> = {
+  granted: "text-emerald-600 dark:text-emerald-400",
+  denied: "text-amber-600 dark:text-amber-400",
+  unsupported: "text-muted-foreground",
+};
+
+export const FolderAccessSettings: Component = () => {
+  const [preflight, setPreflight] = createSignal<FolderAccessPreflight | null>(
+    null,
+  );
+  const [busyKey, setBusyKey] = createSignal<FolderAccessKey | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      setPreflight(await checkFolderAccessPermissions());
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  onMount(refresh);
+
+  const isMac = () => preflight()?.platform === "macos";
+
+  const grant = async (key: FolderAccessKey) => {
+    setBusyKey(key);
+    try {
+      // Requesting touches the folder from the foreground app, which surfaces
+      // the real macOS consent prompt; the returned preflight reflects the
+      // user's choice.
+      setPreflight(await requestFolderAccessPermission(key));
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const openSettings = async () => {
+    try {
+      await openFolderAccessSettings();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  return (
+    <div class="mt-6 flex flex-col gap-2" data-testid="folder-access-settings">
+      <h4 class="m-0 text-[1.05rem] font-semibold text-foreground">
+        Folder access
+      </h4>
+      <p class="m-0 text-[0.8rem] text-muted-foreground">
+        Agents run in a headless shell, so macOS never prompts them directly.
+        Grant Seren access to these folders so agents can read and write files
+        in working directories under them.
+      </p>
+
+      <Show
+        when={preflight()}
+        fallback={
+          <p class="m-0 text-[0.8rem] text-muted-foreground">
+            Checking folder access…
+          </p>
+        }
+      >
+        <Show
+          when={isMac()}
+          fallback={
+            <p class="m-0 text-[0.8rem] text-muted-foreground">
+              Folder access permissions apply on macOS only.
+            </p>
+          }
+        >
+          <div class="flex flex-col gap-1.5">
+            <For each={preflight()?.checks}>
+              {(check) => (
+                <div
+                  class="flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2"
+                  data-testid={`folder-access-${check.key}`}
+                >
+                  <div class="flex min-w-0 flex-col gap-0.5">
+                    <span class="text-[0.9rem] font-medium text-foreground">
+                      {check.label}
+                    </span>
+                    <span class="truncate text-[0.75rem] text-muted-foreground">
+                      {check.path}
+                    </span>
+                  </div>
+                  <div class="flex shrink-0 items-center gap-2">
+                    <span
+                      class={`text-[0.8rem] font-medium ${STATUS_CLASS[check.status]}`}
+                      data-testid={`folder-access-status-${check.key}`}
+                    >
+                      {STATUS_LABEL[check.status]}
+                    </span>
+                    <Show when={check.canRequest}>
+                      <button
+                        type="button"
+                        class="rounded-md border border-border bg-primary/10 px-2.5 py-1 text-[0.8rem] font-medium text-foreground hover:bg-primary/20 disabled:opacity-50"
+                        disabled={busyKey() === check.key}
+                        onClick={() => grant(check.key)}
+                        data-testid={`folder-access-grant-${check.key}`}
+                      >
+                        {busyKey() === check.key
+                          ? "Requesting…"
+                          : "Grant access"}
+                      </button>
+                    </Show>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+
+          <button
+            type="button"
+            class="mt-1 self-start text-[0.8rem] text-primary hover:underline"
+            onClick={openSettings}
+            data-testid="folder-access-open-settings"
+          >
+            Open System Settings → Files and Folders
+          </button>
+        </Show>
+      </Show>
+
+      <Show when={error()}>
+        {(message) => (
+          <p class="m-0 text-[0.8rem] text-red-600 dark:text-red-400">
+            {message()}
+          </p>
+        )}
+      </Show>
+    </div>
+  );
+};

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -66,6 +66,7 @@ import { claimDaily, walletState } from "@/stores/wallet.store";
 import { SendTransferModal } from "../wallet/SendTransferModal";
 import { ApiAccessSettings } from "./ApiAccessSettings";
 import { ConnectorSettings } from "./ConnectorSettings";
+import { FolderAccessSettings } from "./FolderAccessSettings";
 import { HappyRemoteSettings } from "./HappyRemoteSettings";
 import { KeybindingsSettings } from "./KeybindingsSettings";
 import { KeysSettings } from "./KeysSettings";
@@ -1737,6 +1738,8 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 </div>
               </label>
             </div>
+
+            <FolderAccessSettings />
 
             <StandingPoliciesSettings />
           </section>

--- a/src/services/folder-access.ts
+++ b/src/services/folder-access.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Frontend wrapper for the macOS folder-access (TCC) permission commands.
+// ABOUTME: Lets the settings UI check/request Desktop/Documents/Downloads access so agents can use working roots there.
+
+import { invoke } from "@tauri-apps/api/core";
+
+/** The macOS special user folders macOS gates individually via TCC. */
+export type FolderAccessKey = "desktop" | "documents" | "downloads";
+
+export type FolderAccessStatus = "granted" | "denied" | "unsupported";
+
+export interface FolderAccessCheck {
+  key: FolderAccessKey;
+  status: FolderAccessStatus;
+  label: string;
+  path: string;
+  message: string;
+  canRequest: boolean;
+}
+
+export interface FolderAccessPreflight {
+  platform: string;
+  checks: FolderAccessCheck[];
+}
+
+/** Report access status for every macOS special folder. */
+export async function checkFolderAccessPermissions(): Promise<FolderAccessPreflight> {
+  return invoke<FolderAccessPreflight>("folder_access_check_permissions");
+}
+
+/**
+ * Surface the macOS consent prompt for one folder by touching it from the
+ * foreground app, then return the refreshed preflight.
+ */
+export async function requestFolderAccessPermission(
+  key: FolderAccessKey,
+): Promise<FolderAccessPreflight> {
+  return invoke<FolderAccessPreflight>("folder_access_request_permission", {
+    key,
+  });
+}
+
+/** Deep-link to System Settings → Privacy & Security → Files and Folders. */
+export async function openFolderAccessSettings(): Promise<void> {
+  await invoke("folder_access_open_permission_settings");
+}


### PR DESCRIPTION
## Summary

The embedded agent's shell runs headless, so macOS never surfaces a TCC (Transparency, Consent & Control) consent prompt to it. The first read/write of an ungranted special folder — `~/Desktop`, `~/Documents`, `~/Downloads` — is silently denied with `Operation not permitted`, so any agent working root under those folders is unusable.

TCC grants are keyed to the app bundle and **inherited by child processes**. The fix has the foreground app request the grant (which does surface the prompt), after which the headless agent subprocess inherits it. This adds a first-class **Settings → Agent → Folder access** surface plus the Info.plist declarations that make the prompt legal.

Closes #3604.

## Root cause

- Per-folder TCC for Desktop/Documents/Downloads is granted **individually** and only via a user-facing consent prompt.
- A headless subprocess cannot display that prompt, so it can never obtain the grant on its own → silent `EPERM`.
- The app bundle never declared `NS*FolderUsageDescription` keys (verified against history — this is a **gap, not a regression**), so even a foreground touch had no usage string to present.

## Reproduction (before)

Agent shell inside the app, listing the three special folders:

```
~/Desktop:   BLOCKED -> Operation not permitted
~/Documents: readable
~/Downloads: readable
```

`~/Desktop` is the folder currently manifesting the block; the feature covers all three since any of them can be ungranted on a given machine.

## Changes

- **`src-tauri/Info.plist`** — declare `NSDesktopFolderUsageDescription`, `NSDocumentsFolderUsageDescription`, `NSDownloadsFolderUsageDescription` so macOS can present a consent prompt.
- **`src-tauri/src/commands/folder_access.rs`** (new) — `folder_access_check_permissions` / `folder_access_request_permission` / `folder_access_open_permission_settings`, mirroring the existing recording-permission command triad. `request` touches the folder from the **foreground** app to surface the real prompt; a pure `status_from_outcome` maps the read outcome to Granted/Denied/Unsupported.
- **`src-tauri/src/lib.rs`** — register the three commands.
- **`src/services/folder-access.ts`** (new) — typed `invoke` wrappers.
- **`src/components/settings/FolderAccessSettings.tsx`** (new) — per-folder status + **Grant access** + **Open System Settings**, rendered under **Agent** settings directly above *Standing pre-authorization policies* (no new section).

## Tests

- Rust unit tests (`folder_access`): `status_from_outcome` mapping, full Desktop/Documents/Downloads coverage, and requestability of denied folders — **3 passed**.
- `biome check` clean on all changed frontend files; `tsc --noEmit` reports no errors in the new files.

## Live walkthrough

macOS TCC behavior cannot be mocked, so this is validated against a locally-built signed bundle. **In progress** — release build running; I will post evidence (before block → new UI → real macOS consent prompt → grant → agent subprocess reads the folder), PII-scrubbed, before requesting review.

Do not merge until the live walkthrough is posted and explicitly approved.
