### PR TITLE
fix(auth): grant managed deployment lifecycle scopes

### DIFF
--- a/src-tauri/src/credential_lease.rs
+++ b/src-tauri/src/credential_lease.rs
@@ -23,10 +23,15 @@ const LEASE_RENEWAL_WINDOW_SECONDS: i64 = 6 * 60 * 60;
 // A general agent session cannot predict its publisher set at spawn because
 // the Seren MCP catalog is dynamic, so it retains the existing publisher
 // wildcard. Managed deployment mutations are a separate Core capability and
-// must be granted explicitly. Keep this at the narrow update operation needed
-// by managed update/rollback/reconciliation workflows; do not broaden it to
-// `managed-deployment:*`. See #3194 and #3489.
-const VERIFIED_LEASE_SCOPES: &[&str] = &["publisher:*", "managed-deployment:update"];
+// must be granted explicitly. Keep this at the narrow lifecycle operations
+// exposed to automation; do not broaden it to `managed-deployment:*`. See
+// #3194, #3489, and #3606.
+const VERIFIED_LEASE_SCOPES: &[&str] = &[
+    "publisher:*",
+    "managed-deployment:update",
+    "managed-deployment:stop",
+    "managed-deployment:delete",
+];
 
 /// What the renderer and provider runtime are allowed to see. The real key is
 /// deliberately absent: only the loopback broker holds it, and the capability
@@ -804,10 +809,15 @@ mod tests {
     };
 
     #[test]
-    fn credential_lease_requests_exact_managed_update_capability() {
+    fn credential_lease_requests_exact_managed_lifecycle_capabilities() {
         assert_eq!(
             VERIFIED_LEASE_SCOPES,
-            ["publisher:*", "managed-deployment:update"]
+            [
+                "publisher:*",
+                "managed-deployment:update",
+                "managed-deployment:stop",
+                "managed-deployment:delete",
+            ]
         );
         assert!(!VERIFIED_LEASE_SCOPES.contains(&"managed-deployment:*"));
     }

--- a/src/services/desktop-api-access.ts
+++ b/src/services/desktop-api-access.ts
@@ -15,6 +15,8 @@ export const DESKTOP_API_KEY_NAME = "Seren Desktop";
 export const DESKTOP_API_KEY_SCOPES = [
   "publisher:*",
   "managed-deployment:update",
+  "managed-deployment:stop",
+  "managed-deployment:delete",
 ] as const;
 
 export interface CreateApiKeyOptions {

--- a/tests/unit/auth-create-apikey-status.test.ts
+++ b/tests/unit/auth-create-apikey-status.test.ts
@@ -62,7 +62,12 @@ describe("createApiKey HTTP status (#2497 Defect 1)", () => {
         name: "Seren Desktop",
         key_type: undefined,
         agent_identity_id: undefined,
-        scopes: ["publisher:*", "managed-deployment:update"],
+        scopes: [
+          "publisher:*",
+          "managed-deployment:update",
+          "managed-deployment:stop",
+          "managed-deployment:delete",
+        ],
       },
       throwOnError: false,
     });

--- a/tests/unit/desktop-api-access.test.ts
+++ b/tests/unit/desktop-api-access.test.ts
@@ -38,7 +38,7 @@ const staleRecord = {
   name: "Seren Desktop",
   organization_id: "00000000-0000-4000-8000-000000000010",
   revoked_at: null,
-  scopes: ["publisher:*"],
+  scopes: ["publisher:*", "managed-deployment:update"],
 };
 
 const replacementRecord = {
@@ -50,7 +50,12 @@ const replacementRecord = {
   key_type: "user" as const,
   name: "Seren Desktop",
   organization_id: "00000000-0000-4000-8000-000000000010",
-  scopes: ["publisher:*", "managed-deployment:update"],
+  scopes: [
+    "publisher:*",
+    "managed-deployment:update",
+    "managed-deployment:stop",
+    "managed-deployment:delete",
+  ],
 };
 
 describe("Desktop API access reconciliation (#3520)", () => {
@@ -75,11 +80,14 @@ describe("Desktop API access reconciliation (#3520)", () => {
     });
   });
 
-  it("detects a pre-#3490 key, replaces it, and returns a green scope state", async () => {
+  it("detects a pre-#3606 key, replaces it, and returns a green scope state", async () => {
     const stale = await getDesktopApiKeyStatus();
 
     expect(stale.state).toBe("outdated");
-    expect(stale.missingScopes).toEqual(["managed-deployment:update"]);
+    expect(stale.missingScopes).toEqual([
+      "managed-deployment:stop",
+      "managed-deployment:delete",
+    ]);
     expect(stale.unexpectedScopes).toEqual([]);
     expect(stale.maskedValue).toBe("seren_legacy_••••••••");
     expect(JSON.stringify(stale)).not.toContain("seren_legacy_secret");
@@ -94,7 +102,12 @@ describe("Desktop API access reconciliation (#3520)", () => {
         name: "Seren Desktop",
         key_type: undefined,
         agent_identity_id: undefined,
-        scopes: ["publisher:*", "managed-deployment:update"],
+        scopes: [
+          "publisher:*",
+          "managed-deployment:update",
+          "managed-deployment:stop",
+          "managed-deployment:delete",
+        ],
       },
       throwOnError: false,
     });
@@ -119,6 +132,8 @@ describe("Desktop API access reconciliation (#3520)", () => {
             scopes: [
               "publisher:*",
               "managed-deployment:update",
+              "managed-deployment:stop",
+              "managed-deployment:delete",
               "managed-deployment:*",
             ],
           },


### PR DESCRIPTION
Closes #3606

## Summary
- grant the persistent Seren Desktop automation key the exact managed-deployment lifecycle scopes needed for update, stop, and delete
- keep the Rust one-day agent credential lease aligned with the same exact lifecycle capabilities
- preserve least privilege by continuing to reject `managed-deployment:*`
- protect stale-key reconciliation and the lease contract with focused regression coverage

## Root cause
The Desktop key and per-agent lease both granted `publisher:*` plus only `managed-deployment:update`. Settings therefore compared the installed key against an incomplete build-required list, reported **UP TO DATE**, and re-provisioned another key that still could not stop or delete a managed deployment.

## Audited network path
The changed API Access UI path uses signed-user Core SDK routes:
- `GET /organizations/default/api-keys`
- `POST /organizations/default/api-keys`
- `DELETE /organizations/default/api-keys/{record_uuid}`

There is no third-party publisher slug in the changed feature path. Managed lifecycle actions are native Seren MCP tools. The live gateway source of truth enumerated 258 tools, including `stop_seren_agent_deployment` and `delete_seren_agent_deployment`.

## Live macOS walkthrough
Run against the real signed-in validation app and production gateway; no mocks, stubs, or simulated state.

1. Opened **Settings → API Access** on the pre-fix build.
2. Confirmed the key incorrectly reported **UP TO DATE** while both Current scopes and Required by this build contained only `publisher:*` and `managed-deployment:update`.
3. Launched this fixed branch against the same signed-in profile.
4. Startup reconciliation replaced the stale key and revoked the prior record.
5. Confirmed Current scopes and Required by this build now match exactly:
   - `publisher:*`
   - `managed-deployment:update`
   - `managed-deployment:stop`
   - `managed-deployment:delete`
6. Confirmed the UI returned to **UP TO DATE**.
7. Authenticated the replacement Desktop key directly to the live MCP gateway and enumerated both lifecycle tools.
8. Called stop and delete with a newly generated nonexistent deployment UUID. Both reached their live handlers and returned deployment-not-found (404), not scope rejection (403). No real deployment was changed.

PII-free screenshots of the before/after scope panels are attached in the walkthrough evidence comment.

## Validation
- `pnpm test` — 417 files, 2,937 tests passed
- `cargo test --manifest-path src-tauri/Cargo.toml credential_lease::tests --lib -- --nocapture` — 8 passed
- `pnpm build` — passed
- `pnpm check` — passed with 48 pre-existing warnings and no errors
- `git diff --check` — passed