### PR TITLE
fix(orchestrator): announce each model switch once

### DIFF
--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -863,6 +863,7 @@ async fn execute_single_task(
     const MAX_SAME_MODEL_RETRIES: usize = 1;
     let mut network_retry_count: usize = 0;
     let mut failed_attempt_cost: f64 = 0.0;
+    let mut initial_transition_emitted = false;
 
     loop {
         // Bail out if cancellation arrived between iterations (e.g. during
@@ -878,14 +879,20 @@ async fn execute_single_task(
         // Load skills
         let skill_content = load_skill_content(&routing.selected_skills)?;
 
-        // Emit transition
-        let transition = TransitionEvent {
-            conversation_id: conversation_id.to_string(),
-            model_name: routing.model_id.clone(),
-            task_description: routing.reason.clone(),
-        };
-        app.emit("orchestrator://transition", &transition)
-            .map_err(|e| format!("Failed to emit transition event: {}", e))?;
+        // Announce the initial routing choice exactly once. Retry and
+        // reroute iterations re-enter this loop, and every later model
+        // switch is already announced by its WorkerEvent::Reroute — a
+        // second transition here rendered the same reason twice (#3603).
+        if !initial_transition_emitted {
+            let transition = TransitionEvent {
+                conversation_id: conversation_id.to_string(),
+                model_name: routing.model_id.clone(),
+                task_description: routing.reason.clone(),
+            };
+            app.emit("orchestrator://transition", &transition)
+                .map_err(|e| format!("Failed to emit transition event: {}", e))?;
+            initial_transition_emitted = true;
+        }
 
         // Create channel and spawn worker
         let (event_tx, mut event_rx) = mpsc::channel::<WorkerEvent>(256);

--- a/tests/unit/orchestrator-reroute-announcement.test.ts
+++ b/tests/unit/orchestrator-reroute-announcement.test.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Critical regression coverage for single reroute announcements.
+// ABOUTME: Protects the once-per-task transition emission in the retry loop.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+describe("#3603 one announcement per model switch", () => {
+  it("emits the initial routing transition only on the first attempt", () => {
+    const source = readSource("src-tauri/src/orchestrator/service.rs");
+
+    // The retry loop must gate the transition so retry/reroute iterations
+    // cannot re-announce the routing reason a Reroute event already covers.
+    expect(source).toContain("let mut initial_transition_emitted = false;");
+    expect(source).toContain("if !initial_transition_emitted {");
+    expect(source).toContain("initial_transition_emitted = true;");
+  });
+
+  it("keeps reroute announcements and terminal failure rows intact", () => {
+    const source = readSource("src-tauri/src/orchestrator/service.rs");
+
+    // Every model switch still announces itself through WorkerEvent::Reroute,
+    // and terminal give-up paths still emit a failure row.
+    expect(source).toContain("worker_event: WorkerEvent::Reroute {");
+    expect(source).toContain(
+      "emit_terminal_failure(app, conversation_id, &error_msg, failed_attempt_cost);",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3603.

## Root cause

The retry loop in `execute_single_task` emits an `orchestrator://transition` event at the top of **every** iteration, and the auto-reroute path copies the reroute reason into `routing.reason`. So the iteration after a reroute re-rendered the exact reason the `WorkerEvent::Reroute` row had just announced — two rows per model switch. The duplicate has existed since #482 moved the transition emission into the loop; the #3599 walkthrough exposed it.

## Fix

Gate the transition emission to the first attempt. Initial routing still renders one row; every subsequent model switch is announced solely by its highlighted Reroute row (which carries from/to model); terminal failure rows are unchanged. Same-model retries and network retries also stop re-emitting an identical transition row.

Network path: none — this is a local event-handoff fix; no publisher/API path changes.

## Tests

- `tests/unit/orchestrator-reroute-announcement.test.ts` (source-text regression coverage, house convention per `orchestrator-error-handoff.test.ts`)
- `cargo check` clean; focused vitest green.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
