### PR TITLE
fix(chat): keep Auto threads on Auto after a reroute

### DIFF
--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -1338,15 +1338,25 @@ function handleReroute(
   // B's selected model. Persist the rerouted thread's own selectedProvider so
   // the runtime row stays paired with the new model instead of inheriting the
   // global picker's provider.
-  if (conversationId === chatStore.activeConversationId) {
-    providerStore.setActiveModel(event.to_model);
-    chatStore.setModel(event.to_model);
+  //
+  // A thread routed by Auto stays on Auto: the fallback model applies to the
+  // current attempt only (activeStreams above already labels it), and the
+  // next task must re-run Auto selection. Persisting the fallback here pinned
+  // the thread and the visible picker to the last attempted model (#3602).
+  const threadIsAuto =
+    (reroutedConv?.selectedModel ?? providerStore.activeModel) ===
+    AUTO_MODEL_ID;
+  if (!threadIsAuto) {
+    if (conversationId === chatStore.activeConversationId) {
+      providerStore.setActiveModel(event.to_model);
+      chatStore.setModel(event.to_model);
+    }
+    void conversationStore.updateConversationSelection(
+      conversationId,
+      event.to_model,
+      reroutedProvider,
+    );
   }
-  void conversationStore.updateConversationSelection(
-    conversationId,
-    event.to_model,
-    reroutedProvider,
-  );
 
   // Add a reroute announcement message to the conversation
   const rerouteMessage: UnifiedMessage = {

--- a/tests/unit/orchestrator-auto-reroute-selection.test.ts
+++ b/tests/unit/orchestrator-auto-reroute-selection.test.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Critical regression coverage for Auto-mode reroute selection.
+// ABOUTME: Protects Auto threads from being pinned to a fallback model.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+describe("#3602 Auto reroute keeps the thread on Auto", () => {
+  it("gates picker mirrors and persisted selection on the routing mode", () => {
+    const source = readSource("src/services/orchestrator.ts");
+
+    // An automatic fallback must not rewrite an Auto thread's persisted
+    // selection or the visible picker — Auto re-routes on the next task.
+    expect(source).toContain(
+      "(reroutedConv?.selectedModel ?? providerStore.activeModel) ===",
+    );
+    expect(source).toContain("if (!threadIsAuto) {");
+  });
+
+  it("still labels the current attempt with the concrete fallback model", () => {
+    const source = readSource("src/services/orchestrator.ts");
+
+    // The streaming state carries the model actually serving this attempt,
+    // so the runtime row shows the fallback without changing routing mode.
+    expect(source).toContain("modelId: event.to_model,");
+  });
+});


### PR DESCRIPTION
Fixes #3602.

## Root cause

`handleReroute()` unconditionally persisted `event.to_model` as the thread's conversation selection and rewrote the picker mirrors (`providerStore.setActiveModel` / `chatStore.setModel`). A thread the user had on **Auto** therefore ended pinned to the last attempted fallback model, and the next task bypassed Auto routing entirely.

## Fix

Compute the thread's effective routing mode (`reroutedConv?.selectedModel ?? providerStore.activeModel`) and skip both the picker mirrors and the persisted selection when it is `AUTO_MODEL_ID`. The streaming state still labels the current attempt with the concrete fallback model, so the runtime row shows what actually served the attempt. Explicitly-selected threads keep the existing follow-the-fallback behavior. Active/background thread isolation (the `activeConversationId` gate) is preserved.

Network path: `GET /publishers/seren-models/models` (Auto candidates) and `POST /publishers/seren-models/chat/completions` (attempts) are unchanged; no new publisher path.

## Tests

- `tests/unit/orchestrator-auto-reroute-selection.test.ts` (house source-text convention)
- Focused vitest green.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
