### PR TITLE
fix(macos): probe folder access on the blocking pool

### DIFF
--- a/src-tauri/src/commands/folder_access.rs
+++ b/src-tauri/src/commands/folder_access.rs
@@ -146,20 +146,29 @@ fn preflight() -> FolderAccessPreflight {
 
 /// Report access status for every macOS special folder. On macOS the first probe
 /// may itself surface the consent prompt, which is the intended behavior when the
-/// user is on the permissions screen.
+/// user is on the permissions screen. The probe blocks until the user answers,
+/// so it must run on the blocking pool rather than pin an async worker.
 #[tauri::command]
 pub async fn folder_access_check_permissions() -> Result<FolderAccessPreflight, String> {
-    Ok(preflight())
+    tauri::async_runtime::spawn_blocking(preflight)
+        .await
+        .map_err(|error| format!("Folder access preflight failed: {error}"))
 }
 
 /// Touch the requested folder from the foreground app to surface the macOS consent
 /// prompt, then re-report the full preflight so callers see the updated state.
+/// Runs on the blocking pool: the syscall stays pending until the consent
+/// dialog is answered.
 #[tauri::command]
 pub async fn folder_access_request_permission(
     key: FolderAccessKey,
 ) -> Result<FolderAccessPreflight, String> {
-    let _ = check_for(key);
-    Ok(preflight())
+    tauri::async_runtime::spawn_blocking(move || {
+        let _ = check_for(key);
+        preflight()
+    })
+    .await
+    .map_err(|error| format!("Folder access request failed: {error}"))
 }
 
 /// Deep-link to System Settings → Privacy & Security → Files and Folders, where the

--- a/tests/unit/folder-access-blocking.test.ts
+++ b/tests/unit/folder-access-blocking.test.ts
@@ -1,0 +1,16 @@
+// ABOUTME: Critical regression coverage for folder-access probe scheduling.
+// ABOUTME: Protects the blocking-pool wrap around macOS TCC consent probes.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+describe("#3613 folder-access probes run on the blocking pool", () => {
+  it("wraps both probe commands in spawn_blocking", () => {
+    const source = readSource("src-tauri/src/commands/folder_access.rs");
+
+    // A TCC consent probe blocks until the user answers the dialog —
+    // potentially minutes. It must not pin an async runtime worker.
+    expect(source).toContain("tauri::async_runtime::spawn_blocking(preflight)");
+    expect(source).toContain("tauri::async_runtime::spawn_blocking(move || {");
+  });
+});


### PR DESCRIPTION
Fixes #3613.

## Root cause

The macOS folder-access probes (`std::fs::read_dir`) run inline inside `async fn` Tauri commands. The first probe of an ungranted folder blocks the syscall until the user answers the TCC consent dialog — potentially minutes — pinning a tokio runtime worker per probed folder (`folder_access_check_permissions` probes Desktop/Documents/Downloads sequentially, and the settings screen refreshes on mount).

## Fix

Run the probes under `tauri::async_runtime::spawn_blocking` (the same pattern the orchestrator already uses), so pending consent dialogs occupy the blocking pool instead of async workers. Surfacing the prompt from the foreground app process is unchanged — TCC attributes by process, not thread.

## Tests

- `tests/unit/folder-access-blocking.test.ts` (house source-text convention).
- Existing `folder_access` Rust unit tests unaffected; `cargo check` clean.

## Network path

None — local filesystem/TCC only.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
