### PR TITLE
fix(models): hydrate the Seren catalog on all picker surfaces

### DIFF
--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -200,9 +200,10 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
             const models = await getLiveSerenModelCatalog();
             providerStore.setProviderModels("seren", models);
           } catch (error) {
-            // Fail closed instead of putting retired local model IDs back in
-            // the no-query picker when authoritative discovery is unavailable.
-            providerStore.setProviderModels("seren", []);
+            // Fail closed only before the first successful discovery: the
+            // empty default keeps retired local model IDs out of the picker,
+            // while models already hydrated from the live catalog stay usable
+            // across a transient discovery failure.
             console.warn(
               "[ModelSelector] SerenModels curated catalog unavailable:",
               error,

--- a/src/components/chat/ThreadProviderSwitcher.tsx
+++ b/src/components/chat/ThreadProviderSwitcher.tsx
@@ -18,6 +18,7 @@ import {
   switchChatProvider,
 } from "@/services/provider-bindings";
 import type { AgentType } from "@/services/providers";
+import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentDisplayName, agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -130,6 +131,19 @@ export const ThreadProviderSwitcher: Component<Props> = (props) => {
           (policyDefault &&
             models.find((model) => model.id === policyDefault)?.id) ||
           models[0]?.id;
+      } catch (error) {
+        reportSwitchFailure(error);
+        return;
+      }
+    } else if (providerId === "seren") {
+      // The Seren inference catalog is runtime-owned and starts empty, and
+      // agent threads mount no surface that hydrates it — reading the sync
+      // store here refused every cold switch. Fetch the live catalog like
+      // the seren-private branch above.
+      try {
+        const models = await getLiveSerenModelCatalog();
+        providerStore.setProviderModels(providerId, models);
+        fallbackModel = models[0]?.id;
       } catch (error) {
         reportSwitchFailure(error);
         return;

--- a/tests/unit/provider-picker-contract.test.ts
+++ b/tests/unit/provider-picker-contract.test.ts
@@ -30,7 +30,10 @@ describe("provider picker switch contract", () => {
     expect(catalogLoading).toContain(
       'providerStore.setProviderModels("seren", models)',
     );
-    expect(catalogLoading).toContain(
+    // A transient discovery failure must not wipe models already hydrated
+    // from the live catalog; the empty startup default alone keeps retired
+    // static ids out of the picker. #3614
+    expect(catalogLoading).not.toContain(
       'providerStore.setProviderModels("seren", [])',
     );
     expect(catalogLoading).toContain("modelsService.getAvailable()");
@@ -95,6 +98,11 @@ describe("provider picker switch contract", () => {
     expect(selectChatProvider).toContain(
       "privateModelsService.listAvailable()",
     );
+    // The Seren branch must hydrate the runtime-owned catalog the same way —
+    // agent threads mount no ModelSelector, so nothing else populates it and
+    // the sync store read refused every cold switch. #3614
+    expect(selectChatProvider).toContain('providerId === "seren"');
+    expect(selectChatProvider).toContain("getLiveSerenModelCatalog()");
     expect(selectChatProvider).toContain(
       "switchChatProvider(props.threadId, providerId, fallbackModel)",
     );


### PR DESCRIPTION
Fixes #3614.

## Root cause

#3605 correctly retired the static Seren model list (`DEFAULT_MODELS.seren = []`), but two synchronous consumers were left behind:

1. `ThreadProviderSwitcher`'s Seren branch reads `providerStore.getModels("seren")[0]` — agent threads mount no `ModelSelector`, so nothing hydrates the catalog on that surface and every cold switch was refused with "No models available for Seren."
2. `ModelSelector`'s catch reset the seren list to `[]` on any fetch error, wiping models already hydrated from the live catalog and re-arming the refusal.

## Fix

- The switcher's Seren branch awaits `getLiveSerenModelCatalog()` (dedupes in-flight requests) and stores the result before choosing a fallback model — exactly mirroring its seren-private branch.
- The catch keeps previously hydrated live models; the empty startup default alone keeps retired static ids out of the picker. No static ids are resurrected; the catalog stays runtime-owned per #3605's design.
- Verified non-defect while auditing: `resolvedModel()` can hand the `"auto"` sentinel to the audio paths, but `src-tauri/src/audio/llm.rs` explicitly tolerates it (falls back to the SerenModels summarization model), so notes/dictation were never broken.

## Tests

- `tests/unit/provider-picker-contract.test.ts` updated to pin the new contract: no wipe-on-failure, and the switcher's Seren branch must hydrate the live catalog. The original assertion pinned the wipe this PR removes; its intent (no retired static ids) is preserved by the empty-default assertions that remain.

## Network path

`GET /publishers/seren-models/models` — existing first-party discovery path; no new publisher path.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
