### PR TITLE
fix(models): bound the Seren catalog discovery fetch

### DIFF
--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -104,11 +104,16 @@ interface GatewayResponse<T> {
  * defaults. Callers that must only send advertised IDs can treat failures or
  * an empty response as "no model" and use their own safe fallback.
  */
+/** Catalog discovery gates Auto sends, so a stalled connection must become a
+ * rejection the callers' existing failure handling can act on. */
+const CATALOG_TIMEOUT_MS = 15_000;
+
 export async function fetchSerenModelCatalog(): Promise<ProviderModel[]> {
   const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/models`;
   const response = await appFetch(url, {
     method: "GET",
     headers: await getGatewayHeaders(url),
+    signal: AbortSignal.timeout(CATALOG_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/tests/unit/seren-catalog-timeout.test.ts
+++ b/tests/unit/seren-catalog-timeout.test.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Critical regression coverage for the Seren catalog fetch bound.
+// ABOUTME: Protects the timeout signal on the discovery call gating Auto sends.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+describe("#3615 Seren model catalog fetch is bounded", () => {
+  it("passes a timeout signal so a stalled connection rejects", () => {
+    const source = readSource("src/lib/providers/seren.ts");
+
+    expect(source).toContain("signal: AbortSignal.timeout(CATALOG_TIMEOUT_MS)");
+  });
+});


### PR DESCRIPTION
Fixes #3615.

## Root cause

`fetchSerenModelCatalog` carried no timeout, and #3605 made catalog discovery a hard prerequisite for Auto chat sends (plus mission launch catalogs and the run dispatcher) through one shared in-flight promise. A stalled connection blocked Auto sends indefinitely with the loading state up.

## Fix

Pass `AbortSignal.timeout(15_000)` on the discovery fetch, so a stall becomes a rejection the callers' existing failure handling already covers (Auto send surfaces its retry message; pickers keep the last-known catalog).

## Tests

- `tests/unit/seren-catalog-timeout.test.ts` (house source-text convention).

## Network path

`GET /publishers/seren-models/models` — existing first-party discovery path; no new publisher path.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
