### PR TITLE
fix(run): bound hosted-model mission tasks by the turn cap

### DIFF
--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -443,6 +443,34 @@ function isNativeAgentType(agentType: string): agentType is AgentType {
 }
 
 /**
+ * Hosted-model tasks share the native agents' turn cap: a stalled Gateway
+ * stream must fail the attempt and free its dispatch slot instead of holding
+ * the run open forever. The expired stream is abandoned to settle on its own;
+ * only the attempt's outcome is bounded here.
+ */
+function withHostedTaskDeadline(work: Promise<string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `hosted-model task produced no result within ${Math.round(TURN_WAIT_TIMEOUT_MS / 60_000)} minutes`,
+        ),
+      );
+    }, TURN_WAIT_TIMEOUT_MS);
+    work.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
  * Use the signed-in Seren model when a launch-box assignment is not backed by
  * a local CLI, or when a local CLI cannot start. The assignment remains the
  * durable source of truth; this fallback keeps a run honest by recording the
@@ -568,23 +596,17 @@ async function dispatchTask(
     let fallbackDetail: string | null = null;
 
     if (assignment.agent_type === "seren") {
-      response = await runSerenChatTask(
-        snapshot.run.objective,
-        task,
-        assignment.model_id,
+      response = await withHostedTaskDeadline(
+        runSerenChatTask(snapshot.run.objective, task, assignment.model_id),
       );
     } else if (assignment.agent_type === "seren-private") {
-      response = await runSerenPrivateTask(
-        snapshot.run.objective,
-        task,
-        assignment.model_id,
+      response = await withHostedTaskDeadline(
+        runSerenPrivateTask(snapshot.run.objective, task, assignment.model_id),
       );
     } else if (!isNativeAgentType(assignment.agent_type)) {
       fallbackDetail = `assignment ${assignment.agent_type} uses the signed-in Seren chat model because no local runtime supports that label`;
-      response = await runSerenChatTask(
-        snapshot.run.objective,
-        task,
-        assignment.model_id,
+      response = await withHostedTaskDeadline(
+        runSerenChatTask(snapshot.run.objective, task, assignment.model_id),
       );
     } else {
       try {
@@ -608,7 +630,9 @@ async function dispatchTask(
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         fallbackDetail = `${assignment.agent_type} local session unavailable; used the signed-in Seren chat model: ${detail}`;
-        response = await runSerenChatTask(snapshot.run.objective, task);
+        response = await withHostedTaskDeadline(
+          runSerenChatTask(snapshot.run.objective, task),
+        );
       }
     }
 

--- a/tests/unit/run-dispatcher-hosted-cap.test.ts
+++ b/tests/unit/run-dispatcher-hosted-cap.test.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Critical regression coverage for the hosted-model task time bound.
+// ABOUTME: Protects the turn cap applied to every hosted dispatch call site.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+describe("#3616 hosted-model mission tasks are time-bounded", () => {
+  it("wraps every hosted call site in the shared deadline", () => {
+    const source = readSource("src/services/run-dispatcher.ts");
+
+    // All four hosted dispatch paths (seren, seren-private, unknown-label
+    // fallback, native-session fallback) must run under the turn cap so a
+    // stalled stream fails the attempt and frees its slot.
+    const wrapped = source.match(/withHostedTaskDeadline\(\s*runSeren/g) ?? [];
+    expect(wrapped.length).toBe(4);
+
+    // No hosted call site may bypass the deadline.
+    expect(source).not.toMatch(/await runSerenChatTask\(/);
+    expect(source).not.toMatch(/await runSerenPrivateTask\(/);
+  });
+});


### PR DESCRIPTION
Fixes #3616.

## Root cause

Mission tasks assigned to hosted models (`seren`, `seren-private`, unknown-label fallback, native-session fallback) awaited the provider stream with no time bound, while native-agent tasks already carry a 30-minute `waitForTurn` cap. A hung Gateway stream held one of the run's dispatch slots and kept its attempt open indefinitely.

## Fix

A shared `withHostedTaskDeadline` wraps all four hosted call sites with the existing `TURN_WAIT_TIMEOUT_MS` cap. On expiry the attempt fails through the existing catch → coverage-gap → `runFinishAttempt("failed")` path and the slot frees. The expired stream is abandoned to settle on its own — only the attempt's outcome is bounded (no abort plumbing added through the streaming layers; stated deliberately).

## Tests

- `tests/unit/run-dispatcher-hosted-cap.test.ts`: every hosted call site must run under the deadline; none may bypass it.
- Existing `run-dispatcher-selection` tests pass.

## Network path

`POST /publishers/seren-models/chat/completions` and the seren-private equivalent — existing paths; no new publisher path.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
