### PR TITLE
fix(run): cancel a run whose launch fails to provision

### DIFF
--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -149,7 +149,12 @@ function enqueueEvent(event: RunEvent): Promise<void> {
   return applyQueue;
 }
 
+// Runs cancelled because their launch failed. Their late cancel events must
+// not re-open the run overview over the launch form that shows the error.
+const dismissedRunIds = new Set<string>();
+
 async function applyEvent(event: RunEvent): Promise<void> {
+  if (dismissedRunIds.has(event.run_id)) return;
   if (state.activeRunId && event.run_id !== state.activeRunId) return;
   if (event.sequence <= state.lastSequence) return;
 
@@ -223,12 +228,14 @@ async function launch(options: LaunchOptions): Promise<void> {
     return;
   }
   setState({ launchPending: true, error: null });
+  let createdRunId: string | null = null;
   try {
     const run = await runCreate(
       trimmedObjective,
       options.rootPath ?? null,
       options.maxAttempts,
     );
+    createdRunId = run.id;
     for (const agent of options.agents) {
       await runAddAgent(
         run.id,
@@ -270,6 +277,21 @@ async function launch(options: LaunchOptions): Promise<void> {
     setState("activeRunId", run.id);
     await hydrate(run.id);
   } catch (error) {
+    // A run that failed to finish launching must not keep running: its
+    // run_created/task_added events already hydrated a snapshot, which swaps
+    // the panel to the run overview and unmounts the only surface showing
+    // runStore.error — and with no lease the dispatcher would quietly run
+    // the tasks in the real project root instead of the requested isolation.
+    // Cancel the partial run and return to the launch form with the error.
+    if (createdRunId) {
+      dismissedRunIds.add(createdRunId);
+      try {
+        await runCancel(createdRunId);
+      } catch {
+        // Preserve the original launch failure over a cancel failure.
+      }
+      setState({ activeRunId: null, snapshot: null, lastSequence: 0 });
+    }
     setState("error", errorMessage(error));
   } finally {
     setState("launchPending", false);

--- a/tests/unit/run-store-launch-failure.test.ts
+++ b/tests/unit/run-store-launch-failure.test.ts
@@ -1,0 +1,158 @@
+// ABOUTME: Tests the launch failure path of the Mission Control run store.
+// ABOUTME: Protects cancel-on-provision-failure so runs never drop isolation.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/run", async () => {
+  const actual = await vi.importActual<typeof import("@/services/run")>(
+    "@/services/run",
+  );
+  return {
+    ...actual,
+    runAddAgent: vi.fn(),
+    runAddTask: vi.fn(),
+    runCancel: vi.fn(),
+    runCreate: vi.fn(),
+    runGetState: vi.fn(),
+    runProvisionWorkspace: vi.fn(),
+  };
+});
+
+import {
+  type Run,
+  runAddAgent,
+  runAddTask,
+  runCancel,
+  runCreate,
+  runGetState,
+  runProvisionWorkspace,
+  type RunSnapshot,
+  type Task,
+} from "@/services/run";
+import {
+  INITIAL_STATE,
+  runState,
+  runStore,
+  setRunState,
+} from "@/stores/run.store";
+
+const createMock = vi.mocked(runCreate);
+const addAgentMock = vi.mocked(runAddAgent);
+const addTaskMock = vi.mocked(runAddTask);
+const provisionMock = vi.mocked(runProvisionWorkspace);
+const cancelMock = vi.mocked(runCancel);
+const getStateMock = vi.mocked(runGetState);
+
+function snapshot(runRow: Run): RunSnapshot {
+  return {
+    run: runRow,
+    tasks: [],
+    dependencies: [],
+    assignments: [],
+    leases: [],
+    attempts: [],
+    findings: [],
+    checks: [],
+    check_results: [],
+    coverage_gaps: [],
+  };
+}
+
+function run(id: string, status: Run["status"]): Run {
+  return {
+    id,
+    objective: `Objective ${id}`,
+    root_path: "/projects/example",
+    max_attempts: 2,
+    status,
+    cancel_requested: status === "cancelled",
+    interrupted_at: null,
+    created_at: 1,
+    updated_at: 1,
+    completed_at: null,
+  };
+}
+
+function task(id: string, runId: string): Task {
+  return {
+    id,
+    run_id: runId,
+    title: `Task ${id}`,
+    brief: "brief",
+    state: "ready",
+    blocked_reason: null,
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setRunState({ ...INITIAL_STATE });
+});
+
+describe("#3612 launch failure cannot drop workspace isolation", () => {
+  it("cancels the partial run and returns to the launch form", async () => {
+    createMock.mockResolvedValue(run("run-1", "running"));
+    addAgentMock.mockResolvedValue({
+      id: "assignment-1",
+      run_id: "run-1",
+      agent_type: "claude-code",
+      model_id: null,
+      secondary_model_id: null,
+      permission_mode: null,
+      created_at: 1,
+    });
+    addTaskMock.mockResolvedValue(task("task-1", "run-1"));
+    provisionMock.mockRejectedValue(
+      new Error("worktree provisioning requires a git repository"),
+    );
+    cancelMock.mockResolvedValue(run("run-1", "cancelled"));
+
+    await runStore.launch({
+      objective: "Audit the schema",
+      rootPath: "/projects/example",
+      tasks: [{ title: "Audit", brief: "look" }],
+      agents: [{ agentType: "claude-code" }],
+      workspaceMode: "worktree",
+      maxAttempts: 2,
+    });
+
+    // The partial run is cancelled, the launch form stays up, and the
+    // provisioning error is visible on it.
+    expect(cancelMock).toHaveBeenCalledWith("run-1");
+    expect(runState.activeRunId).toBeNull();
+    expect(runState.snapshot).toBeNull();
+    expect(runState.error).toContain("git repository");
+    expect(runState.launchPending).toBe(false);
+  });
+
+  it("keeps the run when every launch step succeeds", async () => {
+    createMock.mockResolvedValue(run("run-2", "running"));
+    addAgentMock.mockResolvedValue({
+      id: "assignment-2",
+      run_id: "run-2",
+      agent_type: "claude-code",
+      model_id: null,
+      secondary_model_id: null,
+      permission_mode: null,
+      created_at: 1,
+    });
+    addTaskMock.mockResolvedValue(task("task-2", "run-2"));
+    provisionMock.mockResolvedValue(undefined);
+    getStateMock.mockResolvedValue(snapshot(run("run-2", "running")));
+
+    await runStore.launch({
+      objective: "Audit the schema",
+      rootPath: "/projects/example",
+      tasks: [{ title: "Audit", brief: "look" }],
+      agents: [{ agentType: "claude-code" }],
+      workspaceMode: "worktree",
+      maxAttempts: 2,
+    });
+
+    expect(cancelMock).not.toHaveBeenCalled();
+    expect(runState.activeRunId).toBe("run-2");
+    expect(runState.error).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3612.

## Root cause

`launch()` provisions workspaces after `runCreate`/`runAddAgent`/`runAddTask`. When provisioning threw (e.g. Worktree mode on a non-git folder — launch validation only checks the path exists, while worktree provisioning hard-requires a git repository), the catch only set `runStore.error` — but the `run_created`/`task_added` events had already hydrated a snapshot, swapping the panel to the run overview and unmounting the only surface that renders that error. The run stayed `running`, and with no active lease the dispatcher's `taskWorkspaceRoot` fell back to the real project root: agents ran unisolated, silently, possibly with workspace-edit permissions.

## Fix

The launch catch now cancels the partially-created run (best-effort, preserving the original error), dismisses that run's late cancel events so they cannot re-open the overview, resets the store to the launch form, and shows the provisioning error there. A run that requested isolation either gets it or fails loudly before dispatch.

## Tests

- `tests/unit/run-store-launch-failure.test.ts`: provisioning failure cancels the created run, returns to the launch form with the error visible; the all-success path is unchanged. (Service layer mocked per the run-store unit test convention from #3598; live behavior covered in the release walkthrough.)

## Network path

None — local run engine and store logic.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
