### PR TITLE
fix(run): land New Mission on the launch form

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -86,6 +86,7 @@ import {
   type KeybindingActionId,
 } from "@/stores/keybindings.store";
 import { meetingStore } from "@/stores/meeting.store";
+import { runStore } from "@/stores/run.store";
 import { skillPublishStore } from "@/stores/skill-publish.store";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
@@ -604,6 +605,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
   };
 
   const handleOpenMissionControl = () => {
+    // New Mission must land on the launch form even when the panel is already
+    // open showing a settled run — re-setting the same panel value alone
+    // notifies nothing. Live runs keep their overview.
+    runStore.showLaunchForm();
     setSlidePanel("missioncontrol");
   };
 

--- a/src/stores/run.store.ts
+++ b/src/stores/run.store.ts
@@ -315,6 +315,17 @@ async function setFindingStatus(
   }
 }
 
+/**
+ * Return to the launch form when the visible run is settled. A running or
+ * interrupted run keeps its overview — starting a new mission must never
+ * discard live work.
+ */
+function showLaunchForm(): void {
+  const status = state.snapshot?.run.status;
+  if (!status || status === "running" || status === "interrupted") return;
+  setState({ activeRunId: null, snapshot: null, lastSequence: 0, error: null });
+}
+
 function needsYou() {
   return (state.snapshot?.findings ?? []).filter(
     (finding) => finding.needs_approval && finding.status === "open",
@@ -361,6 +372,7 @@ export const runStore = {
   launch,
   cancel,
   relaunch,
+  showLaunchForm,
   approveFinding: (findingId: string) =>
     setFindingStatus(findingId, "accepted"),
   rejectFinding: (findingId: string) => setFindingStatus(findingId, "rejected"),

--- a/tests/unit/run-store-show-launch-form.test.ts
+++ b/tests/unit/run-store-show-launch-form.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Tests the New Mission reset path of the Mission Control run store.
+// ABOUTME: Protects settled-run dismissal without discarding live runs.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Run, RunSnapshot } from "@/services/run";
+import {
+  INITIAL_STATE,
+  runState,
+  runStore,
+  setRunState,
+} from "@/stores/run.store";
+
+function snapshot(status: Run["status"]): RunSnapshot {
+  return {
+    run: {
+      id: "run-1",
+      objective: "Objective",
+      root_path: null,
+      max_attempts: 2,
+      status,
+      cancel_requested: false,
+      interrupted_at: status === "interrupted" ? 2 : null,
+      created_at: 1,
+      updated_at: 1,
+      completed_at: null,
+    },
+    tasks: [],
+    dependencies: [],
+    assignments: [],
+    leases: [],
+    attempts: [],
+    findings: [],
+    checks: [],
+    check_results: [],
+    coverage_gaps: [],
+  };
+}
+
+beforeEach(() => {
+  setRunState({ ...INITIAL_STATE });
+});
+
+describe("#3617 New Mission lands on the launch form", () => {
+  it("clears a settled run so the launch form renders", () => {
+    setRunState({
+      activeRunId: "run-1",
+      snapshot: snapshot("completed"),
+      lastSequence: 7,
+    });
+
+    runStore.showLaunchForm();
+
+    expect(runState.snapshot).toBeNull();
+    expect(runState.activeRunId).toBeNull();
+    expect(runState.lastSequence).toBe(0);
+  });
+
+  it.each(["running", "interrupted"] as const)(
+    "keeps a %s run's overview untouched",
+    (status) => {
+      setRunState({
+        activeRunId: "run-1",
+        snapshot: snapshot(status),
+        lastSequence: 7,
+      });
+
+      runStore.showLaunchForm();
+
+      expect(runState.snapshot?.run.status).toBe(status);
+      expect(runState.activeRunId).toBe("run-1");
+    },
+  );
+});


### PR DESCRIPTION
Fixes #3617.

## Root cause

The sidebar's New Mission handler only sets the slide-panel signal to `"missioncontrol"`. Re-setting a Solid signal to its current value notifies nothing — no remount, no re-hydrate — and the panel renders the launch form only when the snapshot is null, which `hydrateLatest` clears only on mount. With the panel already open showing a finished run, the click did nothing and recovery was undiscoverable.

## Fix

`runStore.showLaunchForm()` dismisses a settled run's snapshot (completed/failed/cancelled) so the launch form renders; running and interrupted runs keep their overview so live work is never discarded. The New Mission handler calls it before opening the panel.

## Tests

- `tests/unit/run-store-show-launch-form.test.ts`: settled runs clear to the launch form; running and interrupted runs are untouched.
- Existing `mission-control-sidebar` tests pass.

## Network path

None — local UI/store state.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
