### PR TITLE
fix(run): attach launch scrollbar observer from the ref

### DIFF
--- a/src/components/run/MissionControlPanel.tsx
+++ b/src/components/run/MissionControlPanel.tsx
@@ -79,16 +79,25 @@ export const MissionControlPanel: Component = () => {
       else unlisten = cleanup;
     });
 
+  });
+
+  // The launch form can appear after mount — hydrateLatest clears a settled
+  // run's stale snapshot and the fallback branch renders — so the overlay
+  // observer attaches from the region's ref, not a one-shot mount hook.
+  const attachLaunchScrollRegion = (element: HTMLDivElement) => {
+    launchScrollRegion = element;
     queueMicrotask(() => {
-      const region = launchScrollRegion;
-      if (!region || disposed) return;
+      if (disposed || launchScrollRegion !== element || !element.isConnected) {
+        return;
+      }
+      launchResizeObserver?.disconnect();
       updateLaunchScroll();
       launchResizeObserver = new ResizeObserver(updateLaunchScroll);
-      launchResizeObserver.observe(region);
-      const content = region.firstElementChild;
+      launchResizeObserver.observe(element);
+      const content = element.firstElementChild;
       if (content) launchResizeObserver.observe(content);
     });
-  });
+  };
 
   onCleanup(() => {
     disposed = true;
@@ -108,7 +117,7 @@ export const MissionControlPanel: Component = () => {
         fallback={
           <div class="relative h-full min-h-0">
             <div
-              ref={launchScrollRegion}
+              ref={attachLaunchScrollRegion}
               data-testid="mission-launch-scroll-region"
               data-scrollable={launchScroll().visible ? "true" : "false"}
               tabindex="0"

--- a/tests/unit/run-launchbox.test.ts
+++ b/tests/unit/run-launchbox.test.ts
@@ -62,6 +62,11 @@ describe("RunLaunchBox", () => {
     );
     expect(missionControlSource).toContain("new ResizeObserver");
     expect(missionControlSource).toContain("onScroll={updateLaunchScroll}");
+    // The overlay observer must attach whenever the launch region renders —
+    // the form can appear after mount, when hydrateLatest clears a settled
+    // run's stale snapshot, and a one-shot mount hook missed it. #3618
+    expect(missionControlSource).toContain("ref={attachLaunchScrollRegion}");
+    expect(missionControlSource).not.toContain("ref={launchScrollRegion}");
   });
 
   it("sends every editable launch policy to the store", async () => {


### PR DESCRIPTION
Fixes #3618.

## Root cause

The launch box's overlay-scrollbar ResizeObserver attached exactly once, in a `queueMicrotask` during `onMount`. Reopening Mission Control after a finished run renders the stale run snapshot at mount; `hydrateLatest` then clears it and the launch form appears — but the region ref was unset during the mount microtask, so no observer ever attached for that mount and the overlay only activated after a physical scroll.

## Fix

Attach the observer from the scroll region's ref callback (with the same microtask deferral for post-connect layout reads), disconnecting any prior observer first. The observer now follows the launch form whenever it renders; `onCleanup` disconnect unchanged.

## Tests

- `tests/unit/run-launchbox.test.ts` extended: the region must bind `ref={attachLaunchScrollRegion}` and the one-shot ref shape is rejected.

## Network path

None — local UI.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
