### PR TITLE
fix: bind Gmail sends to host confirmation state

### DIFF
--- a/bin/browser-local/seren-mcp-oauth-proxy.mjs
+++ b/bin/browser-local/seren-mcp-oauth-proxy.mjs
@@ -77,20 +77,42 @@ function isGmailProfileRequest(publisher, tool, method, path) {
     "profile";
 }
 
-function gmailProfileEmail(response) {
-  const text = response?.result?.content?.find(
-    (item) => item?.type === "text" && typeof item.text === "string",
-  )?.text;
-  if (!text) return null;
-  try {
-    const parsed = JSON.parse(text);
-    const candidate = parsed?.emailAddress ?? parsed?.data?.emailAddress;
-    return typeof candidate === "string" && candidate.trim()
-      ? candidate.trim()
-      : null;
-  } catch {
+function gmailProfileEmailAtDepth(value, depth = 0) {
+  if (depth > 8) return null;
+  if (typeof value === "string") {
+    try {
+      return gmailProfileEmailAtDepth(JSON.parse(value), depth + 1);
+    } catch {
+      return null;
+    }
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const email = gmailProfileEmailAtDepth(item, depth + 1);
+      if (email) return email;
+    }
     return null;
   }
+  if (!value || typeof value !== "object") return null;
+
+  const candidate = value.emailAddress;
+  if (typeof candidate === "string" && candidate.trim()) {
+    return candidate.trim();
+  }
+  if (value.type === "text" && typeof value.text === "string") {
+    const email = gmailProfileEmailAtDepth(value.text, depth + 1);
+    if (email) return email;
+  }
+  for (const envelope of ["data", "body", "result", "content"]) {
+    if (!(envelope in value)) continue;
+    const email = gmailProfileEmailAtDepth(value[envelope], depth + 1);
+    if (email) return email;
+  }
+  return null;
+}
+
+function gmailProfileEmail(response) {
+  return gmailProfileEmailAtDepth(response);
 }
 
 function gmailProfileMatchesRouting(routing, connectionId, emailAddress) {

--- a/bin/browser-local/seren-mcp-oauth-proxy.mjs
+++ b/bin/browser-local/seren-mcp-oauth-proxy.mjs
@@ -69,11 +69,86 @@ function isGmailSendRequest(publisher, tool, method, path) {
   );
 }
 
+function isGmailProfileRequest(publisher, tool, method, path) {
+  if (publisher.toLowerCase() !== "gmail") return false;
+  if (tool) return tool.toLowerCase() === "get_profile";
+  if (method.toUpperCase() !== "GET" || !path) return false;
+  return path.split("?", 1)[0].replace(/^\/+|\/+$/g, "").toLowerCase() ===
+    "profile";
+}
+
+function gmailProfileEmail(response) {
+  const text = response?.result?.content?.find(
+    (item) => item?.type === "text" && typeof item.text === "string",
+  )?.text;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    const candidate = parsed?.emailAddress ?? parsed?.data?.emailAddress;
+    return typeof candidate === "string" && candidate.trim()
+      ? candidate.trim()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function gmailProfileMatchesRouting(routing, connectionId, emailAddress) {
+  const expected = routing?.accounts?.gmail?.connections?.find(
+    (connection) => connection?.connectionId === connectionId,
+  )?.label;
+  if (typeof expected !== "string" || !expected.includes("@")) return true;
+  return expected.trim().toLowerCase() === emailAddress.trim().toLowerCase();
+}
+
+/**
+ * Per-provider-session sender checkpoint. Only the desktop runtime can advance
+ * the human turn id; model-authored MCP arguments cannot manufacture a later
+ * turn and therefore cannot self-confirm a Gmail sender.
+ */
+export function createGmailSendConfirmationTracker() {
+  let userTurnId = null;
+  let pending = null;
+  let confirmedConnectionId = null;
+
+  return {
+    setUserTurnId(nextUserTurnId) {
+      userTurnId = nonEmptyString(nextUserTurnId);
+    },
+    noteProfileVerified(connectionId) {
+      const connection = nonEmptyString(connectionId);
+      if (!connection || !userTurnId || confirmedConnectionId === connection) {
+        return;
+      }
+      pending = {
+        preparedAtUserTurnId:
+          pending?.preparedAtUserTurnId ?? userTurnId,
+        verifiedConnectionId: connection,
+      };
+    },
+    canSend(connectionId) {
+      const connection = nonEmptyString(connectionId);
+      if (!connection || !userTurnId) return false;
+      if (confirmedConnectionId === connection) return true;
+      return (
+        pending?.verifiedConnectionId === connection &&
+        pending.preparedAtUserTurnId !== userTurnId
+      );
+    },
+    markSendSucceeded(connectionId) {
+      const connection = nonEmptyString(connectionId);
+      if (!connection) return;
+      confirmedConnectionId = connection;
+      pending = null;
+    },
+  };
+}
+
 /**
  * Decide whether a Seren MCP request can pass through unchanged, must fail
  * closed, or should use the first-party publisher proxy with an OAuth selector.
  */
-export function planSerenMcpRequest(routing, payload) {
+export function planSerenMcpRequest(routing, payload, gmailConfirmation) {
   if (
     !payload ||
     typeof payload !== "object" ||
@@ -130,14 +205,15 @@ export function planSerenMcpRequest(routing, payload) {
   const method = nonEmptyString(args.method) ?? "POST";
   const path = nonEmptyString(args.path);
   if (
-    !selectionWasExplicit &&
-    isGmailSendRequest(publisher, tool, method, path)
+    isGmailSendRequest(publisher, tool, method, path) &&
+    (!selectionWasExplicit ||
+      gmailConfirmation?.canSend(explicitConnectionId) !== true)
   ) {
     return {
       kind: "error",
       response: toolError(
         payload.id,
-        "Gmail send blocked: name the active sender account, ask the user to confirm or choose another account, and wait for a later user reply. After that confirmation, verify gmail/get_profile and retry the send with the confirmed account's top-level connection_id.",
+        "Gmail send blocked: first call gmail/get_profile with the intended account's top-level connection_id, name the verified sender, ask the user to confirm or choose another account, and wait for a later reply from the user. A model-supplied selector cannot confirm a sender on the same human turn.",
       ),
     };
   }
@@ -529,6 +605,7 @@ export async function createSerenMcpOAuthProxy({
   assertRelayableUpstream(api);
 
   let routing = null;
+  const gmailConfirmation = createGmailSendConfirmationTracker();
   let closed = false;
   const routePath = `/${randomBytes(24).toString("hex")}/mcp`;
   const controllers = new Set();
@@ -550,7 +627,11 @@ export async function createSerenMcpOAuthProxy({
       } catch {
         // Let the upstream MCP server return the protocol parse error.
       }
-      const plan = planSerenMcpRequest(routing, payload);
+      const plan = planSerenMcpRequest(
+        routing,
+        payload,
+        gmailConfirmation,
+      );
       if (plan.kind === "error") {
         sendLocalMcpResponse(response, plan.response);
         return;
@@ -561,12 +642,34 @@ export async function createSerenMcpOAuthProxy({
         request.once("aborted", () => controller.abort());
         response.once("close", () => controller.abort());
         try {
-          const routedResponse = await executePublisherPlan(
+          let routedResponse = await executePublisherPlan(
             plan,
             nonEmptyString(request.headers.authorization),
             api.toString(),
             controller.signal,
           );
+          const profileRequest = isGmailProfileRequest(
+            plan.publisher,
+            plan.request.kind === "tool" ? plan.request.tool : null,
+            plan.request.kind === "api" ? plan.request.method : "GET",
+            plan.request.kind === "api" ? plan.request.path : null,
+          );
+          if (profileRequest && routedResponse?.result?.isError !== true) {
+            const profileEmail = gmailProfileEmail(routedResponse);
+            if (
+              !profileEmail ||
+              !gmailProfileMatchesRouting(
+                routing,
+                plan.connectionId,
+                profileEmail,
+              )
+            ) {
+              routedResponse = toolError(
+                plan.id,
+                "Gmail sender verification failed: get_profile did not return the email address for the selected connected account. No sender confirmation was recorded.",
+              );
+            }
+          }
           if (
             plan.selectionWasExplicit &&
             routedResponse?.result?.isError !== true &&
@@ -580,6 +683,20 @@ export async function createSerenMcpOAuthProxy({
             } catch {
               // The publisher call already succeeded. A renderer sync failure
               // must not replace its real result with a proxy error.
+            }
+          }
+          if (routedResponse?.result?.isError !== true) {
+            if (profileRequest) {
+              gmailConfirmation.noteProfileVerified(plan.connectionId);
+            } else if (
+              isGmailSendRequest(
+                plan.publisher,
+                plan.request.kind === "tool" ? plan.request.tool : null,
+                plan.request.kind === "api" ? plan.request.method : "POST",
+                plan.request.kind === "api" ? plan.request.path : null,
+              )
+            ) {
+              gmailConfirmation.markSendSucceeded(plan.connectionId);
             }
           }
           if (!response.destroyed) {
@@ -640,8 +757,12 @@ export async function createSerenMcpOAuthProxy({
       routing = {
         publishers: { ...(nextRouting?.publishers ?? {}) },
         ambiguous: { ...(nextRouting?.ambiguous ?? {}) },
+        accounts: { ...(nextRouting?.accounts ?? {}) },
         available: nextRouting?.available,
       };
+      if (nonEmptyString(nextRouting?.userTurnId)) {
+        gmailConfirmation.setUserTurnId(nextRouting.userTurnId);
+      }
     },
     async close() {
       if (closed) return;

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -619,9 +619,24 @@ created if missing.",
             system_parts.push(skill_content.to_string());
         }
         // Tone and behavior rules — must match JS path TONE_INSTRUCTIONS in
-        // src/services/chat.ts. Appended last so the model reads them after
-        // the tool inventory it is allowed to use.
+        // src/services/chat.ts.
         system_parts.push(TONE_INSTRUCTIONS.to_string());
+
+        // Providers disagree about whether later `role: "system"` messages
+        // retain system priority. Merge dynamic system context (memory,
+        // compacted summaries, and safety guidance such as connected-account
+        // confirmation) into the one primary system message so every model
+        // receives the same instruction hierarchy.
+        for message in conversation_context {
+            if message.get("role").and_then(|role| role.as_str()) != Some("system") {
+                continue;
+            }
+            if let Some(content) = message.get("content").and_then(|content| content.as_str()) {
+                if !content.trim().is_empty() {
+                    system_parts.push(content.to_string());
+                }
+            }
+        }
         let system_content = system_parts.join("\n\n");
 
         messages.push(serde_json::json!({
@@ -631,6 +646,11 @@ created if missing.",
 
         // Conversation history
         for msg in conversation_context {
+            if msg.get("role").and_then(|role| role.as_str()) == Some("system")
+                && msg.get("content").and_then(|content| content.as_str()).is_some()
+            {
+                continue;
+            }
             messages.push(msg.clone());
         }
 
@@ -2564,6 +2584,59 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[1]["content"], "previous message");
         assert_eq!(messages[2]["content"], "Hello world");
+    }
+
+    #[test]
+    fn merges_dynamic_system_context_into_primary_system_prompt() {
+        let worker = ChatModelWorker::new();
+        let routing = RoutingDecision {
+            worker_type: super::super::types::WorkerType::ChatModel,
+            model_id: "meta-llama/llama-3.3-70b-instruct".to_string(),
+            delegation: super::super::types::DelegationType::InLoop,
+            reason: "General chat".to_string(),
+            selected_skills: vec![],
+            publisher_slug: None,
+            reasoning_effort: None,
+            project_root: None,
+        };
+        let dynamic_guidance =
+            "# Seren connected-account confirmation\n\nConfirm the Gmail sender and stop.";
+        let context = vec![
+            serde_json::json!({"role": "system", "content": dynamic_guidance}),
+            serde_json::json!({"role": "user", "content": "Earlier request"}),
+            serde_json::json!({"role": "assistant", "content": "Earlier response"}),
+        ];
+
+        let body = worker.build_request_body(
+            "Send the message",
+            &context,
+            &routing,
+            "",
+            &[],
+            &[],
+            None,
+        );
+        let messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message["role"] == "system")
+                .count(),
+            1,
+            "providers must receive one authoritative system message"
+        );
+        assert!(
+            messages[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains(dynamic_guidance),
+            "dynamic account guidance must retain system priority"
+        );
+        assert_eq!(messages[1]["content"], "Earlier request");
+        assert_eq!(messages[2]["content"], "Earlier response");
+        assert_eq!(messages[3]["content"], "Send the message");
     }
 
     #[test]

--- a/src/lib/agent/oauth-account-guidance.ts
+++ b/src/lib/agent/oauth-account-guidance.ts
@@ -25,6 +25,59 @@ export function isGmailSendTool(
   );
 }
 
+function extractGmailProfileEmailAtDepth(
+  result: unknown,
+  depth: number,
+): string | null {
+  if (depth > 4) return null;
+  let value = result;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value) as unknown;
+    } catch {
+      return null;
+    }
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const content = item as { type?: unknown; text?: unknown };
+      if (content.type !== "text" || typeof content.text !== "string") continue;
+      const email = extractGmailProfileEmailAtDepth(content.text, depth + 1);
+      if (email) return email;
+    }
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const candidate = record.emailAddress;
+  if (typeof candidate === "string" && candidate.trim()) {
+    return candidate.trim();
+  }
+  for (const envelope of ["data", "result", "content"] as const) {
+    if (!(envelope in record)) continue;
+    const email = extractGmailProfileEmailAtDepth(record[envelope], depth + 1);
+    if (email) return email;
+  }
+  return null;
+}
+
+export function extractGmailProfileEmail(result: unknown): string | null {
+  return extractGmailProfileEmailAtDepth(result, 0);
+}
+
+export function gmailProfileMatchesConnection(
+  routing: AgentOAuthRouting | null | undefined,
+  connectionId: string,
+  emailAddress: string,
+): boolean {
+  const expected = routing?.accounts?.gmail?.connections.find(
+    (connection) => connection.connectionId === connectionId,
+  )?.label;
+  if (!expected?.includes("@")) return true;
+  return expected.trim().toLowerCase() === emailAddress.trim().toLowerCase();
+}
+
 function safePromptValue(value: string, maxLength: number): string {
   return JSON.stringify(
     Array.from(value)
@@ -94,9 +147,10 @@ Available Gmail accounts:
 ${accountLines.join("\n")}
 
 Before the first Gmail operation in this thread that sends a message (including post_send, post_messages_send, or post_drafts_by_draft_id_send), you MUST:
-1. Tell the user the exact email account that would be used.
-2. Ask the user to confirm that account or choose one of the other listed account labels.
-3. Stop and wait for a later user reply. The original request to send is not sender confirmation.
+1. Call gmail/get_profile with the currently routed account's opaque value as the top-level connection_id and verify that its emailAddress matches the account label. If it does not match, stop and report the mismatch without sending.
+2. Tell the user the exact verified email account that would be used and list the other account labels when available.
+3. Ask the user to confirm that account or choose one of the other listed account labels.
+4. Stop and wait for a later user reply. The original request to send is not sender confirmation.
 
-After the user confirms or chooses an account, first call gmail/get_profile with that account's opaque value as the top-level connection_id and verify that its emailAddress matches the confirmed account label. If it does not match, stop and report the mismatch without sending. Then call the Gmail send tool with the same top-level connection_id. Do not place connection_id inside tool_args. A successful explicit selection becomes the active Google account for this thread and related Google publishers. Never expose, quote, or describe internal connection_id values to the user.`;
+After the user confirms the verified account, call the Gmail send tool with the same top-level connection_id. If the user chooses another account, first call gmail/get_profile with that account's top-level connection_id and verify its emailAddress, then send with that same selector. The host rejects a send on the same human turn that opened the confirmation checkpoint, even if you supply a connection_id. Do not place connection_id inside tool_args. A successful explicit selection becomes the active Google account for this thread and related Google publishers. Never expose, quote, or describe internal connection_id values to the user.`;
 }

--- a/src/lib/agent/oauth-account-guidance.ts
+++ b/src/lib/agent/oauth-account-guidance.ts
@@ -54,7 +54,7 @@ function extractGmailProfileEmailAtDepth(
   if (typeof candidate === "string" && candidate.trim()) {
     return candidate.trim();
   }
-  for (const envelope of ["data", "result", "content"] as const) {
+  for (const envelope of ["data", "body", "result", "content"] as const) {
     if (!(envelope in record)) continue;
     const email = extractGmailProfileEmailAtDepth(record[envelope], depth + 1);
     if (email) return email;

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -3,7 +3,11 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { isGmailSendTool } from "@/lib/agent/oauth-account-guidance";
+import {
+  extractGmailProfileEmail,
+  gmailProfileMatchesConnection,
+  isGmailSendTool,
+} from "@/lib/agent/oauth-account-guidance";
 import { mcpClient } from "@/lib/mcp/client";
 import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
@@ -25,6 +29,11 @@ import {
 import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
 import { conversationStore } from "@/stores/conversation.store";
+import {
+  hasConfirmedGmailSenderForTurn,
+  markGmailSenderConfirmed,
+  noteGmailSenderProfileVerified,
+} from "@/stores/gmail-send-confirmation.store";
 import { setThreadOAuthConnectionId } from "@/stores/oauth-account.store";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
@@ -1452,31 +1461,49 @@ async function executeGatewayTool(
 ): Promise<ToolResult> {
   try {
     let callArgs = args;
+    const threadId = conversationId ?? conversationStore.activeConversationId;
+    const tracksGmailSenderConfirmation =
+      publisherSlug.toLowerCase() === "gmail" &&
+      (toolName.toLowerCase() === "get_profile" ||
+        isGmailSendTool(publisherSlug, toolName));
+    const userTurnId =
+      threadId && tracksGmailSenderConfirmation
+        ? ([...(conversationStore.getMessagesFor?.(threadId) ?? [])]
+            .reverse()
+            .find((message) => message.role === "user")?.id ?? null)
+        : null;
     const explicitConnectionId =
       typeof args.connection_id === "string" && args.connection_id.trim()
         ? args.connection_id.trim()
         : null;
+    let dispatchedConnectionId = explicitConnectionId;
+    const gmailSendIsBlocked = (
+      connectionId: string | null | undefined,
+    ): boolean =>
+      isGmailSendTool(publisherSlug, toolName) &&
+      (!connectionId ||
+        !hasConfirmedGmailSenderForTurn(threadId, connectionId, userTurnId));
+    const blockedGmailSendResult = (): ToolResult => ({
+      tool_call_id: toolCallId,
+      content:
+        "Gmail send blocked: first call gmail/get_profile with the intended account's top-level connection_id, name the verified sender, ask the user to confirm or change it, and wait for a later reply from the user. A model-supplied selector cannot confirm a sender on the same human turn.",
+      is_error: true,
+    });
 
-    if (isGmailSendTool(publisherSlug, toolName) && !explicitConnectionId) {
-      return {
-        tool_call_id: toolCallId,
-        content:
-          "Gmail send blocked: name the currently active sender account, ask the user to confirm or change it, wait for a later reply, then retry with the confirmed account's top-level connection_id.",
-        is_error: true,
-      };
+    if (gmailSendIsBlocked(explicitConnectionId)) {
+      return blockedGmailSendResult();
     }
 
     const persistExplicitSelection = async (
       isError: boolean,
     ): Promise<void> => {
-      if (isError || !explicitConnectionId) return;
-      const threadId = conversationId ?? conversationStore.activeConversationId;
+      if (isError || !dispatchedConnectionId) return;
       if (!threadId) return;
       const resolution = await resolveOAuthProviderForPublisher(publisherSlug);
       setThreadOAuthConnectionId(
         threadId,
         resolution.providerSlug,
-        explicitConnectionId,
+        dispatchedConnectionId,
       );
     };
 
@@ -1497,7 +1524,14 @@ async function executeGatewayTool(
     const authHandle = auth.handle;
 
     if (auth.connectionId) {
+      dispatchedConnectionId = auth.connectionId;
       callArgs = { ...args, connection_id: auth.connectionId };
+    }
+    // The approval UI can select a different connected account. Re-check the
+    // actual dispatch selector so approving account A cannot authorize an
+    // unverified account B after the model-facing guard has passed.
+    if (gmailSendIsBlocked(dispatchedConnectionId)) {
+      return blockedGmailSendResult();
     }
 
     const resolvedArgs = await resolveGatewayOAuthConnectionArgs(
@@ -1521,6 +1555,36 @@ async function executeGatewayTool(
       callArgs,
       authHandle,
     );
+
+    if (
+      !response.is_error &&
+      publisherSlug.toLowerCase() === "gmail" &&
+      toolName.toLowerCase() === "get_profile" &&
+      dispatchedConnectionId
+    ) {
+      const profileEmail = extractGmailProfileEmail(response.result);
+      const routing = await computeAgentOAuthRouting(threadId);
+      if (
+        !profileEmail ||
+        !gmailProfileMatchesConnection(
+          routing,
+          dispatchedConnectionId,
+          profileEmail,
+        )
+      ) {
+        return {
+          tool_call_id: toolCallId,
+          content:
+            "Gmail sender verification failed: get_profile did not return the email address for the selected connected account. No sender confirmation was recorded.",
+          is_error: true,
+        };
+      }
+      noteGmailSenderProfileVerified(
+        threadId,
+        dispatchedConnectionId,
+        userTurnId,
+      );
+    }
 
     // Check if this is a payment proxy response (requires client-side signing)
     if (response.is_error && response.payment_proxy) {
@@ -1642,6 +1706,12 @@ async function executeGatewayTool(
           await settleLeaseSpend(reservationId, charge.micros);
         }
         await persistExplicitSelection(retryResponse.is_error);
+        if (
+          !retryResponse.is_error &&
+          isGmailSendTool(publisherSlug, toolName)
+        ) {
+          markGmailSenderConfirmed(threadId, dispatchedConnectionId);
+        }
 
         const retryContent =
           typeof retryResponse.result === "string"
@@ -1676,6 +1746,12 @@ async function executeGatewayTool(
           await settleLeaseSpend(reservationId, charge.micros);
         }
         await persistExplicitSelection(retryResponse.is_error);
+        if (
+          !retryResponse.is_error &&
+          isGmailSendTool(publisherSlug, toolName)
+        ) {
+          markGmailSenderConfirmed(threadId, dispatchedConnectionId);
+        }
 
         const retryContent =
           typeof retryResponse.result === "string"
@@ -1704,6 +1780,9 @@ async function executeGatewayTool(
     }
 
     await persistExplicitSelection(response.is_error);
+    if (!response.is_error && isGmailSendTool(publisherSlug, toolName)) {
+      markGmailSenderConfirmed(threadId, dispatchedConnectionId);
+    }
 
     return {
       tool_call_id: toolCallId,

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -129,6 +129,8 @@ export interface AgentOAuthRouting {
   accounts?: Record<string, AgentOAuthPublisherAccounts>;
   /** False when account discovery failed, so runtimes can refuse default-account fallback. */
   available?: boolean;
+  /** Host-created id of the human message currently driving this agent turn. */
+  userTurnId?: string;
 }
 
 export interface AgentOAuthAccountChoice {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1943,6 +1943,19 @@ async function awaitAgentOAuthRoutingForPrompt(
   );
 }
 
+async function setAgentOAuthUserTurn(
+  providerSessionId: string,
+  userTurnId: string | null | undefined,
+): Promise<void> {
+  const turn = userTurnId?.trim();
+  const routing = agentOAuthRoutingSnapshots.get(providerSessionId);
+  if (!turn || !routing) return;
+  await providerService.setOAuthRouting(providerSessionId, {
+    ...routing,
+    userTurnId: turn,
+  });
+}
+
 createRoot(() => {
   createEffect(() => {
     oauthConnectionsRevision();
@@ -2698,6 +2711,7 @@ export const agentStore = {
       }
 
       try {
+        await setAgentOAuthUserTurn(newSessionId, replay?.currentUserMessageId);
         const { merged: retryContext, newSignature } =
           await this.buildPromptContext(
             newSessionId,
@@ -2734,6 +2748,7 @@ export const agentStore = {
             context: promptContext,
             displayContent: replay?.displayContent,
             docNames: replay?.docNames,
+            currentUserMessageId: replay?.currentUserMessageId,
           });
         }
 
@@ -6580,6 +6595,7 @@ export const agentStore = {
       "[AgentStore] Calling providerService.sendPrompt...",
     );
     try {
+      await setAgentOAuthUserTurn(session.info.id, userMessage.id);
       const { merged, newSignature } = await this.buildPromptContext(
         sessionId,
         context,

--- a/src/stores/gmail-send-confirmation.store.ts
+++ b/src/stores/gmail-send-confirmation.store.ts
@@ -1,0 +1,136 @@
+// ABOUTME: Host-owned, per-thread Gmail sender confirmation checkpoints.
+// ABOUTME: Prevents a model-provided OAuth selector from authorizing a same-turn send.
+
+interface PendingGmailSenderConfirmation {
+  preparedAtUserTurnId: string;
+  verifiedConnectionId: string;
+}
+
+interface GmailSenderConfirmation {
+  confirmedConnectionId?: string;
+  pending?: PendingGmailSenderConfirmation;
+}
+
+type GmailSenderConfirmations = Record<string, GmailSenderConfirmation>;
+
+const STORAGE_KEY = "seren.oauth.gmail-send-confirmations.v1";
+
+function getStorage(): Storage | null {
+  if (typeof globalThis === "undefined") return null;
+  try {
+    return "localStorage" in globalThis ? globalThis.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function readConfirmations(): GmailSenderConfirmations {
+  const storage = getStorage();
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object"
+      ? (parsed as GmailSenderConfirmations)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+let confirmations = readConfirmations();
+
+function writeConfirmations(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(confirmations));
+  } catch {
+    // Current-session state remains authoritative when storage is unavailable.
+  }
+}
+
+/**
+ * Record a successful, explicitly routed Gmail profile read. The first such
+ * read opens a checkpoint on the current human turn. Re-verifying another
+ * listed account after the user's reply keeps the original checkpoint while
+ * binding the eventual send to the newly verified connection.
+ */
+export function noteGmailSenderProfileVerified(
+  threadId: string | null | undefined,
+  connectionId: string | null | undefined,
+  userTurnId: string | null | undefined,
+): void {
+  const thread = nonEmpty(threadId);
+  const connection = nonEmpty(connectionId);
+  const turn = nonEmpty(userTurnId);
+  if (!thread || !connection || !turn) return;
+
+  const current = confirmations[thread] ?? {};
+  if (current.confirmedConnectionId === connection) return;
+  confirmations = {
+    ...confirmations,
+    [thread]: {
+      ...current,
+      pending: {
+        preparedAtUserTurnId: current.pending?.preparedAtUserTurnId ?? turn,
+        verifiedConnectionId: connection,
+      },
+    },
+  };
+  writeConfirmations();
+}
+
+/**
+ * A first send is eligible only after a successful profile read and a later
+ * human-authored turn. A model can copy every visible connection_id and still
+ * cannot advance this checkpoint itself.
+ */
+export function hasConfirmedGmailSenderForTurn(
+  threadId: string | null | undefined,
+  connectionId: string | null | undefined,
+  userTurnId: string | null | undefined,
+): boolean {
+  const thread = nonEmpty(threadId);
+  const connection = nonEmpty(connectionId);
+  const turn = nonEmpty(userTurnId);
+  if (!thread || !connection || !turn) return false;
+
+  const current = confirmations[thread];
+  if (current?.confirmedConnectionId === connection) return true;
+  return Boolean(
+    current?.pending?.verifiedConnectionId === connection &&
+      current.pending.preparedAtUserTurnId !== turn,
+  );
+}
+
+/** Mark the selected sender durable only after the external send succeeds. */
+export function markGmailSenderConfirmed(
+  threadId: string | null | undefined,
+  connectionId: string | null | undefined,
+): void {
+  const thread = nonEmpty(threadId);
+  const connection = nonEmpty(connectionId);
+  if (!thread || !connection) return;
+  confirmations = {
+    ...confirmations,
+    [thread]: { confirmedConnectionId: connection },
+  };
+  writeConfirmations();
+}
+
+export function resetGmailSenderConfirmationsForTests(): void {
+  confirmations = {};
+  const storage = getStorage();
+  try {
+    storage?.removeItem(STORAGE_KEY);
+  } catch {
+    // Test state is already reset in memory.
+  }
+}

--- a/tests/unit/agent-oauth-chat-selection.test.ts
+++ b/tests/unit/agent-oauth-chat-selection.test.ts
@@ -38,4 +38,14 @@ describe("chat-selected OAuth account persistence (#3589)", () => {
       expect(source, path).toContain("onConnectionSelected:");
     }
   });
+
+  it("delivers a host-created human turn id to the native OAuth proxy", () => {
+    const store = read("src/stores/agent.store.ts");
+    const proxy = read("bin/browser-local/seren-mcp-oauth-proxy.mjs");
+
+    expect(store).toContain("setAgentOAuthUserTurn");
+    expect(store).toContain("userMessage.id");
+    expect(proxy).toContain("nextRouting?.userTurnId");
+    expect(proxy).toContain("createGmailSendConfirmationTracker");
+  });
 });

--- a/tests/unit/codex-seren-mcp-proxy.test.ts
+++ b/tests/unit/codex-seren-mcp-proxy.test.ts
@@ -371,7 +371,7 @@ describe("native Codex Seren MCP OAuth routing", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            data: { emailAddress: "selected@example.test" },
+            data: { body: { emailAddress: "selected@example.test" } },
           }),
           {
             status: 200,

--- a/tests/unit/codex-seren-mcp-proxy.test.ts
+++ b/tests/unit/codex-seren-mcp-proxy.test.ts
@@ -2,6 +2,7 @@ import net from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildSerenPublisherRequest,
+  createGmailSendConfirmationTracker,
   createSerenMcpOAuthProxy,
   planSerenMcpRequest,
 } from "../../bin/browser-local/seren-mcp-oauth-proxy.mjs";
@@ -188,6 +189,9 @@ describe("native Codex Seren MCP OAuth routing", () => {
   });
 
   it("preserves an explicit selector and fails closed while ambiguous or initializing", () => {
+    const confirmation = createGmailSendConfirmationTracker();
+    confirmation.setUserTurnId("turn-1");
+    confirmation.noteProfileVerified("conn-confirmed");
     expect(
       planSerenMcpRequest(
         { publishers: {}, ambiguous: { gmail: "Choose an account" } },
@@ -213,6 +217,7 @@ describe("native Codex Seren MCP OAuth routing", () => {
           connection_id: "conn-auto",
           _seren_auto_connection_id: true,
         }),
+        confirmation,
       ),
     ).toMatchObject({
       kind: "publisher",
@@ -235,11 +240,29 @@ describe("native Codex Seren MCP OAuth routing", () => {
 
     expect(
       planSerenMcpRequest(
+        { publishers: { gmail: "conn-auto" }, ambiguous: {} },
+        callPublisher({
+          publisher: "gmail",
+          tool: "post_send",
+          connection_id: "conn-confirmed",
+        }),
+        confirmation,
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+
+    confirmation.setUserTurnId("turn-2");
+
+    expect(
+      planSerenMcpRequest(
         { publishers: {}, ambiguous: {}, available: true },
         callPublisher({
           publisher: "gmail",
           tool: "post_send",
         }),
+        confirmation,
       ),
     ).toMatchObject({
       kind: "error",
@@ -255,6 +278,7 @@ describe("native Codex Seren MCP OAuth routing", () => {
           path: "/drafts/draft-safe/send?mode=send",
           connection_id: "conn-confirmed",
         }),
+        confirmation,
       ),
     ).toMatchObject({
       kind: "publisher",
@@ -334,6 +358,113 @@ describe("native Codex Seren MCP OAuth routing", () => {
         publisher: "gmail",
         connectionId: "conn-selected",
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await proxy.close();
+    }
+  });
+
+  it("blocks a native Gmail send until profile verification is followed by a later human turn", async () => {
+    const originalFetch = globalThis.fetch;
+    const upstreamFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: { emailAddress: "selected@example.test" },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "message-safe" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    globalThis.fetch = upstreamFetch as typeof fetch;
+    const proxy = await createSerenMcpOAuthProxy({
+      gatewayUrl: "https://mcp.invalid/mcp",
+      apiUrl: "https://api.invalid",
+    });
+    const call = async (args: Record<string, unknown>) => {
+      const response = await originalFetch(proxy.url, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer desktop-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(callPublisher(args)),
+      });
+      const event = (await response.text())
+        .split("\n")
+        .find((line) => line.startsWith("data: "));
+      return JSON.parse(event?.slice(6) ?? "null");
+    };
+
+    try {
+      proxy.setRouting({
+        publishers: { gmail: "conn-selected" },
+        ambiguous: {},
+        accounts: {
+          gmail: {
+            providerSlug: "google",
+            providerName: "Google",
+            activeConnectionId: "conn-selected",
+            selectionSource: "thread",
+            connections: [
+              {
+                connectionId: "conn-selected",
+                label: "selected@example.test",
+                isDefault: true,
+              },
+            ],
+          },
+        },
+        userTurnId: "turn-1",
+      });
+      const profile = await call({
+        publisher: "gmail",
+        tool: "get_profile",
+        connection_id: "conn-selected",
+        tool_args: {},
+      });
+      const sameTurnSend = await call({
+        publisher: "gmail",
+        tool: "post_send",
+        connection_id: "conn-selected",
+        tool_args: {
+          to: ["recipient@example.test"],
+          subject: "Account confirmation regression",
+          body: "Safe test body",
+        },
+      });
+
+      expect(profile.result.isError).toBe(false);
+      expect(sameTurnSend.result.isError).toBe(true);
+      expect(upstreamFetch).toHaveBeenCalledTimes(1);
+
+      proxy.setRouting({
+        publishers: { gmail: "conn-selected" },
+        ambiguous: {},
+        userTurnId: "turn-2",
+      });
+      const laterTurnSend = await call({
+        publisher: "gmail",
+        tool: "post_send",
+        connection_id: "conn-selected",
+        tool_args: {
+          to: ["recipient@example.test"],
+          subject: "Account confirmation regression",
+          body: "Safe test body",
+        },
+      });
+
+      expect(laterTurnSend.result.isError).toBe(false);
+      expect(upstreamFetch).toHaveBeenCalledTimes(2);
     } finally {
       globalThis.fetch = originalFetch;
       await proxy.close();

--- a/tests/unit/gmail-send-confirmation.test.ts
+++ b/tests/unit/gmail-send-confirmation.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Regression tests for host-owned, cross-turn Gmail sender confirmation.
+// ABOUTME: Proves model-visible selectors cannot authorize a send by themselves.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  hasConfirmedGmailSenderForTurn,
+  markGmailSenderConfirmed,
+  noteGmailSenderProfileVerified,
+  resetGmailSenderConfirmationsForTests,
+} from "@/stores/gmail-send-confirmation.store";
+
+describe("Gmail sender confirmation checkpoints (#3589)", () => {
+  beforeEach(() => resetGmailSenderConfirmationsForTests());
+
+  it("rejects a copied selector until a later human turn", () => {
+    noteGmailSenderProfileVerified("thread-1", "conn-primary", "turn-1");
+
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-primary",
+        "turn-1",
+      ),
+    ).toBe(false);
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-primary",
+        "turn-2",
+      ),
+    ).toBe(true);
+  });
+
+  it("binds the send to the account most recently verified after the reply", () => {
+    noteGmailSenderProfileVerified("thread-1", "conn-primary", "turn-1");
+    noteGmailSenderProfileVerified("thread-1", "conn-secondary", "turn-2");
+
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-primary",
+        "turn-2",
+      ),
+    ).toBe(false);
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-secondary",
+        "turn-2",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the successful sender active and re-checkpoints a changed account", () => {
+    noteGmailSenderProfileVerified("thread-1", "conn-primary", "turn-1");
+    markGmailSenderConfirmed("thread-1", "conn-primary");
+
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-primary",
+        "turn-1",
+      ),
+    ).toBe(true);
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-secondary",
+        "turn-2",
+      ),
+    ).toBe(false);
+
+    noteGmailSenderProfileVerified("thread-1", "conn-secondary", "turn-2");
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-secondary",
+        "turn-2",
+      ),
+    ).toBe(false);
+    expect(
+      hasConfirmedGmailSenderForTurn(
+        "thread-1",
+        "conn-secondary",
+        "turn-3",
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/oauth-account-guidance.test.ts
+++ b/tests/unit/oauth-account-guidance.test.ts
@@ -82,7 +82,7 @@ describe("OAuth account confirmation guidance (#3589)", () => {
           {
             type: "text",
             text: JSON.stringify({
-              data: { emailAddress: "primary@example.test" },
+              data: { body: { emailAddress: "primary@example.test" } },
             }),
           },
         ],

--- a/tests/unit/oauth-account-guidance.test.ts
+++ b/tests/unit/oauth-account-guidance.test.ts
@@ -4,6 +4,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildOAuthAccountConfirmationInstruction,
+  extractGmailProfileEmail,
+  gmailProfileMatchesConnection,
   isGmailSendTool,
   OAUTH_ACCOUNT_GUIDANCE_HEADER,
 } from "@/lib/agent/oauth-account-guidance";
@@ -57,6 +59,7 @@ describe("OAuth account confirmation guidance (#3589)", () => {
       "The original request to send is not sender confirmation",
     );
     expect(guidance).toContain("gmail/get_profile");
+    expect(guidance).toContain("same human turn");
     expect(guidance).toContain("top-level connection_id");
     expect(guidance).toContain("Never expose");
   });
@@ -70,5 +73,35 @@ describe("OAuth account confirmation guidance (#3589)", () => {
         available: true,
       }),
     ).toBeNull();
+  });
+
+  it("accepts only a profile identity that matches the selected connected account", () => {
+    expect(
+      extractGmailProfileEmail(
+        [
+          {
+            type: "text",
+            text: JSON.stringify({
+              data: { emailAddress: "primary@example.test" },
+            }),
+          },
+        ],
+      ),
+    ).toBe("primary@example.test");
+    expect(
+      gmailProfileMatchesConnection(
+        routing,
+        "conn-primary",
+        "PRIMARY@example.test",
+      ),
+    ).toBe(true);
+    expect(
+      gmailProfileMatchesConnection(
+        routing,
+        "conn-primary",
+        "secondary@example.test",
+      ),
+    ).toBe(false);
+    expect(extractGmailProfileEmail({ status: "ok" })).toBeNull();
   });
 });

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   approvalId: "",
   approvalResponse: true,
+  approvalConnectionId: null as string | null,
   // When true, the approval-response listener never fires, so the approval UI's
   // own timeout is what resolves the request (an expiry).
   approvalNoResponse: false,
@@ -64,6 +65,7 @@ vi.mock("@/lib/support/hook", () => ({
 vi.mock("@/stores/conversation.store", () => ({
   conversationStore: {
     activeConversationId: "active-conversation",
+    getMessagesFor: () => [{ id: "user-turn-2", role: "user" }],
   },
 }));
 
@@ -182,10 +184,11 @@ function shellPromptCount(): number {
 }
 
 describe("tool executor authorization gate", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     mocks.approvalId = "";
     mocks.approvalResponse = true;
+    mocks.approvalConnectionId = null;
     mocks.approvalNoResponse = false;
     mocks.shellApprovalId = "";
     mocks.shellApprovalResponse = true;
@@ -216,6 +219,10 @@ describe("tool executor authorization gate", () => {
       isError: false,
     });
     mocks.callSerenTool.mockResolvedValue({ result: "ok", is_error: false });
+    const { resetGmailSenderConfirmationsForTests } = await import(
+      "@/stores/gmail-send-confirmation.store"
+    );
+    resetGmailSenderConfirmationsForTests();
 
     mocks.invoke.mockImplementation(async (cmd: string, args?: unknown) => {
       if (cmd === "authorize_tool_operation") {
@@ -289,14 +296,22 @@ describe("tool executor authorization gate", () => {
       async (
         eventName: string,
         handler: (event: {
-          payload: { id: string; approved: boolean };
+          payload: {
+            id: string;
+            approved: boolean;
+            connectionId?: string | null;
+          };
         }) => void,
       ) => {
         if (eventName === "gateway-tool-approval-response") {
           // Simulate the user never answering: leave the request to time out.
           if (!mocks.approvalNoResponse) {
             handler({
-              payload: { id: mocks.approvalId, approved: mocks.approvalResponse },
+              payload: {
+                id: mocks.approvalId,
+                approved: mocks.approvalResponse,
+                connectionId: mocks.approvalConnectionId,
+              },
             });
           }
         }
@@ -404,6 +419,42 @@ describe("tool executor authorization gate", () => {
     ]);
   });
 
+  it("rechecks a Gmail account substituted by the approval UI", async () => {
+    const [{ executeTool }, { noteGmailSenderProfileVerified }] =
+      await Promise.all([
+        import("@/lib/tools/executor"),
+        import("@/stores/gmail-send-confirmation.store"),
+      ]);
+    noteGmailSenderProfileVerified(
+      "active-conversation",
+      "conn-confirmed",
+      "user-turn-1",
+    );
+    mocks.authorizeDecision.decision = "prompt";
+    mocks.authorizeDecision.promptKind = "one-shot";
+    mocks.authorizeDecision.operationClass = "high-risk";
+    mocks.approvalConnectionId = "conn-substituted";
+
+    const result = await executeTool({
+      id: "gmail-send-account-substitution",
+      type: "function",
+      function: {
+        name: "gateway__gmail__post_messages_send",
+        arguments: JSON.stringify({
+          connection_id: "conn-confirmed",
+          to: ["recipient@example.test"],
+          subject: "Approval substitution regression",
+          body: "Safe test body",
+        }),
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("Gmail send blocked");
+    expect(gatewayPromptCount()).toBe(1);
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("treats an approval-UI timeout as an expiry, not a durable denial", async () => {
     const { executeTool } = await import("@/lib/tools/executor");
     mocks.authorizeDecision.decision = "prompt";
@@ -476,7 +527,7 @@ describe("tool executor authorization gate", () => {
         function: {
           name: "seren__call_publisher",
           arguments: JSON.stringify({
-            publisher: "gmail",
+            publisher: "outbound-mailer",
             tool: "post_send",
             connection_id: "conn-confirmed",
             tool_args: { to: "a@example.com" },
@@ -486,17 +537,17 @@ describe("tool executor authorization gate", () => {
       "conv-a",
     );
 
-    // The gate must classify the REAL operation (gmail/post_send), not the
+    // The gate must classify the REAL operation (outbound-mailer/post_send), not the
     // generic call_publisher envelope, so a high-risk publisher call cannot
     // ride an unclassified-call_publisher session grant. The transport
     // unwraps the same envelope, so the handle binding matches.
     expect(authorizeCalls()[0]).toMatchObject({
       route: "gateway",
-      publisherSlug: "gmail",
+      publisherSlug: "outbound-mailer",
       toolName: "post_send",
     });
     expect(mocks.callGatewayTool).toHaveBeenCalledWith(
-      "gmail",
+      "outbound-mailer",
       "post_send",
       { to: "a@example.com", connection_id: "conn-confirmed" },
       "handle-allow",

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   emit: vi.fn(),
   listen: vi.fn(),
   invoke: vi.fn(),
+  getMessagesFor: vi.fn(),
   startShellProgressListener: vi.fn(),
   handlePaymentRequired: vi.fn(),
 }));
@@ -25,6 +26,7 @@ vi.mock("@/services/publisher-oauth", () => ({
 vi.mock("@/stores/conversation.store", () => ({
   conversationStore: {
     activeConversationId: "thread-1",
+    getMessagesFor: mocks.getMessagesFor,
   },
 }));
 
@@ -53,6 +55,16 @@ describe("tool executor OAuth account routing", () => {
     const { setThreadOAuthConnectionId } = await import(
       "@/stores/oauth-account.store"
     );
+    const { resetGmailSenderConfirmationsForTests } = await import(
+      "@/stores/gmail-send-confirmation.store"
+    );
+    resetGmailSenderConfirmationsForTests();
+    mocks.getMessagesFor.mockImplementation((threadId: string) => [
+      {
+        id: `${threadId}-user-turn-1`,
+        role: "user",
+      },
+    ]);
     setThreadOAuthConnectionId("thread-1", "google", null);
     setThreadOAuthConnectionId("thread-2", "google", null);
     mocks.computeAgentOAuthRouting.mockResolvedValue({
@@ -156,12 +168,135 @@ describe("tool executor OAuth account routing", () => {
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("rejects a model-supplied selector on the same human turn", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.callGatewayTool.mockResolvedValueOnce({
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: { emailAddress: "selected@example.test" },
+          }),
+        },
+      ],
+      is_error: false,
+    });
+
+    const profile = await executeTool({
+      id: "tool-call-profile-same-turn",
+      type: "function",
+      function: {
+        name: "gateway__gmail__get_profile",
+        arguments: JSON.stringify({
+          connection_id: "conn-google-copied",
+        }),
+      },
+    });
+    const send = await executeTool({
+      id: "tool-call-send-same-turn",
+      type: "function",
+      function: {
+        name: "gateway__gmail__post_messages_send",
+        arguments: JSON.stringify({
+          connection_id: "conn-google-copied",
+          to: ["recipient@example.test"],
+          subject: "Account confirmation regression",
+          body: "Safe test body",
+        }),
+      },
+    });
+
+    expect(profile.is_error).toBe(false);
+    expect(send.is_error).toBe(true);
+    expect(send.content).toContain("same human turn");
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not checkpoint a profile identity that mismatches the selected account", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: { gmail: "conn-google-selected" },
+      ambiguous: {},
+      accounts: {
+        gmail: {
+          providerSlug: "google",
+          providerName: "Google",
+          activeConnectionId: "conn-google-selected",
+          selectionSource: "thread",
+          connections: [
+            {
+              connectionId: "conn-google-selected",
+              label: "selected@example.test",
+              isDefault: true,
+            },
+          ],
+        },
+      },
+      available: true,
+    });
+    mocks.callGatewayTool.mockResolvedValueOnce({
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: { emailAddress: "different@example.test" },
+          }),
+        },
+      ],
+      is_error: false,
+    });
+
+    const profile = await executeTool({
+      id: "tool-call-profile-mismatch",
+      type: "function",
+      function: {
+        name: "gateway__gmail__get_profile",
+        arguments: JSON.stringify({
+          connection_id: "conn-google-selected",
+        }),
+      },
+    });
+    mocks.getMessagesFor.mockReturnValue([
+      { id: "thread-1-user-turn-1", role: "user" },
+      { id: "thread-1-user-turn-2", role: "user" },
+    ]);
+    const send = await executeTool({
+      id: "tool-call-send-after-mismatch",
+      type: "function",
+      function: {
+        name: "gateway__gmail__post_messages_send",
+        arguments: JSON.stringify({
+          connection_id: "conn-google-selected",
+          to: ["recipient@example.test"],
+          subject: "Profile mismatch regression",
+          body: "Safe test body",
+        }),
+      },
+    });
+
+    expect(profile.is_error).toBe(true);
+    expect(profile.content).toContain("verification failed");
+    expect(send.is_error).toBe(true);
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(1);
+  });
+
   it("persists a successful explicit chat selection to the owning thread", async () => {
     const [{ executeTool }, { getThreadOAuthConnectionId }] =
       await Promise.all([
         import("@/lib/tools/executor"),
         import("@/stores/oauth-account.store"),
       ]);
+    mocks.callGatewayTool.mockResolvedValueOnce({
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: { emailAddress: "selected@example.test" },
+          }),
+        },
+      ],
+      is_error: false,
+    });
 
     const result = await executeTool(
       {
@@ -185,6 +320,38 @@ describe("tool executor OAuth account routing", () => {
 
   it("forwards a top-level selector through built-in call_publisher sends", async () => {
     const { executeTool } = await import("@/lib/tools/executor");
+    mocks.callGatewayTool.mockResolvedValueOnce({
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: { emailAddress: "selected@example.test" },
+          }),
+        },
+      ],
+      is_error: false,
+    });
+
+    await executeTool(
+      {
+        id: "tool-call-generic-profile",
+        type: "function",
+        function: {
+          name: "seren__call_publisher",
+          arguments: JSON.stringify({
+            publisher: "gmail",
+            tool: "get_profile",
+            connection_id: "conn-google-confirmed",
+            tool_args: {},
+          }),
+        },
+      },
+      "thread-2",
+    );
+    mocks.getMessagesFor.mockImplementation((threadId: string) => [
+      { id: `${threadId}-user-turn-1`, role: "user" },
+      { id: `${threadId}-user-turn-2`, role: "user" },
+    ]);
 
     const result = await executeTool(
       {


### PR DESCRIPTION
## Description

Closes a P0 bypass in Gmail sender confirmation by moving cross-turn confirmation state into a host-owned per-thread store instead of trusting model-supplied selectors.

- keeps connected-account guidance at primary system-prompt priority
- records the host-observed Gmail sender and requires confirmation on a later user turn
- revalidates the actual dispatch connection after approval to prevent account substitution
- parses wrapped Gmail profile responses from the publisher gateway
- adds regression coverage for forged selectors, account switching, approval substitution, prompt placement, and wrapped profile envelopes

## Related Issue

Closes #3628

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Validation

- [x] `pnpm test` — 2,972 tests passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 1,296 tests passed
- [x] `pnpm build`
- [x] `pnpm verify:frontend-build`
- [x] targeted Biome and Node syntax checks
- [x] patch privacy scan found no personal markers or non-reserved email addresses
- [x] live authenticated walkthrough with three connected Google accounts: first-turn send blocked, sender and alternatives identified, later-turn alternate-account confirmation verified, and no message sent

## Checklist

- [x] I have added tests
- [x] No secrets or credentials in code

## Screenshots

Not applicable; no UI changes.