### PR TITLE
docs(release): curated notes for v3.77.0

### DIFF
--- a/.github/release-notes/v3.77.0.md
+++ b/.github/release-notes/v3.77.0.md
@@ -1,0 +1,37 @@
+## What's New
+
+## 🖥️ macOS Folder Access
+
+- Seren now requests macOS folder permissions (Desktop, Documents, Downloads) for agent working roots up front, with a dedicated Settings section to review and grant access — no more silent file-tool failures on first use (#3607). Permission probes run off the async runtime so a pending consent dialog can never stall chat or agents (#3613, #3620).
+
+## 🤖 Smarter Auto Routing
+
+- When a model fails mid-response and Seren reroutes, the switch is announced exactly once — no more duplicate announcement rows (#3603, #3609).
+- A thread set to **Auto** stays on Auto after an automatic fallback: the fallback model serves the current attempt, and the next task re-runs Auto selection instead of being pinned to the fallback (#3602, #3610).
+- Retryable SerenModels stream failures now reroute instead of failing the whole response, with terminal errors reported faithfully (#3599, #3601).
+- Streamed tool calls that a provider finishes with a `stop` label now execute instead of being dropped after rendering, and malformed tool-call batches fail cleanly without leaving stuck cards (#3627, #3638).
+- The model picker, the thread provider switcher, and `/model` all draw from the live Seren catalog — switching a thread to Seren works even before the picker has ever opened, and a transient catalog failure no longer empties the model list (#3600, #3605, #3614, #3621).
+- Catalog discovery is time-bounded, so a stalled connection surfaces a clear retry message instead of blocking Auto sends indefinitely (#3615, #3622).
+
+## 🚀 Mission Control
+
+- Relaunching an interrupted run now settles tasks whose attempt budget is spent instead of looping the dispatcher forever (#3611, #3619).
+- A run that asks for worktree or scratch isolation either gets it or fails loudly on the launch form — a provisioning failure can no longer silently run agents in the real project folder (#3612, #3624).
+- The sidebar's **New Mission** always lands on the launch form, even when Mission Control is already open showing a finished run; live runs are never discarded (#3617, #3625).
+- Hosted-model tasks now share the native agents' 30-minute turn cap, so a stalled stream frees its slot and records a coverage gap instead of holding the run open (#3616, #3623).
+- Advanced launch controls (attempts per task, per-agent models, permission modes) are fully effective (#3598), the launch form scrolls with a proper overlay scrollbar in every path it renders (#3590, #3618, #3626), and Mission Control is reachable from the sidebar (#3591, #3592).
+
+## 📬 Gmail Sender Confirmation
+
+- Before the first Gmail send in a thread, the agent now names the exact connected mailbox in chat, lists connected alternatives, and waits for your confirmation on a later turn. Choosing another account conversationally routes the send through it and becomes the thread's active Google account (#3589, #3596).
+- Confirmation state is host-owned and bound to the actual dispatch connection, so a model-supplied selector can never stand in for your approval, and approving one account can never authorize another (#3628, #3639).
+
+## 👥 Employees & Chat
+
+- Employee threads gained close controls, and archived-employee threads can be closed from the sidebar (#3595, #3597).
+- Terminal employee responses no longer render raw envelope wrappers (#3536, #3593).
+- Managed deployments receive the full lifecycle scopes they need (#3608).
+
+## 🔧 Release Pipeline
+
+- Releases now publish only the artifacts users actually install; internal build byproducts are filtered out (#3586, #3587).


### PR DESCRIPTION
Curated "What's New" for the v3.77.0 tag, consumed verbatim by release.yml's notes step. Covers everything on main since v3.76.0: the macOS TCC folder-access feature, the Auto-routing and reroute fixes, the live-catalog picker work, the Mission Control hardening set, the Gmail sender-confirmation flow and its host-owned hardening, employees/chat fixes, and the release artifact filter.

Docs-only; no code paths. Network path: none.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com