### PR TITLE
fix: preserve intake integrity on Send and Schedule failures

### DIFF
--- a/src/components/interview/InterviewLanding.tsx
+++ b/src/components/interview/InterviewLanding.tsx
@@ -14,8 +14,11 @@ import {
 import {
   catalogAssetUrl,
   clusterLabel,
+  INTAKE_PERSISTENCE_RETRY_MESSAGE,
+  INTAKE_SCHEDULING_RETRY_MESSAGE,
   nextInterviewSelection,
   resolveInterviewEmployeeSlug,
+  runPersistedIntakeHandoff,
 } from "@/components/interview/interviewLandingModel";
 import { openExternalLink } from "@/lib/external-link";
 import {
@@ -133,17 +136,23 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      await submitGeneralEmployeeIntake({
-        selectedEmployeeSlug: selectedSlug(),
-        goals: goals(),
-        requirements: requirements(),
-        tools: tools(),
-        discussionNotes: discussionNotes(),
-      });
-      setStep("complete");
-      await openExternalLink(EMPLOYEE_INTAKE_CALENDLY_URL);
-    } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : String(error));
+      const result = await runPersistedIntakeHandoff(
+        () =>
+          submitGeneralEmployeeIntake({
+            selectedEmployeeSlug: selectedSlug(),
+            goals: goals(),
+            requirements: requirements(),
+            tools: tools(),
+            discussionNotes: discussionNotes(),
+          }),
+        () => setStep("complete"),
+        () => openExternalLink(EMPLOYEE_INTAKE_CALENDLY_URL),
+      );
+      if (result === "scheduling-open-failed") {
+        setSubmitError(INTAKE_SCHEDULING_RETRY_MESSAGE);
+      }
+    } catch {
+      setSubmitError(INTAKE_PERSISTENCE_RETRY_MESSAGE);
     } finally {
       setSubmitting(false);
     }

--- a/src/components/interview/interviewLandingModel.ts
+++ b/src/components/interview/interviewLandingModel.ts
@@ -5,6 +5,32 @@ import type { EmployeeCatalogItem } from "@/api/employee-catalog";
 
 const CATALOG_ASSET_ORIGIN = "https://serendb.com";
 
+export const INTAKE_PERSISTENCE_RETRY_MESSAGE =
+  "We couldn't save your intake. Your answers are still here. Please try Send and Schedule again.";
+
+export const INTAKE_SCHEDULING_RETRY_MESSAGE =
+  "Your intake was saved, but Calendly didn't open. Use Open Calendly below.";
+
+export type PersistedIntakeHandoffResult =
+  | "scheduling-opened"
+  | "scheduling-open-failed";
+
+export async function runPersistedIntakeHandoff(
+  persist: () => Promise<void>,
+  onPersisted: () => void,
+  openScheduling: () => Promise<void>,
+): Promise<PersistedIntakeHandoffResult> {
+  await persist();
+  onPersisted();
+
+  try {
+    await openScheduling();
+    return "scheduling-opened";
+  } catch {
+    return "scheduling-open-failed";
+  }
+}
+
 export function catalogAssetUrl(path: string): string {
   if (/^https?:\/\//.test(path)) return path;
   return `${CATALOG_ASSET_ORIGIN}${path.startsWith("/") ? path : `/${path}`}`;

--- a/tests/unit/interview-landing.test.ts
+++ b/tests/unit/interview-landing.test.ts
@@ -3,11 +3,13 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   catalogAssetUrl,
+  INTAKE_PERSISTENCE_RETRY_MESSAGE,
   nextInterviewSelection,
   resolveInterviewEmployeeSlug,
+  runPersistedIntakeHandoff,
 } from "@/components/interview/interviewLandingModel";
 
 const catalog = Array.from({ length: 15 }, (_, index) => ({
@@ -47,6 +49,62 @@ describe("InterviewLanding", () => {
     expect(nextInterviewSelection(null, catalog, "cfo")).toBe("cfo");
     expect(nextInterviewSelection("removed-role", catalog, "cfo")).toBe("cfo");
     expect(nextInterviewSelection("removed-role", catalog, null)).toBeNull();
+  });
+
+  it("opens scheduling only after intake persistence succeeds", async () => {
+    const order: string[] = [];
+
+    await expect(
+      runPersistedIntakeHandoff(
+        async () => {
+          order.push("persisted");
+        },
+        () => order.push("complete"),
+        async () => {
+          order.push("scheduling-opened");
+        },
+      ),
+    ).resolves.toBe("scheduling-opened");
+
+    expect(order).toEqual(["persisted", "complete", "scheduling-opened"]);
+  });
+
+  it("does not complete or open scheduling when persistence fails", async () => {
+    const persistenceError = new Error("backend detail that must not be shown");
+    const onPersisted = vi.fn();
+    const openScheduling = vi.fn();
+
+    await expect(
+      runPersistedIntakeHandoff(
+        async () => {
+          throw persistenceError;
+        },
+        onPersisted,
+        openScheduling,
+      ),
+    ).rejects.toBe(persistenceError);
+
+    expect(onPersisted).not.toHaveBeenCalled();
+    expect(openScheduling).not.toHaveBeenCalled();
+    expect(INTAKE_PERSISTENCE_RETRY_MESSAGE).not.toContain(
+      persistenceError.message,
+    );
+  });
+
+  it("keeps a persisted intake complete when automatic scheduling fails", async () => {
+    const onPersisted = vi.fn();
+
+    await expect(
+      runPersistedIntakeHandoff(
+        async () => undefined,
+        onPersisted,
+        async () => {
+          throw new Error("opener failed");
+        },
+      ),
+    ).resolves.toBe("scheduling-open-failed");
+
+    expect(onPersisted).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
Closes #3642.

Depends on the now-merged backend hardening in serenorg/seren-website#301.

## Audit result

The reported Internal server error originated in the website persistence path. Moving Calendly ahead of persistence would hide that fault and risk scheduling a call without a stored intake, so this PR keeps the existing integrity contract: persist first, then schedule.

## Desktop fix

- Preserve the populated intake form when persistence fails.
- Replace the raw backend error with an actionable retry message.
- Keep completion state and the Calendly opener untouched on persistence rejection.
- Mark the intake complete only after persistence succeeds.
- Distinguish a scheduling-opener failure from a persistence failure, so a saved intake is never presented as lost.
- Keep the manual Open Calendly recovery action available after persistence succeeds.

## Verification

- Focused Vitest suites passed: 15 tests.
- Regression coverage proves persistence rejection does not complete or schedule, success completes before opening, and opener failure remains distinct from persistence failure.
- Biome passed on every changed file.
- Production Vite build passed.
- Repository-wide TypeScript still reports pre-existing unrelated errors in mission-agent-catalog.ts; no changed file reports a TypeScript error.
- After the backend merge deployed, the exact signed-in flow passed in an isolated npm run tauri:validation:dev build in 1.61 seconds.
- Completion and Calendly confirmation appeared only after the production table contained exactly one matching authenticated row.
- Exactly that synthetic validation row was removed after verification.
- Validation evidence contains no identity, credentials, real intake content, or database details.

## Integrity boundary

This PR does not bypass, suppress, or reinterpret persistence failure as scheduling success. Calendly remains gated on a confirmed persisted response.