### PR TITLE
fix(mission-control): load model catalogs from installed CLIs

### DIFF
--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -103,10 +103,48 @@ function createAcpSessionRecord({
     currentModeId: currentModeId ?? adapter.defaultModeId,
     currentModelId: currentModelId ?? adapter.defaultModelId,
     availableModels: adapter.availableModels,
+    cliModels: [],
     configOptions: [],
     serenMcpConfigured,
     serenMcpProxy,
   };
+}
+
+function normalizeAcpModels(models) {
+  if (!Array.isArray(models)) return [];
+  return models
+    .filter(
+      (model) =>
+        model &&
+        typeof model.modelId === "string" &&
+        model.modelId.trim().length > 0,
+    )
+    .map((model) => ({
+      modelId: model.modelId.trim(),
+      name:
+        typeof model.name === "string" && model.name.trim().length > 0
+          ? model.name.trim()
+          : model.modelId.trim(),
+      ...(typeof model.description === "string" && model.description.length > 0
+        ? { description: model.description }
+        : {}),
+    }));
+}
+
+function applyAcpModelState(session, modelState) {
+  if (!modelState || typeof modelState !== "object") return false;
+  const cliModels = normalizeAcpModels(modelState.availableModels);
+  session.cliModels = cliModels;
+  session.availableModels = cliModels;
+
+  const currentModelId =
+    typeof modelState.currentModelId === "string" &&
+    modelState.currentModelId.trim().length > 0
+      ? modelState.currentModelId.trim()
+      : null;
+  session.currentModelId =
+    currentModelId ?? cliModels[0]?.modelId ?? null;
+  return true;
 }
 
 // ============================================================================
@@ -771,6 +809,21 @@ export function createAcpRuntime({
       );
 
       session.agentSessionId = sessionResult?.sessionId ?? sessionId;
+      applyAcpModelState(session, sessionResult?.models);
+
+      if (
+        typeof initialModelId === "string" &&
+        session.availableModels.some((model) => model.modelId === initialModelId) &&
+        session.currentModelId !== initialModelId
+      ) {
+        await sendRequest(
+          session,
+          "session/set_model",
+          { sessionId: session.agentSessionId, modelId: initialModelId },
+          5_000,
+        );
+        session.currentModelId = initialModelId;
+      }
       session.status = "ready";
 
       emit("provider://session-status", buildSessionStatus(session, "ready"));
@@ -1069,7 +1122,9 @@ export function createAcpRuntime({
     if (!session) {
       throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
     }
-    const known = adapter.availableModels.find((model) => model.modelId === modelId);
+    const known = session.availableModels.find(
+      (model) => model.modelId === modelId,
+    );
     if (!known) {
       throw new Error(`Unknown ${adapter.agentName} model: ${modelId}`);
     }
@@ -1085,6 +1140,10 @@ export function createAcpRuntime({
     });
   }
 
+  function listCliModels(sessionId) {
+    return sessions.get(sessionId)?.cliModels ?? [];
+  }
+
   return {
     hasSession(sessionId) {
       return sessions.has(sessionId);
@@ -1098,11 +1157,13 @@ export function createAcpRuntime({
     setOAuthRouting,
     respondToPermission,
     setModel,
+    listCliModels,
   };
 }
 
 export {
   applyAcpPermissionMode as _applyAcpPermissionMode,
+  applyAcpModelState as _applyAcpModelState,
   emitToolCallUpdate as _emitAcpToolCallUpdate,
   sendRequest as _sendAcpRequest,
 };

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2805,6 +2805,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
             agentSessionId: metadata.agentSessionId,
             claudeVersion: null,
             availableModelRecords: [],
+            cliModelRecords: [],
             currentModelId: metadata.currentModelId,
             currentModeId: "default",
             reasoningEffort: metadata.reasoningEffort,
@@ -2850,6 +2851,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       timeoutSecs: timeoutSecs ?? undefined,
       claudeVersion: null,
       availableModelRecords: [],
+      cliModelRecords: [],
       currentModelId,
       currentModeId,
       mcpConfigJson,
@@ -3184,9 +3186,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         }
       }
 
+      session.cliModelRecords = normalizeModelRecords(initResult);
       session.availableModelRecords = ensurePreferredModelRecord(
         augmentWithLegacyOpus(
-          normalizeModelRecords(initResult),
+          session.cliModelRecords,
         ),
         preferredModel,
       );
@@ -3559,6 +3562,16 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     return session ? buildAvailableModels(session) : [];
   }
 
+  function listCliModels(sessionId) {
+    const session = sessions.get(sessionId);
+    if (!session) return [];
+    return session.cliModelRecords.map((record) => ({
+      modelId: record.modelId,
+      name: record.name,
+      description: record.description,
+    }));
+  }
+
   async function setModel({ sessionId, modelId }) {
     const session = sessions.get(sessionId);
     if (!session) {
@@ -3751,6 +3764,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     respondToPermission,
     setModel,
     listSessionModels,
+    listCliModels,
     setConfigOption,
     forkSession,
     buildSyntheticTranscript,

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -167,11 +167,11 @@ const GEMINI_ADAPTER = {
     "Gemini process exited while prompt was active.",
   loginRequiredMessage:
     "Gemini authentication required. Opening `gemini login` in a Terminal window — finish the sign-in there, then click + New Agent → Gemini Agent again.",
-  async setModel({ modelId, logPrefix }) {
-    console.warn(
-      `${logPrefix} setModel: ${modelId} stored as session intent — ` +
-        "no-op against the running CLI process (Gemini --model is fixed at " +
-        "spawn time). The next session spawn will use this model.",
+  async setModel({ session, modelId, request }) {
+    await request(
+      "session/set_model",
+      { sessionId: session.agentSessionId, modelId },
+      5_000,
     );
   },
 };

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -135,6 +135,7 @@ export function createUnavailableRuntime(label, reason) {
     setOAuthRouting: unavailable,
     respondToPermission: unavailable,
     listRemoteSessions: unavailable,
+    listCliModels: unavailable,
     setModel: unavailable,
     setSessionModel: unavailable,
     setConfigOption: unavailable,
@@ -1764,6 +1765,72 @@ export function createProviderHandlers({
     }
   }
 
+  async function getModelCatalog({ agentType, cwd }) {
+    if (typeof cwd !== "string" || cwd.length === 0) {
+      throw new Error("A working directory is required to load CLI models.");
+    }
+
+    if (agentType === "codex") {
+      return withTemporaryCodexSession(cwd, async (session) => {
+        const result = await sendRequest(session, "model/list", {}, 10_000);
+        return normalizeModelRecords(result).map((record) => ({
+          modelId: record.modelId,
+          name: record.name,
+          description: record.description,
+        }));
+      });
+    }
+
+    const runtimeDefinition =
+      agentType === "claude-code"
+        ? [claudeRuntimeModule, "createClaudeRuntime"]
+        : agentType === "gemini"
+          ? [geminiRuntimeModule, "createGeminiRuntime"]
+          : agentType === "grok"
+            ? [grokRuntimeModule, "createGrokRuntime"]
+            : null;
+    if (!runtimeDefinition) {
+      throw new Error(`Model catalogs are not supported for ${agentType}.`);
+    }
+
+    const probeRuntime = instantiateAgentRuntime(
+      agentType,
+      runtimeDefinition[0],
+      runtimeDefinition[1],
+      { emit: () => {}, runtimeMode: `${runtimeMode}-catalog` },
+    );
+    const sessionId = randomUUID();
+    let spawned = false;
+    try {
+      const sandboxProfile =
+        agentType === "claude-code"
+          ? await resolveSandboxLaunchSpec({
+              sandboxMode: "danger-full-access",
+              cwd,
+              networkEnabled: true,
+            })
+          : null;
+      await probeRuntime.spawnSession({
+        agentType,
+        cwd,
+        localSessionId: sessionId,
+        sandboxMode: "danger-full-access",
+        sandboxProfile,
+        networkEnabled: true,
+        suppressHistoryReplay: true,
+      });
+      spawned = true;
+      if (typeof probeRuntime.listCliModels !== "function") {
+        throw new Error(`${agentType} did not expose its CLI model catalog.`);
+      }
+      return probeRuntime.listCliModels(sessionId);
+    } finally {
+      if (spawned) {
+        await probeRuntime.terminateSession({ sessionId }).catch(() => {});
+      }
+    }
+  }
+
   async function spawnOwnedSession(callerParams) {
     // Every provider_spawn caller reaches this one function — the desktop
     // renderer, a paired role's inner spawn, an orchestrator one-shot, and the
@@ -2819,6 +2886,7 @@ export function createProviderHandlers({
     respondToPermission,
     respondToDiffProposal,
     getAvailableAgents,
+    getModelCatalog,
     checkAgentAvailable,
     checkAgentAuthenticated,
     ensureAgentCli,

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -108,6 +108,10 @@ function registerProviderHandlers() {
     providerHandlers.getAvailableAgents,
   );
   registerHandler(
+    "provider_get_model_catalog",
+    providerHandlers.getModelCatalog,
+  );
+  registerHandler(
     "provider_check_agent_available",
     providerHandlers.checkAgentAvailable,
   );

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -265,6 +265,10 @@ function registerBrowserLocalHandlers() {
     providerHandlers.getAvailableAgents,
   );
   registerHandler(
+    "provider_get_model_catalog",
+    providerHandlers.getModelCatalog,
+  );
+  registerHandler(
     "provider_check_agent_available",
     providerHandlers.checkAgentAvailable,
   );

--- a/scripts/validate-walkthrough.ts
+++ b/scripts/validate-walkthrough.ts
@@ -37,6 +37,7 @@ interface ControlClient {
   navigate(route: string): Promise<unknown>;
   click(selector: string): Promise<unknown>;
   fill(selector: string, value: string): Promise<unknown>;
+  select(selector: string, value: string): Promise<unknown>;
   press(key: string): Promise<unknown>;
   waitFor(selector: string, timeoutMs?: number): Promise<unknown>;
   dumpText(selector?: string): Promise<unknown>;
@@ -94,6 +95,13 @@ async function main(): Promise<void> {
       SEREN_VALIDATION_DEV_PORT: String(slot.port),
       SEREN_VALIDATION_INSTANCE: "1",
     };
+    const cliHome = process.env.SEREN_VALIDATION_CLI_HOME?.trim();
+    if (cliHome) {
+      childEnv.HOME = cliHome;
+      console.log(
+        "[validate:walkthrough] using the signed-in host CLI home; app data remains isolated",
+      );
+    }
     console.log(`[validate:walkthrough] scratch home ${validationHome}`);
 
     await rm(artifactsDir, { recursive: true, force: true });
@@ -255,6 +263,8 @@ function createClient(discovery: DiscoveryFile): ControlClient {
     navigate: (route) => command({ command: "navigate", route }),
     click: (selector) => command({ command: "click", selector }),
     fill: (selector, value) => command({ command: "fill", selector, value }),
+    select: (selector, value) =>
+      command({ command: "select", selector, value }),
     press: (key) => command({ command: "press", key }),
     waitFor: (selector, timeoutMs = 5000) =>
       command({ command: "waitFor", selector, timeoutMs }),

--- a/src-tauri/src/validation/control_server.rs
+++ b/src-tauri/src/validation/control_server.rs
@@ -330,6 +330,7 @@ fn is_allowed_command(command: &str) -> bool {
             // and other context-menu flows are otherwise undrivable). #3355.
             | "contextmenu"
             | "fill"
+            | "select"
             | "press"
             | "waitFor"
             | "dumpText"

--- a/src/components/run/RunLaunchBox.tsx
+++ b/src/components/run/RunLaunchBox.tsx
@@ -105,7 +105,13 @@ export const RunLaunchBox: Component<RunLaunchBoxProps> = (props) => {
     try {
       await Promise.all(
         MISSION_MODEL_TARGETS.map(async (target) => {
-          setModelCatalogs(target, await loadMissionModelCatalog(target));
+          setModelCatalogs(
+            target,
+            await loadMissionModelCatalog(
+              target,
+              fileTreeState.rootPath ?? ".",
+            ),
+          );
         }),
       );
     } finally {

--- a/src/services/mission-agent-catalog.ts
+++ b/src/services/mission-agent-catalog.ts
@@ -13,9 +13,13 @@ import {
   type OrganizationPrivateModelsPolicy,
 } from "@/services/organization-policy";
 import { privateModelsService } from "@/services/private-models";
-import { type AgentType, testLmStudioConnection } from "@/services/providers";
+import {
+  type AgentModelCatalogEntry,
+  type AgentType,
+  getAgentModelCatalog,
+  testLmStudioConnection,
+} from "@/services/providers";
 import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
-import { type AgentModelInfo, agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { settingsStore } from "@/stores/settings.store";
 
@@ -130,70 +134,8 @@ export function createEmptyMissionModelCatalogs(): Record<
 > {
   return Object.fromEntries(
     MISSION_MODEL_TARGETS.map((target) => [target, { models: [], note: null }]),
-  ) as Record<MissionModelTarget, MissionModelCatalog>;
+  ) as unknown as Record<MissionModelTarget, MissionModelCatalog>;
 }
-
-const CLAUDE_MODELS: readonly MissionModelOption[] = [
-  {
-    id: "claude-opus-4-8[1m]",
-    name: "Claude Opus 4.8 · 1M context",
-    description: "SerenDesktop's preferred Claude Code model",
-  },
-  {
-    id: "claude-opus-4-7[1m]",
-    name: "Claude Opus 4.7 · 1M context",
-    description: "Previous Opus generation with a 1M context window",
-  },
-  {
-    id: "claude-sonnet-4-7[1m]",
-    name: "Claude Sonnet 4.7 · 1M context",
-    description: "Faster Claude model with a 1M context window",
-  },
-] as const;
-
-const CODEX_MODELS: readonly MissionModelOption[] = [
-  {
-    id: "gpt-5.6-sol",
-    name: "GPT-5.6 Sol",
-    description: "Flagship Codex model",
-  },
-  {
-    id: "gpt-5.6-luna",
-    name: "GPT-5.6 Luna",
-    description: "Fast, lower-cost Codex model",
-  },
-  {
-    id: "gpt-5.6-terra",
-    name: "GPT-5.6 Terra",
-    description: "Balanced Codex model",
-  },
-] as const;
-
-const GEMINI_MODELS: readonly MissionModelOption[] = [
-  {
-    id: "gemini-2.5-pro",
-    name: "Gemini 2.5 Pro",
-    description: "Most capable Gemini CLI model",
-  },
-  {
-    id: "gemini-2.5-flash",
-    name: "Gemini 2.5 Flash",
-    description: "Fast Gemini CLI model",
-  },
-  {
-    id: "gemini-2.5-flash-lite",
-    name: "Gemini 2.5 Flash Lite",
-    description: "Lowest-latency Gemini CLI model",
-  },
-] as const;
-
-const GROK_MODELS: readonly MissionModelOption[] = [
-  {
-    id: "grok-4.5",
-    name: "Grok 4.5",
-    description: "Grok Build's coding-agent model",
-  },
-] as const;
 
 export const MISSION_PERMISSION_OPTIONS: Record<
   MissionAgentType,
@@ -233,27 +175,46 @@ export const MISSION_PERMISSION_OPTIONS: Record<
   ],
 };
 
-function builtinModels(
+function localAgentForTarget(
   target: MissionModelTarget,
-): readonly MissionModelOption[] {
+): Exclude<AgentType, "claude-codex" | "lmstudio"> | null {
   switch (target) {
     case "claude-code":
     case "claude-codex:planner":
-      return CLAUDE_MODELS;
+      return "claude-code";
     case "codex":
     case "claude-codex:executor":
-      return CODEX_MODELS;
+      return "codex";
     case "gemini":
-      return GEMINI_MODELS;
+      return "gemini";
     case "grok":
-      return GROK_MODELS;
+      return "grok";
     default:
-      return [];
+      return null;
   }
 }
 
+const localCatalogLoads = new Map<string, Promise<AgentModelCatalogEntry[]>>();
+
+function loadLocalCatalog(
+  agentType: Exclude<AgentType, "claude-codex" | "lmstudio">,
+  cwd: string,
+): Promise<AgentModelCatalogEntry[]> {
+  const key = `${agentType}:${cwd}`;
+  const existing = localCatalogLoads.get(key);
+  if (existing) return existing;
+
+  const pending = getAgentModelCatalog(agentType, cwd);
+  localCatalogLoads.set(key, pending);
+  void pending.then(
+    () => localCatalogLoads.delete(key),
+    () => localCatalogLoads.delete(key),
+  );
+  return pending;
+}
+
 function toMissionModel(
-  model: AgentModelInfo | ProviderModel,
+  model: AgentModelCatalogEntry | ProviderModel,
 ): MissionModelOption {
   if ("modelId" in model) {
     return {
@@ -277,25 +238,6 @@ export function mergeMissionModels(
     }
   }
   return [...merged.values()];
-}
-
-function liveSessionModels(target: MissionModelTarget): MissionModelOption[] {
-  const models: MissionModelOption[] = [];
-  for (const session of Object.values(agentStore.sessions)) {
-    if (target === "claude-codex:planner") {
-      const roleModels = session.paired?.planner.models?.availableModels ?? [];
-      models.push(...roleModels.map(toMissionModel));
-      continue;
-    }
-    if (target === "claude-codex:executor") {
-      const roleModels = session.paired?.executor.models?.availableModels ?? [];
-      models.push(...roleModels.map(toMissionModel));
-      continue;
-    }
-    if (session.info.agentType !== target) continue;
-    models.push(...(session.availableModels ?? []).map(toMissionModel));
-  }
-  return models;
 }
 
 export function missionAgentAllowed(
@@ -330,10 +272,8 @@ export function missionAgentRequiresSignIn(
 
 export async function loadMissionModelCatalog(
   target: MissionModelTarget,
+  cwd = ".",
 ): Promise<MissionModelCatalog> {
-  const builtins = builtinModels(target);
-  const runtimeModels = liveSessionModels(target);
-
   if (target === "seren") {
     if (!authStore.isAuthenticated) {
       return { models: [], note: "Sign in to load Seren Models." };
@@ -387,7 +327,7 @@ export async function loadMissionModelCatalog(
         description: model.description,
       }));
       return {
-        models: mergeMissionModels(runtimeModels, models),
+        models: mergeMissionModels(models),
         note:
           models.length > 0
             ? null
@@ -395,17 +335,32 @@ export async function loadMissionModelCatalog(
       };
     } catch {
       return {
-        models: mergeMissionModels(runtimeModels),
+        models: [],
         note: "Start LM Studio to load models downloaded on this device.",
       };
     }
   }
 
-  return {
-    models: mergeMissionModels(runtimeModels, builtins),
-    note:
-      runtimeModels.length > 0
-        ? "Includes models reported by the live runtime."
-        : null,
-  };
+  const localAgent = localAgentForTarget(target);
+  if (localAgent) {
+    try {
+      const models = (await loadLocalCatalog(localAgent, cwd)).map(
+        toMissionModel,
+      );
+      return {
+        models: mergeMissionModels(models),
+        note:
+          models.length > 0
+            ? null
+            : `The installed ${localAgent} CLI reported no selectable models. System default remains available.`,
+      };
+    } catch {
+      return {
+        models: [],
+        note: `The installed ${localAgent} CLI model catalog could not be loaded. System default remains available.`,
+      };
+    }
+  }
+
+  return { models: [], note: null };
 }

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -208,6 +208,12 @@ export interface AgentInfo {
   unavailableReason?: string;
 }
 
+export interface AgentModelCatalogEntry {
+  modelId: string;
+  name: string;
+  description?: string;
+}
+
 // Remote sessions (provider runtime listSessions capability)
 export interface RemoteSessionInfo {
   sessionId: string;
@@ -884,6 +890,18 @@ export async function respondToDiffProposal(
  */
 export async function getAvailableAgents(): Promise<AgentInfo[]> {
   return invokeProvider<AgentInfo[]>("provider_get_available_agents");
+}
+
+/** Read the installed agent CLI's own model catalog without starting a turn. */
+export async function getAgentModelCatalog(
+  agentType: Exclude<AgentType, "claude-codex" | "lmstudio">,
+  cwd: string,
+): Promise<AgentModelCatalogEntry[]> {
+  return invokeProvider<AgentModelCatalogEntry[]>(
+    "provider_get_model_catalog",
+    { agentType, cwd },
+    { timeoutMs: 120_000 },
+  );
 }
 
 /**

--- a/src/services/validation-control.ts
+++ b/src/services/validation-control.ts
@@ -113,6 +113,8 @@ async function handleCommand(command: ValidationCommand): Promise<unknown> {
       return readState(command.invokeName, command.invokeArgs);
     case "fill":
       return fill(command.selector, command.value ?? "");
+    case "select":
+      return select(command.selector, command.value ?? "");
     case "press":
       return press(command.key ?? command.value ?? "");
     case "waitFor":
@@ -157,6 +159,30 @@ function fill(selector: string | undefined, value: string): { filled: string } {
   );
   element.dispatchEvent(new Event("change", { bubbles: true }));
   return { filled: selector ?? "" };
+}
+
+function select(
+  selector: string | undefined,
+  value: string,
+): { selected: string; value: string } {
+  const element = findElement(selector);
+  if (!(element instanceof HTMLSelectElement)) {
+    throw new Error(`Element is not a select: ${selector}`);
+  }
+  if (![...element.options].some((option) => option.value === value)) {
+    throw new Error(
+      `Select option is unavailable: ${value}. Available: ${[...element.options]
+        .map((option) => option.value || "<default>")
+        .join(", ")}`,
+    );
+  }
+  element.focus();
+  element.value = value;
+  element.dispatchEvent(
+    new InputEvent("input", { bubbles: true, data: value }),
+  );
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+  return { selected: selector ?? "", value };
 }
 
 /** Read-only Tauri commands a validation scenario may invoke to assert a

--- a/tests/unit/agent-model-observability.test.ts
+++ b/tests/unit/agent-model-observability.test.ts
@@ -1,6 +1,6 @@
 // ABOUTME: Source-level regression tests for #1718 — instrument all three
 // ABOUTME: agent runtimes (Claude / Codex / Gemini) so picker/runtime model
-// ABOUTME: divergence is always visible in the app log.
+// ABOUTME: selections remain observable or are applied through the live protocol.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -74,17 +74,14 @@ describe("#1718 Codex runtime — thread/start model adoption is logged", () => 
   });
 });
 
-describe("#1718 Gemini runtime — mid-session setModel surfaces as a warn", () => {
-  it("setModel emits a console.warn explaining it is a no-op until the next spawn", () => {
-    // Mid-session setModel does not plumb to gemini-cli (Phase 1 limitation
-    // documented in the runtime). Without a log the user can change the
-    // picker and never know the running process is unchanged.
+describe("#3643 Gemini runtime — mid-session setModel reaches the CLI", () => {
+  it("sends session/set_model with the active CLI session and requested model", () => {
     const fnIdx = geminiRuntime.indexOf("async setModel(");
     expect(fnIdx).toBeGreaterThan(0);
     const region = geminiRuntime.slice(fnIdx, fnIdx + 1200);
-    expect(region).toContain("console.warn(");
-    // Pin the message text so the warn cannot be silently rewritten into
-    // something less honest.
-    expect(region).toMatch(/(no-op|spawn[ -]time)/);
+    expect(region).toContain('"session/set_model"');
+    expect(region).toContain("sessionId: session.agentSessionId");
+    expect(region).toContain("modelId");
+    expect(region).not.toMatch(/(no-op|spawn[ -]time)/);
   });
 });

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -16,12 +16,15 @@ describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
     // running on 1M. chooseUpdatedModelId carries the existing #1763
     // [1m]-preservation guard — reuse it here so spawn-time and per-message
     // resolution agree on the tier marker.
-    const spawnAnchor = "ensurePreferredModelRecord(\n        augmentWithLegacyOpus(";
+    const spawnAnchor =
+      "session.cliModelRecords = normalizeModelRecords(initResult)";
     const idx = claudeRuntimeSource.indexOf(spawnAnchor);
     expect(idx, "spawnSession post-init block must exist").toBeGreaterThan(0);
 
     const block = claudeRuntimeSource.slice(idx, idx + 1200);
-    expect(block).toContain("normalizeModelRecords(initResult)");
+    expect(block).toContain(
+      "augmentWithLegacyOpus(\n          session.cliModelRecords,",
+    );
     expect(block).toContain("preferredModel");
     expect(block).toContain("resolvePostInitCurrentModelId(");
     expect(block).toContain("session.currentModelId,");

--- a/tests/unit/gemini-1480-fixes.test.ts
+++ b/tests/unit/gemini-1480-fixes.test.ts
@@ -1,23 +1,16 @@
 // ABOUTME: Critical regression guards for #1480 — Gemini Agent bottom controls.
-// ABOUTME: Two load-bearing assertions guarding specific footguns (lockedAgentName covered in gemini-agent.test.ts).
+// ABOUTME: Guards locked agent controls and Gemini ACP model-catalog passthrough.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+// @ts-expect-error - acp-runtime.mjs is a plain ESM harness without type declarations
+import { _applyAcpModelState } from "../../bin/browser-local/acp-runtime.mjs";
 
 const agentChatTsx = readFileSync(
   resolve("src/components/chat/AgentChat.tsx"),
   "utf-8",
 );
-const geminiRuntimeMjs = readFileSync(
-  resolve("bin/browser-local/gemini-runtime.mjs"),
-  "utf-8",
-);
-const acpRuntimeMjs = readFileSync(
-  resolve("bin/browser-local/acp-runtime.mjs"),
-  "utf-8",
-);
-
 describe("Gemini Agent #1480 — bottom-control regression guards", () => {
   it("lockedAgentType filter accepts gemini (not just codex/claude-code)", () => {
     // The filter at line 272/276 was: `=== "codex" || === "claude-code"`,
@@ -34,22 +27,44 @@ describe("Gemini Agent #1480 — bottom-control regression guards", () => {
     expect(matches.length).toBe(2);
   });
 
-  it("gemini-runtime advertises a non-empty availableModels list", () => {
-    // The model picker only renders when availableModels.length > 0.
-    // buildSessionStatus must report at least one model so the UI shows
-    // the "Gemini 2.5 Pro" label instead of falling through to the
-    // hidden-picker / wrong-label state.
-    expect(geminiRuntimeMjs).toContain("GEMINI_AVAILABLE_MODELS");
-    expect(geminiRuntimeMjs).toContain("gemini-2.5-pro");
-    expect(geminiRuntimeMjs).toContain(
-      "availableModels: GEMINI_AVAILABLE_MODELS",
-    );
-    // The shared status builder must surface the adapter's non-empty list.
-    const buildIdx = acpRuntimeMjs.indexOf("function buildSessionStatus");
-    expect(buildIdx).toBeGreaterThan(-1);
-    const fn = acpRuntimeMjs.slice(buildIdx, buildIdx + 800);
-    expect(fn).toContain("availableModels: session.availableModels");
-    // Negative: must NOT be the empty array literal anymore.
-    expect(fn).not.toMatch(/availableModels:\s*\[\s*\]/);
+  it("uses the model catalog returned by Gemini session/new verbatim", () => {
+    const session = {
+      currentModelId: "stale-model",
+      availableModels: [{ modelId: "stale-model", name: "Stale" }],
+      cliModels: [],
+    };
+
+    expect(
+      _applyAcpModelState(session, {
+        currentModelId: "gemini-cli-current",
+        availableModels: [
+          {
+            modelId: "gemini-cli-current",
+            name: "Gemini CLI current",
+            description: "Returned by the installed CLI",
+          },
+          { modelId: "gemini-cli-next", name: "Gemini CLI next" },
+        ],
+      }),
+    ).toBe(true);
+    expect(session).toEqual({
+      currentModelId: "gemini-cli-current",
+      availableModels: [
+        {
+          modelId: "gemini-cli-current",
+          name: "Gemini CLI current",
+          description: "Returned by the installed CLI",
+        },
+        { modelId: "gemini-cli-next", name: "Gemini CLI next" },
+      ],
+      cliModels: [
+        {
+          modelId: "gemini-cli-current",
+          name: "Gemini CLI current",
+          description: "Returned by the installed CLI",
+        },
+        { modelId: "gemini-cli-next", name: "Gemini CLI next" },
+      ],
+    });
   });
 });

--- a/tests/unit/mission-agent-catalog.test.ts
+++ b/tests/unit/mission-agent-catalog.test.ts
@@ -3,6 +3,15 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const getAgentModelCatalog = vi.hoisted(() =>
+  vi.fn(async (agentType: string) => [
+    {
+      modelId: `${agentType}-cli-model`,
+      name: `${agentType} CLI model`,
+    },
+  ]),
+);
+
 vi.mock("@/services/organization-policy", () => ({
   allowsClaudeAgent: () => true,
   allowsCodexAgent: () => true,
@@ -16,13 +25,11 @@ vi.mock("@/services/private-models", () => ({
   privateModelsService: { listAvailable: vi.fn(async () => []) },
 }));
 vi.mock("@/services/providers", () => ({
+  getAgentModelCatalog,
   testLmStudioConnection: vi.fn(async () => ({ ok: true, models: [] })),
 }));
 vi.mock("@/services/seren-model-catalog", () => ({
   getLiveSerenModelCatalog: vi.fn(async () => []),
-}));
-vi.mock("@/stores/agent.store", () => ({
-  agentStore: { sessions: {} },
 }));
 vi.mock("@/stores/auth.store", () => ({
   authStore: { isAuthenticated: false, privateChatPolicy: null },
@@ -57,25 +64,48 @@ describe("Mission Control agent catalog", () => {
     ]);
   });
 
-  it("provides named built-in choices for each bundled local runtime", async () => {
-    await expect(loadMissionModelCatalog("claude-code")).resolves.toMatchObject({
-      models: expect.arrayContaining([
-        expect.objectContaining({ id: "claude-opus-4-8[1m]" }),
+  it("uses each local CLI catalog exactly, including paired roles", async () => {
+    await expect(
+      Promise.all([
+        loadMissionModelCatalog("claude-code", "/workspace"),
+        loadMissionModelCatalog("codex", "/workspace"),
+        loadMissionModelCatalog("gemini", "/workspace"),
+        loadMissionModelCatalog("grok", "/workspace"),
+        loadMissionModelCatalog("claude-codex:planner", "/workspace"),
+        loadMissionModelCatalog("claude-codex:executor", "/workspace"),
       ]),
-    });
-    await expect(loadMissionModelCatalog("codex")).resolves.toMatchObject({
-      models: expect.arrayContaining([
-        expect.objectContaining({ id: "gpt-5.6-sol" }),
-      ]),
-    });
-    await expect(loadMissionModelCatalog("gemini")).resolves.toMatchObject({
-      models: expect.arrayContaining([
-        expect.objectContaining({ id: "gemini-2.5-pro" }),
-      ]),
-    });
-    await expect(loadMissionModelCatalog("grok")).resolves.toMatchObject({
-      models: [expect.objectContaining({ id: "grok-4.5" })],
-    });
+    ).resolves.toEqual([
+      {
+        models: [
+          { id: "claude-code-cli-model", name: "claude-code CLI model" },
+        ],
+        note: null,
+      },
+      {
+        models: [{ id: "codex-cli-model", name: "codex CLI model" }],
+        note: null,
+      },
+      {
+        models: [{ id: "gemini-cli-model", name: "gemini CLI model" }],
+        note: null,
+      },
+      {
+        models: [{ id: "grok-cli-model", name: "grok CLI model" }],
+        note: null,
+      },
+      {
+        models: [
+          { id: "claude-code-cli-model", name: "claude-code CLI model" },
+        ],
+        note: null,
+      },
+      {
+        models: [{ id: "codex-cli-model", name: "codex CLI model" }],
+        note: null,
+      },
+    ]);
+
+    expect(getAgentModelCatalog).toHaveBeenCalledTimes(4);
   });
 
   it("deduplicates runtime and built-in choices without changing priority", () => {

--- a/tests/unit/provider-model-catalog-contract.test.ts
+++ b/tests/unit/provider-model-catalog-contract.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Protects the local CLI model-catalog RPC across both runtime entrypoints.
+// ABOUTME: Mission Control must reach the same provider handler in native and browser-local modes.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(path: string): string {
+  return readFileSync(resolve(path), "utf8");
+}
+
+describe("provider model catalog contract", () => {
+  it("registers the catalog RPC in both local runtime entrypoints", () => {
+    for (const path of ["bin/provider-runtime.mjs", "bin/seren-desktop.mjs"]) {
+      const source = readSource(path);
+      expect(source).toContain('"provider_get_model_catalog"');
+      expect(source).toContain("providerHandlers.getModelCatalog");
+    }
+  });
+});

--- a/tests/validation/scenarios/mission-model-catalog.ts
+++ b/tests/validation/scenarios/mission-model-catalog.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Captures Mission Control's real local-CLI model catalog walkthrough.
+// ABOUTME: Uses the validation bridge only for native WebView interaction and evidence.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+const settle = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.waitFor("[data-testid='thread-sidebar']", 30_000);
+  await ctx.client.command({
+    command: "setRootPath",
+    path: "/tmp/seren-model-walkthrough",
+  });
+  await ctx.client.click("[data-testid='titlebar-mission-control-button']");
+  await settle(500);
+  await ctx.client.waitFor("[data-testid='run-launch-start']", 10_000);
+  await ctx.client.click("details > summary");
+  await ctx.client.waitFor("[data-testid='run-model-claude-code']", 10_000);
+
+  for (const agentType of ["gemini", "grok", "claude-codex"]) {
+    await ctx.client.click(`[data-testid='run-agent-${agentType}']`);
+  }
+
+  await settle(15_000);
+  await ctx.writeArtifact(
+    "fable-selection.json",
+    await ctx.client.select(
+      "[data-testid='run-model-claude-code']",
+      "claude-fable-5[1m]",
+    ),
+  );
+  await settle(500);
+  for (const target of [
+    "claude-code",
+    "codex",
+    "gemini",
+    "grok",
+    "claude-codex-planner",
+    "claude-codex-executor",
+  ]) {
+    await ctx.writeArtifact(
+      `model-${target}.json`,
+      await ctx.client.dumpText(`[data-testid='run-model-${target}']`),
+    );
+  }
+
+  await ctx.writeArtifact(
+    "mission-model-catalog-screen.json",
+    await ctx.client.screenshot(
+      "[data-testid='mission-launch-scroll-region']",
+    ),
+  );
+  await ctx.writeArtifact(
+    "mission-model-catalog-native.json",
+    await ctx.client.nativeScreenshot(),
+  );
+  await ctx.writeArtifact(
+    "mission-model-catalog-text.json",
+    await ctx.client.dumpText(
+      "[data-testid='mission-launch-scroll-region']",
+    ),
+  );
+
+  if (process.env.SEREN_VALIDATION_HOLD_OPEN === "1") {
+    await new Promise<void>(() => {});
+  }
+}


### PR DESCRIPTION
Closes #3643

## Summary
- replace Mission Control's hardcoded Claude, Codex, Gemini, and Grok model fallbacks with catalogs returned by the installed local runtimes
- add a local `provider_get_model_catalog` RPC and share in-flight catalog requests between direct and paired roles
- preserve Gemini ACP models returned by `session/new` and apply supported model changes through `session/set_model`
- keep catalog probes non-interactive so loading a picker cannot open a login terminal
- leave the Gemini unsupported-client startup failure visible instead of advertising a fabricated fallback catalog

## Audited path
Mission Control renderer → local provider RPC → provider-specific runtime → installed CLI stdio. No Seren publisher or third-party API path is added.

## Native walkthrough
Validated in the native macOS app against authenticated installed CLIs, with no mocks or simulated catalog state.

- Claude: all 6 returned choices selected across the direct and paired-planner pickers, including Fable
- Codex: all 7 returned choices selected across the direct and paired-executor pickers
- Grok: the returned model selected successfully
- Gemini: the installed client reports the unsupported-client startup error; Mission Control now shows it as unavailable and does not invent model choices

The final app walkthrough remains subject to reporter approval. No screenshot is attached because public artifacts must not expose local workstation information.

## Verification
- `pnpm test` — 429 files / 2,973 tests passed
- focused provider/model suite — 13 files / 75 tests passed
- `pnpm build` — passed
- `cargo check --manifest-path src-tauri/Cargo.toml` — passed with two existing unrelated warnings
- changed runtime `node --check` checks — passed
- targeted Biome checks and `git diff --check` — passed

## Excluded follow-ups
- Gemini's unsupported-client/agent migration is a separate ticket and PR.
- Mission Control's provider-specific permission vocabulary and access-scope labels are tracked separately in #3646.
