### PR TITLE
fix(agents): migrate Gemini agent to Antigravity

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -20,6 +20,12 @@ import {
   loadState,
   runInstalledVersion,
 } from "./cli-updater.mjs";
+import {
+  ANTIGRAVITY_INSTALL_URL,
+  checkAntigravityAuthenticated,
+  ensureAntigravityCli,
+  resolveAntigravityBinary,
+} from "./antigravity-binary.mjs";
 import { resolveGrokBinary } from "./grok-binary.mjs";
 
 // LM Studio support is loaded lazily so a missing LM Studio dependency (e.g.
@@ -162,23 +168,15 @@ function buildLoginShellCommand(command) {
   return `${quoted} login`;
 }
 
-/**
- * Launch `<command> login` in a new terminal window.
- *
- * Accepts either a bare command name (resolved by the user's shell PATH)
- * or an absolute path returned by `resolveInstalled*Binary`. The latter
- * guarantees that login targets the same binary `spawnSession` would have
- * picked, preventing the auth/spawn split-brain in #1876.
- *
- * Exported for #1878 test coverage of shell-quoting behavior.
- */
-export function launchLoginCommand(command) {
+function buildInteractiveShellCommand(command) {
+  const isBare = !/[\s/\\]/.test(command);
+  if (isBare) return command;
+  return `'${command.replace(/'/g, "'\\''")}'`;
+}
+
+function launchTerminalCommand(command, args, shellCommand) {
   if (process.platform === "darwin") {
-    const loginCommand = buildLoginShellCommand(command);
-    // AppleScript string layer: escape backslashes first, then double
-    // quotes. Without this, a path containing `"` would terminate the
-    // do-script string early and inject AppleScript.
-    const escapedForAppleScript = loginCommand
+    const escapedForAppleScript = shellCommand
       .replace(/\\/g, "\\\\")
       .replace(/"/g, '\\"');
     spawn(
@@ -195,25 +193,36 @@ export function launchLoginCommand(command) {
   }
 
   if (process.platform === "win32") {
-    // `start` syntax: `start [title] [command]`. When the first quoted arg
-    // is present, `start` always treats it as the window title — so an
-    // unquoted path with spaces breaks parsing, and a quoted path silently
-    // becomes the title and never runs. Emit an explicit empty title to
-    // pin the window-title slot regardless of what the path looks like.
-    spawn(
-      "cmd",
-      ["/c", "start", "", command, "login"],
-      { detached: true, stdio: "ignore" },
-    ).unref();
+    spawn("cmd", ["/c", "start", "", command, ...args], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
     return;
   }
 
-  // x-terminal-emulator argv form: spaces survive argv boundaries, so the
-  // resolved absolute path needs no shell quoting.
-  spawn("x-terminal-emulator", ["-e", command, "login"], {
+  spawn("x-terminal-emulator", ["-e", command, ...args], {
     detached: true,
     stdio: "ignore",
   }).unref();
+}
+
+/**
+ * Launch `<command> login` in a new terminal window.
+ *
+ * Accepts either a bare command name (resolved by the user's shell PATH)
+ * or an absolute path returned by `resolveInstalled*Binary`. The latter
+ * guarantees that login targets the same binary `spawnSession` would have
+ * picked, preventing the auth/spawn split-brain in #1876.
+ *
+ * Exported for #1878 test coverage of shell-quoting behavior.
+ */
+export function launchLoginCommand(command) {
+  launchTerminalCommand(command, ["login"], buildLoginShellCommand(command));
+}
+
+/** Launch a CLI's interactive first-run flow without inventing a login subcommand. */
+export function launchInteractiveCommand(command) {
+  launchTerminalCommand(command, [], buildInteractiveShellCommand(command));
 }
 
 function execText(command, args) {
@@ -299,22 +308,6 @@ function hasCodexCredentials() {
   ]);
 }
 
-function hasGeminiCredentials() {
-  const home = os.homedir();
-  const appData = process.env.APPDATA;
-  return Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) ||
-    hasAnyCredentialPath([
-      path.join(home, ".gemini", "oauth_creds.json"),
-      path.join(home, ".gemini", "credentials.json"),
-      ...(appData
-        ? [
-            path.join(appData, "gemini", "oauth_creds.json"),
-            path.join(appData, "Google", "Gemini", "oauth_creds.json"),
-          ]
-        : []),
-    ]);
-}
-
 function hasGrokCredentials() {
   return (
     Boolean(process.env.XAI_API_KEY) ||
@@ -329,7 +322,7 @@ function isAgentAuthenticated(agentType) {
     case "codex":
       return hasCodexCredentials();
     case "gemini":
-      return hasGeminiCredentials();
+      return false;
     case "grok":
       return hasGrokCredentials();
     case "lmstudio":
@@ -640,86 +633,6 @@ async function ensureClaudeCodeCli(emit) {
 }
 
 /**
- * Resolve the installed Gemini CLI binary path.
- *
- * Mirrors `resolveInstalledClaudeBinary()` below. Prefers the binary that
- * the embedded runtime's `npm install -g @google/gemini-cli` would have
- * placed at `<prefix>/bin/gemini` (Unix) or `<nodeDir>/gemini.cmd` (Windows)
- * over any system install (Homebrew, system npm, etc.).
- *
- * Why: Homebrew's gemini-cli formula skips the `node-gyp rebuild` postinstall
- * step that compiles `keytar.node`, so the Homebrew binary cannot read
- * stored credentials when launched as a child process from a GUI app and
- * fails immediately with "When using Gemini API, you must specify the
- * GEMINI_API_KEY environment variable" (#1476). Preferring the embedded
- * install ensures Seren controls the install path end-to-end and the
- * keychain integration actually works.
- *
- * Returns the bare "gemini" string if no install is found, so the caller
- * can trigger ensureCli() to install via the embedded runtime's npm.
- */
-function resolveInstalledGeminiBinary() {
-  // IMPORTANT: Gemini intentionally does NOT include /usr/local/bin,
-  // /opt/homebrew/bin, /usr/bin (Unix), or C:\Program Files\nodejs\
-  // (Windows MSI) in its candidate list — even though Codex and Claude
-  // do post-#1665. The Homebrew gemini-cli formula (and other system
-  // installs that don't run npm scripts) skip the keytar postinstall, so
-  // a system-installed gemini binary cannot read its own keychain when
-  // spawned from a GUI app and fails first-run auth with a misleading
-  // "GEMINI_API_KEY environment variable" message (#1476).
-  //
-  // Mirroring the deliberate exclusion in `resolveGeminiBinary` at
-  // bin/browser-local/gemini-runtime.mjs:30. If install-detection here
-  // discovered a system Gemini, ensureCli() would return "available" and
-  // skip the bundled-runtime install where keytar IS run correctly. The
-  // spawn path (which intentionally still excludes the same locations)
-  // would then fall through to bare "gemini", PATH would resolve the
-  // broken system install, and auth would silently fail. Keep the
-  // bundled+user-local-only restriction here too.
-  //
-  // The auto-updater (#1637) returning skipped:unresolved for Gemini in
-  // this configuration is the intended outcome — we do not want to
-  // auto-update a binary we can't safely spawn. See #1665 PR for the
-  // full audit.
-  if (process.platform === "win32") {
-    const home = os.homedir();
-    const appData = process.env.APPDATA ?? "";
-    const nodeDir = path.dirname(process.execPath);
-    const candidates = [
-      // npm global install via embedded runtime's npm (prefix = node dir on Windows)
-      path.join(nodeDir, "gemini.cmd"),
-      path.join(nodeDir, "gemini"),
-      // npm global install via system npm
-      ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
-      // Generic install fallbacks
-      path.join(home, ".local", "bin", "gemini.exe"),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  } else {
-    const home = os.homedir();
-    const nodeDir = path.dirname(process.execPath);
-    const prefix = path.dirname(nodeDir);
-    const candidates = [
-      // npm global install via embedded runtime's npm — check FIRST so a
-      // broken Homebrew install doesn't shadow our working bundled one.
-      path.join(prefix, "bin", "gemini"),
-      // Generic user-local install fallbacks
-      path.join(home, ".local", "bin", "gemini"),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return resolveViaNpmGlobalPrefix("gemini.cmd", "gemini") ?? "gemini";
-}
-
-/**
  * Resolve the installed Claude Code binary path.
  * GUI apps don't inherit shell PATH updates made by installers, so check
  * well-known install locations before falling back to bare command name.
@@ -1014,29 +927,26 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     },
     gemini: {
       type: "gemini",
-      name: "Gemini",
-      description: "Google Gemini via gemini-cli (Agent Client Protocol)",
-      command: "gemini",
+      name: "Antigravity",
+      description: "Google Antigravity coding agent",
+      command: "agy",
       async getAvailability() {
-        // Resolve via the embedded-install-aware path, NOT bare PATH lookup.
-        // A Homebrew gemini-cli on PATH cannot read its own keychain when
-        // spawned from a GUI app (#1476), so we report the agent as needing
-        // install whenever our embedded npm install path is empty — even if
-        // some other gemini is on PATH.
-        const resolved = resolveInstalledGeminiBinary();
-        const installed = resolved !== "gemini";
+        const resolved = resolveAntigravityBinary();
+        const installed = resolved !== "agy";
         return {
           type: "gemini",
-          name: "Gemini",
-          description: "Google Gemini via gemini-cli (Agent Client Protocol)",
-          command: "gemini",
+          name: "Antigravity",
+          description: "Google Antigravity coding agent",
+          command: "agy",
           available: true,
-          authenticated: isAgentAuthenticated("gemini"),
+          authenticated: installed
+            ? await checkAntigravityAuthenticated(resolved)
+            : false,
           ...(installed
             ? {}
             : {
                 unavailableReason:
-                  "Gemini CLI is not installed yet. Seren can install it automatically on first launch.",
+                  "Antigravity CLI is not installed yet. Seren can install Google's verified binary on first launch.",
               }),
         };
       },
@@ -1044,25 +954,31 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return true;
       },
       async ensureCli() {
-        // Short-circuit if our embedded install already exists. This prevents
-        // re-running npm on every spawn while still bypassing broken system
-        // installs that might be on PATH.
-        const resolved = resolveInstalledGeminiBinary();
-        if (resolved !== "gemini") {
-          return resolved;
+        try {
+          return await ensureAntigravityCli({ emit });
+        } catch (error) {
+          emit?.("provider://cli-install-progress", {
+            stage: "action_required",
+            message:
+              "Antigravity needs your attention before Seren can use it.",
+          });
+          emit?.("provider://cli-update-action-required", {
+            label: "Antigravity",
+            bareCommand: "agy",
+            packageName: "antigravity-cli",
+            reason: "installation_required",
+            actions: ["retry", "open_official_instructions"],
+            officialInstructionsUrl: ANTIGRAVITY_INSTALL_URL,
+          });
+          throw error;
         }
-        return ensureGlobalNpmPackage({
-          emit,
-          command: "gemini",
-          packageName: "@google/gemini-cli",
-          label: "Gemini",
-        });
       },
       launchLogin() {
-        // Use the resolved embedded-install path so the user runs `gemini login`
-        // with the WORKING binary (with compiled keytar), not the broken one.
-        const resolved = resolveInstalledGeminiBinary();
-        launchLoginCommand(resolved !== "gemini" ? resolved : "gemini");
+        const resolved = resolveAntigravityBinary();
+        launchInteractiveCommand(resolved !== "agy" ? resolved : "agy");
+      },
+      async checkAuthenticated() {
+        return checkAntigravityAuthenticated(resolveAntigravityBinary());
       },
     },
     grok: {

--- a/bin/browser-local/antigravity-binary.mjs
+++ b/bin/browser-local/antigravity-binary.mjs
@@ -1,0 +1,341 @@
+// ABOUTME: Resolves and installs Google's native Antigravity CLI binary.
+// ABOUTME: Verifies the official platform manifest and SHA-512 before activation.
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  constants as fsConstants,
+  existsSync,
+} from "node:fs";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export const ANTIGRAVITY_MIN_VERSION = "1.1.8";
+export const ANTIGRAVITY_INSTALL_URL =
+  "https://antigravity.google/docs/cli/getting-started";
+
+const MANIFEST_ORIGIN =
+  "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app";
+const ARTIFACT_ORIGIN = "https://storage.googleapis.com";
+const ARTIFACT_PATH_PREFIX = "/antigravity-public/antigravity-cli/";
+
+function isExecutable(candidate) {
+  try {
+    accessSync(candidate, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathCandidates() {
+  const executable = process.platform === "win32" ? "agy.exe" : "agy";
+  const home = os.homedir();
+  const pathEntries = String(process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((entry) => path.join(entry, executable));
+
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? "";
+    return [
+      ...(localAppData
+        ? [path.join(localAppData, "agy", "bin", "agy.exe")]
+        : []),
+      path.join(home, ".local", "bin", "agy.exe"),
+      ...pathEntries,
+    ];
+  }
+
+  return [
+    path.join(home, ".local", "bin", "agy"),
+    "/opt/homebrew/bin/agy",
+    "/usr/local/bin/agy",
+    "/usr/bin/agy",
+    ...pathEntries,
+  ];
+}
+
+export function resolveAntigravityBinary() {
+  for (const candidate of new Set(pathCandidates())) {
+    if (existsSync(candidate) && isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+  return "agy";
+}
+
+function parseVersion(value) {
+  const match = String(value ?? "").match(/\b(\d+)\.(\d+)\.(\d+)\b/);
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+export function isAntigravityVersionSupported(version) {
+  const actual = parseVersion(version);
+  const minimum = parseVersion(ANTIGRAVITY_MIN_VERSION);
+  if (!actual || !minimum) return false;
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (actual[index] > minimum[index]) return true;
+    if (actual[index] < minimum[index]) return false;
+  }
+  return true;
+}
+
+function execFileText(command, args, timeout = 10_000) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = execFile(
+      command,
+      args,
+      {
+        timeout,
+        windowsHide: true,
+        shell: false,
+        env: {
+          ...process.env,
+          AGY_CLI_HIDE_ACCOUNT_INFO: "1",
+          CI: "1",
+          BROWSER: "false",
+        },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          rejectPromise(new Error(String(stderr || stdout || error.message).trim()));
+          return;
+        }
+        resolvePromise(String(stdout).trim());
+      },
+    );
+    child.stdin?.end();
+  });
+}
+
+export async function readAntigravityVersion(binary = resolveAntigravityBinary()) {
+  if (binary === "agy") return null;
+  try {
+    const output = await execFileText(binary, ["--version"]);
+    return output.match(/\b\d+\.\d+\.\d+\b/)?.[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkAntigravityAuthenticated(
+  binary = resolveAntigravityBinary(),
+) {
+  if (binary === "agy") return false;
+  try {
+    await execFileText(binary, ["models"], 8_000);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function linuxUsesMusl() {
+  if (process.platform !== "linux") return false;
+  if (
+    existsSync("/lib/libc.musl-x86_64.so.1") ||
+    existsSync("/lib/libc.musl-aarch64.so.1")
+  ) {
+    return true;
+  }
+  return !process.report?.getReport?.().header?.glibcVersionRuntime;
+}
+
+export function antigravityPlatformId() {
+  const arch =
+    process.arch === "x64"
+      ? "amd64"
+      : process.arch === "arm64"
+        ? "arm64"
+        : null;
+  if (!arch) {
+    throw new Error(`Antigravity does not support ${process.arch}.`);
+  }
+  if (process.platform === "darwin") return `darwin_${arch}`;
+  if (process.platform === "win32") return `windows_${arch}`;
+  if (process.platform === "linux") {
+    return `linux_${arch}${linuxUsesMusl() ? "_musl" : ""}`;
+  }
+  throw new Error(`Antigravity does not support ${process.platform}.`);
+}
+
+function validateManifest(manifest) {
+  if (
+    !manifest ||
+    typeof manifest.version !== "string" ||
+    typeof manifest.url !== "string" ||
+    typeof manifest.sha512 !== "string" ||
+    !/^[a-f0-9]{128}$/i.test(manifest.sha512)
+  ) {
+    throw new Error("The Antigravity release manifest is invalid.");
+  }
+  if (!isAntigravityVersionSupported(manifest.version)) {
+    throw new Error(
+      `The official Antigravity release ${manifest.version} is below Seren's ${ANTIGRAVITY_MIN_VERSION} minimum.`,
+    );
+  }
+  const artifactUrl = new URL(manifest.url);
+  if (
+    artifactUrl.protocol !== "https:" ||
+    artifactUrl.origin !== ARTIFACT_ORIGIN ||
+    !artifactUrl.pathname.startsWith(ARTIFACT_PATH_PREFIX)
+  ) {
+    throw new Error("The Antigravity manifest selected an untrusted artifact URL.");
+  }
+  return { ...manifest, artifactUrl };
+}
+
+async function fetchOk(fetchImpl, url, description) {
+  const response = await fetchImpl(url, { redirect: "follow" });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${description}: HTTP ${response.status}.`,
+    );
+  }
+  return response;
+}
+
+async function extractArchive(archivePath, stagingDir) {
+  await new Promise((resolvePromise, rejectPromise) => {
+    execFile(
+      "tar",
+      ["-xzf", archivePath, "-C", stagingDir, "antigravity"],
+      { windowsHide: true, shell: false },
+      (error, _stdout, stderr) => {
+        if (error) {
+          rejectPromise(
+            new Error(
+              `Failed to extract the Antigravity release: ${String(stderr || error.message).trim()}`,
+            ),
+          );
+          return;
+        }
+        resolvePromise();
+      },
+    );
+  });
+  return path.join(stagingDir, "antigravity");
+}
+
+function installTarget() {
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (!localAppData) {
+      throw new Error("LOCALAPPDATA is required to install Antigravity on Windows.");
+    }
+    return path.join(localAppData, "agy", "bin", "agy.exe");
+  }
+  return path.join(os.homedir(), ".local", "bin", "agy");
+}
+
+export async function installAntigravity({
+  emit,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("This runtime cannot download Antigravity.");
+  }
+
+  emit?.("provider://cli-install-progress", {
+    stage: "installing",
+    message: "Installing Antigravity CLI from Google's verified release...",
+  });
+
+  const platform = antigravityPlatformId();
+  const manifestUrl = `${MANIFEST_ORIGIN}/manifests/${platform}.json`;
+  const manifestResponse = await fetchOk(
+    fetchImpl,
+    manifestUrl,
+    "the Antigravity release manifest",
+  );
+  if (new URL(manifestResponse.url).origin !== MANIFEST_ORIGIN) {
+    throw new Error("The Antigravity manifest request left Google's updater.");
+  }
+  const manifest = validateManifest(await manifestResponse.json());
+  const artifactResponse = await fetchOk(
+    fetchImpl,
+    manifest.artifactUrl,
+    "Antigravity CLI",
+  );
+  const finalArtifactUrl = new URL(artifactResponse.url);
+  if (
+    finalArtifactUrl.origin !== ARTIFACT_ORIGIN ||
+    !finalArtifactUrl.pathname.startsWith(ARTIFACT_PATH_PREFIX)
+  ) {
+    throw new Error("The Antigravity artifact request left Google's storage path.");
+  }
+
+  const payload = Buffer.from(await artifactResponse.arrayBuffer());
+  const actualHash = createHash("sha512").update(payload).digest("hex");
+  if (actualHash.toLowerCase() !== manifest.sha512.toLowerCase()) {
+    throw new Error(
+      "Security halt: Antigravity CLI checksum verification failed.",
+    );
+  }
+
+  const stagingDir = await mkdtemp(path.join(os.tmpdir(), "seren-agy-"));
+  const target = installTarget();
+  const stagedTarget = `${target}.seren-new`;
+  try {
+    const isArchive = manifest.artifactUrl.pathname.endsWith(".tar.gz");
+    const payloadPath = path.join(
+      stagingDir,
+      isArchive ? "antigravity.tar.gz" : "agy.exe",
+    );
+    await writeFile(payloadPath, payload, { mode: 0o600 });
+    const extracted = isArchive
+      ? await extractArchive(payloadPath, stagingDir)
+      : payloadPath;
+
+    await mkdir(path.dirname(target), { recursive: true });
+    await copyFile(extracted, stagedTarget);
+    if (process.platform !== "win32") {
+      await chmod(stagedTarget, 0o755);
+    }
+    try {
+      await rename(stagedTarget, target);
+    } catch (error) {
+      if (process.platform !== "win32") throw error;
+      await copyFile(stagedTarget, target);
+      await rm(stagedTarget, { force: true });
+    }
+  } finally {
+    await rm(stagedTarget, { force: true }).catch(() => {});
+    await rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+  }
+
+  const installedVersion = await readAntigravityVersion(target);
+  if (!isAntigravityVersionSupported(installedVersion)) {
+    throw new Error(
+      `Antigravity installed but reported ${installedVersion ?? "an unknown version"}; Seren requires ${ANTIGRAVITY_MIN_VERSION} or newer.`,
+    );
+  }
+
+  emit?.("provider://cli-install-progress", {
+    stage: "complete",
+    message: `Antigravity CLI ${installedVersion} installed successfully`,
+  });
+  return target;
+}
+
+export async function ensureAntigravityCli({ emit } = {}) {
+  const resolved = resolveAntigravityBinary();
+  const installedVersion = await readAntigravityVersion(resolved);
+  if (isAntigravityVersionSupported(installedVersion)) {
+    return resolved;
+  }
+  return installAntigravity({ emit });
+}
+
+export const _validateAntigravityManifest = validateManifest;

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -1,82 +1,190 @@
-// ABOUTME: Gemini-specific configuration for the shared browser-local ACP runtime.
-// ABOUTME: Preserves gemini-cli resolution, modes, model metadata, and authentication behavior.
+// ABOUTME: Antigravity CLI runtime behind Seren's durable `gemini` agent ID.
+// ABOUTME: Runs one structured headless process per turn and resumes its conversation ID.
 
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { execFile, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import readline from "node:readline";
 
-import { createAcpRuntime } from "./acp-runtime.mjs";
+import {
+  ANTIGRAVITY_MIN_VERSION,
+  isAntigravityVersionSupported,
+  readAntigravityVersion,
+  resolveAntigravityBinary,
+} from "./antigravity-binary.mjs";
+import { providerLogPrefix } from "./logging.mjs";
 
-const GEMINI_AVAILABLE_MODELS = [
-  {
-    modelId: "gemini-2.5-pro",
-    name: "Gemini 2.5 Pro",
-    description: "Most capable Gemini model — 1M context window",
-  },
-  {
-    modelId: "gemini-2.5-flash",
-    name: "Gemini 2.5 Flash",
-    description: "Fast and cheap — 1M context window",
-  },
-  {
-    modelId: "gemini-2.5-flash-lite",
-    name: "Gemini 2.5 Flash Lite",
-    description: "Lowest cost / latency — 1M context window",
-  },
-];
+const logPrefix = providerLogPrefix("gemini");
 
-const GEMINI_DEFAULT_MODEL_ID = "gemini-2.5-pro";
-
-/**
- * GUI apps do not inherit shell PATH updates. Prefer the embedded npm install
- * and deliberately exclude Homebrew builds, whose skipped keytar postinstall
- * breaks Gemini credential access when launched by the desktop. #1476.
- */
-function resolveGeminiBinary() {
-  if (process.platform === "win32") {
-    const home = os.homedir();
-    const appData = process.env.APPDATA ?? "";
-    const nodeDir = path.dirname(process.execPath);
-    const candidates = [
-      path.join(nodeDir, "gemini.cmd"),
-      path.join(nodeDir, "gemini"),
-      ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
-      path.join(home, ".local", "bin", "gemini.exe"),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate;
-    }
-  } else {
-    const nodeDir = path.dirname(process.execPath);
-    const prefix = path.dirname(nodeDir);
-    const home = os.homedir();
-    const candidates = [
-      path.join(prefix, "bin", "gemini"),
-      path.join(home, ".local", "bin", "gemini"),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate;
+function killChildTree(child) {
+  if (!child) return;
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      return;
+    } catch {
+      // Fall through to direct termination.
     }
   }
-  return "gemini";
+  try {
+    child.kill();
+  } catch {
+    // Ignore duplicate close/cancel races.
+  }
 }
 
-function isGeminiAuthError(message) {
-  const lower = String(message).toLowerCase();
-  if (lower.includes("not authenticated")) return true;
-  if (lower.includes("authentication required")) return true;
-  if (lower.includes("auth required")) return true;
-  if (lower.includes("login required")) return true;
-  if (lower.includes("not logged in")) return true;
-  if (lower.includes("please run") && lower.includes("login")) return true;
-  if (lower.includes("gemini_api_key")) return true;
-  if (lower.includes("api key is missing")) return true;
-  if (lower.includes("api key is not configured")) return true;
-  return lower.includes("keychain initialization") && lower.includes("keytar");
+function stripAnsi(value) {
+  return String(value ?? "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\r/g, "");
 }
 
-function resolveGeminiMode({ approvalPolicy, sandboxMode }) {
+export function isAntigravityAuthError(message) {
+  const normalized = String(message ?? "").toLowerCase();
+  return (
+    normalized.includes("please sign in") ||
+    normalized.includes("sign-in required") ||
+    normalized.includes("authentication required") ||
+    normalized.includes("not authenticated") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("no valid oauth token") ||
+    normalized.includes("no valid refresh token") ||
+    normalized.includes("failed to load token")
+  );
+}
+
+function normalizeModelObject(model) {
+  if (!model || typeof model !== "object") return null;
+  const modelId =
+    model.modelId ??
+    model.model_id ??
+    model.id ??
+    model.value ??
+    model.name;
+  if (typeof modelId !== "string" || modelId.trim().length === 0) return null;
+  const name =
+    model.displayName ?? model.display_name ?? model.label ?? model.name ?? modelId;
+  const description = model.description ?? model.summary;
+  return {
+    modelId: modelId.trim(),
+    name: typeof name === "string" && name.trim() ? name.trim() : modelId.trim(),
+    ...(typeof description === "string" && description.trim()
+      ? { description: description.trim() }
+      : {}),
+  };
+}
+
+function modelsFromJson(value) {
+  const candidates = Array.isArray(value)
+    ? value
+    : value?.models ?? value?.availableModels ?? value?.available_models;
+  if (!Array.isArray(candidates)) return [];
+  return candidates.map(normalizeModelObject).filter(Boolean);
+}
+
+export function normalizeAntigravityModels(output) {
+  const text = stripAnsi(output).trim();
+  if (!text) return [];
+  try {
+    const parsed = modelsFromJson(JSON.parse(text));
+    if (parsed.length > 0) return parsed;
+  } catch {
+    // The documented `models` subcommand currently emits human-readable text.
+  }
+
+  const records = [];
+  const seen = new Set();
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine
+      .replace(/^\s*(?:[>*•-]|\d+[.)])\s*/, "")
+      .replace(/\s+\(current\)\s*$/i, "")
+      .trim();
+    if (
+      !line ||
+      /^(?:available\s+)?models?:?$/i.test(line) ||
+      /^[-=\s]+$/.test(line)
+    ) {
+      continue;
+    }
+
+    const parenthetical = line.match(/^(.*?)\s+\(([^()]+)\)$/);
+    const columns = line.split(/\s{2,}|\t+/).filter(Boolean);
+    const identifier = line.match(
+      /\b(?:gemini|claude|gpt|auto)[a-z0-9]*(?:[-_.][a-z0-9][a-z0-9_.-]*)+\b/i,
+    )?.[0];
+    const modelId =
+      identifier ??
+      (parenthetical && /[-_.]/.test(parenthetical[2])
+        ? parenthetical[2].trim()
+        : columns.length > 1 && /[-_.]/.test(columns[0])
+          ? columns[0]
+          : line);
+    const name =
+      parenthetical && modelId === parenthetical[2].trim()
+        ? parenthetical[1].trim()
+        : columns.length > 1 && modelId === columns[0]
+          ? columns.slice(1).join(" ")
+          : line.replace(modelId, "").replace(/^\s*[-:|]\s*|\s*[-:|]\s*$/g, "").trim() || modelId;
+    if (seen.has(modelId)) continue;
+    seen.add(modelId);
+    records.push({ modelId, name });
+  }
+  return records;
+}
+
+function execText(command, args, { cwd, timeout = 15_000 } = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = execFile(
+      command,
+      args,
+      {
+        cwd,
+        timeout,
+        maxBuffer: 4 * 1024 * 1024,
+        windowsHide: true,
+        shell: false,
+        env: {
+          ...process.env,
+          AGY_CLI_HIDE_ACCOUNT_INFO: "1",
+          BROWSER: "false",
+          CI: "1",
+          NO_COLOR: "1",
+          TERM: "dumb",
+        },
+      },
+      (error, stdout, stderr) => {
+        const standardOutput = stripAnsi(stdout).trim();
+        const standardError = stripAnsi(stderr).trim();
+        if (error) {
+          rejectPromise(
+            new Error(standardError || standardOutput || error.message),
+          );
+          return;
+        }
+        resolvePromise(standardOutput);
+      },
+    );
+    child.stdin?.end();
+  });
+}
+
+export async function listAntigravityModels({
+  binary = resolveAntigravityBinary(),
+  cwd,
+} = {}) {
+  if (binary === "agy") {
+    throw new Error("Antigravity CLI is not installed.");
+  }
+  const output = await execText(binary, ["models"], { cwd });
+  const models = normalizeAntigravityModels(output);
+  if (models.length === 0) {
+    throw new Error("Antigravity returned no available models.");
+  }
+  return models;
+}
+
+function resolveAntigravityMode({ approvalPolicy, sandboxMode }) {
   if (sandboxMode === "read-only") return "plan";
   if (sandboxMode === "danger-full-access" || sandboxMode === "full-access") {
     return "yolo";
@@ -84,100 +192,539 @@ function resolveGeminiMode({ approvalPolicy, sandboxMode }) {
   if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
     return "default";
   }
-  return "auto_edit";
+  return "accept-edits";
 }
 
-function buildGeminiModes(session) {
+function buildModes(session) {
   return {
-    currentModeId: session?.currentModeId ?? "default",
+    currentModeId: session.currentModeId,
     availableModes: [
       {
         modeId: "default",
-        name: "Default",
-        description: "Prompt for approval on each tool use",
+        name: "Saved rules",
+        description:
+          "Use saved Antigravity rules; headless requests that need a prompt are denied",
       },
       {
-        modeId: "auto_edit",
-        name: "Auto Edit",
-        description: "Auto-approve edit tools, prompt for everything else",
-      },
-      {
-        modeId: "yolo",
-        name: "YOLO",
-        description: "Auto-approve all tools (use with caution)",
+        modeId: "accept-edits",
+        name: "Accept edits",
+        description: "Automatically approve file edits; command rules still apply",
       },
       {
         modeId: "plan",
         name: "Plan",
-        description: "Read-only — propose changes without executing",
+        description: "Analyze with read-only tools and return an execution plan",
+      },
+      {
+        modeId: "yolo",
+        name: "Skip permissions",
+        description: "Auto-approve all tool requests without sandbox restrictions",
       },
     ],
   };
 }
 
-function geminiSandboxEnv({ sandboxMode, networkEnabled } = {}) {
-  const fullAccess =
-    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
-  if (fullAccess) return { GEMINI_SANDBOX: "false" };
-
+function buildStatus(session, status = session.status) {
   return {
-    GEMINI_SANDBOX: "true",
-    ...(process.platform === "darwin"
-      ? {
-          SEATBELT_PROFILE:
-            networkEnabled === false ? "strict-proxied" : "strict-open",
-        }
-      : {}),
+    sessionId: session.id,
+    status,
+    agentSessionId: session.agentSessionId,
+    agentInfo: {
+      name: "Antigravity CLI",
+      version: session.agentVersion ?? "unknown",
+    },
+    models: {
+      currentModelId: session.currentModelId,
+      availableModels: session.availableModels,
+    },
+    modes: buildModes(session),
+    configOptions: [],
+    pid: session.process?.pid ?? null,
   };
 }
 
-function spawnGeminiProcess(cwd, { extraEnv = {}, params = {} } = {}) {
-  return spawn(resolveGeminiBinary(), ["--acp"], {
-    cwd,
-    env: {
-      ...process.env,
-      NODE_NO_READLINE: "1",
-      ...extraEnv,
-      ...geminiSandboxEnv(params),
-    },
-    stdio: ["pipe", "pipe", "pipe"],
-    shell: process.platform === "win32",
+export function buildAntigravityArgs(session, prompt) {
+  const args = [
+    "--print",
+    prompt,
+    "--output-format",
+    "stream-json",
+    "--print-timeout",
+    `${session.timeoutSecs ?? 600}s`,
+  ];
+  if (session.agentSessionId) {
+    args.push("--conversation", session.agentSessionId);
+  }
+  if (session.currentModelId) {
+    args.push("--model", session.currentModelId);
+  }
+  if (session.currentModeId === "accept-edits") {
+    args.push("--mode", "accept-edits");
+  } else if (session.currentModeId === "plan") {
+    args.push("--mode", "plan");
+  } else if (session.currentModeId === "yolo") {
+    args.push("--dangerously-skip-permissions");
+  }
+  if (
+    session.currentModeId !== "yolo" &&
+    session.sandboxMode !== "danger-full-access" &&
+    session.sandboxMode !== "full-access"
+  ) {
+    args.push("--sandbox");
+  }
+  return args;
+}
+
+function firstString(value, keys) {
+  for (const key of keys) {
+    const candidate = value?.[key];
+    if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  }
+  return "";
+}
+
+function eventConversationId(event) {
+  return firstString(event, ["conversation_id", "conversationId"]) ||
+    firstString(event?.conversation, ["id", "conversation_id", "conversationId"]);
+}
+
+function eventText(value) {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+  return firstString(value, [
+    "text",
+    "content",
+    "message",
+    "delta",
+    "output",
+    "response",
+    "result",
+  ]);
+}
+
+function emitTextDelta(emit, session, key, text, isThought = false) {
+  if (!text) return;
+  const previous = session.stepText.get(key) ?? "";
+  const delta = text.startsWith(previous) ? text.slice(previous.length) : text;
+  session.stepText.set(key, text);
+  if (!delta) return;
+  session.assistantText += delta;
+  emit("provider://message-chunk", {
+    sessionId: session.id,
+    text: delta,
+    ...(isThought ? { isThought: true } : {}),
   });
 }
 
-const GEMINI_ADAPTER = {
-  agentType: "gemini",
-  agentName: "Gemini",
-  agentInfoName: "Gemini ACP",
-  defaultModelId: GEMINI_DEFAULT_MODEL_ID,
-  availableModels: GEMINI_AVAILABLE_MODELS,
-  // Preserve Gemini's pre-refactor behavior: the ACP process does not receive
-  // an initial model and every fresh session starts on the static default.
-  resolveInitialModelId: () => GEMINI_DEFAULT_MODEL_ID,
-  defaultModeId: "default",
-  validModeIds: ["default", "auto_edit", "yolo", "plan"],
-  autoApproveModeIds: ["yolo"],
-  buildModes: buildGeminiModes,
-  resolveInitialMode: resolveGeminiMode,
-  spawnProcess: spawnGeminiProcess,
-  isAuthError: isGeminiAuthError,
-  stoppedBeforeRequestMessage:
-    "Gemini agent stopped before request completed.",
-  processExitedWhilePromptMessage:
-    "Gemini process exited while prompt was active.",
-  loginRequiredMessage:
-    "Gemini authentication required. Opening `gemini login` in a Terminal window — finish the sign-in there, then click + New Agent → Gemini Agent again.",
-  async setModel({ session, modelId, request }) {
-    await request(
-      "session/set_model",
-      { sessionId: session.agentSessionId, modelId },
-      5_000,
-    );
-  },
-};
-
-export function createGeminiRuntime(options) {
-  return createAcpRuntime({ ...options, adapter: GEMINI_ADAPTER });
+function emitToolUpdate(emit, session, step) {
+  const tool = step.tool_info ?? step.toolInfo;
+  if (!tool || typeof tool !== "object") return false;
+  const toolCallId = String(
+    step.step_id ?? step.stepId ?? tool.id ?? tool.tool_call_id ?? randomUUID(),
+  );
+  const status = step.status ?? tool.status ?? "running";
+  emit("provider://tool-call", {
+    sessionId: session.id,
+    toolCallId,
+    title: tool.title ?? tool.name ?? tool.tool_name ?? "Tool call",
+    kind: tool.name ?? tool.tool_name ?? "tool",
+    status,
+    parameters: tool.parameters ?? tool.input ?? {},
+  });
+  const output = tool.output ?? tool.result;
+  if (
+    output !== undefined ||
+    ["completed", "complete", "error", "failed"].includes(status)
+  ) {
+    const failed = status === "error" || status === "failed" || tool.is_error === true;
+    emit("provider://tool-result", {
+      sessionId: session.id,
+      toolCallId,
+      status: failed ? "error" : "completed",
+      result: typeof output === "string" ? output : output == null ? undefined : JSON.stringify(output),
+      ...(failed
+        ? { error: eventText(tool.error) || eventText(output) || "Tool call failed" }
+        : {}),
+    });
+  }
+  return true;
 }
 
-export { geminiSandboxEnv as _geminiSandboxEnv };
+function usageMeta(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const input = usage.input_tokens ?? usage.inputTokens;
+  const output = usage.output_tokens ?? usage.outputTokens;
+  if (typeof input !== "number" && typeof output !== "number") return null;
+  return {
+    usage: {
+      ...(typeof input === "number" ? { input_tokens: input } : {}),
+      ...(typeof output === "number" ? { output_tokens: output } : {}),
+      ...(typeof usage.cache_read_tokens === "number"
+        ? { cache_read_tokens: usage.cache_read_tokens }
+        : {}),
+    },
+  };
+}
+
+export function handleAntigravityEvent(emit, session, event) {
+  if (!event || typeof event !== "object") return;
+  const type = event.type ?? event.event;
+  const conversationId = eventConversationId(event);
+  if (conversationId) session.agentSessionId = conversationId;
+
+  if (type === "init") {
+    const model = firstString(event, ["model", "model_id", "modelId"]);
+    if (model) session.currentModelId = model;
+    return;
+  }
+
+  if (type === "step_update") {
+    const step = event.step ?? event.update ?? event;
+    if (emitToolUpdate(emit, session, step)) return;
+    const stepType = String(step.step_type ?? step.stepType ?? "").toLowerCase();
+    const text = eventText(step);
+    const key = String(
+      step.step_id ?? step.stepId ?? (stepType || "assistant"),
+    );
+    emitTextDelta(
+      emit,
+      session,
+      key,
+      text,
+      /thought|reason|analysis/.test(stepType),
+    );
+    return;
+  }
+
+  if (type === "result") {
+    const resultText = eventText(event.result) || eventText(event);
+    if (resultText) {
+      const delta = resultText.startsWith(session.assistantText)
+        ? resultText.slice(session.assistantText.length)
+        : session.assistantText.includes(resultText)
+          ? ""
+          : resultText;
+      if (delta) {
+        session.assistantText += delta;
+        emit("provider://message-chunk", { sessionId: session.id, text: delta });
+      }
+    }
+    session.resultEvent = event;
+    session.resultError =
+      event.is_error === true || event.success === false
+        ? eventText(event.error) || resultText || "Antigravity task failed."
+        : null;
+    session.usageMeta = usageMeta(event.usage);
+  }
+}
+
+function createSessionRecord(params, models, version) {
+  const currentModeId = resolveAntigravityMode(params);
+  const requestedModel =
+    typeof params.initialModelId === "string" &&
+    models.some((model) => model.modelId === params.initialModelId)
+      ? params.initialModelId
+      : null;
+  return {
+    id: params.localSessionId ?? randomUUID(),
+    agentType: "gemini",
+    cwd: params.cwd,
+    status: "ready",
+    createdAt: new Date().toISOString(),
+    agentSessionId: params.resumeAgentSessionId ?? undefined,
+    timeoutSecs: params.timeoutSecs ?? undefined,
+    currentModelId: requestedModel ?? models[0]?.modelId ?? null,
+    currentModeId,
+    sandboxMode: params.sandboxMode,
+    availableModels: models,
+    cliModels: models,
+    agentVersion: version,
+    process: null,
+    output: null,
+    currentPrompt: false,
+    cancelled: false,
+    terminated: false,
+    stepText: new Map(),
+    assistantText: "",
+    resultEvent: null,
+    resultError: null,
+    usageMeta: null,
+  };
+}
+
+export function createGeminiRuntime({ emit }) {
+  const runtimeSessions = new Map();
+  const runtime = {};
+
+  async function spawnSession(params) {
+    if (params.requireExactResume === true && !params.resumeAgentSessionId) {
+      throw new Error("Antigravity exact resume requires a conversation ID.");
+    }
+    const sessionId = params.localSessionId ?? randomUUID();
+    const binary = resolveAntigravityBinary();
+    const version = await readAntigravityVersion(binary);
+    if (!isAntigravityVersionSupported(version)) {
+      throw new Error(
+        `Antigravity CLI ${ANTIGRAVITY_MIN_VERSION} or newer is required.`,
+      );
+    }
+
+    let models;
+    try {
+      models = await listAntigravityModels({ binary, cwd: params.cwd });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isAntigravityAuthError(message)) {
+        emit("provider://login-required", {
+          sessionId,
+          agentType: "gemini",
+          reason: message,
+        });
+        emit("provider://error", {
+          sessionId,
+          error:
+            "Antigravity authentication required. Finish Google Sign-In in the Terminal window, then start Antigravity again.",
+        });
+      }
+      throw error;
+    }
+
+    const session = createSessionRecord({ ...params, localSessionId: sessionId }, models, version);
+    runtimeSessions.set(sessionId, session);
+    emit("provider://session-status", buildStatus(session, "ready"));
+    return {
+      id: session.id,
+      agentType: session.agentType,
+      cwd: session.cwd,
+      status: session.status,
+      createdAt: session.createdAt,
+      agentSessionId: session.agentSessionId,
+      timeoutSecs: session.timeoutSecs,
+      serenMcpConfigured: false,
+      pid: null,
+    };
+  }
+
+  async function sendPrompt({ sessionId, prompt, context, onAccepted }) {
+    const session = runtimeSessions.get(sessionId);
+    if (!session) throw new Error(`No Antigravity session: ${sessionId}`);
+    if (session.currentPrompt) {
+      throw new Error("Another prompt is already active for this session.");
+    }
+
+    const contextText = Array.isArray(context)
+      ? context
+          .map((entry) => entry?.text)
+          .filter((value) => typeof value === "string" && value.length > 0)
+          .join("\n\n")
+      : "";
+    const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
+    const binary = resolveAntigravityBinary();
+
+    session.currentPrompt = true;
+    session.cancelled = false;
+    session.stepText.clear();
+    session.assistantText = "";
+    session.resultEvent = null;
+    session.resultError = null;
+    session.usageMeta = null;
+    session.status = "prompting";
+
+    const child = spawn(binary, buildAntigravityArgs(session, combinedPrompt), {
+      cwd: session.cwd,
+      env: {
+        ...process.env,
+        AGY_CLI_HIDE_ACCOUNT_INFO: "1",
+        CI: "1",
+        NO_COLOR: "1",
+        TERM: "dumb",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      shell: false,
+    });
+    session.process = child;
+    session.output = readline.createInterface({ input: child.stdout });
+    emit("provider://session-status", buildStatus(session, "prompting"));
+
+    let stderrTail = "";
+    let accepted = false;
+    const markAccepted = () => {
+      if (accepted) return;
+      accepted = true;
+      onAccepted?.();
+    };
+    child.once("spawn", markAccepted);
+    child.stderr.on("data", (chunk) => {
+      const message = stripAnsi(chunk);
+      stderrTail = `${stderrTail}${message}`.slice(-8192);
+      if (message.trim()) console.log(`${logPrefix} ${message.trim()}`);
+    });
+    session.output.on("line", (line) => {
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        return;
+      }
+      handleAntigravityEvent(emit, session, event);
+      if (event?.type === "init") {
+        emit("provider://session-status", {
+          ...buildStatus(session, "prompting"),
+          readinessUnchanged: true,
+        });
+      }
+    });
+
+    try {
+      const exit = await new Promise((resolvePromise, rejectPromise) => {
+        child.once("error", rejectPromise);
+        child.once("close", (code, signal) => resolvePromise({ code, signal }));
+      });
+      if (session.cancelled) throw new Error("Task cancelled");
+      if (session.terminated) throw new Error("Session terminated.");
+      const authMessage = isAntigravityAuthError(stderrTail) ? stderrTail.trim() : "";
+      if (authMessage) {
+        emit("provider://login-required", {
+          sessionId,
+          agentType: "gemini",
+          reason: authMessage,
+        });
+        throw new Error(
+          "Antigravity authentication required. Finish Google Sign-In in the Terminal window, then retry.",
+        );
+      }
+      if (session.resultError) throw new Error(session.resultError);
+      if (exit.code !== 0) {
+        throw new Error(
+          stderrTail.trim() ||
+            `Antigravity stopped while prompt was active (${exit.signal ?? `code ${exit.code}`}).`,
+        );
+      }
+      if (!session.resultEvent) {
+        throw new Error("Antigravity ended without a terminal result event.");
+      }
+      if (!session.agentSessionId) {
+        throw new Error("Antigravity did not return a resumable conversation ID.");
+      }
+
+      session.status = "ready";
+      emit("provider://prompt-complete", {
+        sessionId,
+        stopReason: "end_turn",
+        ...(session.usageMeta ? { meta: session.usageMeta } : {}),
+      });
+      emit("provider://session-status", buildStatus(session, "ready"));
+    } catch (error) {
+      session.status = "ready";
+      const message = error instanceof Error ? error.message : String(error);
+      if (runtimeSessions.get(sessionId) === session) {
+        emit("provider://error", { sessionId, error: message });
+        emit("provider://session-status", buildStatus(session, "ready"));
+      }
+      throw error;
+    } finally {
+      session.currentPrompt = false;
+      session.process = null;
+      try {
+        session.output?.close();
+      } catch {
+        // Ignore close races after cancellation.
+      }
+      session.output = null;
+    }
+  }
+
+  async function cancelPrompt({ sessionId }) {
+    const session = runtimeSessions.get(sessionId);
+    if (!session) throw new Error(`No Antigravity session: ${sessionId}`);
+    session.cancelled = true;
+    killChildTree(session.process);
+    session.status = "ready";
+    emit("provider://error", { sessionId, error: "Task cancelled" });
+    emit("provider://session-status", buildStatus(session, "ready"));
+  }
+
+  async function terminateSession({ sessionId }) {
+    const session = runtimeSessions.get(sessionId);
+    if (!session) throw new Error(`No Antigravity session: ${sessionId}`);
+    runtimeSessions.delete(sessionId);
+    session.terminated = true;
+    killChildTree(session.process);
+    emit("provider://session-status", {
+      sessionId,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  }
+
+  async function setPermissionMode({ sessionId, mode }) {
+    const session = runtimeSessions.get(sessionId);
+    if (!session) throw new Error(`No Antigravity session: ${sessionId}`);
+    if (!["default", "accept-edits", "plan", "yolo"].includes(mode)) {
+      throw new Error(`Unknown Antigravity mode: ${mode}`);
+    }
+    if (session.currentPrompt) {
+      throw new Error("Antigravity mode cannot change during an active turn.");
+    }
+    session.currentModeId = mode;
+    emit("provider://session-status", {
+      ...buildStatus(session),
+      readinessUnchanged: true,
+    });
+  }
+
+  async function setModel({ sessionId, modelId }) {
+    const session = runtimeSessions.get(sessionId);
+    if (!session) throw new Error(`No Antigravity session: ${sessionId}`);
+    if (!session.availableModels.some((model) => model.modelId === modelId)) {
+      throw new Error(`Unknown Antigravity model: ${modelId}`);
+    }
+    if (session.currentPrompt) {
+      throw new Error("Antigravity model cannot change during an active turn.");
+    }
+    session.currentModelId = modelId;
+    emit("provider://session-status", buildStatus(session));
+  }
+
+  Object.assign(runtime, {
+    hasSession(sessionId) {
+      return runtimeSessions.has(sessionId);
+    },
+    spawnSession,
+    sendPrompt,
+    cancelPrompt,
+    terminateSession,
+    async listSessions() {
+      return Array.from(runtimeSessions.values()).map((session) => ({
+        id: session.id,
+        agentType: session.agentType,
+        cwd: session.cwd,
+        status: session.status,
+        createdAt: session.createdAt,
+        agentSessionId: session.agentSessionId,
+        timeoutSecs: session.timeoutSecs,
+        currentModelId: session.currentModelId,
+        currentModeId: session.currentModeId,
+        pendingPermissions: [],
+        serenMcpConfigured: false,
+        pid: session.process?.pid ?? null,
+      }));
+    },
+    setPermissionMode,
+    async setOAuthRouting() {},
+    async respondToPermission({ sessionId }) {
+      if (!runtimeSessions.has(sessionId)) {
+        throw new Error(`No Antigravity session: ${sessionId}`);
+      }
+      throw new Error(
+        "Antigravity headless mode cannot pause for interactive permission responses.",
+      );
+    },
+    setModel,
+    listCliModels(sessionId) {
+      return runtimeSessions.get(sessionId)?.cliModels ?? [];
+    },
+  });
+  return runtime;
+}

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -586,7 +586,6 @@ try {
   `$agentCliPackages = @(
     @{ Label = "Claude Code"; Package = "@anthropic-ai/claude-code@latest"; Binary = "claude.cmd" },
     @{ Label = "Codex"; Package = "@openai/codex@latest"; Binary = "codex.cmd" },
-    @{ Label = "Gemini"; Package = "@google/gemini-cli@latest"; Binary = "gemini.cmd" },
     @{ Label = "Grok"; Package = "@xai-official/grok@latest"; Binary = "grok.cmd" }
   )
   # The installed app resolves agent CLIs from the real default npm global
@@ -616,6 +615,35 @@ try {
     }
     Invoke-LoggedNative "Verify `$(`$agentCli.Label) CLI" `$cliPath @("--version") 120
   }
+
+  # Antigravity is a native Google binary, not an npm package. Match the
+  # production installer: trust only Google's platform manifest/storage path
+  # and verify SHA-512 before the release gate launches the app.
+  `$agyManifestOrigin = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app"
+  `$agyManifest = Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json"
+  `$agyArtifactUri = [Uri][string]`$agyManifest.url
+  if (
+    `$agyArtifactUri.Scheme -ne "https" -or
+    `$agyArtifactUri.Host -ne "storage.googleapis.com" -or
+    -not `$agyArtifactUri.AbsolutePath.StartsWith("/antigravity-public/antigravity-cli/")
+  ) {
+    throw "Antigravity manifest selected an untrusted artifact URL"
+  }
+  `$agyBinDir = Join-Path `$env:LOCALAPPDATA "agy\bin"
+  `$agyPath = Join-Path `$agyBinDir "agy.exe"
+  New-Item -ItemType Directory -Path `$agyBinDir -Force | Out-Null
+  `$previousProgress = `$ProgressPreference
+  `$ProgressPreference = "SilentlyContinue"
+  try {
+    Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath
+  } finally {
+    `$ProgressPreference = `$previousProgress
+  }
+  `$agyHash = (Get-FileHash -LiteralPath `$agyPath -Algorithm SHA512).Hash.ToLowerInvariant()
+  if (`$agyHash -ne ([string]`$agyManifest.sha512).ToLowerInvariant()) {
+    throw "Antigravity release checksum verification failed"
+  }
+  Invoke-LoggedNative "Verify Antigravity CLI" `$agyPath @("--version") 120
   Invoke-LoggedNative "Playwright Chromium install" "pnpm" @("exec", "playwright", "install", "chromium") 600
   `$harnessArgs = @(
     "-NoProfile",

--- a/src-tauri/src/commands/cli_installer.rs
+++ b/src-tauri/src/commands/cli_installer.rs
@@ -18,7 +18,7 @@ pub async fn check_cli_installed(tool: CliTool) -> Result<bool, String> {
     let bin_name = match tool {
         CliTool::Claude => "claude",
         CliTool::Codex => "codex",
-        CliTool::Gemini => "gemini",
+        CliTool::Gemini => "agy",
     };
 
     // Try to run --version command
@@ -48,7 +48,7 @@ fn manual_install_url(tool: &CliTool) -> &'static str {
     match tool {
         CliTool::Claude => "https://code.claude.com/docs/en/installation",
         CliTool::Codex => "https://developers.openai.com/codex/cli/",
-        CliTool::Gemini => "https://github.com/google-gemini/gemini-cli",
+        CliTool::Gemini => "https://antigravity.google/docs/cli/getting-started",
     }
 }
 

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -629,7 +629,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       case "codex":
         return "Codex";
       case "gemini":
-        return "Gemini";
+        return "Antigravity";
       case "grok":
         return "Grok";
       case "claude-codex":
@@ -2073,7 +2073,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             agentType === "codex"
               ? "Codex"
               : agentType === "gemini"
-                ? "Gemini"
+                ? "Antigravity"
                 : agentType === "grok"
                   ? "Grok"
                   : agentType === "claude-codex"

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -770,9 +770,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                     {"\u2728"}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="font-medium">Gemini</div>
+                    <div class="font-medium">Antigravity</div>
                     <div class="text-[11px] text-muted-foreground">
-                      Google · chat-style coding agent
+                      Google · Antigravity coding agent
                     </div>
                   </div>
                   <LauncherChip variant="subscription">

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -360,7 +360,7 @@ export const ThreadTabBar: Component = () => {
                 <span class="text-[13px] w-[18px] text-center shrink-0">
                   ✨
                 </span>
-                <div class="flex-1 min-w-0 font-medium">Gemini</div>
+                <div class="flex-1 min-w-0 font-medium">Antigravity</div>
                 <Chip variant="subscription">Subscription</Chip>
               </button>
             </Show>

--- a/src/lib/agent/bootstrap-context.ts
+++ b/src/lib/agent/bootstrap-context.ts
@@ -12,7 +12,7 @@ export function agentDisplayName(agentType?: string): string {
     case "claude-code":
       return "Claude Code";
     case "gemini":
-      return "Gemini";
+      return "Antigravity";
     case "grok":
       return "Grok";
     case "claude-codex":
@@ -30,7 +30,7 @@ export function agentInitializationFailureMessage(agentType?: string): string {
     agentType === "codex"
       ? "Codex is installed and signed in"
       : agentType === "gemini"
-        ? "Gemini is installed and signed in"
+        ? "Antigravity is installed and signed in"
         : agentType === "grok"
           ? "Grok is installed and signed in"
           : agentType === "lmstudio"

--- a/src/lib/provider-boundaries.ts
+++ b/src/lib/provider-boundaries.ts
@@ -24,7 +24,7 @@ export function providerDisplayName(
     case "codex":
       return "Codex";
     case "gemini":
-      return "Gemini";
+      return "Antigravity";
     case "grok":
       return "Grok";
     case "claude-codex":

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -335,8 +335,7 @@ export const CONFIGURABLE_PROVIDERS: ProviderId[] = ["anthropic", "openai"];
 
 /**
  * List of provider IDs that support OAuth.
- * Currently empty — Gemini OAuth was removed in favor of the Gemini Agent
- * (gemini-cli via ACP), which handles its own auth.
+ * Currently empty — Google coding-agent auth is handled by Antigravity CLI.
  */
 export const OAUTH_PROVIDERS: ProviderId[] = [];
 

--- a/src/services/mission-agent-catalog.ts
+++ b/src/services/mission-agent-catalog.ts
@@ -70,9 +70,9 @@ export const MISSION_AGENT_DEFINITIONS: readonly MissionAgentDefinition[] = [
   },
   {
     id: "gemini",
-    label: "Gemini",
+    label: "Antigravity",
     source: "Google",
-    description: "Gemini CLI coding agent",
+    description: "Google's Antigravity coding agent",
     defaultSelected: false,
   },
   {

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -1,5 +1,5 @@
 // ABOUTME: OAuth service for provider authentication flows.
-// ABOUTME: Handles PKCE-based OAuth 2.0 for OpenAI. Gemini OAuth was removed in favor of the Gemini Agent (gemini-cli).
+// ABOUTME: Handles PKCE-based OAuth 2.0 for OpenAI; Google's Antigravity CLI owns its coding-agent auth.
 
 import { appFetch } from "@/lib/fetch";
 import type { OAuthCredentials, ProviderId } from "@/lib/providers/types";

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -962,9 +962,9 @@ export async function getPendingCliUpdateAction(): Promise<CliUpdateActionRequir
 }
 
 /**
- * Ensure Gemini CLI (`@google/gemini-cli`) is installed.
- * Installs or upgrades via npm if needed.
- * Returns the bin directory path containing the gemini binary.
+ * Ensure Google Antigravity CLI (`agy`) is installed at the supported baseline.
+ * The local provider runtime verifies Google's release manifest and SHA-512.
+ * The durable service name remains Gemini for saved-session compatibility.
  */
 export async function ensureGeminiCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3217,7 +3217,7 @@ export const agentStore = {
       (resolvedAgentType === "codex"
         ? "Codex Agent"
         : resolvedAgentType === "gemini"
-          ? "Gemini Agent"
+          ? "Antigravity Agent"
           : resolvedAgentType === "grok"
             ? "Grok Agent"
             : resolvedAgentType === "claude-codex"

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -21,7 +21,7 @@ const geminiModulePath = new URL(
   "../../bin/browser-local/gemini-runtime.mjs",
   import.meta.url,
 ).href;
-const { _geminiSandboxEnv: geminiSandboxEnv } = await import(
+const { buildAntigravityArgs } = await import(
   /* @vite-ignore */ geminiModulePath
 );
 const claudeHookPath = fileURLToPath(
@@ -237,19 +237,26 @@ describe("Windows bounded-session containment (#3514)", () => {
   });
 });
 
-describe("Gemini ACP containment (#3091)", () => {
-  it("enables Gemini's project sandbox except for explicit Full Access", () => {
-    expect(
-      geminiSandboxEnv({
+describe("Antigravity headless containment (#3648)", () => {
+  it("enables Antigravity's sandbox except for explicit Full Access", () => {
+    const bounded = buildAntigravityArgs(
+      {
+        timeoutSecs: 60,
+        currentModeId: "accept-edits",
         sandboxMode: "workspace-write",
-        networkEnabled: true,
-      }).GEMINI_SANDBOX,
-    ).toBe("true");
-    expect(
-      geminiSandboxEnv({
+      },
+      "test",
+    );
+    const fullAccess = buildAntigravityArgs(
+      {
+        timeoutSecs: 60,
+        currentModeId: "yolo",
         sandboxMode: "full-access",
-        networkEnabled: true,
-      }).GEMINI_SANDBOX,
-    ).toBe("false");
+      },
+      "test",
+    );
+    expect(bounded).toContain("--sandbox");
+    expect(fullAccess).not.toContain("--sandbox");
+    expect(fullAccess).toContain("--dangerously-skip-permissions");
   });
 });

--- a/tests/unit/agent-model-observability.test.ts
+++ b/tests/unit/agent-model-observability.test.ts
@@ -74,14 +74,13 @@ describe("#1718 Codex runtime — thread/start model adoption is logged", () => 
   });
 });
 
-describe("#3643 Gemini runtime — mid-session setModel reaches the CLI", () => {
-  it("sends session/set_model with the active CLI session and requested model", () => {
-    const fnIdx = geminiRuntime.indexOf("async setModel(");
+describe("#3648 Antigravity runtime — model selection reaches the next CLI turn", () => {
+  it("stores a validated selection and passes it through --model", () => {
+    const fnIdx = geminiRuntime.indexOf("async function setModel(");
     expect(fnIdx).toBeGreaterThan(0);
     const region = geminiRuntime.slice(fnIdx, fnIdx + 1200);
-    expect(region).toContain('"session/set_model"');
-    expect(region).toContain("sessionId: session.agentSessionId");
-    expect(region).toContain("modelId");
-    expect(region).not.toMatch(/(no-op|spawn[ -]time)/);
+    expect(region).toContain("session.availableModels.some");
+    expect(region).toContain("session.currentModelId = modelId");
+    expect(geminiRuntime).toContain('args.push("--model", session.currentModelId)');
   });
 });

--- a/tests/unit/agent-resolver-paths.test.ts
+++ b/tests/unit/agent-resolver-paths.test.ts
@@ -9,6 +9,10 @@ const registrySource = readFileSync(
   resolve("bin/browser-local/agent-registry.mjs"),
   "utf-8",
 );
+const antigravitySource = readFileSync(
+  resolve("bin/browser-local/antigravity-binary.mjs"),
+  "utf-8",
+);
 
 function sliceFn(name: string): string {
   const start = registrySource.indexOf(`function ${name}`);
@@ -68,40 +72,18 @@ describe("#1665 — Claude + Codex Windows resolvers cover MSI + user prefix", (
   });
 });
 
-describe("#1665 follow-up — Gemini resolver INTENTIONALLY excludes system + Homebrew paths (#1476 keytar)", () => {
-  // The Homebrew gemini-cli formula skips the keytar postinstall, so a
-  // system-installed gemini cannot read its own keychain when spawned from
-  // a GUI app and silently fails first-run auth. Mirroring the deliberate
-  // exclusion in resolveGeminiBinary at gemini-runtime.mjs.
-  it("does NOT include /usr/local/bin/gemini", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).not.toContain("/usr/local/bin/gemini");
+describe("#3648 — Antigravity resolver covers Google's documented install paths", () => {
+  it("prefers the official per-user install and covers common managed paths", () => {
+    expect(antigravitySource).toContain('path.join(home, ".local", "bin", "agy")');
+    expect(antigravitySource).toContain('path.join(localAppData, "agy", "bin", "agy.exe")');
+    expect(antigravitySource).toContain('"/opt/homebrew/bin/agy"');
+    expect(antigravitySource).toContain('"/usr/local/bin/agy"');
   });
 
-  it("does NOT include /opt/homebrew/bin/gemini", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).not.toContain("/opt/homebrew/bin/gemini");
-  });
-
-  it("does NOT include /usr/bin/gemini", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).not.toContain("/usr/bin/gemini");
-  });
-
-  it("does NOT read ProgramFiles\\nodejs (Windows MSI install)", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).not.toContain("process.env.ProgramFiles");
-  });
-
-  it("does NOT include <HOME>\\.npm-global on Windows", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).not.toContain('".npm-global"');
-  });
-
-  it("DOES include the bundled-runtime prefix and ~/.local/bin (the safe channels)", () => {
-    const fn = sliceFn("resolveInstalledGeminiBinary");
-    expect(fn).toContain('path.join(prefix, "bin", "gemini")');
-    expect(fn).toContain('path.join(home, ".local", "bin", "gemini")');
+  it("also searches inherited PATH without using a shell", () => {
+    expect(antigravitySource).toContain("process.env.PATH");
+    expect(antigravitySource).toContain("path.delimiter");
+    expect(antigravitySource).toContain("shell: false");
   });
 });
 
@@ -129,7 +111,6 @@ describe("#3377 — resolvers fall back to the dynamic npm global prefix", () =>
   it.each([
     "resolveInstalledCodexBinary",
     "resolveInstalledClaudeBinary",
-    "resolveInstalledGeminiBinary",
   ])(
     "%s consults the dynamic prefix for custom / version-manager installs",
     (name) => {

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -11,7 +11,6 @@ const agentChatSource = readSource("src/components/chat/AgentChat.tsx");
 const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
 const codexRuntimeSource = readSource("bin/browser-local/providers.mjs");
 const geminiRuntimeSource = readSource("bin/browser-local/gemini-runtime.mjs");
-const acpRuntimeSource = readSource("bin/browser-local/acp-runtime.mjs");
 
 describe("#1805 — death-string catalog matches what runtimes emit", () => {
   // The error event handler's session-death detection MUST stay in sync with
@@ -42,14 +41,10 @@ describe("#1805 — death-string catalog matches what runtimes emit", () => {
     );
   });
 
-  it("Gemini runtime emits the documented death strings", () => {
+  it("Antigravity runtime emits a documented mid-prompt death string", () => {
     expect(geminiRuntimeSource).toContain(
-      '"Gemini agent stopped before request completed."',
+      "Antigravity stopped while prompt was active",
     );
-    expect(acpRuntimeSource).toContain(
-      '"Session terminated before request completed."',
-    );
-    expect(acpRuntimeSource).toContain("stoppedBeforeRequestMessage");
   });
 });
 

--- a/tests/unit/antigravity-runtime.test.ts
+++ b/tests/unit/antigravity-runtime.test.ts
@@ -1,0 +1,141 @@
+// ABOUTME: Critical contract tests for the Antigravity migration (#3648).
+// ABOUTME: Protects verified releases, resumable headless args, and stream event translation.
+
+import { describe, expect, it } from "vitest";
+// @ts-ignore - browser-local runtime is plain ESM without declarations.
+import { _validateAntigravityManifest } from "../../bin/browser-local/antigravity-binary.mjs";
+// @ts-ignore - browser-local runtime is plain ESM without declarations.
+import * as antigravityRuntime from "../../bin/browser-local/gemini-runtime.mjs";
+
+const {
+  buildAntigravityArgs,
+  handleAntigravityEvent,
+  normalizeAntigravityModels,
+} = antigravityRuntime;
+
+describe("Antigravity verified release contract", () => {
+  const manifest = {
+    version: "1.1.10",
+    url: "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.10/build/agy.exe",
+    sha512: "a".repeat(128),
+  };
+
+  it("accepts only a supported Google-hosted artifact with a SHA-512 digest", () => {
+    expect(_validateAntigravityManifest(manifest).version).toBe("1.1.10");
+    expect(() =>
+      _validateAntigravityManifest({
+        ...manifest,
+        url: "https://example.com/agy.exe",
+      }),
+    ).toThrow(/untrusted artifact URL/);
+    expect(() =>
+      _validateAntigravityManifest({ ...manifest, sha512: "abcd" }),
+    ).toThrow(/manifest is invalid/);
+    expect(() =>
+      _validateAntigravityManifest({ ...manifest, version: "1.1.7" }),
+    ).toThrow(/below Seren's 1.1.8 minimum/);
+  });
+});
+
+describe("Antigravity resumable headless contract", () => {
+  it("passes the selected model, conversation, mode, and sandbox explicitly", () => {
+    const args = buildAntigravityArgs(
+      {
+        timeoutSecs: 90,
+        agentSessionId: "conversation-123",
+        currentModelId: "gemini-3.1-pro",
+        currentModeId: "accept-edits",
+        sandboxMode: "workspace-write",
+      },
+      "Fix the bug",
+    );
+
+    expect(args).toEqual([
+      "--print",
+      "Fix the bug",
+      "--output-format",
+      "stream-json",
+      "--print-timeout",
+      "90s",
+      "--conversation",
+      "conversation-123",
+      "--model",
+      "gemini-3.1-pro",
+      "--mode",
+      "accept-edits",
+      "--sandbox",
+    ]);
+  });
+
+  it("preserves every model printed by the authenticated CLI", () => {
+    expect(
+      normalizeAntigravityModels(
+        [
+          "gemini-3.6-flash-high",
+          "claude-opus-4-6-thinking",
+          "gpt-oss-120b-medium",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { modelId: "gemini-3.6-flash-high", name: "gemini-3.6-flash-high" },
+      {
+        modelId: "claude-opus-4-6-thinking",
+        name: "claude-opus-4-6-thinking",
+      },
+      { modelId: "gpt-oss-120b-medium", name: "gpt-oss-120b-medium" },
+    ]);
+  });
+});
+
+describe("Antigravity structured stream translation", () => {
+  it("captures the native conversation and emits only incremental text", () => {
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    const emit = (name: string, payload: Record<string, unknown>) => {
+      events.push({ name, payload });
+    };
+    const session = {
+      id: "local-session",
+      agentSessionId: undefined,
+      currentModelId: null,
+      stepText: new Map(),
+      assistantText: "",
+      resultEvent: null,
+      resultError: null,
+      usageMeta: null,
+    };
+
+    handleAntigravityEvent(emit, session, {
+      type: "init",
+      conversation_id: "conversation-123",
+      model: "gemini-3.1-pro",
+    });
+    handleAntigravityEvent(emit, session, {
+      type: "step_update",
+      step_id: "answer",
+      step_type: "assistant_message",
+      content: "Hello",
+    });
+    handleAntigravityEvent(emit, session, {
+      type: "step_update",
+      step_id: "answer",
+      step_type: "assistant_message",
+      content: "Hello world",
+    });
+    handleAntigravityEvent(emit, session, {
+      type: "result",
+      result: "Hello world",
+      usage: { input_tokens: 12, output_tokens: 2, cache_read_tokens: 5 },
+    });
+
+    expect(session.agentSessionId).toBe("conversation-123");
+    expect(session.currentModelId).toBe("gemini-3.1-pro");
+    expect(
+      events
+        .filter((event) => event.name === "provider://message-chunk")
+        .map((event) => event.payload.text),
+    ).toEqual(["Hello", " world"]);
+    expect(session.usageMeta).toEqual({
+      usage: { input_tokens: 12, output_tokens: 2, cache_read_tokens: 5 },
+    });
+  });
+});

--- a/tests/unit/claude-cli-baseline-gate.test.ts
+++ b/tests/unit/claude-cli-baseline-gate.test.ts
@@ -36,7 +36,7 @@ describe("#3443 claude-code spawn wiring enforces the baseline", () => {
       "async function ensureClaudeCodeCli",
     );
     const end = agentRegistrySource.indexOf(
-      "function resolveInstalledGeminiBinary",
+      "export function resolveInstalledClaudeBinary",
     );
     const helper = agentRegistrySource.slice(start, end);
 

--- a/tests/unit/gemini-1476-fixes.test.ts
+++ b/tests/unit/gemini-1476-fixes.test.ts
@@ -12,6 +12,10 @@ const geminiRuntimeMjs = readFileSync(
   resolve("bin/browser-local/gemini-runtime.mjs"),
   "utf-8",
 );
+const agentRegistryMjs = readFileSync(
+  resolve("bin/browser-local/agent-registry.mjs"),
+  "utf-8",
+);
 const agentStoreTs = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
@@ -44,17 +48,15 @@ describe("Gemini Agent #1476 — load-bearing regression guards", () => {
     expect(viteConfigTs).toMatch(/find:\s*\/\^qrcode\$\//);
   });
 
-  // ─── Slice B: never accept Homebrew gemini-cli ───────────────────────
-  it("gemini-runtime resolveGeminiBinary does NOT include Homebrew paths", () => {
-    // The whole reason this PR exists. /usr/local/bin/gemini and
-    // /opt/homebrew/bin/gemini are deliberately excluded — Homebrew's
-    // gemini-cli ships without compiled keytar and cannot read its
-    // own keychain when launched from a GUI app.
-    const idx = geminiRuntimeMjs.indexOf("function resolveGeminiBinary");
+  // ─── Slice B: Antigravity first-run auth ─────────────────────────────
+  it("launches agy itself because Antigravity has no login subcommand", () => {
+    const idx = agentRegistryMjs.indexOf("gemini: {");
     expect(idx).toBeGreaterThan(-1);
-    const fnSlice = geminiRuntimeMjs.slice(idx, idx + 2000);
-    expect(fnSlice).not.toContain('"/usr/local/bin/gemini"');
-    expect(fnSlice).not.toContain('"/opt/homebrew/bin/gemini"');
+    const definition = agentRegistryMjs.slice(idx, idx + 2400);
+    expect(definition).toContain("launchInteractiveCommand");
+    expect(definition).not.toContain("launchLoginCommand");
+    expect(geminiRuntimeMjs).toContain("isAntigravityAuthError");
+    expect(geminiRuntimeMjs).toContain('"provider://login-required"');
   });
 
   // ─── Slice C: login-required handler position ───────────────────────

--- a/tests/unit/gemini-1480-fixes.test.ts
+++ b/tests/unit/gemini-1480-fixes.test.ts
@@ -1,11 +1,11 @@
 // ABOUTME: Critical regression guards for #1480 — Gemini Agent bottom controls.
-// ABOUTME: Guards locked agent controls and Gemini ACP model-catalog passthrough.
+// ABOUTME: Guards locked agent controls and Antigravity model-catalog passthrough.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-// @ts-expect-error - acp-runtime.mjs is a plain ESM harness without type declarations
-import { _applyAcpModelState } from "../../bin/browser-local/acp-runtime.mjs";
+// @ts-expect-error - browser-local runtime is plain ESM without type declarations
+import { normalizeAntigravityModels } from "../../bin/browser-local/gemini-runtime.mjs";
 
 const agentChatTsx = readFileSync(
   resolve("src/components/chat/AgentChat.tsx"),
@@ -27,44 +27,27 @@ describe("Gemini Agent #1480 — bottom-control regression guards", () => {
     expect(matches.length).toBe(2);
   });
 
-  it("uses the model catalog returned by Gemini session/new verbatim", () => {
-    const session = {
-      currentModelId: "stale-model",
-      availableModels: [{ modelId: "stale-model", name: "Stale" }],
-      cliModels: [],
-    };
-
+  it("uses the model catalog returned by agy models verbatim", () => {
     expect(
-      _applyAcpModelState(session, {
-        currentModelId: "gemini-cli-current",
-        availableModels: [
-          {
-            modelId: "gemini-cli-current",
-            name: "Gemini CLI current",
-            description: "Returned by the installed CLI",
-          },
-          { modelId: "gemini-cli-next", name: "Gemini CLI next" },
-        ],
-      }),
-    ).toBe(true);
-    expect(session).toEqual({
-      currentModelId: "gemini-cli-current",
-      availableModels: [
+      normalizeAntigravityModels(
+        JSON.stringify({
+          models: [
+            {
+              modelId: "gemini-cli-current",
+              name: "Gemini CLI current",
+              description: "Returned by the installed CLI",
+            },
+            { modelId: "gemini-cli-next", name: "Gemini CLI next" },
+          ],
+        }),
+      ),
+    ).toEqual([
         {
           modelId: "gemini-cli-current",
           name: "Gemini CLI current",
           description: "Returned by the installed CLI",
         },
         { modelId: "gemini-cli-next", name: "Gemini CLI next" },
-      ],
-      cliModels: [
-        {
-          modelId: "gemini-cli-current",
-          name: "Gemini CLI current",
-          description: "Returned by the installed CLI",
-        },
-        { modelId: "gemini-cli-next", name: "Gemini CLI next" },
-      ],
-    });
+      ]);
   });
 });

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Critical regression guards for the Gemini Agent integration (#1471).
-// ABOUTME: Asserts wiring across runtime, agent registry, dispatcher, and OAuth-removal sites.
+// ABOUTME: Critical regression guards for Antigravity behind the durable Gemini agent ID.
+// ABOUTME: Asserts runtime, registry, dispatcher, UI, and OAuth boundaries.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -17,8 +17,8 @@ const geminiRuntimeMjs = readFileSync(
   resolve("bin/browser-local/gemini-runtime.mjs"),
   "utf-8",
 );
-const acpRuntimeMjs = readFileSync(
-  resolve("bin/browser-local/acp-runtime.mjs"),
+const antigravityBinaryMjs = readFileSync(
+  resolve("bin/browser-local/antigravity-binary.mjs"),
   "utf-8",
 );
 const agentStoreTs = readFileSync(
@@ -74,77 +74,56 @@ describe("Gemini Agent — runtime wiring (#1471)", () => {
 
 });
 
-describe("Gemini Agent — registry definition (#1471)", () => {
+describe("Antigravity Agent — registry definition (#3648)", () => {
   it("agent-registry.mjs defines a 'gemini' entry", () => {
     expect(agentRegistryMjs).toContain("gemini: {");
     expect(agentRegistryMjs).toContain('type: "gemini"');
-    expect(agentRegistryMjs).toContain('packageName: "@google/gemini-cli"');
+    expect(agentRegistryMjs).toContain('name: "Antigravity"');
+    expect(agentRegistryMjs).toContain('command: "agy"');
   });
 
-  it("agent-registry.mjs uses ensureGlobalNpmPackage for gemini install", () => {
-    // Same install pattern as Codex — npm global, not the Claude native installer.
+  it("uses the verified native installer, never the retired Gemini npm package", () => {
     const geminiSection = agentRegistryMjs.slice(
       agentRegistryMjs.indexOf("gemini: {"),
     );
-    expect(geminiSection).toContain("ensureGlobalNpmPackage");
-    expect(geminiSection).toContain('command: "gemini"');
+    expect(geminiSection).toContain("ensureAntigravityCli");
+    expect(geminiSection).toContain("launchInteractiveCommand");
+    expect(geminiSection).not.toContain("@google/gemini-cli");
+    expect(antigravityBinaryMjs).toContain('createHash("sha512")');
+    expect(antigravityBinaryMjs).toContain("storage.googleapis.com");
   });
 });
 
-describe("Gemini Agent — shared ACP client (#1471, #3084)", () => {
-  it("keeps createGeminiRuntime as a thin adapter over the shared factory", () => {
+describe("Antigravity Agent — structured headless runtime (#3648)", () => {
+  it("keeps the serialized gemini route while removing the deprecated ACP transport", () => {
     expect(geminiRuntimeMjs).toContain("export function createGeminiRuntime");
-    expect(geminiRuntimeMjs).toContain(
-      'import { createAcpRuntime } from "./acp-runtime.mjs"',
-    );
-    expect(geminiRuntimeMjs).toContain("adapter: GEMINI_ADAPTER");
-    // Must expose hasSession so providers.mjs fallback chain works.
-    expect(acpRuntimeMjs).toContain("hasSession(sessionId)");
-    // Public RPC surface.
-    expect(acpRuntimeMjs).toContain("spawnSession");
-    expect(acpRuntimeMjs).toContain("sendPrompt");
-    expect(acpRuntimeMjs).toContain("cancelPrompt");
-    expect(acpRuntimeMjs).toContain("terminateSession");
-    expect(acpRuntimeMjs).toContain("respondToPermission");
+    expect(geminiRuntimeMjs).toContain('agentType: "gemini"');
+    expect(geminiRuntimeMjs).not.toContain("createAcpRuntime");
+    expect(geminiRuntimeMjs).not.toContain('"--acp"');
   });
 
-  it("spawns gemini-cli with the --acp flag", () => {
-    // The whole point of this PR — gemini-cli must be invoked in ACP mode,
-    // not interactive TUI mode.
-    expect(geminiRuntimeMjs).toContain('"--acp"');
+  it("spawns Antigravity stream-json and resumes its conversation ID", () => {
+    expect(geminiRuntimeMjs).toContain('"--output-format"');
+    expect(geminiRuntimeMjs).toContain('"stream-json"');
+    expect(geminiRuntimeMjs).toContain('"--conversation"');
+    expect(geminiRuntimeMjs).toContain("session.agentSessionId");
   });
 
-  it("speaks ACP method names verbatim from the schema", () => {
-    // Catches accidental rename to e.g. "session/newSession" or "newSession".
-    expect(acpRuntimeMjs).toContain('"initialize"');
-    expect(acpRuntimeMjs).toContain('"session/new"');
-    expect(acpRuntimeMjs).toContain('"session/prompt"');
-    expect(acpRuntimeMjs).toContain('"session/cancel"');
-    expect(acpRuntimeMjs).toContain('"session/request_permission"');
-  });
-
-  it("translates ACP session/update notifications to provider:// events", () => {
-    // The session/update branch must handle each ACP update type and emit
-    // the existing provider:// events the desktop already knows.
-    expect(acpRuntimeMjs).toContain('"agent_message_chunk"');
-    expect(acpRuntimeMjs).toContain('"agent_thought_chunk"');
-    expect(acpRuntimeMjs).toContain('"tool_call"');
-    expect(acpRuntimeMjs).toContain('"tool_call_update"');
-    expect(acpRuntimeMjs).toContain('"plan"');
-    expect(acpRuntimeMjs).toContain('"provider://message-chunk"');
-    expect(acpRuntimeMjs).toContain('"provider://tool-call"');
-    expect(acpRuntimeMjs).toContain('"provider://prompt-complete"');
-  });
-
-  it("declares an ACP protocol version constant", () => {
-    expect(acpRuntimeMjs).toContain("ACP_PROTOCOL_VERSION");
+  it("translates typed stream events to the existing provider event surface", () => {
+    expect(geminiRuntimeMjs).toContain('type === "init"');
+    expect(geminiRuntimeMjs).toContain('type === "step_update"');
+    expect(geminiRuntimeMjs).toContain('type === "result"');
+    expect(geminiRuntimeMjs).toContain('"provider://message-chunk"');
+    expect(geminiRuntimeMjs).toContain('"provider://tool-call"');
+    expect(geminiRuntimeMjs).toContain('"provider://prompt-complete"');
   });
 });
 
 describe("Gemini Agent — agent.store.ts wiring (#1471)", () => {
   it("agentDisplayName has a 'gemini' case", () => {
-    // Whitespace-tolerant: case "gemini": ... return "Gemini";
-    expect(bootstrapContextTs).toMatch(/case\s+"gemini":\s*\n\s*return\s+"Gemini"/);
+    expect(bootstrapContextTs).toMatch(
+      /case\s+"gemini":\s*\n\s*return\s+"Antigravity"/,
+    );
   });
 
   it("CLI ensure dispatcher routes gemini to providerService.ensureGeminiCli", () => {
@@ -194,18 +173,20 @@ describe("LM Studio Agent — thread.store.ts auto-detect (#2451)", () => {
 });
 
 describe("Gemini Agent — UI surface (#1471)", () => {
-  it("ThreadTabBar '+ New' menu includes a Gemini button", () => {
+  it("ThreadTabBar '+ New' menu includes an Antigravity button", () => {
     // Label dropped the "Agent" suffix in #1832 once the chip vocabulary was added —
     // the chip + section header now convey the kind. Wiring = testid + handler.
     expect(threadTabBarTsx).toContain("allowsGeminiAgent");
     expect(threadTabBarTsx).toContain('data-testid="new-gemini-agent"');
     expect(threadTabBarTsx).toContain('handleNewAgent("gemini")');
+    expect(threadTabBarTsx).toContain("Antigravity");
   });
 
-  it("ThreadSidebar agent launcher includes a Gemini button", () => {
+  it("ThreadSidebar agent launcher includes an Antigravity button", () => {
     expect(threadSidebarTsx).toContain("allowsGeminiAgent");
     expect(threadSidebarTsx).toContain('data-testid="new-gemini-agent"');
     expect(threadSidebarTsx).toContain('handleNewAgent("gemini")');
+    expect(threadSidebarTsx).toContain("Antigravity");
     // Helper still routes to threadStore.createAgentThread under the hood.
     expect(threadSidebarTsx).toMatch(
       /threadStore\.createAgentThread\(\s*agentType\s*,\s*cwd\s*\)/,

--- a/tests/unit/provider-agent-auth-status.test.ts
+++ b/tests/unit/provider-agent-auth-status.test.ts
@@ -15,7 +15,8 @@ describe("provider agent authentication status", () => {
     expect(registrySource).toContain("authenticated: isAgentAuthenticated");
     expect(registrySource).toContain('path.join(home, ".claude", ".credentials.json")');
     expect(registrySource).toContain('path.join(home, ".codex", "auth.json")');
-    expect(registrySource).toContain('path.join(home, ".gemini", "oauth_creds.json")');
+    expect(registrySource).toContain("checkAntigravityAuthenticated");
+    expect(registrySource).toContain("resolveAntigravityBinary");
     expect(registrySource).toContain('path.join(os.homedir(), ".grok", "auth.json")');
   });
 

--- a/tests/unit/provider-boundaries.test.ts
+++ b/tests/unit/provider-boundaries.test.ts
@@ -61,7 +61,7 @@ describe("providerDisplayName", () => {
   it("renders external agent types with friendly labels", () => {
     expect(providerDisplayName("claude-code")).toBe("Claude Code");
     expect(providerDisplayName("codex")).toBe("Codex");
-    expect(providerDisplayName("gemini")).toBe("Gemini");
+    expect(providerDisplayName("gemini")).toBe("Antigravity");
     expect(providerDisplayName("grok")).toBe("Grok");
     expect(providerDisplayName("lmstudio")).toBe("LM Studio");
   });

--- a/tests/unit/provider-cancel-parity.test.ts
+++ b/tests/unit/provider-cancel-parity.test.ts
@@ -13,6 +13,10 @@ const acpSource = readFileSync(
   resolve("bin/browser-local/acp-runtime.mjs"),
   "utf-8",
 );
+const antigravitySource = readFileSync(
+  resolve("bin/browser-local/gemini-runtime.mjs"),
+  "utf-8",
+);
 
 /** Slice a top-level `async function <name>(` body, bounded by the next
  * `\n  async function ` (sibling closure methods share indent-2). */
@@ -73,5 +77,20 @@ describe("#2304 — ACP cancelPrompt escalates to a hard kill when the agent doe
       body,
       "the kill must be gated on the turn not settling (currentPrompt liveness).",
     ).toContain("currentPrompt");
+  });
+});
+
+describe("#3648 — Antigravity cancelPrompt terminates its process-per-turn child", () => {
+  const body = sliceAsyncFn(
+    antigravitySource,
+    "async function cancelPrompt({ sessionId })",
+  );
+
+  it("marks the active turn cancelled before killing the child", () => {
+    expect(body, "Antigravity cancelPrompt body must be non-empty").not.toBe("");
+    const cancelledAt = body.indexOf("session.cancelled = true");
+    const killAt = body.indexOf("killChildTree(session.process)");
+    expect(cancelledAt).toBeGreaterThan(-1);
+    expect(killAt).toBeGreaterThan(cancelledAt);
   });
 });

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -547,12 +547,16 @@ describe("Windows production e2e release gate", () => {
     expect(cliSetupAt).toBeLessThan(appHarnessAt);
     expect(taskUserRunner).toContain("@anthropic-ai/claude-code@latest");
     expect(taskUserRunner).toContain("@openai/codex@latest");
-    expect(taskUserRunner).toContain("@google/gemini-cli@latest");
+    expect(taskUserRunner).toContain(
+      "manifests/windows_amd64.json",
+    );
+    expect(taskUserRunner).toContain("Get-FileHash");
+    expect(taskUserRunner).toContain("SHA512");
+    expect(taskUserRunner).toContain('"agy.exe"');
     expect(taskUserRunner).toContain("@xai-official/grok@latest");
     for (const [label, binary] of [
       ["Claude Code", "claude.cmd"],
       ["Codex", "codex.cmd"],
-      ["Gemini", "gemini.cmd"],
       ["Grok", "grok.cmd"],
     ]) {
       expect(taskUserRunner).toContain(

--- a/tests/validation/scenarios/antigravity-agent.ts
+++ b/tests/validation/scenarios/antigravity-agent.ts
@@ -1,0 +1,163 @@
+// ABOUTME: Live, signed-in Antigravity walkthrough for the retired Gemini Agent path.
+// ABOUTME: Verifies CLI/UI catalog parity plus a resumable two-turn conversation without mocks.
+
+import { execFileSync } from "node:child_process";
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+// @ts-ignore - browser-local runtime is plain ESM without declarations.
+import { resolveAntigravityBinary } from "../../../bin/browser-local/antigravity-binary.mjs";
+// @ts-ignore - browser-local runtime is plain ESM without declarations.
+import { normalizeAntigravityModels } from "../../../bin/browser-local/gemini-runtime.mjs";
+
+interface TextDump {
+  text?: string;
+}
+
+interface CliModel {
+  modelId: string;
+  name: string;
+}
+
+const FIRST_MARKER = "ANTIGRAVITY_FIRST_TURN_3648";
+const MEMORY_TOKEN = "ORBITAL_MEMORY_3648";
+const RESUME_MARKER = `ANTIGRAVITY_RESUMED_${MEMORY_TOKEN}`;
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? ((value as TextDump).text as string)
+    : JSON.stringify(value);
+}
+
+async function waitForBodyText(
+  ctx: ScenarioContext,
+  marker: string,
+  timeoutMs: number,
+): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started <= timeoutMs) {
+    if (textOf(await ctx.client.dumpText("body")).includes(marker)) return;
+    await sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for sanitized marker ${marker}`);
+}
+
+async function sendPrompt(
+  ctx: ScenarioContext,
+  prompt: string,
+): Promise<void> {
+  await ctx.client.waitFor(".chat-composer-form textarea", 60_000);
+  await ctx.client.fill(".chat-composer-form textarea", prompt);
+  await ctx.client.waitFor(
+    ".chat-composer-form button[type='submit']",
+    60_000,
+  );
+  await ctx.client.click(".chat-composer-form button[type='submit']");
+}
+
+function liveCliModels(): CliModel[] {
+  const binary = resolveAntigravityBinary();
+  const output = execFileSync(binary, ["models"], {
+    encoding: "utf8",
+    input: "",
+    env: {
+      ...process.env,
+      AGY_CLI_HIDE_ACCOUNT_INFO: "1",
+      CI: "1",
+      NO_COLOR: "1",
+      TERM: "dumb",
+    },
+  });
+  const models = normalizeAntigravityModels(output);
+  if (models.length === 0) {
+    throw new Error("The signed-in Antigravity CLI returned no models");
+  }
+  return models as CliModel[];
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const expectedModels = liveCliModels();
+
+  await ctx.client.command({
+    command: "setRootPath",
+    path: "/tmp/seren-antigravity-walkthrough",
+  });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-gemini-agent']", 10_000);
+
+  const launcherText = textOf(
+    await ctx.client.dumpText("[data-testid='new-gemini-agent']"),
+  );
+  if (!launcherText.includes("Antigravity")) {
+    throw new Error("The retired Gemini label is still visible in the launcher");
+  }
+  await ctx.client.click("[data-testid='new-gemini-agent']");
+
+  await ctx.client.waitFor("button[title='Change model']", 60_000);
+  await ctx.client.click("button[title='Change model']");
+  const modelMenu = await ctx.client.dumpText("body");
+  const modelMenuText = textOf(modelMenu);
+  for (const model of expectedModels) {
+    if (!modelMenuText.includes(model.name)) {
+      throw new Error(
+        `Antigravity model picker omitted CLI model ${model.modelId}`,
+      );
+    }
+  }
+  await ctx.writeArtifact("antigravity-model-menu.json", modelMenu);
+  await ctx.client.press("Escape");
+
+  await ctx.client.waitFor("button[title='Change permission mode']", 10_000);
+  await ctx.client.click("button[title='Change permission mode']");
+  const modeMenu = await ctx.client.dumpText("body");
+  const modeMenuText = textOf(modeMenu);
+  for (const mode of [
+    "Saved rules",
+    "Accept edits",
+    "Plan",
+    "Skip permissions",
+  ]) {
+    if (!modeMenuText.includes(mode)) {
+      throw new Error(`Antigravity permission picker omitted ${mode}`);
+    }
+  }
+  await ctx.writeArtifact("antigravity-mode-menu.json", modeMenu);
+  await ctx.client.press("Escape");
+
+  await sendPrompt(
+    ctx,
+    `Remember ${MEMORY_TOKEN} for the next turn. Do not use tools. Reply with exactly ${FIRST_MARKER}.`,
+  );
+  await waitForBodyText(ctx, FIRST_MARKER, 180_000);
+
+  await sendPrompt(
+    ctx,
+    `Without using tools, prove this is the same conversation by replying with exactly ANTIGRAVITY_RESUMED_ followed by the token I asked you to remember.`,
+  );
+  await waitForBodyText(ctx, RESUME_MARKER, 180_000);
+
+  await ctx.writeArtifact("antigravity-live-result.json", {
+    signedIn: true,
+    launcherLabel: "Antigravity",
+    cliModelCount: expectedModels.length,
+    cliModelIds: expectedModels.map((model) => model.modelId),
+    uiModelCount: expectedModels.length,
+    permissionModesVerified: 4,
+    firstTurnCompleted: true,
+    exactConversationResumed: true,
+  });
+  await ctx.writeArtifact(
+    "antigravity-live-native.json",
+    await ctx.client.nativeScreenshot(),
+  );
+  await ctx.writeArtifact(
+    "antigravity-live-text.json",
+    await ctx.client.dumpText("body"),
+  );
+
+  if (process.env.SEREN_VALIDATION_HOLD_OPEN === "1") {
+    await new Promise<void>(() => {});
+  }
+}


### PR DESCRIPTION
Closes #3648

## Summary
- keep Seren's durable `gemini` agent identifier while replacing the retired Gemini CLI ACP transport with Google Antigravity CLI 1.1.8+
- install or update Google's native `agy` binary from its per-platform manifest, allowlist the artifact origin/path, and verify SHA-512 before activation
- run one structured `stream-json` process per turn, translate text/tool/usage events, persist the returned conversation ID, and resume subsequent turns with `--conversation`
- query the authenticated `agy models` catalog without fallbacks and expose only Antigravity modes that headless execution can enforce
- launch Antigravity's interactive first-run Google Sign-In flow and update all user-facing agent copy while preserving saved-session compatibility
- update the Windows release gate and critical installer, auth, catalog, lifecycle, cancellation, and resume regression coverage

## Audited path
Seren renderer → local provider runtime → verified installed Antigravity CLI → Google's authenticated Antigravity service. No Seren publisher or third-party API path is added.

## Native walkthrough
Validated in the native macOS app against the authenticated Antigravity 1.1.10 CLI, with no mocks or simulated runtime state.

- Antigravity installed and authenticated successfully
- all 11 CLI-reported models appeared in the model picker
- all four enforceable modes appeared: Saved rules, Accept edits, Plan, and Skip permissions
- the first prompt completed successfully
- a second prompt resumed the exact Antigravity conversation and recalled the prior-turn token

The walkthrough was approved by @taariq and recorded on #3648. No screenshot is attached because public artifacts must not expose local workstation information.

## Verification
- `pnpm test` — 430 files / 2,974 tests passed
- focused Antigravity/provider suite — 9 files / 92 tests passed
- `pnpm build` — passed
- `cargo check` — passed with one existing unrelated warning
- changed runtime `node --check` checks — passed
- changed-file TypeScript filtering and `git diff --check` — passed
- `pnpm lint` — passed with existing repository warnings

## Excluded follow-up
- Mission Control's provider-specific permission vocabulary and access-scope labels remain tracked separately in #3646.
