### PR TITLE
fix(agents): stop capping and double-reporting Antigravity turns

### DIFF
--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -252,6 +252,12 @@ function buildStatus(session, status = session.status) {
   };
 }
 
+// `--print-timeout` caps the whole turn, not idle time, and the CLI applies
+// its own 5m default when the flag is absent. A session without an explicit
+// timeout waits for as long as the work takes, so pass a duration long enough
+// to never fire rather than omitting the flag. #3662
+const ANTIGRAVITY_UNBOUNDED_TURN = "8760h";
+
 export function buildAntigravityArgs(session, prompt) {
   const args = [
     "--print",
@@ -259,7 +265,9 @@ export function buildAntigravityArgs(session, prompt) {
     "--output-format",
     "stream-json",
     "--print-timeout",
-    `${session.timeoutSecs ?? 600}s`,
+    session.timeoutSecs
+      ? `${session.timeoutSecs}s`
+      : ANTIGRAVITY_UNBOUNDED_TURN,
   ];
   if (session.agentSessionId) {
     args.push("--conversation", session.agentSessionId);
@@ -627,7 +635,10 @@ export function createGeminiRuntime({ emit }) {
     } catch (error) {
       session.status = "ready";
       const message = error instanceof Error ? error.message : String(error);
-      if (runtimeSessions.get(sessionId) === session) {
+      // cancelPrompt already emitted the cancellation, and the killed child
+      // then lands here with the same message. Emitting again persists a
+      // duplicate error row for every cancel. #3664
+      if (!session.cancelled && runtimeSessions.get(sessionId) === session) {
         emit("provider://error", { sessionId, error: message });
         emit("provider://session-status", buildStatus(session, "ready"));
       }

--- a/tests/unit/antigravity-cancel-emit.test.ts
+++ b/tests/unit/antigravity-cancel-emit.test.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Regression coverage for #3664: cancelling an Antigravity turn must
+// ABOUTME: persist one cancellation entry, not one per terminal event.
+
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// A real executable standing in for the Antigravity CLI: it answers the
+// version and model probes, then blocks so the turn can be cancelled while
+// it is still running. No runtime behavior is stubbed.
+const binDir = mkdtempSync(path.join(tmpdir(), "seren-agy-test-"));
+const stubBinary = path.join(binDir, "agy-stub.mjs");
+writeFileSync(
+  stubBinary,
+  `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "--version") { console.log("1.1.10"); process.exit(0); }
+if (args[0] === "models") { console.log("gemini-3.1-pro-high"); process.exit(0); }
+setInterval(() => {}, 1000);
+`,
+);
+chmodSync(stubBinary, 0o755);
+
+vi.mock("../../bin/browser-local/antigravity-binary.mjs", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../bin/browser-local/antigravity-binary.mjs")
+  >("../../bin/browser-local/antigravity-binary.mjs");
+  return { ...actual, resolveAntigravityBinary: () => stubBinary };
+});
+
+// @ts-expect-error — browser-local runtime is plain ESM without declarations.
+const { createGeminiRuntime } = await import(
+  "../../bin/browser-local/gemini-runtime.mjs"
+);
+
+describe("Antigravity cancellation (#3664)", () => {
+  it("emits one error for a cancelled turn even after the killed child closes", async () => {
+    const events: { name: string; payload: { error?: string } }[] = [];
+    const runtime = createGeminiRuntime({
+      emit: (name: string, payload: { error?: string }) =>
+        events.push({ name, payload }),
+    });
+
+    const session = await runtime.spawnSession({
+      localSessionId: "session-1",
+      cwd: binDir,
+    });
+
+    const prompt = runtime.sendPrompt({
+      sessionId: session.id,
+      prompt: "long running work",
+    });
+    await vi.waitFor(() => expect(events.some((e) => e.name === "provider://session-status")).toBe(true));
+
+    await runtime.cancelPrompt({ sessionId: session.id });
+    // The killed child's close lands after cancel and drives sendPrompt into
+    // its catch carrying the same "Task cancelled" message.
+    await expect(prompt).rejects.toThrow(/Task cancelled/);
+
+    const cancellations = events.filter(
+      (event) =>
+        event.name === "provider://error" &&
+        event.payload.error === "Task cancelled",
+    );
+    expect(cancellations).toHaveLength(1);
+  });
+});

--- a/tests/unit/antigravity-runtime.test.ts
+++ b/tests/unit/antigravity-runtime.test.ts
@@ -67,6 +67,17 @@ describe("Antigravity resumable headless contract", () => {
     ]);
   });
 
+  it("does not cap a turn when the session carries no explicit timeout", () => {
+    // Desktop sessions always leave timeoutSecs undefined: an agent may think,
+    // wait for approval, or work for a long stretch, and killing it is never
+    // right. `--print-timeout` bounds the whole turn and the CLI defaults to
+    // 5m when the flag is absent, so the flag must be present and large. #3662
+    const args = buildAntigravityArgs({}, "Refactor the module");
+    const timeout = args[args.indexOf("--print-timeout") + 1];
+
+    expect(timeout).toBe("8760h");
+  });
+
   it("preserves every model printed by the authenticated CLI", () => {
     expect(
       normalizeAntigravityModels(


### PR DESCRIPTION
Closes #3662
Closes #3664

## Summary

- Remove the hardcoded 600 s turn cap from Antigravity sessions; an explicit `session.timeoutSecs` is still honored.
- Emit one cancellation entry per cancelled turn instead of two.
- Add regression coverage for both, including a real-executable test for the cancel path.

## #3662 — turns were killed at 10 minutes

`--print-timeout` bounds the entire turn, not idle time. The desktop store always leaves `timeoutSecs` undefined by design ("agent sessions wait indefinitely... Killing the session is never the right call"), so the 600 s fallback applied to every turn and killed any longer piece of work.

Verified against the installed Antigravity CLI 1.1.10 — a prompt run with `--print-timeout 5s` is terminated with no output at all:

    {"event":"result","result":{"status":"ERROR","response":"",
     "error":"timeout waiting for response","duration_seconds":0.017634,...}}

Omitting the flag is not a fix — the CLI's own default is 5m, which is worse. The flag now carries a duration long enough never to fire, which the CLI accepts and runs normally.

## #3664 — cancel wrote two rows

`cancelPrompt` emits the cancellation and leaves the session in the map, so the killed child's close drives `sendPrompt` into its catch with the same message and the identity guard passes. The catch now skips the emit when the turn was cancelled, mirroring the existing Codex guard. `session.cancelled` resets at the start of every prompt, so genuine failures on later turns still report.

## Audited path

Renderer → local provider runtime → installed Antigravity CLI. No Seren publisher or third-party API path is added or changed.

## Validation

- 5 Antigravity/Gemini suites: 34 tests passed.
- The new cancel test was confirmed to fail without the fix (2 events) and pass with it (1), so it genuinely protects the behavior.
- The cancel test drives the real runtime against a real stub executable rather than a mocked child.
- Biome passed on all changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
