### PR TITLE
fix(agents): keep the agent roster off the Antigravity auth round-trip

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -23,6 +23,7 @@ import {
 import {
   ANTIGRAVITY_INSTALL_URL,
   checkAntigravityAuthenticated,
+  clearAntigravityAuthCache,
   ensureAntigravityCli,
   resolveAntigravityBinary,
 } from "./antigravity-binary.mjs";
@@ -975,6 +976,9 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       },
       launchLogin() {
         const resolved = resolveAntigravityBinary();
+        // Sign-in changes the verdict the cached probe recorded, so drop it
+        // and let the next query observe the new state immediately. #3663
+        clearAntigravityAuthCache();
         launchInteractiveCommand(resolved !== "agy" ? resolved : "agy");
       },
       async checkAuthenticated() {

--- a/bin/browser-local/antigravity-binary.mjs
+++ b/bin/browser-local/antigravity-binary.mjs
@@ -129,14 +129,55 @@ export async function readAntigravityVersion(binary = resolveAntigravityBinary()
   }
 }
 
+export function isAntigravityAuthError(message) {
+  const normalized = String(message ?? "").toLowerCase();
+  return (
+    normalized.includes("please sign in") ||
+    normalized.includes("sign-in required") ||
+    normalized.includes("authentication required") ||
+    normalized.includes("not authenticated") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("no valid oauth token") ||
+    normalized.includes("no valid refresh token") ||
+    normalized.includes("failed to load token")
+  );
+}
+
+// `agy models` is the only way to observe Antigravity's auth state, and it is a
+// network round-trip that every agent-roster query would otherwise pay. Cache
+// the verdict briefly so the roster is not gated on Google, and hold the last
+// verdict when the CLI fails for a reason other than authentication — a slow or
+// offline network must not report a signed-in user as signed out. #3663
+const AUTH_CACHE_TTL_MS = 60_000;
+const authCache = new Map();
+
+export function clearAntigravityAuthCache() {
+  authCache.clear();
+}
+
 export async function checkAntigravityAuthenticated(
   binary = resolveAntigravityBinary(),
+  { now = Date.now } = {},
 ) {
   if (binary === "agy") return false;
+  const checkedAt = now();
+  const cached = authCache.get(binary);
+  if (cached && checkedAt - cached.checkedAt < AUTH_CACHE_TTL_MS) {
+    return cached.authenticated;
+  }
+
   try {
     await execFileText(binary, ["models"], 8_000);
+    authCache.set(binary, { authenticated: true, checkedAt });
     return true;
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!isAntigravityAuthError(message) && cached) {
+      // Unreachable or slow, not signed out. Keep the known verdict and let
+      // the next query past the TTL settle it.
+      return cached.authenticated;
+    }
+    authCache.set(binary, { authenticated: false, checkedAt });
     return false;
   }
 }

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -7,6 +7,7 @@ import readline from "node:readline";
 
 import {
   ANTIGRAVITY_MIN_VERSION,
+  isAntigravityAuthError,
   isAntigravityVersionSupported,
   readAntigravityVersion,
   resolveAntigravityBinary,
@@ -38,20 +39,6 @@ function stripAnsi(value) {
   return String(value ?? "")
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
     .replace(/\r/g, "");
-}
-
-export function isAntigravityAuthError(message) {
-  const normalized = String(message ?? "").toLowerCase();
-  return (
-    normalized.includes("please sign in") ||
-    normalized.includes("sign-in required") ||
-    normalized.includes("authentication required") ||
-    normalized.includes("not authenticated") ||
-    normalized.includes("not logged in") ||
-    normalized.includes("no valid oauth token") ||
-    normalized.includes("no valid refresh token") ||
-    normalized.includes("failed to load token")
-  );
 }
 
 function normalizeModelObject(model) {

--- a/tests/unit/antigravity-auth-cache.test.ts
+++ b/tests/unit/antigravity-auth-cache.test.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Regression coverage for #3663: the Antigravity auth probe must not
+// ABOUTME: run per roster query, nor report a network failure as signed out.
+
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+// @ts-expect-error — browser-local runtime is plain ESM without declarations.
+import {
+  checkAntigravityAuthenticated,
+  clearAntigravityAuthCache,
+  isAntigravityAuthError,
+} from "../../bin/browser-local/antigravity-binary.mjs";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "seren-agy-auth-"));
+const callLog = path.join(workDir, "calls.log");
+const stubBinary = path.join(workDir, "agy-stub.mjs");
+
+// A real executable whose behavior is switched by a file on disk, so the
+// caching and failure-classification logic runs against actual process
+// execution rather than a stubbed function.
+writeFileSync(
+  stubBinary,
+  `#!/usr/bin/env node
+import { appendFileSync, readFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(callLog)}, "call\\n");
+const mode = readFileSync(${JSON.stringify(path.join(workDir, "mode"))}, "utf8").trim();
+if (mode === "ok") { console.log("gemini-3.1-pro-high"); process.exit(0); }
+if (mode === "network") { console.error("dial tcp: i/o timeout"); process.exit(1); }
+console.error("Please sign in to continue");
+process.exit(1);
+`,
+);
+chmodSync(stubBinary, 0o755);
+
+function setMode(mode: "ok" | "network" | "signed-out") {
+  writeFileSync(path.join(workDir, "mode"), mode);
+}
+
+function callCount() {
+  try {
+    return readFileSync(callLog, "utf8").trim().split("\n").filter(Boolean)
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+describe("Antigravity auth probe caching (#3663)", () => {
+  beforeEach(() => {
+    clearAntigravityAuthCache();
+    writeFileSync(callLog, "");
+  });
+
+  it("does not re-run the probe for every roster query", async () => {
+    setMode("ok");
+
+    const results = await Promise.all([
+      checkAntigravityAuthenticated(stubBinary),
+      checkAntigravityAuthenticated(stubBinary),
+      checkAntigravityAuthenticated(stubBinary),
+    ]);
+
+    expect(results).toEqual([true, true, true]);
+    // Concurrent calls may all miss the cold cache; what matters is that a
+    // later query is served from cache rather than spawning again.
+    const afterConcurrent = callCount();
+    expect(await checkAntigravityAuthenticated(stubBinary)).toBe(true);
+    expect(callCount()).toBe(afterConcurrent);
+  });
+
+  it("keeps the known verdict when the probe fails for a network reason", async () => {
+    setMode("ok");
+    expect(await checkAntigravityAuthenticated(stubBinary)).toBe(true);
+
+    setMode("network");
+    const pastTtl = { now: () => Date.now() + 120_000 };
+
+    expect(await checkAntigravityAuthenticated(stubBinary, pastTtl)).toBe(true);
+  });
+
+  it("reports signed out when the CLI says authentication is required", async () => {
+    setMode("ok");
+    expect(await checkAntigravityAuthenticated(stubBinary)).toBe(true);
+
+    setMode("signed-out");
+    const pastTtl = { now: () => Date.now() + 120_000 };
+
+    expect(await checkAntigravityAuthenticated(stubBinary, pastTtl)).toBe(
+      false,
+    );
+  });
+
+  it("classifies a network failure as something other than an auth error", () => {
+    expect(isAntigravityAuthError("dial tcp: i/o timeout")).toBe(false);
+    expect(isAntigravityAuthError("Please sign in to continue")).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3663

## Summary

- Cache the Antigravity authentication verdict so the agent roster is not gated on a live Google round-trip.
- Hold the last known verdict when the probe fails for a reason other than authentication.
- Clear the cache on sign-in so a newly authenticated user is recognized immediately.

## The problem

`agy models` is a network call. It ran on every `getAvailability()` for the Antigravity agent, and `getAvailableAgents()` joins all agents with `Promise.all`, so the entire roster waited on it — on the app-init backoff loop and again on every `provider-runtime://ready` event. Every other agent (Claude, Codex, Grok, Claude+Codex) answers from local credential state with no network call.

Measured against the real authenticated CLI 1.1.10, three consecutive cold runs: 2404 ms / 2092 ms / 2074 ms.

Separately, the `catch` mapped every failure to `authenticated: false`, so an offline or slow network silently reported a signed-in user as signed out.

## The fix

The probe remains the only source of truth, per the #3648/#3650 design that deliberately avoids fabricated fallback catalogs. What changed is how often it runs and how its failures are read:

- A 60 s TTL cache keyed by resolved binary.
- A failure that is not an authentication error keeps the previous verdict rather than asserting signed out; a genuine auth error still reports signed out immediately.
- `launchLogin()` clears the cache, so completing Google Sign-In is reflected on the next query rather than after the TTL.

`isAntigravityAuthError` moves from `gemini-runtime.mjs` into `antigravity-binary.mjs`, where the probe classifies its own failures. `gemini-runtime.mjs` already imports from that module, so the dependency direction is preserved and no cycle is introduced.

## Measured result

Against the real installed CLI, same authenticated account:

    cold  : true 2637 ms
    cached: true 0 ms
    cached: true 0 ms

## Audited path

Renderer → local provider runtime → installed Antigravity CLI → Google's authenticated service. No Seren publisher or third-party API path is added or changed.

## Validation

- 6 affected suites: 79 tests passed.
- All 4 new tests confirmed to fail without the fix.
- The new tests drive the real probe against a real stub executable whose behavior (authenticated / network failure / signed out) is switched on disk, so caching and failure classification run against actual process execution rather than a stubbed function.
- Biome passed on all changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
