### PR TITLE
fix(agents): make the first Antigravity spawn survive install edge cases

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -957,18 +957,13 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         try {
           return await ensureAntigravityCli({ emit });
         } catch (error) {
+          // The recovery card is driven by the npm update path, which cannot
+          // reinstall a native binary — a card here would offer a Retry that
+          // throws. The install-progress message and the thrown error are what
+          // reach the user. #3665
           emit?.("provider://cli-install-progress", {
             stage: "action_required",
-            message:
-              "Antigravity needs your attention before Seren can use it.",
-          });
-          emit?.("provider://cli-update-action-required", {
-            label: "Antigravity",
-            bareCommand: "agy",
-            packageName: "antigravity-cli",
-            reason: "installation_required",
-            actions: ["retry", "open_official_instructions"],
-            officialInstructionsUrl: ANTIGRAVITY_INSTALL_URL,
+            message: `Antigravity could not be installed automatically. Install it from ${ANTIGRAVITY_INSTALL_URL}, then start Antigravity again.`,
           });
           throw error;
         }

--- a/bin/browser-local/antigravity-binary.mjs
+++ b/bin/browser-local/antigravity-binary.mjs
@@ -329,13 +329,34 @@ export async function installAntigravity({
   return target;
 }
 
+// Every Antigravity spawn calls through here, so two concurrent first-run
+// spawns would otherwise run two installs against the same staged path and
+// one would fail on a vanished rename. Share a single install instead. #3665
+let installInFlight = null;
+
 export async function ensureAntigravityCli({ emit } = {}) {
   const resolved = resolveAntigravityBinary();
   const installedVersion = await readAntigravityVersion(resolved);
   if (isAntigravityVersionSupported(installedVersion)) {
     return resolved;
   }
-  return installAntigravity({ emit });
+  if (installedVersion === null && resolved !== "agy") {
+    // A resolved install whose version probe fails is usable, not missing:
+    // on an IO-starved machine the probe can time out for a healthy binary,
+    // and failing closed here forces a full re-download — or fails the spawn
+    // outright when offline. Matches the Claude policy from #3471.
+    console.warn(
+      `[antigravity] version probe failed at ${resolved}; spawning without the baseline check`,
+    );
+    return resolved;
+  }
+
+  if (!installInFlight) {
+    installInFlight = installAntigravity({ emit }).finally(() => {
+      installInFlight = null;
+    });
+  }
+  return installInFlight;
 }
 
 export const _validateAntigravityManifest = validateManifest;

--- a/tests/unit/antigravity-install-robustness.test.ts
+++ b/tests/unit/antigravity-install-robustness.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Regression coverage for #3665: a first-run Antigravity spawn must
+// ABOUTME: tolerate a healthy binary whose version probe cannot answer.
+
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+// @ts-expect-error — browser-local runtime is plain ESM without declarations.
+import {
+  ensureAntigravityCli,
+  resolveAntigravityBinary,
+} from "../../bin/browser-local/antigravity-binary.mjs";
+
+// A real executable that never answers --version, standing in for a healthy
+// install on an IO-starved machine whose probe times out. It is placed at the
+// location the production resolver looks in first, under a temporary home, so
+// the real resolver runs unmodified.
+const fakeHome = mkdtempSync(path.join(tmpdir(), "seren-agy-home-"));
+const binDir = path.join(fakeHome, ".local", "bin");
+mkdirSync(binDir, { recursive: true });
+const stubBinary = path.join(binDir, "agy");
+writeFileSync(stubBinary, "#!/bin/sh\nsleep 60\n");
+chmodSync(stubBinary, 0o755);
+
+const originalHome = process.env.HOME;
+const originalPath = process.env.PATH;
+process.env.HOME = fakeHome;
+process.env.PATH = binDir;
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  process.env.PATH = originalPath;
+});
+
+describe("Antigravity first-run install robustness (#3665)", () => {
+  it("spawns a resolved binary whose version probe never answers", async () => {
+    expect(resolveAntigravityBinary()).toBe(stubBinary);
+
+    // Without the tolerance this re-downloads, and fails outright offline.
+    await expect(ensureAntigravityCli({})).resolves.toBe(stubBinary);
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #3665

## Summary

- Tolerate a resolved Antigravity binary whose version probe cannot answer, instead of re-downloading or failing the spawn.
- Share one in-flight install so concurrent first-run spawns cannot race on the staged file.
- Remove an install-failure recovery card the store drops, and name the official install page in the message that does reach the user.

## 1. An unprobeable binary forced a re-download

`readAntigravityVersion` returns `null` on any probe failure, including a timeout on an IO-starved machine, and `null` was treated as unsupported. A perfectly healthy install therefore triggered a full network reinstall on every spawn, and offline the spawn failed outright with a download error.

This is the same failure mode the v3.75.0 release gate hit for Claude (#3471), which is why `allowUnprobeableInstall` exists. Antigravity now follows that policy: a resolved binary whose probe fails spawns permissively and logs; baseline enforcement resumes on the next probe that succeeds.

The regression test demonstrates the difference against a real executable that never answers `--version`. Without the fix the test takes ~16 s and fails, having actually downloaded the release from Google; with the fix it resolves immediately.

## 2. Concurrent installs raced on a shared staged path

`ensureGeminiCli` runs on every spawn, and `installAntigravity` staged to a fixed `<target>.seren-new` sibling. Two concurrent first-run spawns — a chat thread plus a Mission Control lane, or two quick new-thread clicks — could have one install rename the staged file away while the other was mid-flight, or have one `finally` delete the other's staged copy before its rename. Both writers carry identical SHA-512-verified bytes, so no corrupt binary could ever activate, but a spawn failed visibly.

Installs now share a single in-flight promise. Staging deliberately stays on the sibling path: `os.tmpdir()` can be a different filesystem, where `rename` fails EXDEV.

## 3. A recovery card that could not recover

The install-failure path emitted `provider://cli-update-action-required` with `bareCommand: "agy"`. The store filters that to claude/codex, so it was dropped — and correctly so: the card's Retry routes to `runCliUpdate`, whose `cliUpdateConfigs` has no `agy` entry and throws `Unsupported CLI update target`. Surfacing the card would have handed the user a button that fails.

Rather than add UI to explain a dead end, the dead emit is removed and the `provider://cli-install-progress` message — which the store does consume and display — now names the official install page. Wiring a real retry for a native-binary installer is a separate design question.

## Audited path

Renderer → local provider runtime → Google's manifest and storage origin for the verified binary. No Seren publisher or third-party API path is added or changed. Manifest origin pinning, artifact allowlisting, SHA-512 verification, and the post-install version gate are all untouched.

## Validation

- 5 affected suites: 82 tests passed.
- The new test was confirmed to fail without the fix and pass with it.
- It drives the real resolver and the real `ensureAntigravityCli` against a real executable under a temporary home — nothing is mocked.
- The install dedupe is not unit-tested: forcing it would require two concurrent 165 MB downloads from Google. It is a single shared promise around the existing call and is covered by the live walkthrough.
- Biome passed on all changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
