### PR TITLE
fix(ci): fail fast on a stalled Antigravity fetch in the Windows gate

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -620,7 +620,7 @@ try {
   # production installer: trust only Google's platform manifest/storage path
   # and verify SHA-512 before the release gate launches the app.
   `$agyManifestOrigin = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app"
-  `$agyManifest = Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json"
+  `$agyManifest = Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json" -UseBasicParsing -TimeoutSec 60
   `$agyArtifactUri = [Uri][string]`$agyManifest.url
   if (
     `$agyArtifactUri.Scheme -ne "https" -or
@@ -635,7 +635,7 @@ try {
   `$previousProgress = `$ProgressPreference
   `$ProgressPreference = "SilentlyContinue"
   try {
-    Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath
+    Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath -UseBasicParsing -TimeoutSec 300
   } finally {
     `$ProgressPreference = `$previousProgress
   }

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -553,6 +553,15 @@ describe("Windows production e2e release gate", () => {
     expect(taskUserRunner).toContain("Get-FileHash");
     expect(taskUserRunner).toContain("SHA512");
     expect(taskUserRunner).toContain('"agy.exe"');
+    // Windows PowerShell 5.1 applies no timeout by default, so a stalled
+    // Antigravity fetch would hang the gate until the outer task timeout
+    // instead of failing fast. #3668
+    for (const antigravityFetch of [
+      'Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json" -UseBasicParsing -TimeoutSec 60',
+      "Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath -UseBasicParsing -TimeoutSec 300",
+    ]) {
+      expect(taskUserRunner).toContain(antigravityFetch);
+    }
     expect(taskUserRunner).toContain("@xai-official/grok@latest");
     for (const [label, binary] of [
       ["Claude Code", "claude.cmd"],


### PR DESCRIPTION
Closes #3668

## Summary

Add `-UseBasicParsing -TimeoutSec` to the two Antigravity network calls in the Windows release-gate script, matching the Node download beside them.

## Why

The generated script runs under Windows PowerShell 5.1 as a freshly created disposable user. PS 5.1 applies no default timeout, so a stalled manifest fetch or binary download hangs the gate until the outer 4800 s task timeout kills the entire run — a slow, illegible release failure instead of the fast fail this script standardized in #3136.

The Node download in the same script has used these flags all along:

    Invoke-WebRequest -Uri $nodeUrl -OutFile $nodeZip -UseBasicParsing -TimeoutSec 120

The two Antigravity calls added by #3650 had neither. `-UseBasicParsing` additionally avoids the PS 5.1 Internet-Explorer-engine error that a fresh user profile can hit when a response engages HTML parsing, such as an HTML error or redirect body.

## Validation

- Windows release-gate suite: 36 tests passed.
- The new assertions were confirmed to fail when only the script is reverted, so they pin the flags rather than passing vacuously.
- **This block has never run on the real e2e box** — no tag has been cut since the Antigravity migration merged. Per the Windows harness constraint, it can only be validated by a real tag-driven release run, which the v3.78.0 tag will be. The unit assertions pin the script contract; they do not prove PowerShell behavior.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
