### PR TITLE
fix(deps): pin the secrets crypto dependency to an exact revision

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "seren-secrets-crypto"
 version = "0.4.0"
-source = "git+https://github.com/serenorg/seren-secrets.git#8d1b94a3e1bf30650798b3c68905933a3579fad8"
+source = "git+https://github.com/serenorg/seren-secrets.git?rev=8d1b94a3e1bf30650798b3c68905933a3579fad8#8d1b94a3e1bf30650798b3c68905933a3579fad8"
 dependencies = [
  "aes",
  "argon2",
@@ -8073,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "seren-secrets-macros"
 version = "0.4.0"
-source = "git+https://github.com/serenorg/seren-secrets.git#8d1b94a3e1bf30650798b3c68905933a3579fad8"
+source = "git+https://github.com/serenorg/seren-secrets.git?rev=8d1b94a3e1bf30650798b3c68905933a3579fad8#8d1b94a3e1bf30650798b3c68905933a3579fad8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,7 +66,7 @@ postgres = { version = "0.19", features = ["with-serde_json-1"] }
 tokio-postgres-rustls = "0.14"
 rustls = "0.23"
 webpki-roots = "1"
-seren-secrets-crypto = { git = "https://github.com/serenorg/seren-secrets.git" }
+seren-secrets-crypto = { git = "https://github.com/serenorg/seren-secrets.git", rev = "8d1b94a3e1bf30650798b3c68905933a3579fad8" }
 rmcp = { version = "1.2", features = [
     "client",
     "transport-io",                           # stdio for local MCP servers


### PR DESCRIPTION
Closes #3667

## Summary

Pin `seren-secrets-crypto` to the exact revision `Cargo.lock` already resolves to, restoring an immutable reference for the crate that encrypts stored secrets.

## Why

The dependency was changed from `tag = "v0.4.0"` to an unpinned git dependency, unrelated to the stated purpose of the commit that made the change. `Cargo.lock` pinned `8d1b94a3`, which is currently upstream `main` HEAD, so today's build was deterministic — but the guardrail was gone:

- A future `cargo update` would silently adopt whatever landed on that branch, with no review checkpoint, on the crate that protects secrets at rest.
- A rebase or force-push upstream that drops `8d1b94a3` would break every release build with an unfetchable revision.

The upstream content bump itself was intentional — `8d1b94a3` is three commits past `v0.4.0` and carries the hosted-employee identity signing the employees work depends on. Only the missing pin was the defect, so this pins forward rather than reverting to `v0.4.0`.

## No build change

`Cargo.lock` resolves to the same commit before and after:

    source = "git+https://github.com/serenorg/seren-secrets.git?rev=8d1b94a3...#8d1b94a3..."

Both `seren-secrets-crypto` and the transitive `seren-secrets-macros` now carry the explicit `rev`.

A tag upstream (for example `v0.5.0`) would read better than a raw revision; that requires a release in the seren-secrets repository, so this pins by revision now and can move to a tag whenever one is cut.

## Validation

- `cargo check` passed against the pinned revision.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
