### PR TITLE
fix(auth): give skill processes a publisher-only key

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -1049,7 +1049,7 @@ pub async fn recall_preference_from_db(
 /// API key is missing the user needs to log in to Seren Desktop (the login
 /// flow stores the key via `storeSerenApiKey()`).
 fn read_seren_api_key(app: &AppHandle) -> Result<String, String> {
-    let key = crate::credential_store::get_seren_api_key(app)?.unwrap_or_default();
+    let key = crate::credential_store::get_seren_skill_api_key(app)?.unwrap_or_default();
     if key.is_empty() {
         return Err(
             "SerenDB API key not available — log in to Seren Desktop so the key is provisioned"

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -197,7 +197,7 @@ pub async fn claude_memory_render_memory_md(
     let encoded = claude_memory::encode_project_dir(Path::new(&project_cwd));
     let claude_project_dir: PathBuf = root.join(&encoded);
 
-    let api_key = crate::credential_store::get_seren_api_key(&app)?.unwrap_or_default();
+    let api_key = crate::credential_store::get_seren_skill_api_key(&app)?.unwrap_or_default();
     if api_key.is_empty() {
         return Err(
             "SerenDB API key not available — log in to Seren Desktop so the key is provisioned"

--- a/src-tauri/src/credential_store.rs
+++ b/src-tauri/src/credential_store.rs
@@ -17,6 +17,7 @@ const METADATA_STORE: &str = "credential-metadata.json";
 const TOKEN_KEY: &str = "token";
 const REFRESH_TOKEN_KEY: &str = "refresh_token";
 const SEREN_API_KEY: &str = "seren_api_key";
+const SEREN_SKILL_API_KEY: &str = "seren_skill_api_key";
 const MCP_ACCESS_TOKEN_KEY: &str = "mcp_access_token";
 const MCP_REFRESH_TOKEN_KEY: &str = "mcp_refresh_token";
 
@@ -27,6 +28,7 @@ const PROVIDER_OAUTH: &str = "provider_oauth";
 const ACCESS_TOKEN_ACCOUNT: &str = "seren.auth.access-token.v1";
 const REFRESH_TOKEN_ACCOUNT: &str = "seren.auth.refresh-token.v1";
 const SEREN_API_KEY_ACCOUNT: &str = "seren.api-key.v1";
+const SEREN_SKILL_API_KEY_ACCOUNT: &str = "seren.skill-api-key.v1";
 const MCP_ACCESS_TOKEN_ACCOUNT: &str = "seren.mcp-oauth.access-token.v1";
 const MCP_REFRESH_TOKEN_ACCOUNT: &str = "seren.mcp-oauth.refresh-token.v1";
 
@@ -142,6 +144,7 @@ impl SecureBackend for TestMemorySecureBackend {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProtectedSetting {
     SerenApiKey,
+    SerenSkillApiKey,
     McpAccessToken,
     McpRefreshToken,
 }
@@ -149,6 +152,7 @@ pub(crate) enum ProtectedSetting {
 pub(crate) fn protected_setting(store: &str, key: &str) -> Option<ProtectedSetting> {
     match (store, key) {
         (AUTH_STORE, SEREN_API_KEY) => Some(ProtectedSetting::SerenApiKey),
+        (AUTH_STORE, SEREN_SKILL_API_KEY) => Some(ProtectedSetting::SerenSkillApiKey),
         (MCP_OAUTH_STORE, MCP_ACCESS_TOKEN_KEY) => Some(ProtectedSetting::McpAccessToken),
         (MCP_OAUTH_STORE, MCP_REFRESH_TOKEN_KEY) => Some(ProtectedSetting::McpRefreshToken),
         _ => None,
@@ -189,6 +193,15 @@ impl CredentialDescriptor<'static> {
             AUTH_STORE,
             SEREN_API_KEY,
             "Seren API key",
+        )
+    }
+
+    fn seren_skill_api_key() -> Self {
+        Self::fixed(
+            SEREN_SKILL_API_KEY_ACCOUNT,
+            AUTH_STORE,
+            SEREN_SKILL_API_KEY,
+            "Seren skill API key",
         )
     }
 
@@ -741,6 +754,27 @@ pub(crate) fn clear_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), 
     delete(app, CredentialDescriptor::seren_api_key())
 }
 
+pub(crate) fn store_seren_skill_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+    value: &str,
+) -> Result<(), String> {
+    store(app, CredentialDescriptor::seren_skill_api_key(), value)
+}
+
+/// The publisher-invocation-only key handed to skill child processes and the
+/// SerenDB data plane. Deliberately separate from the Desktop key, which also
+/// carries publisher-administration scopes for the approval-gated MCP path
+/// and must never be exported into a child process. #3675
+pub(crate) fn get_seren_skill_api_key<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Option<String>, String> {
+    read(app, CredentialDescriptor::seren_skill_api_key())
+}
+
+pub(crate) fn clear_seren_skill_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    delete(app, CredentialDescriptor::seren_skill_api_key())
+}
+
 pub(crate) fn store_provider_api_key<R: Runtime>(
     app: &AppHandle<R>,
     provider: &str,
@@ -842,6 +876,7 @@ pub(crate) fn get_protected_setting<R: Runtime>(
 ) -> Result<Option<String>, String> {
     match setting {
         ProtectedSetting::SerenApiKey => get_seren_api_key(app),
+        ProtectedSetting::SerenSkillApiKey => get_seren_skill_api_key(app),
         ProtectedSetting::McpAccessToken => read(app, CredentialDescriptor::mcp_access_token()),
         ProtectedSetting::McpRefreshToken => read(app, CredentialDescriptor::mcp_refresh_token()),
     }
@@ -855,6 +890,7 @@ pub(crate) fn set_protected_setting<R: Runtime>(
     if value.trim().is_empty() {
         return match setting {
             ProtectedSetting::SerenApiKey => clear_seren_api_key(app),
+            ProtectedSetting::SerenSkillApiKey => clear_seren_skill_api_key(app),
             ProtectedSetting::McpAccessToken => {
                 delete(app, CredentialDescriptor::mcp_access_token())
             }
@@ -866,6 +902,7 @@ pub(crate) fn set_protected_setting<R: Runtime>(
 
     match setting {
         ProtectedSetting::SerenApiKey => store_seren_api_key(app, value),
+        ProtectedSetting::SerenSkillApiKey => store_seren_skill_api_key(app, value),
         ProtectedSetting::McpAccessToken => {
             store(app, CredentialDescriptor::mcp_access_token(), value)
         }
@@ -926,6 +963,26 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// The skill key exists so a child process never receives the Desktop
+    /// key's publisher-administration scopes. Aliasing the two slots would
+    /// silently hand the broad key back to skills. #3675
+    #[test]
+    fn skill_key_never_aliases_the_desktop_key_slot() {
+        let desktop = CredentialDescriptor::seren_api_key();
+        let skill = CredentialDescriptor::seren_skill_api_key();
+
+        assert_ne!(desktop.account, skill.account);
+        assert_ne!(desktop.legacy_key, skill.legacy_key);
+        assert_eq!(
+            protected_setting(AUTH_STORE, SEREN_SKILL_API_KEY),
+            Some(ProtectedSetting::SerenSkillApiKey)
+        );
+        assert_eq!(
+            protected_setting(AUTH_STORE, SEREN_API_KEY),
+            Some(ProtectedSetting::SerenApiKey)
+        );
+    }
 
     #[derive(Default)]
     struct MemorySecureBackend {

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -678,8 +678,13 @@ async fn spawn_one_shot(
     })
 }
 
+/// Skills receive the publisher-invocation-only key, never the Desktop key.
+/// The Desktop key also carries publisher-administration scopes, and those are
+/// protected by the in-app approval gate on the MCP dispatch path — a gate that
+/// cannot apply to a value a child process already holds in its environment.
+/// Fails closed: a signed-out user has no key either way. #3675
 fn read_stored_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
-    let key = crate::credential_store::get_seren_api_key(app)?.unwrap_or_default();
+    let key = crate::credential_store::get_seren_skill_api_key(app)?.unwrap_or_default();
 
     let trimmed = key.trim();
     if trimmed.is_empty() {
@@ -820,7 +825,9 @@ mod tests {
 
         app.manage(crate::credential_store::CredentialStoreState::new_memory_for_tests());
         if let Some(api_key) = api_key {
-            crate::credential_store::store_seren_api_key(app.handle(), api_key)
+            // Skills receive the publisher-invocation-only key, so that is the
+            // slot these command tests seed. #3675
+            crate::credential_store::store_seren_skill_api_key(app.handle(), api_key)
                 .expect("test API key stores in memory");
         }
 
@@ -904,7 +911,34 @@ mod tests {
         assert_eq!(result.exit_code, Some(0));
         assert!(
             result.stdout.contains("seren_test_shell_key"),
-            "skill-path commands must keep receiving desktop auth"
+            "skill-path commands must keep receiving Seren auth"
+        );
+    }
+
+    /// The Desktop key carries publisher-administration scopes that are only
+    /// safe behind the in-app approval gate. A skill process holds whatever it
+    /// is handed, so the Desktop key must never reach one — even when it is the
+    /// only credential stored. #3675
+    #[tokio::test]
+    async fn skill_path_command_never_receives_the_desktop_key() {
+        let app = mock_app_with_api_key(None);
+        crate::credential_store::store_seren_api_key(app.handle(), "seren_desktop_admin_key")
+            .expect("desktop key stores in memory");
+        let command = format!(
+            "cd ~/.config/seren/skills/example 2>/dev/null; {}",
+            print_seren_key_env_command()
+        );
+
+        let auth_handle = handle_for_command(&app, &command);
+        let result =
+            execute_shell_command(app.handle().clone(), command, Some(5), Some(true), auth_handle)
+                .await
+                .expect("command succeeds");
+
+        assert_eq!(result.exit_code, Some(0));
+        assert!(
+            !result.stdout.contains("seren_desktop_admin_key"),
+            "the Desktop key must never be exported into a skill process"
         );
     }
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -9,6 +9,7 @@ import {
 const TOKEN_STORAGE_KEY = "seren_token";
 const REFRESH_TOKEN_STORAGE_KEY = "seren_refresh_token";
 const API_KEY_STORAGE_KEY = "seren_api_key";
+const SKILL_API_KEY_STORAGE_KEY = "seren_skill_api_key";
 const DEFAULT_ORG_ID_STORAGE_KEY = "seren_default_org_id";
 
 /**
@@ -159,6 +160,38 @@ export async function storeSerenApiKey(apiKey: string): Promise<void> {
 }
 
 /**
+ * Store the publisher-invocation-only key handed to skill child processes and
+ * the SerenDB data plane. Kept apart from the Desktop key, which also carries
+ * publisher-administration scopes that must stay behind the approval gate.
+ * See #3675.
+ */
+export async function storeSerenSkillApiKey(apiKey: string): Promise<void> {
+  const invoke = await getInvoke();
+  if (invoke) {
+    await invoke("set_setting", {
+      store: "auth.json",
+      key: "seren_skill_api_key",
+      value: apiKey,
+    });
+  } else {
+    devStorage.setItem(SKILL_API_KEY_STORAGE_KEY, apiKey);
+  }
+}
+
+/** Retrieve the stored skill API key. Returns null if none is stored. */
+export async function getSerenSkillApiKey(): Promise<string | null> {
+  const invoke = await getInvoke();
+  if (invoke) {
+    const result = await invoke<string | null>("get_setting", {
+      store: "auth.json",
+      key: "seren_skill_api_key",
+    });
+    return result && result.length > 0 ? result : null;
+  }
+  return devStorage.getItem(SKILL_API_KEY_STORAGE_KEY);
+}
+
+/**
  * Retrieve stored Seren API key.
  * Returns null if no key is stored.
  */
@@ -189,6 +222,20 @@ export async function clearSerenApiKey(): Promise<void> {
   } else {
     // Browser fallback for testing
     devStorage.removeItem(API_KEY_STORAGE_KEY);
+  }
+}
+
+/** Clear the stored skill API key (logout). */
+export async function clearSerenSkillApiKey(): Promise<void> {
+  const invoke = await getInvoke();
+  if (invoke) {
+    await invoke("set_setting", {
+      store: "auth.json",
+      key: "seren_skill_api_key",
+      value: "",
+    });
+  } else {
+    devStorage.removeItem(SKILL_API_KEY_STORAGE_KEY);
   }
 }
 

--- a/src/services/desktop-api-access.ts
+++ b/src/services/desktop-api-access.ts
@@ -9,9 +9,25 @@ import {
   listDefaultOrgApiKeys,
   revokeDefaultOrgApiKey,
 } from "@/api";
-import { getSerenApiKey, storeSerenApiKey } from "@/lib/tauri-bridge";
+import {
+  getSerenApiKey,
+  getSerenSkillApiKey,
+  storeSerenApiKey,
+  storeSerenSkillApiKey,
+} from "@/lib/tauri-bridge";
 
 export const DESKTOP_API_KEY_NAME = "Seren Desktop";
+export const SKILL_API_KEY_NAME = "Seren Desktop Skills";
+
+/**
+ * Skill child processes and the SerenDB data plane only ever invoke
+ * publishers. They receive this key instead of the Desktop key so that the
+ * publisher-administration scopes below — which are safe on the Desktop key
+ * because every mutation there is approval-gated on the MCP dispatch path —
+ * are never exported into a process that can call the REST API directly.
+ * See #3675.
+ */
+export const SKILL_API_KEY_SCOPES = ["publisher:*"] as const;
 export const DESKTOP_API_KEY_SCOPES = [
   "publisher:*",
   "managed-deployment:update",
@@ -285,4 +301,71 @@ export function repairDesktopApiKey(
   });
 
   return repairInFlight;
+}
+
+async function skillKeyNeedsReplacement(storedKey: string): Promise<boolean> {
+  const keyId = publicKeyId(storedKey);
+  if (!keyId) return true;
+
+  const { data, error, response } = await listDefaultOrgApiKeys({
+    throwOnError: false,
+  });
+  if (error || !data?.data) {
+    throw await apiKeyRequestError("Failed to inspect skill API key", response);
+  }
+
+  const record = data.data.find((candidate) => candidate.key_id === keyId);
+  if (!record || record.revoked_at) return true;
+  if (
+    record.expires_at !== null &&
+    record.expires_at !== undefined &&
+    new Date(record.expires_at).getTime() <= Date.now()
+  ) {
+    return true;
+  }
+
+  const scopes = new Set(record.scopes ?? []);
+  const required = new Set<string>(SKILL_API_KEY_SCOPES);
+  return (
+    scopes.size !== required.size ||
+    [...required].some((scope) => !scopes.has(scope))
+  );
+}
+
+let skillKeyInFlight: Promise<void> | null = null;
+
+/**
+ * Provision the publisher-invocation-only key that skill child processes and
+ * the SerenDB data plane receive. Reconciled the same way as the Desktop key so
+ * a key minted by an older build cannot linger with broader scopes.
+ */
+export function ensureSkillApiKey(): Promise<void> {
+  if (skillKeyInFlight) return skillKeyInFlight;
+
+  skillKeyInFlight = (async () => {
+    const existing = await getSerenSkillApiKey();
+    if (existing && !(await skillKeyNeedsReplacement(existing))) return;
+
+    const previousKeyId = existing ? publicKeyId(existing) : null;
+    const created = await createApiKeyRecord({
+      name: SKILL_API_KEY_NAME,
+      scopes: SKILL_API_KEY_SCOPES,
+    });
+    // Store before revoking so a failed revoke cannot strand skills without a
+    // usable key, matching repairDesktopApiKey.
+    await storeSerenSkillApiKey(created.api_key);
+
+    if (previousKeyId) {
+      const { data } = await listDefaultOrgApiKeys({ throwOnError: false });
+      const stale = data?.data?.find(
+        (candidate) =>
+          candidate.key_id === previousKeyId && !candidate.revoked_at,
+      );
+      if (stale) await revokeKeyRecord(stale).catch(() => undefined);
+    }
+  })().finally(() => {
+    skillKeyInFlight = null;
+  });
+
+  return skillKeyInFlight;
 }

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -7,6 +7,7 @@ import { runtimeHasCapability } from "@/lib/runtime";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
   clearSerenApiKey,
+  clearSerenSkillApiKey,
   getSerenApiKey,
   isTauriRuntime,
   storeSerenApiKey,
@@ -19,6 +20,7 @@ import {
 } from "@/services/auth";
 import { resumeCredentialLeases } from "@/services/credential-lease";
 import {
+  ensureSkillApiKey,
   getDesktopApiKeyStatus,
   repairDesktopApiKey,
 } from "@/services/desktop-api-access";
@@ -102,6 +104,7 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
           "[Auth Store] Stored API key scopes are current",
         );
       }
+      await ensureSkillApiKey();
       return { ok: true };
     }
 
@@ -114,6 +117,7 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
     verboseRuntimeConsole.debug(
       "[Auth Store] API key created and stored successfully",
     );
+    await ensureSkillApiKey();
     return { ok: true };
   } catch (error) {
     console.error("[Auth Store] Failed to ensure API key:", error);
@@ -356,8 +360,9 @@ export async function logout(): Promise<void> {
   // Reset MCP Gateway state
   await resetGateway();
 
-  // Clear stored API key
+  // Clear stored API keys
   await clearSerenApiKey();
+  await clearSerenSkillApiKey();
 
   await authLogout();
   await resetSkillsCatalog();

--- a/tests/unit/claude-memory-user-scoped-auth.test.ts
+++ b/tests/unit/claude-memory-user-scoped-auth.test.ts
@@ -27,9 +27,18 @@ describe("seren-db memory path uses the user-scoped credential (#2497 Defect 2)"
     // …and that key is read through the same OS-backed boundary the desktop
     // key lands in, never directly from auth.json.
     expect(rustWatcher).toMatch(/fn read_seren_api_key/);
-    expect(rustWatcher).toMatch(/credential_store::get_seren_api_key\(app\)/);
+    // The credential is the publisher-invocation-only key (#3675). It is still
+    // user-scoped and still read through the OS-backed boundary; it simply
+    // omits the publisher-administration scopes this path never uses.
+    expect(rustWatcher).toMatch(
+      /credential_store::get_seren_skill_api_key\(app\)/,
+    );
+    expect(rustWatcher).not.toMatch(/credential_store::get_seren_api_key\(app\)/);
     expect(credentialStore).toMatch(
       /const SEREN_API_KEY_ACCOUNT: &str = "seren\.api-key\.v1"/,
+    );
+    expect(credentialStore).toMatch(
+      /const SEREN_SKILL_API_KEY_ACCOUNT: &str = "seren\.skill-api-key\.v1"/,
     );
     expect(rustWatcher).not.toMatch(/\.store\("auth\.json"\)/);
   });

--- a/tests/unit/skill-api-key-scopes.test.ts
+++ b/tests/unit/skill-api-key-scopes.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Regression coverage for #3675: the key injected into skill child
+// ABOUTME: processes must never carry publisher-administration scopes.
+
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_API_KEY_SCOPES,
+  SKILL_API_KEY_SCOPES,
+} from "@/services/desktop-api-access";
+
+const ADMINISTRATION_PREFIXES = [
+  "publisher-definition:",
+  "publisher-pricing:",
+  "oauth-provider:",
+  "oauth-connection:",
+  "organization:",
+  "managed-deployment:",
+];
+
+describe("skill API key scopes (#3675)", () => {
+  it("grants publisher invocation and nothing else", () => {
+    expect([...SKILL_API_KEY_SCOPES]).toEqual(["publisher:*"]);
+  });
+
+  it("carries no administration scope that the approval gate protects", () => {
+    // These are safe on the Desktop key because every mutation through it is
+    // classified HighRisk on the MCP dispatch path. That gate cannot apply to
+    // a value a skill process already holds, so it must not be exported.
+    for (const scope of SKILL_API_KEY_SCOPES) {
+      for (const prefix of ADMINISTRATION_PREFIXES) {
+        expect(scope.startsWith(prefix)).toBe(false);
+      }
+    }
+  });
+
+  it("is a strict subset of the Desktop key", () => {
+    const desktop = new Set<string>(DESKTOP_API_KEY_SCOPES);
+    for (const scope of SKILL_API_KEY_SCOPES) {
+      expect(desktop.has(scope)).toBe(true);
+    }
+    expect(SKILL_API_KEY_SCOPES.length).toBeLessThan(
+      DESKTOP_API_KEY_SCOPES.length,
+    );
+  });
+});


### PR DESCRIPTION
Closes #3675

## Summary

Skill child processes and the SerenDB data plane now receive a publisher-invocation-only key instead of the key the chat Gateway MCP uses. The Desktop key and the MCP path are untouched.

## The problem

One stored credential served two channels with very different protections.

`src/services/mcp-gateway.ts:388/414/715` authenticates the built-in Seren MCP connection with the Desktop key, and every mutation there is classified `HighRisk` in `tool_authorization.rs`, so `create_publisher`, `update_publisher_pricing`, `create_org_oauth_provider` and friends each prompt for explicit approval. That channel is correct and genuinely needs the scopes #3652 added.

`src-tauri/src/shell.rs` read the same key and exported it into skill processes as `SEREN_API_KEY` / `API_KEY`. Once a skill holds that value it can call `api.serendb.com` directly with `curl`; `classify_operation` never runs, because that gate covers the app's MCP dispatch, not an environment variable inside a child process. `oauth-provider:update` in that position is a credential-interception primitive — an approved skill could repoint an organization OAuth provider's `token_url` at an endpoint it controls, affecting every user who later connects that provider.

## The fix

Neither credential-injected consumer needs an administration scope — skills invoke publishers, and Claude memory calls `/publishers/seren-db/*`. So the credential is split rather than the shared one narrowed, which keeps #3652's design intact:

- New `SKILL_API_KEY_SCOPES = ["publisher:*"]`, provisioned as a `Seren Desktop Skills` key through the existing create/reconcile/revoke machinery in `desktop-api-access.ts`. It reconciles the same way the Desktop key does, so a key minted by an older build cannot linger with broader scopes.
- New `seren_skill_api_key` credential slot (`seren.skill-api-key.v1`), distinct account and legacy key from the Desktop slot.
- `shell.rs`, `claude_memory.rs`, and `commands/claude_memory.rs` read the new slot.
- Provisioned inside `ensureApiKey()` — the same sign-in flow that mints the Desktop key — and cleared on logout alongside it.

`DESKTOP_API_KEY_SCOPES`, `getDesktopApiKeyStatus`, `repairDesktopApiKey`, the Settings surface, and the Gateway MCP path are all unchanged.

**Fails closed by construction.** A signed-out user has no key in either slot, so injection stays empty exactly as before. `publisher:*` alone was the Desktop key's entire scope set before #3606 added managed-deployment lifecycle, so a publisher-only key is a shape the Gateway has always accepted.

## Regression coverage

- `tests/unit/skill-api-key-scopes.test.ts` — the injected scope set is exactly `publisher:*`, carries no `publisher-definition:` / `publisher-pricing:` / `oauth-provider:` / `oauth-connection:` / `organization:` / `managed-deployment:` scope, and is a strict subset of the Desktop key.
- `shell.rs::skill_path_command_never_receives_the_desktop_key` — with only the Desktop key stored, a skill-path command's environment does not contain it. This is the assertion that would have caught the original defect.
- `credential_store.rs::skill_key_never_aliases_the_desktop_key_slot` — the two descriptors cannot collapse onto one slot.
- `claude-memory-user-scoped-auth.test.ts` updated: its #2497 invariant (user-scoped credential through the OS-backed boundary, never an agent/gateway key, never raw `auth.json`) is preserved and now also pins that the broad key is *not* used.

## Validation

- Full Rust suite: 1,312 passed, 0 failed.
- Full frontend suite: 437 files, 3,005 tests passed.
- `pnpm check` passes; production build passes.

**Not yet verified live:** minting the narrow key against the Gateway and confirming it invokes a publisher while a publisher-administration call returns 403. That needs a signed-in session and creates a real key on the org, so it is left for a signed-in run rather than done unprompted. To close it: sign in, then confirm a `Seren Desktop Skills` key appears with only `publisher:*`, that an installed skill using `SEREN_API_KEY` still succeeds, and that Claude memory sync still works.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
