### PR TITLE
fix(auth): stop a skill key failure from signing the user out

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -81,6 +81,23 @@ type EnsureApiKeyResult =
  * Fresh installs create one. Existing installs reconcile the server-side scope
  * record so keys minted by an older Desktop build cannot remain under-scoped.
  */
+/**
+ * The skill key is needed only by skill child processes and the Claude memory
+ * interceptor — never by sign-in or the chat path. Its failure must not reach
+ * `ensureApiKey`'s result, because a 403 there clears the session and raises
+ * the blocking sign-in modal. Retries on the next refresh. #3677
+ */
+async function provisionSkillApiKey(): Promise<void> {
+  try {
+    await ensureSkillApiKey();
+  } catch (error) {
+    console.warn(
+      "[Auth Store] Skill API key provisioning failed; skills and Claude memory will retry on next refresh:",
+      error,
+    );
+  }
+}
+
 export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
   try {
     const existingKey = await getSerenApiKey();
@@ -104,7 +121,7 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
           "[Auth Store] Stored API key scopes are current",
         );
       }
-      await ensureSkillApiKey();
+      await provisionSkillApiKey();
       return { ok: true };
     }
 
@@ -117,7 +134,7 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
     verboseRuntimeConsole.debug(
       "[Auth Store] API key created and stored successfully",
     );
-    await ensureSkillApiKey();
+    await provisionSkillApiKey();
     return { ok: true };
   } catch (error) {
     console.error("[Auth Store] Failed to ensure API key:", error);

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -13,6 +13,7 @@ const {
   createApiKeyMock,
   getDesktopApiKeyStatusMock,
   repairDesktopApiKeyMock,
+  ensureSkillApiKeyMock,
   authLogoutMock,
   initializeGatewayMock,
   resetGatewayMock,
@@ -41,6 +42,7 @@ const {
     createApiKeyMock: vi.fn(async () => "seren-api-key-fresh"),
     getDesktopApiKeyStatusMock: vi.fn(),
     repairDesktopApiKeyMock: vi.fn(),
+    ensureSkillApiKeyMock: vi.fn(async () => {}),
     authLogoutMock: vi.fn(async () => {}),
     initializeGatewayMock: vi.fn(async () => {}),
     resetGatewayMock: vi.fn(async () => {}),
@@ -81,6 +83,7 @@ vi.mock("@/services/auth", () => ({
 vi.mock("@/services/desktop-api-access", () => ({
   getDesktopApiKeyStatus: getDesktopApiKeyStatusMock,
   repairDesktopApiKey: repairDesktopApiKeyMock,
+  ensureSkillApiKey: ensureSkillApiKeyMock,
 }));
 
 vi.mock("@/api", () => ({
@@ -332,6 +335,27 @@ describe("auth.store #2497 — API key provisioning failure handling", () => {
       expect(authStore.isAuthenticated).toBe(false);
       expect(authStore.signInModalRequested).toBe(true);
       expect(storeSerenApiKeyMock).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const status of [403, 500]) {
+    it(`skill key failure (HTTP ${status}) keeps the session signed in`, async () => {
+      // The skill key serves skill child processes and the Claude memory
+      // interceptor only. A 403 on the Desktop key legitimately forces
+      // re-sign-in; the same status on this secondary key must not. #3677
+      storedKeyRef.value = null;
+      ensureSkillApiKeyMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Forbidden (returned HTTP ${status})`), {
+          status,
+        }),
+      );
+
+      await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+      expect(authStore.isAuthenticated).toBe(true);
+      expect(authStore.signInModalRequested).toBe(false);
+      // The Desktop key still provisioned normally.
+      expect(storeSerenApiKeyMock).toHaveBeenCalled();
     });
   }
 


### PR DESCRIPTION
Closes #3677

## Summary

- A skill API key failure can no longer sign the user out.
- Restore the auth-store key-ordering suite, which had silently stopped covering its success path.

## The sign-out defect

#3676 called `ensureSkillApiKey()` inside `ensureApiKey()`'s `try` block, so an error it threw became `ensureApiKey()`'s result. The caller reads that status as a verdict on the session:

    if (apiKey.status === 401 || apiKey.status === 403) {
      clearAuthState();
      requestSignInModal();
      return false;
    }

A 403 on the second create call — an organization key policy, a quota, or any permission difference between the two calls — therefore cleared the session and raised the blocking sign-in modal for a user whose JWT and Desktop key were both healthy.

The surrounding code already reasons about this correctly for the Desktop key: its comment notes that the SerenDB key is needed by MCP tools and the Claude memory interceptor but "NOT by the primary chat path", and that blocking there "would break chat for an otherwise-valid user". The skill key is strictly weaker again — skill child processes and Claude memory only — so it must never be able to fail a sign-in.

It is now provisioned through a wrapper that logs and continues, and retries on the next refresh. `ensureApiKey`'s contract about the Desktop key is unchanged, so the existing 401/403 and 5xx behavior for that key still holds.

## The silent test regression

`tests/unit/auth-store-apikey-ordering.test.ts` mocks `@/services/desktop-api-access` with an explicit factory. #3676 added an `ensureSkillApiKey` import to the store without adding it to that mock, so every test in the file hit:

    [Auth Store] Failed to ensure API key: Error: [vitest] No "ensureSkillApiKey" export is defined on the "@/services/desktop-api-access" mock.

The store caught it and returned `{ ok: false }`, so all ten tests kept passing — while exercising the provisioning-failure path instead of the success path they were written to protect. The mock now provides the export, and the "Failed to ensure API key" noise is gone from the run.

This is the failure mode the repository's testing rules call out: green tests that no longer touch the layer they claim to cover. Worth noting it would have gone unnoticed had the post-merge walkthrough not read the test output rather than just the pass count.

## Regression coverage

`skill key failure (HTTP 403|500) keeps the session signed in` — asserts `isAuthenticated` stays true, no sign-in modal is raised, and the Desktop key still stores. Confirmed to fail on the 403 case without the wrapper and pass with it.

## Validation

- Full frontend suite: 437 files, 3,007 tests passed.
- `pnpm check` passes; production build passes.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
