### PR TITLE
fix(agent): restore automatic CLI provisioning

### DIFF
--- a/.github/workflows/validation-walkthrough.yml
+++ b/.github/workflows/validation-walkthrough.yml
@@ -42,8 +42,16 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev xvfb dbus-x11 gnome-keyring
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run automatic CLI walkthrough (macOS / Windows)
-        if: matrix.os != 'ubuntu-latest'
+      - name: Run automatic CLI walkthrough (macOS)
+        if: matrix.os == 'macos-latest'
+        run: pnpm validate:walkthrough automatic-cli-provisioning
+      - name: Run automatic CLI walkthrough (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          # A pristine Windows runner compiles nearly 900 Rust targets before
+          # the app can publish discovery. Keep this separate from scenario
+          # timeouts, which still fail quickly after Seren has launched.
+          SEREN_VALIDATION_DISCOVERY_TIMEOUT_MS: "1200000"
         run: pnpm validate:walkthrough automatic-cli-provisioning
       - name: Run automatic CLI walkthrough (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/validation-walkthrough.yml
+++ b/.github/workflows/validation-walkthrough.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - "src/**"
       - "src-tauri/**"
+      - "bin/browser-local/**"
       - "scripts/validate-walkthrough.ts"
+      - "scripts/validation-env.ts"
       - "scripts/validation-dev.ts"
       - "scripts/validation-slots.ts"
       - "tests/unit/validation-slots.test.ts"
@@ -18,8 +20,12 @@ on:
 jobs:
   walkthrough:
     if: contains(github.event.pull_request.labels.*.name, 'needs-validation')
-    runs-on: macos-latest
-    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4
@@ -29,13 +35,22 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      - name: Install Linux desktop dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev xvfb dbus-x11 gnome-keyring
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run validation walkthrough
-        run: pnpm validate:walkthrough app-ready
+      - name: Run automatic CLI walkthrough (macOS / Windows)
+        if: matrix.os != 'ubuntu-latest'
+        run: pnpm validate:walkthrough automatic-cli-provisioning
+      - name: Run automatic CLI walkthrough (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run -a pnpm validate:walkthrough automatic-cli-provisioning
       - name: Upload validation artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: validation-walkthrough
+          name: validation-walkthrough-${{ matrix.os }}
           path: artifacts/validation-walkthrough

--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -19,15 +19,16 @@ import {
   isBelowBaseline,
   loadState,
   runInstalledVersion,
+  saveState,
 } from "./cli-updater.mjs";
 import {
-  ANTIGRAVITY_INSTALL_URL,
   checkAntigravityAuthenticated,
   clearAntigravityAuthCache,
   ensureAntigravityCli,
   resolveAntigravityBinary,
 } from "./antigravity-binary.mjs";
 import { resolveGrokBinary } from "./grok-binary.mjs";
+import { managedCliBinary, managedCliPrefix } from "./cli-paths.mjs";
 
 // LM Studio support is loaded lazily so a missing LM Studio dependency (e.g.
 // @lmstudio/sdk) never crashes the registry, which every agent relies on for
@@ -365,88 +366,37 @@ function resolveNpmCliScript() {
   return null;
 }
 
-async function ensureGlobalNpmPackage({ emit, command, packageName, label }) {
-  if (await isCommandAvailable(command)) {
-    return command;
+const AGENT_CLI_PROVISIONING = Object.freeze({
+  codex: { kind: "npm", target: "codex" },
+  "claude-code": { kind: "npm", target: "claude" },
+  "claude-codex": {
+    kind: "derived",
+    dependencies: ["claude-code", "codex"],
+  },
+  gemini: { kind: "verified-artifact", target: "antigravity" },
+  grok: { kind: "npm", target: "grok" },
+  lmstudio: { kind: "external-app", target: "lmstudio" },
+});
+
+function assertAgentCliProvisioningComplete(definitions, provisioning) {
+  const definitionTypes = Object.keys(definitions).sort();
+  const provisioningTypes = Object.keys(provisioning).sort();
+  if (JSON.stringify(definitionTypes) !== JSON.stringify(provisioningTypes)) {
+    throw new Error(
+      `Agent CLI provisioning is incomplete: registry=${definitionTypes.join(",")} ` +
+        `provisioning=${provisioningTypes.join(",")}`,
+    );
   }
-
-  emit("provider://cli-install-progress", {
-    stage: "installing",
-    message: `Installing ${label} CLI...`,
-  });
-
-  // Invoke node with npm-cli.js directly to avoid shell wrapper shims that
-  // break execFile() after Tauri replaces bin/npm symlinks with shell scripts.
-  const npmCliScript = resolveNpmCliScript();
-  if (npmCliScript) {
-    await new Promise((resolvePromise, rejectPromise) => {
-      execFile(
-        process.execPath,
-        [npmCliScript, "install", "-g", packageName],
-        (error, stdout, stderr) => {
-          if (error) {
-            rejectPromise(new Error(stderr || error.message));
-            return;
-          }
-          resolvePromise(stdout.trim());
-        },
+  for (const [agentType, entry] of Object.entries(provisioning)) {
+    if (
+      entry.kind === "derived" &&
+      entry.dependencies.some((dependency) => !definitions[dependency])
+    ) {
+      throw new Error(
+        `Agent CLI provisioning for ${agentType} references an unknown dependency.`,
       );
-    });
-  } else {
-    // Fallback: try npm directly, for a dev checkout where symlinks are intact.
-    // Node refuses to exec a .cmd shim without a shell, so Windows needs one.
-    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-    await new Promise((resolvePromise, rejectPromise) => {
-      execFile(
-        npmCommand,
-        ["install", "-g", packageName],
-        { shell: process.platform === "win32" },
-        (error, stdout, stderr) => {
-          if (error) {
-            rejectPromise(new Error(stderr || error.message));
-            return;
-          }
-          resolvePromise(stdout.trim());
-        },
-      );
-    });
+    }
   }
-
-  emit("provider://cli-install-progress", {
-    stage: "complete",
-    message: `${label} CLI installed successfully`,
-  });
-
-  return command;
-}
-
-const CLI_INSTALL_INSTRUCTIONS = {
-  "@anthropic-ai/claude-code":
-    "https://code.claude.com/docs/en/installation",
-  "@openai/codex": "https://developers.openai.com/codex/cli/",
-  "@xai-official/grok": "https://docs.x.ai/build/overview",
-};
-
-function emitCliActionRequired(
-  emit,
-  { label, bareCommand, packageName, from = null, to = null, reason },
-) {
-  const officialInstructionsUrl = CLI_INSTALL_INSTRUCTIONS[packageName];
-  emit?.("provider://cli-install-progress", {
-    stage: "action_required",
-    message: `${label} needs your attention before Seren can use it.`,
-  });
-  emit?.("provider://cli-update-action-required", {
-    label,
-    bareCommand,
-    packageName,
-    from,
-    to,
-    reason,
-    actions: ["retry", "open_official_instructions"],
-    officialInstructionsUrl,
-  });
-  return officialInstructionsUrl;
 }
 
 /**
@@ -455,7 +405,7 @@ function emitCliActionRequired(
  * the Codex (#2904) and Claude Code (#3443) spawn paths so both degrade
  * identically: an at-or-above-baseline install returns immediately with no
  * network access; a below-baseline install triggers a blocking verified
- * update and fails closed — with an actionable retry/instructions handoff —
+ * update and fails closed without asking the user to manage installations
  * when the update cannot be confirmed (offline, scan rejection, stale shim).
  *
  * `_runInstalledVersion` / `_backgroundUpdateCli` are test seams; production
@@ -491,14 +441,49 @@ async function ensureCliBaselineViaUpdater(
       );
       return resolved;
     }
-    const url = emitCliActionRequired(emit, {
+    emit("provider://cli-install-progress", {
+      stage: "installing",
+      message: `Installing ${label} CLI automatically...`,
+    });
+    const outcome = await _backgroundUpdateCli({
       label,
       bareCommand,
       packageName,
-      reason: "installation_required",
+      resolvedPath: bareCommand,
+      npmCliScript: resolveNpmCliScript(),
+      force: true,
+      installIfMissing: true,
+      installPrefix: managedCliPrefix(),
+      resolveInstalledPath: resolveBinary,
+      onUpdated: ({ label: updatedLabel, from, to }) =>
+        emit?.("provider://cli-updated", {
+          label: updatedLabel,
+          from,
+          to,
+        }),
+      onScanRejected: (event) =>
+        emit?.("provider://cli-scan-rejected", event),
+      onActionRequired: (event) =>
+        emit?.("provider://cli-update-action-required", event),
     });
+    resolved = resolveBinary();
+    const installedAfterProvision = await _runInstalledVersion(
+      resolved,
+      bareCommand,
+    );
+    if (
+      installedAfterProvision &&
+      !isBelowBaseline(installedAfterProvision, baseline)
+    ) {
+      emit("provider://cli-install-progress", {
+        stage: "complete",
+        message: `${label} CLI installed successfully`,
+      });
+      return resolved;
+    }
     throw new Error(
-      `${label} CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
+      `Seren could not install ${label} automatically. Seren will retry ` +
+        `automatically. (${outcome.outcome})`,
     );
   }
   if (!isBelowBaseline(installed, baseline)) {
@@ -517,6 +502,8 @@ async function ensureCliBaselineViaUpdater(
     packageName,
     npmCliScript: resolveNpmCliScript(),
     force: true,
+    installPrefix: managedCliPrefix(),
+    resolveInstalledPath: resolveBinary,
     onUpdated: ({ label, from, to }) =>
       emit?.("provider://cli-updated", { label, from, to }),
     onScanRejected: (event) =>
@@ -534,8 +521,8 @@ async function ensureCliBaselineViaUpdater(
   ) {
     throw new Error(
       `${label} CLI is still ${updated ?? "unknown"}; Seren requires ${baseline} ` +
-        `or newer. Update it from ${CLI_INSTALL_INSTRUCTIONS[packageName]}, ` +
-        `then retry. (${outcome.outcome})`,
+        `or newer and will retry the verified update automatically. ` +
+        `(${outcome.outcome})`,
     );
   }
 
@@ -596,41 +583,44 @@ async function ensureClaudeCodeCli(emit) {
       existsSync(resolvedPath) &&
       binaryRunsOnHost(resolvedPath)
     ) {
-      // Custom PATH installs are outside every channel the updater manages
-      // (classifyInstallChannel calls them unresolved), so no auto-update
-      // is attempted. Still refuse to spawn a CLI that is determinately
-      // below the baseline: it would reject the default model id with a
-      // far less actionable error (#3443). An unprobeable version stays
-      // permissive so a working custom setup is not blocked.
+      // Custom PATH installs are outside every channel the updater manages.
+      // If one is determinately stale, provision Seren's verified managed
+      // copy rather than pushing an update decision back to the user.
       const baseline = CLI_MIN_VERSION_BASELINE["@anthropic-ai/claude-code"];
       const installed = await runInstalledVersion(resolvedPath, "claude");
       if (isBelowBaseline(installed, baseline)) {
-        const url = emitCliActionRequired(emit, {
+        return ensureCliBaselineViaUpdater(emit, {
           label: "Claude Code",
           bareCommand: "claude",
           packageName: "@anthropic-ai/claude-code",
-          from: installed,
-          to: baseline,
-          reason: "update_required",
+          resolveBinary: resolveInstalledClaudeBinary,
+          allowUnprobeableInstall: true,
         });
-        throw new Error(
-          `Claude Code CLI is ${installed}; Seren requires ${baseline} or newer. ` +
-            `Update it from ${url}, then retry.`,
-        );
       }
       return "claude";
     }
   }
 
-  const url = emitCliActionRequired(emit, {
+  return ensureCliBaselineViaUpdater(emit, {
     label: "Claude Code",
     bareCommand: "claude",
     packageName: "@anthropic-ai/claude-code",
-    reason: "installation_required",
+    resolveBinary: resolveInstalledClaudeBinary,
+    allowUnprobeableInstall: true,
   });
-  throw new Error(
-    `Claude Code CLI is not installed. Install it from ${url}, then retry.`,
-  );
+}
+
+async function ensureGrokCliViaUpdater(emit) {
+  const resolved = resolveGrokBinary();
+  if (resolved !== "grok") return resolved;
+  if (await isCommandAvailable("grok")) return "grok";
+  return ensureCliBaselineViaUpdater(emit, {
+    label: "Grok",
+    bareCommand: "grok",
+    packageName: "@xai-official/grok",
+    resolveBinary: resolveGrokBinary,
+    allowUnprobeableInstall: true,
+  });
 }
 
 /**
@@ -652,6 +642,8 @@ export function resolveInstalledClaudeBinary() {
     const programFilesX86 =
       process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
+      // Seren's verified copy must outrank a stale user-managed install.
+      managedCliBinary("claude"),
       // Native installer location (install.ps1 puts it here)
       path.join(home, ".local", "bin", "claude.exe"),
       // Older native installer location
@@ -679,6 +671,8 @@ export function resolveInstalledClaudeBinary() {
     const nodeDir = path.dirname(process.execPath);
     const prefix = path.dirname(nodeDir);
     const candidates = [
+      // Seren's verified copy must outrank a stale user-managed install.
+      managedCliBinary("claude"),
       path.join(home, ".claude", "bin", "claude"),
       path.join(home, ".local", "bin", "claude"),
       // npm global install via embedded runtime's npm
@@ -765,6 +759,8 @@ export function resolveInstalledCodexBinary() {
     const programFilesX86 =
       process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
+      // Seren-managed verified npm install.
+      managedCliBinary("codex"),
       ...(appData ? [path.join(appData, "npm", "codex.cmd")] : []),
       ...(appData ? [path.join(appData, "npm", "codex.ps1")] : []),
       path.join(nodeDir, "codex.cmd"),
@@ -785,6 +781,8 @@ export function resolveInstalledCodexBinary() {
     const nodeDir = path.dirname(process.execPath);
     const prefix = path.dirname(nodeDir);
     const candidates = [
+      // Seren-managed verified npm install.
+      managedCliBinary("codex"),
       path.join(prefix, "bin", "codex"),
       path.join(home, ".local", "bin", "codex"),
       // System npm prefix /usr/local — Intel macOS + most Linux distros. The
@@ -812,7 +810,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       description: "OpenAI Codex via direct App Server integration",
       command: "codex",
       async getAvailability() {
-        const installed = await isCommandAvailable("codex");
+        const installed = resolveInstalledCodexBinary() !== "codex";
         return {
           type: "codex",
           name: "Codex",
@@ -824,7 +822,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Codex CLI is not installed. Seren will open the official installation instructions when you start this agent.",
+                  "Seren is preparing the Codex CLI automatically.",
               }),
         };
       },
@@ -849,7 +847,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       description: "Anthropic Claude Code via direct provider runtime",
       command: "claude",
       async getAvailability() {
-        const installed = await isCommandAvailable("claude");
+        const installed = resolveInstalledClaudeBinary() !== "claude";
         return {
           type: "claude-code",
           name: "Claude Code",
@@ -861,7 +859,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Claude Code CLI is not installed. Seren will open the official installation instructions when you start this agent.",
+                  "Seren is preparing the Claude Code CLI automatically.",
               }),
         };
       },
@@ -888,8 +886,8 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       description: "Paired workflow — Claude plans and reviews, Codex executes",
       command: "claude",
       async getAvailability() {
-        const claudeInstalled = await isCommandAvailable("claude");
-        const codexInstalled = await isCommandAvailable("codex");
+        const claudeInstalled = resolveInstalledClaudeBinary() !== "claude";
+        const codexInstalled = resolveInstalledCodexBinary() !== "codex";
         const missing = [
           ...(claudeInstalled ? [] : ["Claude Code"]),
           ...(codexInstalled ? [] : ["Codex"]),
@@ -905,7 +903,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           ...(missing.length === 0
             ? {}
             : {
-                unavailableReason: `${missing.join(" and ")} CLI${missing.length > 1 ? "s are" : " is"} not installed. Seren will provide official installation instructions when you start this agent.`,
+                unavailableReason: `Seren is preparing the ${missing.join(" and ")} CLI${missing.length > 1 ? "s" : ""} automatically.`,
               }),
         };
       },
@@ -947,7 +945,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Antigravity CLI is not installed yet. Seren can install Google's verified binary on first launch.",
+                  "Seren is preparing the Antigravity CLI automatically.",
               }),
         };
       },
@@ -958,13 +956,12 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         try {
           return await ensureAntigravityCli({ emit });
         } catch (error) {
-          // The recovery card is driven by the npm update path, which cannot
-          // reinstall a native binary — a card here would offer a Retry that
-          // throws. The install-progress message and the thrown error are what
-          // reach the user. #3665
+          // Installation remains Seren-owned. Report a retryable preparation
+          // failure without handing a download decision to the user. #3680
           emit?.("provider://cli-install-progress", {
             stage: "action_required",
-            message: `Antigravity could not be installed automatically. Install it from ${ANTIGRAVITY_INSTALL_URL}, then start Antigravity again.`,
+            message:
+              "Seren could not prepare Antigravity yet and will retry automatically.",
           });
           throw error;
         }
@@ -999,7 +996,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Grok CLI is not installed yet. Seren can install it automatically on first launch.",
+                  "Seren is preparing the Grok CLI automatically.",
               }),
         };
       },
@@ -1007,37 +1004,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return true;
       },
       async ensureCli() {
-        const resolved = resolveGrokBinary();
-        if (resolved !== "grok") {
-          return resolved;
-        }
-        await ensureGlobalNpmPackage({
-          emit,
-          command: "grok",
-          packageName: "@xai-official/grok",
-          label: "Grok",
-        });
-        const installed = resolveGrokBinary();
-        if (installed !== "grok") {
-          return installed;
-        }
-        // A user-managed grok outside the paths resolveGrokBinary knows is
-        // still spawnable, so PATH decides before we give up.
-        if (await isCommandAvailable("grok")) {
-          return "grok";
-        }
-        // Returning the bare command here spawned an ENOENT that surfaced as
-        // "Grok agent stopped before request completed", which says nothing
-        // about a missing install. Mirrors Claude/Codex. #3154
-        const url = emitCliActionRequired(emit, {
-          label: "Grok",
-          bareCommand: "grok",
-          packageName: "@xai-official/grok",
-          reason: "installation_required",
-        });
-        throw new Error(
-          `Grok CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
-        );
+        return ensureGrokCliViaUpdater(emit);
       },
       launchLogin() {
         const resolved = resolveGrokBinary();
@@ -1099,6 +1066,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       },
     },
   };
+  assertAgentCliProvisioningComplete(definitions, AGENT_CLI_PROVISIONING);
 
   function getDefinition(agentType) {
     const definition = definitions[agentType];
@@ -1108,16 +1076,28 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     return definition;
   }
 
-  // Fire-and-forget background update checks for bundled CLIs (#1637).
-  // TTL-gated to 24h inside backgroundUpdateCli and same-channel only. Any
-  // verification failure emits one deduplicated recovery event. Do not await
-  // here — registry init must not block on npm.
+  // Fire-and-forget automatic provisioning and background update checks for
+  // every Seren-managed CLI. Installed CLIs remain TTL-gated; missing CLIs
+  // bypass the TTL and install into Seren's writable per-user prefix. Do not
+  // await here — registry init must not block on downloads.
   const npmCliScript = resolveNpmCliScript();
   const persistedUpdaterState = loadState();
-  let pendingCliUpdateAction = [
-    persistedUpdaterState["pendingAction:codex"],
-    persistedUpdaterState["pendingAction:claude"],
-  ]
+  const managedNpmTargets = Object.values(AGENT_CLI_PROVISIONING)
+    .filter((entry) => entry.kind === "npm")
+    .map((entry) => entry.target);
+  let removedStaleInstallAction = false;
+  const persistedActions = managedNpmTargets.map((target) => {
+    const key = `pendingAction:${target}`;
+    const action = persistedUpdaterState[key];
+    if (action?.reason === "installation_required") {
+      persistedUpdaterState[key] = null;
+      removedStaleInstallAction = true;
+      return null;
+    }
+    return action;
+  });
+  if (removedStaleInstallAction) saveState(persistedUpdaterState);
+  let pendingCliUpdateAction = persistedActions
     .filter(Boolean)
     .sort((left, right) => (right.at ?? 0) - (left.at ?? 0))[0] ?? null;
   const onUpdated = async ({ label, bareCommand, from, to }) => {
@@ -1184,7 +1164,18 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       packageName: "@anthropic-ai/claude-code",
       resolvePath: resolveInstalledClaudeBinary,
     },
+    grok: {
+      label: "Grok",
+      bareCommand: "grok",
+      packageName: "@xai-official/grok",
+      resolvePath: resolveGrokBinary,
+    },
   };
+  for (const target of new Set(managedNpmTargets)) {
+    if (!cliUpdateConfigs[target]) {
+      throw new Error(`Missing managed npm CLI provisioner for ${target}.`);
+    }
+  }
   const runCliUpdate = async (bareCommand, { force = false } = {}) => {
     const config = cliUpdateConfigs[bareCommand];
     if (!config) {
@@ -1197,6 +1188,9 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       packageName: config.packageName,
       npmCliScript,
       force,
+      installIfMissing: true,
+      installPrefix: managedCliPrefix(),
+      resolveInstalledPath: config.resolvePath,
       onUpdated,
       onScanRejected,
       onActionRequired,
@@ -1211,8 +1205,26 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     }
     return result;
   };
-  void runCliUpdate("codex");
-  void runCliUpdate("claude");
+  for (const target of new Set(managedNpmTargets)) {
+    void runCliUpdate(target);
+  }
+  const verifiedArtifactProvisioners = {
+    antigravity: () => ensureAntigravityCli({ emit }),
+  };
+  const verifiedArtifactTargets = Object.values(AGENT_CLI_PROVISIONING)
+    .filter((entry) => entry.kind === "verified-artifact")
+    .map((entry) => entry.target);
+  for (const target of new Set(verifiedArtifactTargets)) {
+    const provision = verifiedArtifactProvisioners[target];
+    if (!provision) {
+      throw new Error(`Missing verified artifact CLI provisioner for ${target}.`);
+    }
+    void provision().catch((error) => {
+      console.warn(
+        `[agent-registry] ${target} automatic provisioning will retry: ${error?.message ?? String(error)}`,
+      );
+    });
+  }
 
   return {
     async getAvailableAgents() {
@@ -1260,11 +1272,13 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   };
 }
 
-// Exported for regression tests. A package missing from this map makes its
-// ensureCli failure interpolate `undefined` in place of the install URL,
-// which is the unhelpful error #3154 was filed about.
-export { CLI_INSTALL_INSTRUCTIONS as _CLI_INSTALL_INSTRUCTIONS };
 // Exported for regression tests of the spawn-path baseline gate (#2904,
 // #3443). Production callers go through ensureCodexCliViaUpdater /
 // ensureClaudeCodeCli.
 export { ensureCliBaselineViaUpdater as _ensureCliBaselineViaUpdater };
+// Exported for a completeness guard: every locally enumerated agent must state
+// whether Seren provisions it, derives it, or depends on an external app.
+export { AGENT_CLI_PROVISIONING as _AGENT_CLI_PROVISIONING };
+export {
+  assertAgentCliProvisioningComplete as _assertAgentCliProvisioningComplete,
+};

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -35,6 +35,7 @@ import {
 } from "./synthetic-transcript.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { createAdmissionGate } from "./session-admission.mjs";
+import { managedCliBinary } from "./cli-paths.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -67,6 +68,8 @@ function resolveClaudeBinary() {
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
     const candidates = [
+      // Seren's verified copy must outrank a stale user-managed install.
+      managedCliBinary("claude"),
       // Native installer (install.ps1) places the binary here
       path.join(home, ".local", "bin", "claude.exe"),
       // Older native installer location
@@ -108,6 +111,8 @@ function resolveClaudeBinary() {
   const nodeDir = path.dirname(process.execPath);
   const prefix = path.dirname(nodeDir);
   const candidates = [
+    // Seren's verified copy must outrank a stale user-managed install.
+    managedCliBinary("claude"),
     path.join(home, ".claude", "bin", "claude"),
     path.join(home, ".local", "bin", "claude"),
     // npm global install via embedded runtime's npm
@@ -3103,13 +3108,14 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
           /bad cpu type in executable/i.test(spawnError.message ?? "");
         let errorMessage;
         if (spawnError.code === "ENOENT") {
-          errorMessage = `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`;
+          errorMessage =
+            `Seren could not start Claude Code at "${claudeBin}". ` +
+            "Seren will repair the managed CLI automatically.";
         } else if (isBadArch) {
           errorMessage =
             `Claude Code CLI at "${claudeBin}" is the wrong CPU type for this Mac ` +
-            `(host arch: ${process.arch}). Install Rosetta 2 with ` +
-            `'softwareupdate --install-rosetta --agree-to-license', or delete that ` +
-            `binary and let Seren reinstall via npm on next launch.`;
+            `(host arch: ${process.arch}). Seren will replace it with the correct ` +
+            "managed CLI automatically.";
         } else {
           errorMessage = `Failed to start Claude Code: ${spawnError.message}`;
         }

--- a/bin/browser-local/cli-paths.mjs
+++ b/bin/browser-local/cli-paths.mjs
@@ -1,0 +1,38 @@
+// ABOUTME: Defines Seren's writable per-user install prefix for managed agent CLIs.
+// ABOUTME: Keeps installer and runtime resolvers on one durable path across every desktop OS.
+
+import os from "node:os";
+import path from "node:path";
+
+export function serenDataDir({
+  platform = process.platform,
+  home = os.homedir(),
+  appData = process.env.APPDATA ?? "",
+} = {}) {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  if (platform === "win32") {
+    return platformPath.join(appData || home, "Seren");
+  }
+  return platformPath.join(home, ".seren");
+}
+
+export function managedCliPrefix({ platform = process.platform, ...options } = {}) {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  return platformPath.join(
+    serenDataDir({ platform, ...options }),
+    "cli-tools",
+  );
+}
+
+export function managedCliBinary(
+  command,
+  {
+    platform = process.platform,
+    prefix = managedCliPrefix({ platform }),
+  } = {},
+) {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  return platform === "win32"
+    ? platformPath.join(prefix, `${command}.cmd`)
+    : platformPath.join(prefix, "bin", command);
+}

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -1,5 +1,5 @@
-// ABOUTME: Background updates for bundled agent CLIs (Codex, Claude Code) per #1637.
-// ABOUTME: Verifies candidate bytes and post-update health before reporting success.
+// ABOUTME: Automatic verified provisioning and updates for Seren-managed npm agent CLIs.
+// ABOUTME: Verifies candidate bytes and post-install health before reporting success.
 
 import { execFile } from "node:child_process";
 import {
@@ -11,7 +11,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -21,6 +20,7 @@ import {
   scanTarball,
   verifyTarballIntegrity,
 } from "./cli-scanner.mjs";
+import { serenDataDir } from "./cli-paths.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -67,14 +67,6 @@ export function isBelowBaseline(installed, baseline) {
     if (ai !== bi) return ai < bi;
   }
   return false;
-}
-
-function serenDataDir() {
-  if (process.platform === "win32") {
-    const base = process.env.APPDATA ?? os.homedir();
-    return path.join(base, "Seren");
-  }
-  return path.join(os.homedir(), ".seren");
 }
 
 function statePath() {
@@ -273,11 +265,20 @@ async function runNpmInstallLatest(packageName, { npmCliScript } = {}) {
  * passes — we install the exact bytes we scanned, not whatever the registry
  * serves at install time. Eliminates the post-scan/pre-install TOCTOU window.
  */
-async function runNpmInstallFromTarball(tarballPath, { npmCliScript } = {}) {
+async function runNpmInstallFromTarball(
+  tarballPath,
+  { npmCliScript, installPrefix } = {},
+) {
+  const installArgs = [
+    "install",
+    "-g",
+    ...(installPrefix ? ["--prefix", installPrefix] : []),
+    tarballPath,
+  ];
   if (npmCliScript) {
     await execFileAsync(
       process.execPath,
-      [npmCliScript, "install", "-g", tarballPath],
+      [npmCliScript, ...installArgs],
       { timeout: NPM_INSTALL_TIMEOUT_MS },
     );
     return;
@@ -285,10 +286,21 @@ async function runNpmInstallFromTarball(tarballPath, { npmCliScript } = {}) {
   const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
   await execFileAsync(
     npmCommand,
-    ["install", "-g", tarballPath],
+    installArgs,
     // Node refuses to exec a .cmd shim without a shell.
     { timeout: NPM_INSTALL_TIMEOUT_MS, shell: process.platform === "win32" },
   );
+}
+
+// All managed npm CLIs share one global prefix. npm mutates that prefix as a
+// single dependency tree, so startup provisioning must serialize only the
+// install phase even though registry lookup and scanning can run in parallel.
+let npmInstallTail = Promise.resolve();
+
+function enqueueNpmInstall(install) {
+  const pending = npmInstallTail.then(install, install);
+  npmInstallTail = pending.catch(() => {});
+  return pending;
 }
 
 /**
@@ -314,6 +326,7 @@ const HOSTNAME_ALLOWLIST = {
     "github.com",
     "githubusercontent.com",
   ],
+  "@xai-official/grok": ["x.ai", "grok.com"],
 };
 
 const FIRST_BASELINE_POLICIES = {
@@ -335,11 +348,22 @@ const FIRST_BASELINE_POLICIES = {
     executableFiles: ["bin/codex.js"],
     hostnameAllowlist: HOSTNAME_ALLOWLIST["@openai/codex"],
   },
+  "@xai-official/grok": {
+    installScripts: { postinstall: "node bin/postinstall.js" },
+    dependencyPatterns: [
+      /^@xai-official\/grok-(darwin|linux|win32)-(arm64|x64)$/,
+      /^@iarna\/toml$/,
+    ],
+    binEntries: { grok: "bin/grok" },
+    executableFiles: ["bin/grok"],
+    hostnameAllowlist: HOSTNAME_ALLOWLIST["@xai-official/grok"],
+  },
 };
 
 const OFFICIAL_INSTRUCTIONS_URLS = {
   "@anthropic-ai/claude-code": "https://code.claude.com/docs/en/installation",
   "@openai/codex": "https://developers.openai.com/codex/cli/",
+  "@xai-official/grok": "https://docs.x.ai/build/overview",
 };
 
 /**
@@ -483,7 +507,7 @@ function emitOutcomeLog({ packageName, outcome, details, logger }) {
  * Every invocation emits exactly one log line + (for success or scan_rejected)
  * exactly one provider event. See #1646.
  */
-export async function backgroundUpdateCli({
+async function runBackgroundUpdateCli({
   label,
   bareCommand,
   resolvedPath,
@@ -492,6 +516,9 @@ export async function backgroundUpdateCli({
   now = Date.now(),
   state,
   force = false,
+  installIfMissing = false,
+  installPrefix,
+  resolveInstalledPath,
   onUpdated,
   onScanRejected,
   onActionRequired,
@@ -545,22 +572,27 @@ export async function backgroundUpdateCli({
     const pendingActionKey = `pendingAction:${bareCommand}`;
     const lastCheck = persisted[key];
 
-    const channel = classifyInstallChannel(resolvedPath, bareCommand);
-    if (channel === "unresolved") {
+    let channel = classifyInstallChannel(resolvedPath, bareCommand);
+    const installFromMissing = channel === "unresolved" && installIfMissing;
+    if (channel === "unresolved" && !installFromMissing) {
       // Don't write state — we want to re-check next launch in case the
       // install completes between now and then.
       return report("skipped:unresolved");
     }
+    if (installFromMissing) channel = "npm";
 
     // Read installed version up-front so the baseline gate can override TTL.
     // The npm view is still deferred until we decide whether to run.
-    const installed = await installedVersionFn(resolvedPath, bareCommand);
+    const installed = installFromMissing
+      ? null
+      : await installedVersionFn(resolvedPath, bareCommand);
     const baseline = CLI_MIN_VERSION_BASELINE[packageName];
     const belowBaseline =
       typeof baseline === "string" && isBelowBaseline(installed, baseline);
 
     if (
       !force &&
+      !installFromMissing &&
       !belowBaseline &&
       typeof lastCheck === "number" &&
       now - lastCheck < UPDATE_CHECK_TTL_MS
@@ -583,6 +615,19 @@ export async function backgroundUpdateCli({
     }
 
     function requireAction(reason, details = {}) {
+      if (installFromMissing) {
+        // First install is Seren-owned recovery work, not a decision to push
+        // onto a clean user. Keep the failure retryable without persisting the
+        // manual Retry / instructions card used for an existing CLI update.
+        persisted[pendingActionKey] = null;
+        if (ownsPersistence) saveState(persisted);
+        return report(`skipped:${reason}`, {
+          from: installed,
+          to: latest,
+          installedFromMissing: true,
+          ...details,
+        });
+      }
       const actionKey = `lastActionRequired:${bareCommand}:${latest}`;
       const lastAction = persisted[actionKey];
       const actionRequired = {
@@ -614,20 +659,27 @@ export async function backgroundUpdateCli({
       });
     }
 
-    if (installed && latest && isNewer(installed, latest)) {
+    if (
+      latest &&
+      (installFromMissing || (installed && isNewer(installed, latest)))
+    ) {
       // Native-channel binaries and Codex's package-manager-aware updater must
       // verify the resulting bytes before success is surfaced. Never fall back
       // to a downloaded installer script when self-update fails.
-      if (channel === "native" || packageName === "@openai/codex") {
+      if (
+        installed &&
+        (channel === "native" || packageName === "@openai/codex")
+      ) {
         const selfOk = await selfUpdateFn(resolvedPath);
         if (!selfOk) {
           return requireAction("self_update_failed", { channel });
         }
+        const installedPath = resolveInstalledPath?.() ?? resolvedPath;
         const verifiedVersion = await installedVersionFn(
-          resolvedPath,
+          installedPath,
           bareCommand,
         );
-        const healthy = await healthCheckFn(resolvedPath);
+        const healthy = await healthCheckFn(installedPath);
         if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
           return requireAction("verification_required", {
             channel,
@@ -758,7 +810,12 @@ export async function backgroundUpdateCli({
         // verdict is "pass" or a policy-approved "no_baseline" — install the
         // exact integrity-verified tarball and seed the next diff baseline.
         try {
-          await installFromTarballFn(tarballPath, { npmCliScript });
+          await enqueueNpmInstall(() =>
+            installFromTarballFn(tarballPath, {
+              npmCliScript,
+              installPrefix,
+            }),
+          );
         } catch {
           saveState(persisted);
           cleanupStaging();
@@ -769,11 +826,12 @@ export async function backgroundUpdateCli({
           });
         }
 
+        const installedPath = resolveInstalledPath?.() ?? resolvedPath;
         const verifiedVersion = await installedVersionFn(
-          resolvedPath,
+          installedPath,
           bareCommand,
         );
-        const healthy = await healthCheckFn(resolvedPath);
+        const healthy = await healthCheckFn(installedPath);
         if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
           cleanupStaging();
           return requireAction("verification_required", {
@@ -811,6 +869,7 @@ export async function backgroundUpdateCli({
           channel,
           tarballSha512: scan.candidate.tarballSha512,
           firstInstall: scan.verdict === "no_baseline",
+          installedFromMissing: installFromMissing,
           verifiedVersion,
         });
       } catch {
@@ -829,6 +888,25 @@ export async function backgroundUpdateCli({
     // registry init path.
     return report("skipped:error");
   }
+}
+
+const updatesInFlight = new Map();
+
+/**
+ * Share one real update/install per CLI. Provider startup and an immediate
+ * user launch can ask for the same missing binary concurrently; both callers
+ * must await the same verified bytes instead of racing global npm installs.
+ */
+export function backgroundUpdateCli(options) {
+  const key = `${options.packageName}:${options.bareCommand}`;
+  const existing = updatesInFlight.get(key);
+  if (existing) return existing;
+
+  const pending = runBackgroundUpdateCli(options).finally(() => {
+    if (updatesInFlight.get(key) === pending) updatesInFlight.delete(key);
+  });
+  updatesInFlight.set(key, pending);
+  return pending;
 }
 
 export { formatOutcomeLog as _formatOutcomeLog };

--- a/bin/browser-local/grok-binary.mjs
+++ b/bin/browser-local/grok-binary.mjs
@@ -5,6 +5,8 @@ import { existsSync, lstatSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { managedCliBinary, managedCliPrefix } from "./cli-paths.mjs";
+
 function isSymlink(candidate) {
   try {
     return lstatSync(candidate).isSymbolicLink();
@@ -19,6 +21,7 @@ export function resolveGrokBinary({
   arch = process.arch,
   home = os.homedir(),
   appData = process.env.APPDATA ?? "",
+  managedPrefix = managedCliPrefix({ platform, home, appData }),
   // Absolute install locations outside the caller's control, checked last.
   // Injectable so a hermetic test can supply an empty list and assert the bare
   // "grok" fallback without a real system grok on the host tainting the result.
@@ -40,9 +43,26 @@ export function resolveGrokBinary({
     "bin",
     executableName,
   );
+  const managedNative = path.join(
+    managedPrefix,
+    platform === "win32" ? "node_modules" : "lib/node_modules",
+    "@xai-official",
+    "grok",
+    "node_modules",
+    "@xai-official",
+    `grok-${platform}-${arch}`,
+    "bin",
+    executableName,
+  );
+  const managedShim = managedCliBinary("grok", {
+    platform,
+    prefix: managedPrefix,
+  });
 
   if (platform === "win32") {
     const candidates = [
+      managedNative,
+      managedShim,
       // Prefer the package-owned native binary. Unlike npm's command shim it
       // remains executable after Tauri relocates embedded resources. #3088.
       embeddedNative,
@@ -61,6 +81,8 @@ export function resolveGrokBinary({
 
   const embeddedShim = path.join(npmPrefix, "bin", "grok");
   const candidates = [
+    managedNative,
+    ...(isSymlink(managedShim) ? [managedShim] : []),
     // Tauri dereferences npm bin symlinks while staging resources. Executing
     // the relocated CommonJS trampoline from node/bin makes Node classify it
     // as ESM under Seren's package root. Use the official native payload (or

--- a/docs/validation-isolated-launch.md
+++ b/docs/validation-isolated-launch.md
@@ -10,6 +10,12 @@ Run the validation app and walkthrough:
 pnpm validate:walkthrough app-ready
 ```
 
+Run the clean-profile coding-agent CLI walkthrough:
+
+```bash
+pnpm validate:walkthrough automatic-cli-provisioning
+```
+
 Run the validation app manually:
 
 ```bash
@@ -36,7 +42,7 @@ The validation Tauri config uses base bundle identifier `com.serendb.desktop.val
 
 At runtime the validation build sets isolated roots for app config, Seren skill authoring, and Claude skills under the validation app-data directory. The app-wide OAuth callback server binds an isolated loopback port and frontend OAuth flows ask the running app for the active callback URL.
 
-The validation control channel is compiled only with the `validation` Cargo feature and only starts for the base validation identifier or one of its numeric slot identifiers. It writes a tokenized loopback discovery file and accepts only typed commands: navigate, click, fill, press, waitFor, dumpText, and screenshot.
+The validation control channel is compiled only with the `validation` Cargo feature and only starts for the base validation identifier or one of its numeric slot identifiers. It writes a tokenized loopback discovery file and accepts only typed commands: navigate, click, contextmenu, readState, fill, select, press, waitFor, dumpText, screenshot, and setRootPath. `readState` has a separate read-only native-command allowlist.
 
 ## Evidence
 
@@ -54,4 +60,4 @@ For macOS native pixels, grant Screen Recording permission to the validation app
 
 ## CI
 
-The `validation-walkthrough` workflow is label-gated. Add the `needs-validation` PR label to run `pnpm validate:walkthrough app-ready` on macOS and upload the artifact directory.
+The `validation-walkthrough` workflow is label-gated. Add the `needs-validation` PR label to run the clean-profile automatic CLI scenario in real Tauri apps on macOS, Ubuntu (under Xvfb), and Windows, with one artifact bundle per operating system.

--- a/scripts/validate-walkthrough.ts
+++ b/scripts/validate-walkthrough.ts
@@ -15,6 +15,7 @@ import {
   ensureValidationHome,
   resolvePnpmStoreDir,
   validationChildEnv,
+  validationTauriCliCommand,
 } from "./validation-env";
 
 interface DiscoveryFile {
@@ -106,8 +107,12 @@ async function main(): Promise<void> {
 
     await rm(artifactsDir, { recursive: true, force: true });
     await mkdir(artifactsDir, { recursive: true });
-    app = launchValidationApp(slot, childEnv);
-    discovery = await waitForDiscovery(discoveryPath, discoveryTimeoutMs);
+    const launchedApp = launchValidationApp(slot, childEnv);
+    app = launchedApp.child;
+    discovery = await Promise.race([
+      waitForDiscovery(discoveryPath, discoveryTimeoutMs),
+      launchedApp.failure,
+    ]);
     await waitForFrontendReady(discovery, 60_000);
     const client = createClient(discovery);
     const scenario = (await import(
@@ -178,11 +183,16 @@ async function waitForFrontendReady(
 function launchValidationApp(
   slot: ValidationSlot,
   childEnv: NodeJS.ProcessEnv,
-): ChildProcess {
+): { child: ChildProcess; failure: Promise<never> } {
+  // Run Tauri's JavaScript entrypoint with the current Node executable. A
+  // bare `pnpm` spawn cannot launch pnpm.cmd on Windows without a shell and
+  // previously left the walkthrough waiting ten minutes for an app that never
+  // started. Direct Node execution is shell-free and identical on every OS.
+  const invocation = validationTauriCliCommand({ repoRoot: root });
   const child = spawn(
-    "pnpm",
+    invocation.command,
     [
-      "tauri",
+      invocation.cliScript,
       "dev",
       "--no-watch",
       "--features",
@@ -204,16 +214,24 @@ function launchValidationApp(
     },
   );
 
-  child.on("exit", (code, signal) => {
-    if (code !== null && code !== 0) {
-      console.error(`[validate:walkthrough] app exited with code ${code}`);
-    }
-    if (signal) {
-      console.error(`[validate:walkthrough] app exited with signal ${signal}`);
-    }
+  const failure = new Promise<never>((_resolve, reject) => {
+    child.once("error", (error) => {
+      reject(
+        new Error(`Validation app failed to start: ${error.message}`, {
+          cause: error,
+        }),
+      );
+    });
+    child.once("exit", (code, signal) => {
+      const detail = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+      if (code !== 0 || signal) {
+        console.error(`[validate:walkthrough] app exited with ${detail}`);
+      }
+      reject(new Error(`Validation app exited before discovery (${detail})`));
+    });
   });
 
-  return child;
+  return { child, failure };
 }
 
 async function waitForDiscovery(

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -13,6 +13,25 @@ export function validationHomeForSlot(repoRoot: string, port: number): string {
   return path.join(repoRoot, "artifacts", "validation-home", `slot${port}`);
 }
 
+export function validationTauriCliCommand(inputs: {
+  repoRoot: string;
+  execPath?: string;
+  platform?: NodeJS.Platform;
+}): { command: string; cliScript: string } {
+  const platform = inputs.platform ?? process.platform;
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  return {
+    command: inputs.execPath ?? process.execPath,
+    cliScript: platformPath.join(
+      inputs.repoRoot,
+      "node_modules",
+      "@tauri-apps",
+      "cli",
+      "tauri.js",
+    ),
+  };
+}
+
 export function validationChildEnv(inputs: {
   baseEnv: NodeJS.ProcessEnv;
   port: number;

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -19,9 +19,11 @@ export function validationChildEnv(inputs: {
   repoRoot: string;
   realHome: string;
   pnpmStoreDir?: string | null;
+  platform?: NodeJS.Platform;
 }): NodeJS.ProcessEnv {
   const validationHome = validationHomeForSlot(inputs.repoRoot, inputs.port);
   const validationIdentifier = `com.serendb.desktop.validation.slot${inputs.port}`;
+  const platform = inputs.platform ?? process.platform;
   const env: NodeJS.ProcessEnv = {
     ...inputs.baseEnv,
     HOME: validationHome,
@@ -41,8 +43,17 @@ export function validationChildEnv(inputs: {
   // macOS Foundation resolves Tauri's app-data directory from
   // CFFIXED_USER_HOME rather than HOME. Keep the validation app's database,
   // discovery token, and keychain in the same per-slot sandbox after a restart.
-  if (process.platform === "darwin") {
+  if (platform === "darwin") {
     env.CFFIXED_USER_HOME = validationHome;
+  }
+
+  // Windows resolves both Seren's app state and its managed npm prefix from
+  // USERPROFILE/APPDATA rather than HOME. Point all three at the disposable
+  // slot so a hosted-runner walkthrough proves a genuinely clean first run.
+  if (platform === "win32") {
+    env.USERPROFILE = validationHome;
+    env.APPDATA = path.join(validationHome, "AppData", "Roaming");
+    env.LOCALAPPDATA = path.join(validationHome, "AppData", "Local");
   }
 
   if (inputs.pnpmStoreDir != null) {

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import process from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { chromium } from "@playwright/test";
@@ -34,11 +36,8 @@ const WINDOWS_BOUNDED_BLOCKED_AGENT_TYPES = new Set([
 ]);
 const WINDOWS_BOUNDED_BLOCK_REASON =
   "cannot prevent reads outside the selected project";
-// npm-backed CLIs are installed and version-checked by the disposable Windows
-// test-user setup before the app starts. Exercise the production resolver for
-// every corresponding provider here without requiring credentials or turning
-// provider_ensure_agent_cli back into an installer. LM Studio is excluded:
-// its `lms` CLI ships with the separately installed LM Studio application.
+// Exercise automatic production provisioning for every CLI-backed agent. LM
+// Studio is excluded because its `lms` CLI ships with the external desktop app.
 const CLI_COMPATIBILITY_AGENT_TYPES = [
   "codex",
   "claude-code",
@@ -46,6 +45,27 @@ const CLI_COMPATIBILITY_AGENT_TYPES = [
   "gemini",
   "grok",
 ];
+const LIVE_AGENT_TYPES = [
+  "codex",
+  "claude-code",
+  PAIRED_AGENT_TYPE,
+  "gemini",
+  "grok",
+  "lmstudio",
+];
+const AGENT_LAUNCHER_ROWS = [
+  { type: "claude-code", testId: "new-claude-agent", label: "Claude Code" },
+  { type: "codex", testId: "new-codex-agent", label: "Codex" },
+  { type: PAIRED_AGENT_TYPE, testId: "new-claude-codex-agent", label: "Claude + Codex" },
+  { type: "gemini", testId: "new-gemini-agent", label: "Antigravity" },
+  { type: "grok", testId: "new-grok-agent", label: "Grok" },
+  { type: "lmstudio", testId: "new-lmstudio-agent", label: "LM Studio Agent" },
+];
+const CLI_LAUNCHER_ROWS = [
+  { cliKind: "claude", testId: "new-claude-cli", label: "Claude Code" },
+  { cliKind: "codex", testId: "new-codex-cli", label: "Codex" },
+];
+const ARTIFACT_DIR = requiredEnv("SEREN_E2E_ARTIFACT_DIR");
 // Every shipped subscription coding-agent journey is certified, not one
 // env-selected type (#2375). Override with a comma list for ad-hoc runs.
 const AGENT_JOURNEYS = (
@@ -913,9 +933,100 @@ async function verifyAgentCliCompatibility(ws) {
   for (const agentType of CLI_COMPATIBILITY_AGENT_TYPES) {
     await ensureAgentCli(ws, agentType);
   }
+  verifyManagedCliArtifacts();
   logStage(
     `all provider CLI resolution checks passed: ${CLI_COMPATIBILITY_AGENT_TYPES.join(", ")}`,
   );
+}
+
+function readCliVersion(binary) {
+  assert(existsSync(binary), `Seren did not create managed CLI binary ${path.basename(binary)}`);
+  const output = execFileSync(binary, ["--version"], {
+    encoding: "utf8",
+    shell: binary.endsWith(".cmd"),
+    timeout: 120_000,
+    windowsHide: true,
+  });
+  const version = String(output).match(/\b\d+\.\d+\.\d+\b/)?.[0];
+  assert(version, `${path.basename(binary)} did not report a semantic version`);
+  return version;
+}
+
+function verifyManagedCliArtifacts() {
+  const appData = requiredEnv("APPDATA");
+  const localAppData = requiredEnv("LOCALAPPDATA");
+  const binaries = {
+    claude: path.join(appData, "Seren", "cli-tools", "claude.cmd"),
+    codex: path.join(appData, "Seren", "cli-tools", "codex.cmd"),
+    grok: path.join(appData, "Seren", "cli-tools", "grok.cmd"),
+    antigravity: path.join(localAppData, "agy", "bin", "agy.exe"),
+  };
+  const versions = Object.fromEntries(
+    Object.entries(binaries).map(([name, binary]) => [name, readCliVersion(binary)]),
+  );
+  logStage(`Seren-managed CLI versions verified: ${JSON.stringify(versions)}`);
+}
+
+async function verifyLiveAgentRosterAndLaunchers(ws, page) {
+  const agents = await rpcWithTimeout(
+    ws,
+    "provider_get_available_agents",
+    {},
+    PROVIDER_RPC_TIMEOUT_MS,
+    "live agent roster",
+  );
+  const liveTypes = Array.isArray(agents)
+    ? agents.map((agent) => agent?.type).filter(Boolean)
+    : [];
+  assert(
+    liveTypes.length === LIVE_AGENT_TYPES.length &&
+      LIVE_AGENT_TYPES.every((type) => liveTypes.includes(type)),
+    `live agent roster mismatch: ${liveTypes.join(", ")}`,
+  );
+
+  await page.getByTestId("new-thread-button").click();
+  for (const target of AGENT_LAUNCHER_ROWS) {
+    const row = page.getByTestId(target.testId);
+    await row.waitFor({ state: "visible", timeout: 20_000 });
+    assert((await row.innerText()).includes(target.label), `${target.type} launcher label mismatch`);
+    await row.screenshot({ path: path.join(ARTIFACT_DIR, `launcher-${target.type}.png`) });
+  }
+  for (const target of CLI_LAUNCHER_ROWS) {
+    const row = page.getByTestId(target.testId);
+    await row.waitFor({ state: "visible", timeout: 20_000 });
+    assert((await row.innerText()).includes(target.label), `${target.cliKind} CLI label mismatch`);
+    await row.screenshot({
+      path: path.join(ARTIFACT_DIR, `launcher-${target.cliKind}-cli.png`),
+    });
+  }
+  assert(
+    (await page.getByTestId("cli-update-action-required").count()) === 0,
+    "launcher exposed a user-intervention control",
+  );
+
+  for (const [index, target] of CLI_LAUNCHER_ROWS.entries()) {
+    await page.getByTestId(target.testId).click();
+    await page.getByTestId("terminal-launch-mode-toggle").waitFor({
+      state: "visible",
+      timeout: 20_000,
+    });
+    await sleep(2_000);
+    const buffers = await tauriInvoke(page, "terminal_list_buffers");
+    const terminal = Array.isArray(buffers)
+      ? buffers.filter((buffer) => buffer?.cliKind === target.cliKind).at(-1)
+      : null;
+    assert(
+      terminal?.status === "running",
+      `${target.cliKind} terminal did not stay running after automatic provisioning`,
+    );
+    await page.getByTestId("terminal-launch-mode-toggle").screenshot({
+      path: path.join(ARTIFACT_DIR, `running-${target.cliKind}-cli.png`),
+    });
+    if (index < CLI_LAUNCHER_ROWS.length - 1) {
+      await page.getByTestId("new-thread-button").click();
+    }
+  }
+  logStage(`live registry and launcher parity verified: ${liveTypes.join(", ")}`);
 }
 
 // A raw spawn/prompt failure carries a generic message; the runtime also emits
@@ -1330,6 +1441,7 @@ async function exerciseAgentRuntime(page) {
   const buffer = createRuntimeBuffer(ws);
   try {
     await verifyAgentCliCompatibility(ws);
+    await verifyLiveAgentRosterAndLaunchers(ws, page);
     for (const journey of AGENT_JOURNEYS) {
       if (WINDOWS_BOUNDED_BLOCKED_AGENT_TYPES.has(journey)) {
         await runBlockedWindowsBoundedJourney(ws, journey);

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -402,6 +402,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:SEREN_E2E_API_BASE) -and $env:SEREN_E
 }
 $env:SEREN_E2E_API_BASE = "https://api.serendb.com"
 $env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$RemoteDebugPort"
+$env:SEREN_E2E_ARTIFACT_DIR = $e2eLogDir
 
 if ([string]::IsNullOrWhiteSpace($InstallDir)) {
   $InstallDir = Get-DefaultInstallDir

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -578,72 +578,19 @@ try {
   # app's full tree, so this completes in seconds. The tight timeout turns a
   # hung install into a fast failure instead of a 20-minute stall. #3136
   Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 300
-  # #3096 intentionally removed provider-startup installation. The release
-  # user is disposable and starts empty, so provision its real CLI prerequisites
-  # explicitly as test setup using the vendors' documented npm packages. This
-  # must remain outside provider_ensure_agent_cli: production startup should
-  # continue to hand a missing CLI to the user for review/manual installation.
-  `$agentCliPackages = @(
-    @{ Label = "Claude Code"; Package = "@anthropic-ai/claude-code@latest"; Binary = "claude.cmd" },
-    @{ Label = "Codex"; Package = "@openai/codex@latest"; Binary = "codex.cmd" },
-    @{ Label = "Grok"; Package = "@xai-official/grok@latest"; Binary = "grok.cmd" }
-  )
-  # The installed app resolves agent CLIs from the real default npm global
-  # prefix (%APPDATA%\npm), NOT this portable toolchain Node's own dir, which is
-  # where a zip Node otherwise plants its globals. Pin the prefix to %APPDATA%\npm
-  # so the app's production resolver (resolveInstalledCodexBinary, candidate #1)
-  # finds them exactly as on a real MSI-Node user profile. Without this the box
-  # installed codex-cli 0.145.0 into the scratch Node dir, the app could not see
-  # it, and the codex journey died with "not installed in a verifiable location"
-  # while build+publish were correctly skipped (run 30159367572).
-  `$appDataNpmPrefix = Join-Path `$env:APPDATA "npm"
-  New-Item -ItemType Directory -Path `$appDataNpmPrefix -Force | Out-Null
-  `$env:npm_config_prefix = `$appDataNpmPrefix
-  `$agentCliInstallArgs = @("install", "--global", "--no-audit", "--no-fund") + @(
-    `$agentCliPackages | ForEach-Object { `$_.Package }
-  )
-  Invoke-LoggedNative "Install e2e agent CLIs" "npm" `$agentCliInstallArgs 1200
-  `$npmGlobalPrefix = [string](& npm prefix --global | Select-Object -Last 1)
-  `$npmGlobalPrefix = `$npmGlobalPrefix.Trim()
-  if ([string]::IsNullOrWhiteSpace(`$npmGlobalPrefix)) {
-    throw "npm did not report a global prefix after installing the e2e agent CLIs"
-  }
-  foreach (`$agentCli in `$agentCliPackages) {
-    `$cliPath = Join-Path `$npmGlobalPrefix `$agentCli.Binary
-    if (-not (Test-Path -LiteralPath `$cliPath)) {
-      throw "Required `$(`$agentCli.Label) e2e agent CLI was not installed at the npm global prefix"
+  # This temporary Windows profile is intentionally born without coding-agent
+  # binaries. The installed Seren app must provision every managed CLI itself;
+  # test setup must never mask a regression by preinstalling them first.
+  foreach (`$commandName in @("claude", "codex", "grok", "agy")) {
+    if (Get-Command `$commandName -ErrorAction SilentlyContinue) {
+      throw "Clean Windows e2e profile unexpectedly resolves `$commandName before Seren starts"
     }
-    Invoke-LoggedNative "Verify `$(`$agentCli.Label) CLI" `$cliPath @("--version") 120
   }
-
-  # Antigravity is a native Google binary, not an npm package. Match the
-  # production installer: trust only Google's platform manifest/storage path
-  # and verify SHA-512 before the release gate launches the app.
-  `$agyManifestOrigin = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app"
-  `$agyManifest = Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json" -UseBasicParsing -TimeoutSec 60
-  `$agyArtifactUri = [Uri][string]`$agyManifest.url
-  if (
-    `$agyArtifactUri.Scheme -ne "https" -or
-    `$agyArtifactUri.Host -ne "storage.googleapis.com" -or
-    -not `$agyArtifactUri.AbsolutePath.StartsWith("/antigravity-public/antigravity-cli/")
-  ) {
-    throw "Antigravity manifest selected an untrusted artifact URL"
+  `$managedCliPrefix = Join-Path `$env:APPDATA "Seren\cli-tools"
+  if (Test-Path -LiteralPath `$managedCliPrefix) {
+    throw "Clean Windows e2e profile already contains Seren-managed agent CLIs"
   }
-  `$agyBinDir = Join-Path `$env:LOCALAPPDATA "agy\bin"
-  `$agyPath = Join-Path `$agyBinDir "agy.exe"
-  New-Item -ItemType Directory -Path `$agyBinDir -Force | Out-Null
-  `$previousProgress = `$ProgressPreference
-  `$ProgressPreference = "SilentlyContinue"
-  try {
-    Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath -UseBasicParsing -TimeoutSec 300
-  } finally {
-    `$ProgressPreference = `$previousProgress
-  }
-  `$agyHash = (Get-FileHash -LiteralPath `$agyPath -Algorithm SHA512).Hash.ToLowerInvariant()
-  if (`$agyHash -ne ([string]`$agyManifest.sha512).ToLowerInvariant()) {
-    throw "Antigravity release checksum verification failed"
-  }
-  Invoke-LoggedNative "Verify Antigravity CLI" `$agyPath @("--version") 120
+  Write-TaskLog "Confirmed clean profile; Seren must provision every managed agent CLI automatically"
   Invoke-LoggedNative "Playwright Chromium install" "pnpm" @("exec", "playwright", "install", "chromium") 600
   `$harnessArgs = @(
     "-NoProfile",

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -430,7 +430,8 @@ pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &
 
     // Keep the user's order, but append missing common locations.
     // GUI apps don't source shell profiles so CLI install directories
-    // (e.g., ~/.claude/bin, %APPDATA%\npm) are typically missing from PATH.
+    // (e.g., Seren's managed CLI directory, ~/.claude/bin, %APPDATA%\npm)
+    // are typically missing from PATH.
     {
         use std::collections::HashSet;
 
@@ -441,6 +442,7 @@ pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &
         {
             let home = std::env::var("HOME").unwrap_or_default();
             if !home.is_empty() {
+                common_bins.push(format!("{}/.seren/cli-tools/bin", home));
                 common_bins.push(format!("{}/.claude/bin", home));
                 common_bins.push(format!("{}/.local/bin", home));
             }
@@ -479,6 +481,7 @@ pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &
             // npm global installs land here
             let appdata = std::env::var("APPDATA").unwrap_or_default();
             if !appdata.is_empty() {
+                common_bins.push(format!("{}\\Seren\\cli-tools", appdata));
                 common_bins.push(format!("{}\\npm", appdata));
             }
         }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Starts the bundled runtime on localhost and returns connection config to the frontend.
 
 use serde::Serialize;
+use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -477,6 +478,45 @@ fn find_provider_runtime_mjs(app: &AppHandle) -> Result<PathBuf, String> {
     ))
 }
 
+/// Node 24 cannot execute a script whose argv entrypoint uses Windows'
+/// verbatim `\\?\` prefix: it collapses `\\?\D:\...` to `D:` and exits with
+/// EISDIR before loading the runtime. Rust and Tauri may return that prefix
+/// from `current_exe`/resource resolution, so remove it only at the Node
+/// process boundary. Preserve ordinary paths and device/volume namespaces;
+/// translate verbatim UNC paths to their equivalent ordinary UNC form.
+fn node_compatible_path(path: &Path) -> Cow<'_, Path> {
+    #[cfg(windows)]
+    if let Some(raw_path) = path.to_str() {
+        if let Some(normalized) = strip_node_unsupported_windows_verbatim_prefix(raw_path) {
+            return Cow::Owned(PathBuf::from(normalized));
+        }
+    }
+
+    Cow::Borrowed(path)
+}
+
+#[cfg(any(windows, test))]
+fn strip_node_unsupported_windows_verbatim_prefix(path: &str) -> Option<String> {
+    const VERBATIM_PREFIX: &str = r"\\?\";
+    const VERBATIM_UNC_PREFIX: &str = r"\\?\UNC\";
+
+    if path
+        .get(..VERBATIM_UNC_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(VERBATIM_UNC_PREFIX))
+    {
+        let network_path = path.get(VERBATIM_UNC_PREFIX.len()..)?;
+        return Some(format!(r"\\{network_path}"));
+    }
+
+    let local_path = path.strip_prefix(VERBATIM_PREFIX)?;
+    let bytes = local_path.as_bytes();
+    let is_drive_absolute = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/');
+    is_drive_absolute.then(|| local_path.to_string())
+}
+
 fn spawn_node_process(
     node_bin: &std::path::Path,
     runtime_entry: &std::path::Path,
@@ -484,9 +524,10 @@ fn spawn_node_process(
     port: u16,
     token: &str,
 ) -> Result<Child, String> {
+    let runtime_entry_for_node = node_compatible_path(runtime_entry);
     let mut command = Command::new(node_bin);
     command
-        .arg(runtime_entry)
+        .arg(&*runtime_entry_for_node)
         .arg("--host")
         .arg(host)
         .arg("--port")
@@ -531,7 +572,8 @@ fn spawn_node_process(
     // sees the tools. Expose the absolute embedded node binary so
     // `mcp-config.mjs` can rewrite `node` → absolute path before emitting
     // the per-CLI config JSON / TOML.
-    command.env("SEREN_EMBEDDED_NODE_BIN", node_bin);
+    let node_bin_for_runtime = node_compatible_path(node_bin);
+    command.env("SEREN_EMBEDDED_NODE_BIN", &*node_bin_for_runtime);
 
     // serenorg/seren-desktop#3230 — a bounded agent's launch spec is produced by
     // this binary's `__seren-sandbox-spec` subcommand, not by whichever caller
@@ -539,7 +581,8 @@ fn spawn_node_process(
     // for the spec and every bounded launch fails closed.
     match std::env::current_exe() {
         Ok(app_binary) => {
-            command.env("SEREN_SANDBOX_SPEC_BIN", app_binary);
+            let app_binary_for_runtime = node_compatible_path(&app_binary);
+            command.env("SEREN_SANDBOX_SPEC_BIN", &*app_binary_for_runtime);
         }
         Err(err) => {
             log::error!(
@@ -1034,6 +1077,46 @@ pub async fn provider_force_kill_session(
 mod tests {
     use super::*;
     use tokio::process::Command as TokioCommand;
+
+    #[test]
+    fn node_entrypoint_strips_local_windows_verbatim_prefix() {
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(
+                r"\\?\D:\a\seren-desktop\provider-runtime.mjs",
+            ),
+            Some(r"D:\a\seren-desktop\provider-runtime.mjs".to_string()),
+        );
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(
+                r"D:\a\seren-desktop\provider-runtime.mjs",
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn node_entrypoint_normalizes_unc_without_touching_device_namespaces() {
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(
+                r"\\?\UNC\server\share\provider-runtime.mjs",
+            ),
+            Some(r"\\server\share\provider-runtime.mjs".to_string()),
+        );
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(r"\\server\share\provider-runtime.mjs",),
+            None,
+        );
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(r"\\.\PIPE\seren"),
+            None,
+        );
+        assert_eq!(
+            strip_node_unsupported_windows_verbatim_prefix(
+                r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\provider-runtime.mjs",
+            ),
+            None,
+        );
+    }
 
     #[test]
     fn validation_cli_home_is_scoped_to_validation_provider_runtime() {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -3721,8 +3721,9 @@ fn compose_cli_command(
 
 /// PATH for terminal child processes — the embedded runtime directories
 /// plus the parent process PATH plus the CLI install dirs
-/// (`~/.claude/bin`, `~/.local/bin`, Homebrew, `%APPDATA%\npm`) a
-/// GUI-launched Tauri app typically misses.
+/// (`~/.seren/cli-tools/bin`, `~/.claude/bin`, `~/.local/bin`, Homebrew,
+/// `%APPDATA%\Seren\cli-tools`, `%APPDATA%\npm`) a GUI-launched Tauri app
+/// typically misses.
 ///
 /// Single source of truth for both the PTY spawn and the `claude
 /// --version` probe so a regression in one surface can't desync from
@@ -4248,20 +4249,24 @@ mod tests {
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             let home = std::env::var("HOME").expect("HOME must be set for this test");
-            let expected = format!("{}/.local/bin", home);
+            let managed = format!("{}/.seren/cli-tools/bin", home);
+            let native = format!("{}/.local/bin", home);
             assert!(
-                path.split(':').any(|p| p == expected),
-                "expected {expected} to be in augmented PATH, got: {path}",
+                path.split(':').any(|p| p == managed),
+                "expected {managed} to be in augmented PATH, got: {path}",
+            );
+            assert!(
+                path.split(':').any(|p| p == native),
+                "expected {native} to be in augmented PATH, got: {path}",
             );
         }
         #[cfg(target_os = "windows")]
         {
-            let userprofile =
-                std::env::var("USERPROFILE").expect("USERPROFILE must be set for this test");
-            let expected = format!(r"{}\.claude\bin", userprofile);
+            let appdata = std::env::var("APPDATA").expect("APPDATA must be set for this test");
+            let managed = format!(r"{}\Seren\cli-tools", appdata);
             assert!(
-                path.split(';').any(|p| p == expected),
-                "expected {expected} to be in augmented PATH, got: {path}",
+                path.split(';').any(|p| p == managed),
+                "expected {managed} to be in augmented PATH, got: {path}",
             );
         }
     }

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -941,8 +941,7 @@ export async function getAgentPermissionCatalog(
 }
 
 /**
- * Ensure Claude Code CLI is installed. Missing installs surface an explicit
- * official-instructions recovery action instead of running a remote script.
+ * Ensure Claude Code CLI is installed through Seren's verified managed path.
  */
 export async function ensureClaudeCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
@@ -952,8 +951,7 @@ export async function ensureClaudeCli(): Promise<string> {
 
 /**
  * Ensure Codex CLI (`@openai/codex`) is installed and meets the minimum version.
- * Missing installs require official manual setup; upgrades are verified before
- * success is reported.
+ * Missing installs and upgrades are verified before success is reported.
  */
 export async function ensureCodexCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
@@ -972,7 +970,7 @@ export type CliUpdateOutcome = {
 
 export type CliUpdateActionRequired = {
   label: string;
-  bareCommand: "claude" | "codex";
+  bareCommand: "claude" | "codex" | "grok";
   packageName: string;
   from?: string | null;
   to?: string | null;
@@ -983,7 +981,7 @@ export type CliUpdateActionRequired = {
 
 /** Retry one supported CLI update through the verified runtime path. */
 export async function retryCliUpdate(
-  bareCommand: "claude" | "codex",
+  bareCommand: "claude" | "codex" | "grok",
 ): Promise<CliUpdateOutcome> {
   return invokeProvider<CliUpdateOutcome>("provider_retry_cli_update", {
     bareCommand,
@@ -1008,7 +1006,7 @@ export async function ensureGeminiCli(): Promise<string> {
   });
 }
 
-/** Ensure the official Grok Build CLI is installed in the embedded runtime. */
+/** Ensure the official Grok Build CLI is installed in Seren's managed prefix. */
 export async function ensureGrokCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
     agentType: "grok",

--- a/src/services/validation-control.ts
+++ b/src/services/validation-control.ts
@@ -195,6 +195,7 @@ const READ_STATE_ALLOWLIST = new Set([
   "list_capability_leases",
   "list_pending_approvals",
   "provider_get_available_agents",
+  "terminal_list_buffers",
 ]);
 
 async function readState(

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1073,21 +1073,28 @@ function subscribeToCliScanRejections(): void {
  */
 function applyCliUpdateAction(payload: unknown, notify = true): void {
   const event = payload as Partial<providerService.CliUpdateActionRequired>;
-  if (event.bareCommand !== "claude" && event.bareCommand !== "codex") {
-    return;
-  }
+  const updateSources = {
+    claude: {
+      packageName: "@anthropic-ai/claude-code",
+      instructionsOrigin: "https://code.claude.com/",
+    },
+    codex: {
+      packageName: "@openai/codex",
+      instructionsOrigin: "https://developers.openai.com/",
+    },
+    grok: {
+      packageName: "@xai-official/grok",
+      instructionsOrigin: "https://docs.x.ai/",
+    },
+  } as const;
+  if (!event.bareCommand || !(event.bareCommand in updateSources)) return;
   const bareCommand = event.bareCommand;
-  const expectedPackage =
-    bareCommand === "claude" ? "@anthropic-ai/claude-code" : "@openai/codex";
-  const expectedInstructionsOrigin =
-    bareCommand === "claude"
-      ? "https://code.claude.com/"
-      : "https://developers.openai.com/";
+  const source = updateSources[bareCommand];
   const officialInstructionsUrl = event.officialInstructionsUrl;
   if (
-    event.packageName !== expectedPackage ||
+    event.packageName !== source.packageName ||
     typeof officialInstructionsUrl !== "string" ||
-    !officialInstructionsUrl.startsWith(expectedInstructionsOrigin)
+    !officialInstructionsUrl.startsWith(source.instructionsOrigin)
   ) {
     return;
   }
@@ -1752,7 +1759,7 @@ export interface AgentState {
   /** Pending manual recovery for a failed or unverifiable CLI update. */
   cliUpdateActionRequired: {
     label: string;
-    bareCommand: "claude" | "codex";
+    bareCommand: "claude" | "codex" | "grok";
     packageName: string;
     from: string | null;
     to: string | null;
@@ -7159,7 +7166,9 @@ export const agentStore = {
     const url = state.cliUpdateActionRequired?.officialInstructionsUrl;
     if (
       url &&
-      /^https:\/\/(code\.claude\.com|developers\.openai\.com)\//.test(url)
+      /^https:\/\/(code\.claude\.com|developers\.openai\.com|docs\.x\.ai)\//.test(
+        url,
+      )
     ) {
       void openExternalLink(url);
     }

--- a/tests/unit/agent-cli-provisioning.test.ts
+++ b/tests/unit/agent-cli-provisioning.test.ts
@@ -1,0 +1,139 @@
+// ABOUTME: Completeness guard for automatic coding-agent CLI provisioning across the live roster.
+// ABOUTME: Verifies every desktop OS resolves the same writable Seren-managed install prefix.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const registryModule = new URL(
+  "../../bin/browser-local/agent-registry.mjs",
+  import.meta.url,
+).href;
+const cliPathsModule = new URL(
+  "../../bin/browser-local/cli-paths.mjs",
+  import.meta.url,
+).href;
+
+const {
+  _AGENT_CLI_PROVISIONING: provisioning,
+  _assertAgentCliProvisioningComplete: assertAgentCliProvisioningComplete,
+} = await import(/* @vite-ignore */ registryModule);
+const { managedCliBinary, managedCliPrefix } = await import(
+  /* @vite-ignore */ cliPathsModule
+);
+
+const registrySource = readFileSync(
+  new URL("../../bin/browser-local/agent-registry.mjs", import.meta.url),
+  "utf8",
+);
+const claudeRuntimeSource = readFileSync(
+  new URL("../../bin/browser-local/claude-runtime.mjs", import.meta.url),
+  "utf8",
+);
+const grokResolverSource = readFileSync(
+  new URL("../../bin/browser-local/grok-binary.mjs", import.meta.url),
+  "utf8",
+);
+
+describe("#3680 complete automatic CLI provisioning roster", () => {
+  it("classifies every CLI-backed agent enumerated by the live registry", () => {
+    expect(provisioning).toEqual({
+      codex: { kind: "npm", target: "codex" },
+      "claude-code": { kind: "npm", target: "claude" },
+      "claude-codex": {
+        kind: "derived",
+        dependencies: ["claude-code", "codex"],
+      },
+      gemini: { kind: "verified-artifact", target: "antigravity" },
+      grok: { kind: "npm", target: "grok" },
+      lmstudio: { kind: "external-app", target: "lmstudio" },
+    });
+  });
+
+  it("fails closed when the runtime roster and provisioning source drift", () => {
+    const completeDefinitions = Object.fromEntries(
+      Object.keys(provisioning).map((agentType) => [agentType, {}]),
+    );
+    expect(() =>
+      assertAgentCliProvisioningComplete(completeDefinitions, provisioning),
+    ).not.toThrow();
+    expect(() =>
+      assertAgentCliProvisioningComplete(
+        { ...completeDefinitions, futureAgent: {} },
+        provisioning,
+      ),
+    ).toThrow(/provisioning is incomplete/);
+  });
+
+  it("derives startup provisioning from the roster instead of a partial hardcoded list", () => {
+    expect(registrySource).toContain(
+      "Object.values(AGENT_CLI_PROVISIONING)",
+    );
+    expect(registrySource).toContain(
+      "assertAgentCliProvisioningComplete(definitions, AGENT_CLI_PROVISIONING)",
+    );
+    expect(registrySource).toContain("for (const target of new Set(managedNpmTargets))");
+    expect(registrySource).not.toContain('void runCliUpdate("codex")');
+    expect(registrySource).not.toContain('void runCliUpdate("claude")');
+  });
+
+  it("routes install, availability, and runtime spawn through the managed prefix", () => {
+    expect(registrySource).toContain('managedCliBinary("claude")');
+    expect(registrySource).toContain('managedCliBinary("codex")');
+    expect(registrySource).toContain("installPrefix: managedCliPrefix()");
+    expect(claudeRuntimeSource).toContain('managedCliBinary("claude")');
+    expect(grokResolverSource).toContain("managedCliPrefix");
+    expect(grokResolverSource).toContain("managedNative");
+  });
+
+  it("keeps Seren's verified Claude copy ahead of stale user-managed installs", () => {
+    for (const source of [registrySource, claudeRuntimeSource]) {
+      const managedPositions = [
+        ...source.matchAll(/managedCliBinary\("claude"\)/g),
+      ].map((match) => match.index);
+      const userManagedPositions = [
+        ...source.matchAll(
+          /path\.join\(home, "\.claude", "bin", "claude(?:\.exe)?"\)/g,
+        ),
+      ].map((match) => match.index);
+      expect(managedPositions).toHaveLength(2);
+      expect(userManagedPositions).toHaveLength(2);
+      expect(managedPositions[0]).toBeLessThan(userManagedPositions[0]);
+      expect(managedPositions[1]).toBeLessThan(userManagedPositions[1]);
+    }
+  });
+
+  it.each([
+    {
+      platform: "win32",
+      home: "C:\\Users\\person",
+      appData: "C:\\Users\\person\\AppData\\Roaming",
+      expectedPrefix:
+        "C:\\Users\\person\\AppData\\Roaming\\Seren\\cli-tools",
+      expectedBinary:
+        "C:\\Users\\person\\AppData\\Roaming\\Seren\\cli-tools\\codex.cmd",
+    },
+    {
+      platform: "darwin",
+      home: "/Users/person",
+      appData: "",
+      expectedPrefix: "/Users/person/.seren/cli-tools",
+      expectedBinary: "/Users/person/.seren/cli-tools/bin/codex",
+    },
+    {
+      platform: "linux",
+      home: "/home/person",
+      appData: "",
+      expectedPrefix: "/home/person/.seren/cli-tools",
+      expectedBinary: "/home/person/.seren/cli-tools/bin/codex",
+    },
+  ])("uses a per-user managed prefix on $platform", (fixture) => {
+    const prefix = managedCliPrefix(fixture);
+    expect(prefix).toBe(fixture.expectedPrefix);
+    expect(
+      managedCliBinary("codex", {
+        platform: fixture.platform,
+        prefix,
+      }),
+    ).toBe(fixture.expectedBinary);
+  });
+});

--- a/tests/unit/claude-cli-baseline-gate.test.ts
+++ b/tests/unit/claude-cli-baseline-gate.test.ts
@@ -43,9 +43,10 @@ describe("#3443 claude-code spawn wiring enforces the baseline", () => {
     expect(helper).toContain("ensureCliBaselineViaUpdater(emit");
     expect(helper).toContain('packageName: "@anthropic-ai/claude-code"');
     expect(helper).toContain("resolveBinary: resolveInstalledClaudeBinary");
-    // Custom PATH installs cannot be auto-updated, but a determinately
-    // below-baseline one must still be refused with an actionable error.
+    // A determinately stale custom PATH install is replaced by Seren's
+    // verified managed copy without a manual update handoff.
     expect(helper).toContain("isBelowBaseline(installed, baseline)");
+    expect(agentRegistrySource).toContain("installIfMissing: true");
     // A large JS CLI can outlive the version-probe timeout on a slow
     // machine; failing closed there turned a slow disk into "not
     // installed" and broke the v3.75.0 release gate (#3471).
@@ -136,26 +137,50 @@ describe("#3443 shared baseline gate decision logic", () => {
     ).rejects.toThrow(/still 2\.1\.100; Seren requires 2\.1\.197/);
   });
 
-  it("hands off with installation_required when no version can be probed", async () => {
+  it("automatically provisions a missing CLI with no action-required handoff (#3680)", async () => {
     const events: EmittedEvent[] = [];
-    const updaterCalls: unknown[] = [];
-    await expect(
-      ensureCliBaselineViaUpdater(makeEmit(events), {
-        ...CLAUDE_BASELINE_CONFIG,
-        resolveBinary: () => "claude",
-        _runInstalledVersion: async () => null,
-        _backgroundUpdateCli: async (options: unknown) => {
-          updaterCalls.push(options);
-          return { outcome: "success" };
-        },
-      }),
-    ).rejects.toThrow(/not installed in a verifiable location/);
+    const updaterCalls: Array<Record<string, unknown>> = [];
+    const resolved = ["claude", "/managed/bin/claude"];
+    let versionCalls = 0;
+    const result = await ensureCliBaselineViaUpdater(makeEmit(events), {
+      ...CLAUDE_BASELINE_CONFIG,
+      resolveBinary: () => resolved.shift() ?? "/managed/bin/claude",
+      _runInstalledVersion: async () =>
+        versionCalls++ === 0 ? null : "2.1.221",
+      _backgroundUpdateCli: async (options: Record<string, unknown>) => {
+        updaterCalls.push(options);
+        return { outcome: "success" };
+      },
+    });
 
-    expect(updaterCalls).toHaveLength(0);
-    const action = events.find(
-      (event) => event.name === "provider://cli-update-action-required",
-    );
-    expect(action?.payload.reason).toBe("installation_required");
+    expect(result).toBe("/managed/bin/claude");
+    expect(updaterCalls).toHaveLength(1);
+    expect(updaterCalls[0]).toMatchObject({
+      force: true,
+      installIfMissing: true,
+    });
+    expect(updaterCalls[0].installPrefix).toEqual(expect.any(String));
+    expect(
+      events.some(
+        (event) => event.name === "provider://cli-update-action-required",
+      ),
+    ).toBe(false);
+  });
+
+  it("uses a verified first install when the updater's cold health probe times out (#3680)", async () => {
+    const resolved = ["claude", "/managed/bin/claude"];
+    let versionCalls = 0;
+    const result = await ensureCliBaselineViaUpdater(makeEmit([]), {
+      ...CLAUDE_BASELINE_CONFIG,
+      resolveBinary: () => resolved.shift() ?? "/managed/bin/claude",
+      _runInstalledVersion: async () =>
+        versionCalls++ === 0 ? null : "2.1.221",
+      _backgroundUpdateCli: async () => ({
+        outcome: "skipped:verification_required",
+      }),
+    });
+
+    expect(result).toBe("/managed/bin/claude");
   });
 
   it("spawns a resolved install permissively when the probe fails and the CLI opts in (#3471)", async () => {
@@ -177,26 +202,19 @@ describe("#3443 shared baseline gate decision logic", () => {
     expect(events).toHaveLength(0);
   });
 
-  it("still hands off an UNRESOLVED install even when the CLI opts in (#3471)", async () => {
-    await expect(
-      ensureCliBaselineViaUpdater(makeEmit([]), {
-        ...CLAUDE_BASELINE_CONFIG,
-        resolveBinary: () => "claude",
-        allowUnprobeableInstall: true,
-        _runInstalledVersion: async () => null,
-        _backgroundUpdateCli: async () => ({ outcome: "success" }),
-      }),
-    ).rejects.toThrow(/not installed in a verifiable location/);
-  });
+  it("repairs an unprobeable strict CLI automatically — the Codex contract (#3680)", async () => {
+    const resolved = ["/broken/bin/codex", "/managed/bin/codex"];
+    let versionCalls = 0;
+    const result = await ensureCliBaselineViaUpdater(makeEmit([]), {
+      label: "Codex",
+      bareCommand: "codex",
+      packageName: "@openai/codex",
+      resolveBinary: () => resolved.shift() ?? "/managed/bin/codex",
+      _runInstalledVersion: async () =>
+        versionCalls++ === 0 ? null : "0.146.0",
+      _backgroundUpdateCli: async () => ({ outcome: "success" }),
+    });
 
-  it("keeps the strict handoff for CLIs that do not opt in — the Codex contract (#2904)", async () => {
-    await expect(
-      ensureCliBaselineViaUpdater(makeEmit([]), {
-        ...CLAUDE_BASELINE_CONFIG,
-        resolveBinary: () => "/fake/bin/codex",
-        _runInstalledVersion: async () => null,
-        _backgroundUpdateCli: async () => ({ outcome: "success" }),
-      }),
-    ).rejects.toThrow(/not installed in a verifiable location/);
+    expect(result).toBe("/managed/bin/codex");
   });
 });

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -187,6 +187,247 @@ describe("backgroundUpdateCli TTL gate", () => {
   });
 });
 
+describe("automatic verified first install (#3680)", () => {
+  const codexCandidate = {
+    version: "0.146.0",
+    tarballSha512: "verified-codex",
+    installScripts: {},
+    declaredDependencies: ["@openai/codex-darwin-arm64"],
+    binEntries: { codex: "bin/codex.js" },
+    executableFiles: ["bin/codex.js"],
+    networkHosts: [],
+    files: ["package.json", "bin/codex.js"],
+    fileHashes: { "package.json": "package", "bin/codex.js": "bin" },
+  };
+
+  function firstInstallInvocation(
+    overrides: Record<string, unknown> = {},
+  ) {
+    let resolved = "codex";
+    return {
+      options: {
+        label: "Codex",
+        bareCommand: "codex",
+        resolvedPath: "codex",
+        packageName: "@openai/codex",
+        installIfMissing: true,
+        installPrefix: "/managed/cli-tools",
+        resolveInstalledPath: () => resolved,
+        state: {} as Record<string, unknown>,
+        now: Date.now(),
+        _versionOverrides: {
+          runInstalledVersion: async () =>
+            resolved === "codex" ? null : "0.146.0",
+          runNpmView: async () => "0.146.0",
+          runNpmViewIntegrity: async () => "sha512-verified",
+          runCliHealthCheck: async () => true,
+        },
+        _scannerOverrides: {
+          npmPackToDirectory: async () => "/tmp/codex-0.146.0.tgz",
+          verifyTarballIntegrity: () => true,
+          scanTarball: async () => ({
+            verdict: "no_baseline",
+            flags: [],
+            candidate: codexCandidate,
+          }),
+          runNpmInstallFromTarball: async (
+            _tarball: string,
+            installOptions: Record<string, unknown>,
+          ) => {
+            expect(installOptions.installPrefix).toBe("/managed/cli-tools");
+            resolved = "/managed/cli-tools/bin/codex";
+          },
+        },
+        ...overrides,
+      },
+      setResolved(value: string) {
+        resolved = value;
+      },
+    };
+  }
+
+  it("installs a missing CLI into Seren's managed prefix and verifies the resolved binary", async () => {
+    const { options } = firstInstallInvocation();
+    const result = await backgroundUpdateCli(options);
+
+    expect(result).toMatchObject({
+      outcome: "success",
+      installedFromMissing: true,
+      firstInstall: true,
+      verifiedVersion: "0.146.0",
+    });
+  });
+
+  it("keeps subsequent npm updates in Seren's managed prefix", async () => {
+    let installedVersion = "2.1.220";
+    let receivedPrefix: unknown;
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/home/person/.seren/cli-tools/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      installPrefix: "/home/person/.seren/cli-tools",
+      resolveInstalledPath: () =>
+        "/home/person/.seren/cli-tools/bin/claude",
+      state: {},
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => installedVersion,
+        runNpmView: async () => "2.1.221",
+        runNpmViewIntegrity: async () => "sha512-verified",
+        runCliHealthCheck: async () => true,
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/claude-2.1.221.tgz",
+        verifyTarballIntegrity: () => true,
+        scanTarball: async () => ({
+          verdict: "pass",
+          flags: [],
+          candidate: {
+            ...codexCandidate,
+            version: "2.1.221",
+            tarballSha512: "verified-claude",
+          },
+        }),
+        runNpmInstallFromTarball: async (
+          _tarball: string,
+          installOptions: Record<string, unknown>,
+        ) => {
+          receivedPrefix = installOptions.installPrefix;
+          installedVersion = "2.1.221";
+        },
+      },
+    });
+
+    expect(result.outcome).toBe("success");
+    expect(receivedPrefix).toBe("/home/person/.seren/cli-tools");
+  });
+
+  it("fails closed without creating a manual-install action when integrity is wrong", async () => {
+    const actions: unknown[] = [];
+    let installCalled = false;
+    const state: Record<string, unknown> = {
+      "pendingAction:codex": { reason: "installation_required" },
+    };
+    const { options } = firstInstallInvocation({
+      state,
+      onActionRequired: (event: unknown) => actions.push(event),
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/codex-0.146.0.tgz",
+        verifyTarballIntegrity: () => false,
+        scanTarball: async () => {
+          throw new Error("unverified bytes must not be scanned");
+        },
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+
+    const result = await backgroundUpdateCli(options);
+    expect(result).toMatchObject({
+      outcome: "skipped:integrity_failed",
+      installedFromMissing: true,
+    });
+    expect(installCalled).toBe(false);
+    expect(actions).toHaveLength(0);
+    expect(state["pendingAction:codex"]).toBeNull();
+  });
+
+  it("shares one install when startup and spawn request the same missing CLI", async () => {
+    let installCalls = 0;
+    let resolved = "codex";
+    const options = {
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "codex",
+      packageName: "@openai/codex",
+      installIfMissing: true,
+      installPrefix: "/managed/cli-tools",
+      resolveInstalledPath: () => resolved,
+      state: {} as Record<string, unknown>,
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () =>
+          resolved === "codex" ? null : "0.146.0",
+        runNpmView: async () => "0.146.0",
+        runNpmViewIntegrity: async () => "sha512-verified",
+        runCliHealthCheck: async () => true,
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/codex-0.146.0.tgz",
+        verifyTarballIntegrity: () => true,
+        scanTarball: async () => ({
+          verdict: "no_baseline",
+          flags: [],
+          candidate: codexCandidate,
+        }),
+        runNpmInstallFromTarball: async () => {
+          installCalls += 1;
+          resolved = "/managed/cli-tools/bin/codex";
+        },
+      },
+    };
+
+    const [startup, spawn] = await Promise.all([
+      backgroundUpdateCli(options),
+      backgroundUpdateCli(options),
+    ]);
+    expect(startup.outcome).toBe("success");
+    expect(spawn).toBe(startup);
+    expect(installCalls).toBe(1);
+  });
+
+  it("accepts the current Grok package shape before its first managed install", async () => {
+    let resolved = "grok";
+    const result = await backgroundUpdateCli({
+      label: "Grok",
+      bareCommand: "grok",
+      resolvedPath: "grok",
+      packageName: "@xai-official/grok",
+      installIfMissing: true,
+      installPrefix: "/managed/cli-tools",
+      resolveInstalledPath: () => resolved,
+      state: {},
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () =>
+          resolved === "grok" ? null : "0.2.118",
+        runNpmView: async () => "0.2.118",
+        runNpmViewIntegrity: async () => "sha512-verified",
+        runCliHealthCheck: async () => true,
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/grok-0.2.118.tgz",
+        verifyTarballIntegrity: () => true,
+        scanTarball: async () => ({
+          verdict: "no_baseline",
+          flags: [],
+          candidate: {
+            version: "0.2.118",
+            tarballSha512: "verified-grok",
+            installScripts: { postinstall: "node bin/postinstall.js" },
+            declaredDependencies: [
+              "@iarna/toml",
+              "@xai-official/grok-win32-x64",
+            ],
+            binEntries: { grok: "bin/grok" },
+            executableFiles: ["bin/grok"],
+            networkHosts: [],
+            files: ["package.json", "bin/grok"],
+            fileHashes: { "package.json": "package", "bin/grok": "bin" },
+          },
+        }),
+        runNpmInstallFromTarball: async () => {
+          resolved = "/managed/cli-tools/bin/grok";
+        },
+      },
+    });
+
+    expect(result.outcome).toBe("success");
+  });
+});
+
 describe("isBelowBaseline (#1761)", () => {
   it("returns true when installed is older on any semver component", () => {
     expect(isBelowBaseline("2.1.30", "2.1.120")).toBe(true);
@@ -763,5 +1004,6 @@ describe("verified fail-closed updates (#3092)", () => {
     expect(card).toContain("agentStore.openCliUpdateInstructions()");
     expect(store).toContain("https://code.claude.com/");
     expect(store).toContain("https://developers.openai.com/");
+    expect(store).toContain("https://docs.x.ai/");
   });
 });

--- a/tests/unit/codex-cli-upgrade-gate.test.ts
+++ b/tests/unit/codex-cli-upgrade-gate.test.ts
@@ -11,8 +11,14 @@ const agentRegistrySource = readFileSync(
 
 describe("#2904 Codex CLI upgrade gate", () => {
   it("Codex ensureCli uses the blocking updater before provider spawn", () => {
-    const codexDefStart = agentRegistrySource.indexOf("codex: {");
-    const claudeDefStart = agentRegistrySource.indexOf('"claude-code": {');
+    const registryStart = agentRegistrySource.indexOf(
+      "export function createBrowserLocalAgentRegistry",
+    );
+    const codexDefStart = agentRegistrySource.indexOf("codex: {", registryStart);
+    const claudeDefStart = agentRegistrySource.indexOf(
+      '"claude-code": {',
+      codexDefStart,
+    );
     const codexDefinition = agentRegistrySource.slice(
       codexDefStart,
       claudeDefStart,

--- a/tests/unit/gemini-1476-fixes.test.ts
+++ b/tests/unit/gemini-1476-fixes.test.ts
@@ -50,7 +50,10 @@ describe("Gemini Agent #1476 — load-bearing regression guards", () => {
 
   // ─── Slice B: Antigravity first-run auth ─────────────────────────────
   it("launches agy itself because Antigravity has no login subcommand", () => {
-    const idx = agentRegistryMjs.indexOf("gemini: {");
+    const registryStart = agentRegistryMjs.indexOf(
+      "export function createBrowserLocalAgentRegistry",
+    );
+    const idx = agentRegistryMjs.indexOf("gemini: {", registryStart);
     expect(idx).toBeGreaterThan(-1);
     const definition = agentRegistryMjs.slice(idx, idx + 2400);
     expect(definition).toContain("launchInteractiveCommand");

--- a/tests/unit/grok-agent.test.ts
+++ b/tests/unit/grok-agent.test.ts
@@ -10,8 +10,6 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-// @ts-ignore - browser-local runtime is plain ESM.
-import { _CLI_INSTALL_INSTRUCTIONS } from "../../bin/browser-local/agent-registry.mjs";
 import { resolveGrokBinary } from "../../bin/browser-local/grok-binary.mjs";
 import { describe, expect, it } from "vitest";
 
@@ -115,20 +113,7 @@ describe("Grok native ACP agent (#3084)", () => {
     }
   });
 
-  it("publishes official install instructions for the Grok package (#3154)", () => {
-    // emitCliActionRequired reads this map. A missing entry interpolates
-    // `undefined` into the thrown message and leaves the action-required
-    // event with no URL to open.
-    const url = _CLI_INSTALL_INSTRUCTIONS["@xai-official/grok"];
-    expect(url).toBe("https://docs.x.ai/build/overview");
-    expect(() => new URL(url)).not.toThrow();
-    expect(new URL(url).protocol).toBe("https:");
-  });
-
-  it("reports a missing install instead of spawning a bare command (#3154)", () => {
-    // Returning "grok" when nothing resolved produced a spawn ENOENT that
-    // reached the user as "Grok agent stopped before request completed",
-    // which says nothing about a missing install. Mirrors Claude/Codex.
+  it("automatically provisions a missing install instead of spawning a bare command (#3680)", () => {
     const start = registrySource.indexOf("    grok: {");
     const end = registrySource.indexOf("    lmstudio: {", start);
     expect(start).toBeGreaterThan(-1);
@@ -138,14 +123,20 @@ describe("Grok native ACP agent (#3084)", () => {
       end,
     );
 
-    expect(ensureCli).toContain("emitCliActionRequired");
-    expect(ensureCli).toContain('packageName: "@xai-official/grok"');
-    expect(ensureCli).toContain('reason: "installation_required"');
-    expect(ensureCli).toMatch(/throw new Error\(/);
-    expect(ensureCli).toContain("Install it from ${url}");
+    expect(ensureCli).toContain("ensureGrokCliViaUpdater(emit)");
+    const helperStart = registrySource.indexOf(
+      "async function ensureGrokCliViaUpdater",
+    );
+    const helperEnd = registrySource.indexOf(
+      "export function resolveInstalledClaudeBinary",
+      helperStart,
+    );
+    const helper = registrySource.slice(helperStart, helperEnd);
+    expect(helper).toContain('packageName: "@xai-official/grok"');
+    expect(registrySource).toContain("installIfMissing: true");
     // A user-managed grok on PATH sits outside every path the resolver
-    // knows; it must still spawn rather than hit the throw.
-    expect(ensureCli).toContain('isCommandAvailable("grok")');
+    // knows; it must still spawn rather than create a shadow install.
+    expect(helper).toContain('isCommandAvailable("grok")');
   });
 
   it("routes Grok through the registry, runtime dispatcher, and public agent type", () => {

--- a/tests/unit/launch-login-resolver.test.ts
+++ b/tests/unit/launch-login-resolver.test.ts
@@ -9,9 +9,12 @@ const registryPath = resolve("bin/browser-local/agent-registry.mjs");
 const registrySource = readFileSync(registryPath, "utf-8");
 
 function sliceDefinition(key: string): string {
+  const registryStart = registrySource.indexOf(
+    "export function createBrowserLocalAgentRegistry",
+  );
   // Object literal keys may be quoted ("claude-code") or bare (codex).
-  const quoted = registrySource.indexOf(`"${key}": {`);
-  const bare = registrySource.indexOf(`\n    ${key}: {`);
+  const quoted = registrySource.indexOf(`"${key}": {`, registryStart);
+  const bare = registrySource.indexOf(`\n    ${key}: {`, registryStart);
   const start = quoted >= 0 ? quoted : bare >= 0 ? bare + 1 : -1;
   if (start < 0) throw new Error(`Definition not found: ${key}`);
   const window = registrySource.slice(start, start + 4000);

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -102,6 +102,24 @@ describe("validation environment", () => {
     expect(defaults.RUSTUP_HOME).toBe(path.join("/real-home", ".rustup"));
   });
 
+  it("isolates Windows profile and app-data roots for clean CLI provisioning", () => {
+    const env = validationChildEnv({
+      baseEnv: {},
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+      platform: "win32",
+    });
+
+    expect(env.USERPROFILE).toBe(env.HOME);
+    expect(env.APPDATA).toBe(
+      path.join(env.HOME as string, "AppData", "Roaming"),
+    );
+    expect(env.LOCALAPPDATA).toBe(
+      path.join(env.HOME as string, "AppData", "Local"),
+    );
+  });
+
   it("sets the pnpm store only when one is provided", () => {
     const withStore = validationChildEnv({
       baseEnv: {},

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -142,6 +142,17 @@ describe("validation environment", () => {
     expect(viteConfig).toContain('"**/artifacts/validation-home/**"');
   });
 
+  it("allows a clean Windows runner to finish its cold Rust build", () => {
+    const workflow = readFileSync(
+      path.resolve(".github/workflows/validation-walkthrough.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(
+      'SEREN_VALIDATION_DISCOVERY_TIMEOUT_MS: "1200000"',
+    );
+  });
+
   it("sets the pnpm store only when one is provided", () => {
     const withStore = validationChildEnv({
       baseEnv: {},

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Protects the validation launcher's hermetic child environment.
 // ABOUTME: Covers worktree state roots while keeping toolchain caches stable.
 
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -133,6 +134,12 @@ describe("validation environment", () => {
       cliScript:
         "D:\\a\\seren-desktop\\node_modules\\@tauri-apps\\cli\\tauri.js",
     });
+  });
+
+  it("keeps disposable validation profiles outside Vite's file watcher", () => {
+    const viteConfig = readFileSync(path.resolve("vite.config.ts"), "utf8");
+
+    expect(viteConfig).toContain('"**/artifacts/validation-home/**"');
   });
 
   it("sets the pnpm store only when one is provided", () => {

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -7,6 +7,7 @@ import {
   ensureValidationKeychain,
   validationChildEnv,
   validationHomeForSlot,
+  validationTauriCliCommand,
 } from "../../scripts/validation-env";
 import { shouldSkipValidationBuild } from "../../scripts/validation-dev-args";
 
@@ -118,6 +119,20 @@ describe("validation environment", () => {
     expect(env.LOCALAPPDATA).toBe(
       path.join(env.HOME as string, "AppData", "Local"),
     );
+  });
+
+  it("launches the Tauri CLI through Node instead of a Windows command shim", () => {
+    expect(
+      validationTauriCliCommand({
+        repoRoot: "D:\\a\\seren-desktop",
+        execPath: "C:\\hostedtoolcache\\node.exe",
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\hostedtoolcache\\node.exe",
+      cliScript:
+        "D:\\a\\seren-desktop\\node_modules\\@tauri-apps\\cli\\tauri.js",
+    });
   });
 
   it("sets the pnpm store only when one is provided", () => {

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -348,16 +348,15 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("initialModelId");
   });
 
-  it("installs the agent CLIs where the app's production resolver looks (run 30159367572)", () => {
-    // The harness provisions a portable toolchain Node whose npm global prefix
-    // is the scratch Node dir, but the installed app resolves agent CLIs from
-    // %APPDATA%\npm (resolveInstalledCodexBinary candidate #1). Pin the install
-    // prefix to %APPDATA%\npm so the app can actually see the codex it installed;
-    // otherwise the codex journey dies with "not installed in a verifiable
-    // location" while the box demonstrably has the CLI.
-    expect(taskUserRunner).toContain("npm_config_prefix");
-    expect(taskUserRunner).toContain("appDataNpmPrefix");
-    expect(agentRegistry).toContain('path.join(appData, "npm", "codex.cmd")');
+  it("makes the installed app provision CLIs into its managed Windows prefix", () => {
+    // The temporary profile must begin without agent binaries. The probe then
+    // verifies the exact files Seren created rather than accepting test-setup
+    // preinstalls that can mask a production regression.
+    expect(taskUserRunner).not.toContain('Invoke-LoggedNative "Install e2e agent CLIs"');
+    expect(taskUserRunner).toContain("Clean Windows e2e profile unexpectedly resolves");
+    expect(taskUserRunner).toContain('Join-Path `$env:APPDATA "Seren\\cli-tools"');
+    expect(agentRegistry).toContain("managedCliBinary");
+    expect(probe).toContain('path.join(appData, "Seren", "cli-tools", "codex.cmd")');
   });
 
   it("keeps codex credentials required under Bedrock — Bedrock waives only Claude (run 30159367572)", () => {
@@ -532,50 +531,19 @@ describe("Windows production e2e release gate", () => {
     expect(releaseWorkflow).toContain("windows-app-e2e-logs");
   });
 
-  it("preprovisions real agent CLIs outside provider startup before checking release-gate availability (#2481, #3100)", () => {
-    // #3096 removed automatic provider-startup installers. The disposable
-    // Windows release user must install its explicit test prerequisites before
-    // app launch, while the production RPC only verifies resolution.
-    const cliSetupAt = taskUserRunner.indexOf(
-      'Invoke-LoggedNative "Install e2e agent CLIs"',
+  it("certifies automatic provisioning on a clean Windows profile (#3680)", () => {
+    const cleanProfileAt = taskUserRunner.indexOf(
+      "Confirmed clean profile; Seren must provision every managed agent CLI automatically",
     );
     const appHarnessAt = taskUserRunner.indexOf(
       'Invoke-LoggedNative "Windows app harness"',
     );
-    expect(cliSetupAt).toBeGreaterThanOrEqual(0);
+    expect(cleanProfileAt).toBeGreaterThanOrEqual(0);
     expect(appHarnessAt).toBeGreaterThanOrEqual(0);
-    expect(cliSetupAt).toBeLessThan(appHarnessAt);
-    expect(taskUserRunner).toContain("@anthropic-ai/claude-code@latest");
-    expect(taskUserRunner).toContain("@openai/codex@latest");
-    expect(taskUserRunner).toContain(
-      "manifests/windows_amd64.json",
-    );
-    expect(taskUserRunner).toContain("Get-FileHash");
-    expect(taskUserRunner).toContain("SHA512");
-    expect(taskUserRunner).toContain('"agy.exe"');
-    // Windows PowerShell 5.1 applies no timeout by default, so a stalled
-    // Antigravity fetch would hang the gate until the outer task timeout
-    // instead of failing fast. #3668
-    for (const antigravityFetch of [
-      'Invoke-RestMethod -Uri "`$agyManifestOrigin/manifests/windows_amd64.json" -UseBasicParsing -TimeoutSec 60',
-      "Invoke-WebRequest -Uri `$agyArtifactUri.AbsoluteUri -OutFile `$agyPath -UseBasicParsing -TimeoutSec 300",
-    ]) {
-      expect(taskUserRunner).toContain(antigravityFetch);
-    }
-    expect(taskUserRunner).toContain("@xai-official/grok@latest");
-    for (const [label, binary] of [
-      ["Claude Code", "claude.cmd"],
-      ["Codex", "codex.cmd"],
-      ["Grok", "grok.cmd"],
-    ]) {
-      expect(taskUserRunner).toContain(
-        `Label = "${label}"; Package =`,
-      );
-      expect(taskUserRunner).toContain(`Binary = "${binary}"`);
-    }
-    expect(taskUserRunner).toContain(
-      'Invoke-LoggedNative "Verify `$(`$agentCli.Label) CLI"',
-    );
+    expect(cleanProfileAt).toBeLessThan(appHarnessAt);
+    expect(taskUserRunner).not.toContain("@anthropic-ai/claude-code@latest");
+    expect(taskUserRunner).not.toContain("@openai/codex@latest");
+    expect(taskUserRunner).not.toContain("@xai-official/grok@latest");
 
     expect(probe).toContain("provider_ensure_agent_cli");
     expect(probe).toContain("ensureAgentCli");
@@ -583,6 +551,9 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("provider CLI ready");
     expect(probe).toContain("CLI_COMPATIBILITY_AGENT_TYPES");
     expect(probe).toContain("verifyAgentCliCompatibility");
+    expect(probe).toContain("verifyManagedCliArtifacts");
+    expect(probe).toContain("provider_get_available_agents");
+    expect(probe).toContain("verifyLiveAgentRosterAndLaunchers");
     expect(probe).toContain("all provider CLI resolution checks passed");
     for (const agentType of [
       "codex",
@@ -592,6 +563,21 @@ describe("Windows production e2e release gate", () => {
       "grok",
     ]) {
       expect(probe).toContain(`"${agentType}"`);
+    }
+    for (const binary of ["claude.cmd", "codex.cmd", "grok.cmd", "agy.exe"]) {
+      expect(probe).toContain(`"${binary}"`);
+    }
+    for (const testId of [
+      "new-claude-agent",
+      "new-codex-agent",
+      "new-claude-codex-agent",
+      "new-gemini-agent",
+      "new-grok-agent",
+      "new-lmstudio-agent",
+      "new-claude-cli",
+      "new-codex-cli",
+    ]) {
+      expect(probe).toContain(`"${testId}"`);
     }
     const runtimeExerciseAt = probe.indexOf("async function exerciseAgentRuntime");
     const compatibilityCheckAt = probe.indexOf(

--- a/tests/validation/scenarios/automatic-cli-provisioning.ts
+++ b/tests/validation/scenarios/automatic-cli-provisioning.ts
@@ -1,0 +1,258 @@
+// ABOUTME: Proves first-run coding-agent CLI provisioning in the real validation app.
+// ABOUTME: Compares every launcher row with the live native registry without mocks.
+
+import { execFile } from "node:child_process";
+import { access, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface LiveAgent {
+  type?: string;
+  name?: string;
+  available?: boolean;
+}
+
+interface LiveTerminalBuffer {
+  id?: string;
+  cliKind?: "claude" | "codex" | null;
+  status?: "running" | "exited";
+}
+
+const TARGETS = [
+  {
+    type: "claude-code",
+    testId: "new-claude-agent",
+    label: "Claude Code",
+  },
+  { type: "codex", testId: "new-codex-agent", label: "Codex" },
+  {
+    type: "claude-codex",
+    testId: "new-claude-codex-agent",
+    label: "Claude + Codex",
+  },
+  { type: "gemini", testId: "new-gemini-agent", label: "Antigravity" },
+  { type: "grok", testId: "new-grok-agent", label: "Grok" },
+  {
+    type: "lmstudio",
+    testId: "new-lmstudio-agent",
+    label: "LM Studio Agent",
+  },
+] as const;
+
+const CLI_LAUNCHERS = [
+  { cliKind: "claude", testId: "new-claude-cli", label: "Claude Code" },
+  { cliKind: "codex", testId: "new-codex-cli", label: "Codex" },
+] as const;
+
+const execFileAsync = promisify(execFile);
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function managedCliBinary(validationHome: string, command: string): string {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (!appData) throw new Error("Windows validation requires APPDATA");
+    return path.join(appData, "Seren", "cli-tools", `${command}.cmd`);
+  }
+  return path.join(validationHome, ".seren", "cli-tools", "bin", command);
+}
+
+function antigravityBinary(validationHome: string): string {
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (!localAppData) throw new Error("Windows validation requires LOCALAPPDATA");
+    return path.join(localAppData, "agy", "bin", "agy.exe");
+  }
+  return path.join(validationHome, ".local", "bin", "agy");
+}
+
+async function readVersion(binary: string): Promise<string | null> {
+  try {
+    if (path.isAbsolute(binary)) await access(binary);
+    const { stdout } = await execFileAsync(binary, ["--version"], {
+      encoding: "utf8",
+      shell:
+        process.platform === "win32" &&
+        (!path.isAbsolute(binary) || binary.endsWith(".cmd")),
+      timeout: 15_000,
+    });
+    return stdout.match(/\b\d+\.\d+\.\d+\b/)?.[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForUsableClis(
+  validationHome: string,
+): Promise<{
+  versions: Record<string, string>;
+  serenManaged: Record<string, boolean>;
+}> {
+  const candidates = {
+    claude: [managedCliBinary(validationHome, "claude"), "claude"],
+    codex: [managedCliBinary(validationHome, "codex"), "codex"],
+    grok: [managedCliBinary(validationHome, "grok"), "grok"],
+    antigravity: [antigravityBinary(validationHome), "agy"],
+  };
+  const started = Date.now();
+  while (Date.now() - started <= 360_000) {
+    const resolved = Object.fromEntries(
+      await Promise.all(
+        Object.entries(candidates).map(async ([name, binaries]) => {
+          for (const [index, binary] of binaries.entries()) {
+            const version = await readVersion(binary);
+            if (version) return [name, { version, serenManaged: index === 0 }];
+          }
+          return [name, null];
+        }),
+      ),
+    );
+    if (Object.values(resolved).every(Boolean)) {
+      const entries = Object.entries(resolved) as Array<
+        [string, { version: string; serenManaged: boolean }]
+      >;
+      return {
+        versions: Object.fromEntries(
+          entries.map(([name, result]) => [name, result.version]),
+        ),
+        serenManaged: Object.fromEntries(
+          entries.map(([name, result]) => [name, result.serenManaged]),
+        ),
+      };
+    }
+    await sleep(1_000);
+  }
+  throw new Error("Timed out waiting for automatic managed CLI provisioning");
+}
+
+async function assertAbsent(
+  ctx: ScenarioContext,
+  selector: string,
+): Promise<void> {
+  try {
+    await ctx.client.waitFor(selector, 250);
+  } catch {
+    return;
+  }
+  throw new Error(`Unexpected user-intervention control: ${selector}`);
+}
+
+async function assertRunningCliTerminal(
+  ctx: ScenarioContext,
+  cliKind: "claude" | "codex",
+): Promise<void> {
+  await sleep(1_500);
+  const buffers = (await ctx.client.command({
+    command: "readState",
+    invokeName: "terminal_list_buffers",
+  })) as LiveTerminalBuffer[];
+  const matching = Array.isArray(buffers)
+    ? buffers.filter((buffer) => buffer.cliKind === cliKind).at(-1)
+    : undefined;
+  if (!matching?.id || matching.status !== "running") {
+    throw new Error(
+      `${cliKind} terminal did not stay running after its real CLI launch`,
+    );
+  }
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const projectPath = path.join(
+    os.tmpdir(),
+    "seren-cli-provisioning-walkthrough",
+  );
+  await mkdir(projectPath, { recursive: true });
+  await ctx.client.command({ command: "setRootPath", path: projectPath });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+
+  const clis = await waitForUsableClis(ctx.validationHome);
+  await assertAbsent(ctx, "[data-testid='cli-update-action-required']");
+
+  const liveAgents = (await ctx.client.command({
+    command: "readState",
+    invokeName: "provider_get_available_agents",
+  })) as LiveAgent[];
+  if (!Array.isArray(liveAgents)) {
+    throw new Error("The native provider runtime did not return an agent list");
+  }
+  const liveTypes = liveAgents
+    .filter((agent): agent is LiveAgent & { type: string } =>
+      Boolean(agent.type),
+    )
+    .map((agent) => agent.type);
+  const expectedTypes = TARGETS.map((target) => target.type);
+  if (
+    liveTypes.length !== expectedTypes.length ||
+    expectedTypes.some((type) => !liveTypes.includes(type))
+  ) {
+    throw new Error(
+      `Live registry mismatch: expected ${expectedTypes.join(", ")}; received ${liveTypes.join(", ")}`,
+    );
+  }
+
+  await ctx.client.click("[data-testid='new-thread-button']");
+  for (const target of TARGETS) {
+    const selector = `[data-testid='${target.testId}']`;
+    await ctx.client.waitFor(selector, 10_000);
+    const row = (await ctx.client.dumpText(selector)) as { text?: string };
+    if (!row.text?.includes(target.label)) {
+      throw new Error(`${target.type} launcher omitted ${target.label}`);
+    }
+    await ctx.writeArtifact(
+      `launcher-${target.type}.json`,
+      await ctx.client.screenshot(selector),
+    );
+  }
+  for (const launcher of CLI_LAUNCHERS) {
+    const selector = `[data-testid='${launcher.testId}']`;
+    await ctx.client.waitFor(selector, 10_000);
+    const row = (await ctx.client.dumpText(selector)) as { text?: string };
+    if (!row.text?.includes(launcher.label)) {
+      throw new Error(`${launcher.cliKind} CLI launcher omitted ${launcher.label}`);
+    }
+    await ctx.writeArtifact(
+      `launcher-${launcher.cliKind}-cli.json`,
+      await ctx.client.screenshot(selector),
+    );
+  }
+  await assertAbsent(ctx, "[data-testid='cli-update-action-required']");
+
+  for (const launcher of CLI_LAUNCHERS) {
+    await ctx.client.click(`[data-testid='${launcher.testId}']`);
+    await ctx.client.waitFor(
+      "[data-testid='terminal-launch-mode-toggle']",
+      20_000,
+    );
+    await assertRunningCliTerminal(ctx, launcher.cliKind);
+    if (launcher.cliKind === "claude") {
+      await ctx.client.waitFor("[data-testid='claude-cli-version-pill']", 20_000);
+    }
+    await ctx.writeArtifact(
+      `running-${launcher.cliKind}-cli.json`,
+      await ctx.client.screenshot(),
+    );
+    if (launcher.cliKind !== CLI_LAUNCHERS.at(-1)?.cliKind) {
+      await ctx.client.click("[data-testid='new-thread-button']");
+    }
+  }
+
+  await ctx.writeArtifact("automatic-cli-provisioning-result.json", {
+    platform: process.platform,
+    architecture: process.arch,
+    cliVersions: clis.versions,
+    serenManagedInstall: clis.serenManaged,
+    liveAgentTypes: liveTypes,
+    launcherAgentTypes: expectedTypes,
+    launcherCliKinds: CLI_LAUNCHERS.map((launcher) => launcher.cliKind),
+    everyManagedCliUsable: Object.keys(clis.versions).length === 4,
+    everyLiveLocalAgentRendered: liveTypes.length === TARGETS.length,
+    everyCliTerminalLaunched: true,
+    userInterventionRequired: false,
+  });
+
+  if (process.env.SEREN_VALIDATION_HOLD_OPEN === "1") {
+    await new Promise<void>(() => {});
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,8 +152,14 @@ export default defineConfig(async () => ({
         }
       : undefined,
     watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**", "**/.agent-shell/**"],
+      // 3. tell Vite to ignore generated/native trees and validation profiles.
+      // Windows creates locked INetCache files inside the scratch HOME; asking
+      // Chokidar to watch those files crashes the validation app with EBUSY.
+      ignored: [
+        "**/src-tauri/**",
+        "**/.agent-shell/**",
+        "**/artifacts/validation-home/**",
+      ],
     },
   },
 }));


### PR DESCRIPTION
## Description

Restores Seren-owned, verified first-install provisioning for every managed coding-agent CLI. Missing Claude Code, Codex, Grok, and Antigravity binaries are installed silently into a writable per-user Seren prefix; the live registry remains the completeness source of truth, and paired/external-app agents are classified explicitly.

The change also extends the terminal PATH to the managed prefix and replaces the Windows test-side preinstallation with a clean-profile assertion so setup cannot mask this regression.

## Related Issue

Fixes #3680

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring

## Functional walkthrough status

Original behavior: on a clean profile, the background updater skipped an unresolved binary and provider launch surfaced an installation-required/manual handoff instead of starting the agent.

Verified after behavior:

- macOS real Tauri app: all six live agent types rendered; Claude and Codex CLI terminals reached running state; no user-intervention card appeared.
- Linux real Tauri app in a blank OS user/profile: Seren installed and verified Claude Code 2.1.221, Codex 0.146.0, Grok 0.2.118, and Antigravity 1.1.10; all six agents rendered; Claude and Codex terminals ran; no intervention appeared.
- Windows real Tauri clean-profile walkthrough: triggered by the `needs-validation` matrix and pending on this PR. The Windows release harness now also asserts all four binaries are absent before Seren starts.

PII-scrubbed step-by-step evidence and per-screen artifacts will be posted after the cross-platform validation matrix completes. This PR remains incomplete until that evidence is attached and the live walkthrough is explicitly approved.

## Verification

- `pnpm test` — 438 files / 3,020 tests passed
- `pnpm build && pnpm verify:frontend-build` — passed
- `pnpm build:provider-runtime` — passed
- `pnpm lint` — passed with existing warnings only
- focused Rust terminal PATH test — passed
- PowerShell AST parse and workflow YAML parse — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added critical regression tests
- [x] I have updated validation documentation
- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] No secrets, credentials, or personal data in code or PR text

## Screenshots

Cross-platform walkthrough artifacts pending the label-gated validation jobs.