### PR TITLE
fix(chat): stop rewriting model disclaimers as outages

### DIFF
--- a/src/lib/agent-output-validation/claims.ts
+++ b/src/lib/agent-output-validation/claims.ts
@@ -7,10 +7,10 @@ type ClaimMatcher = {
   kind: ClaimKind;
   pattern: RegExp;
   /** Additional condition on the same sentence. The claim is only extracted
-   * when this also matches, so a matcher can constrain what a sentence is
+   * when this also holds, so a matcher can constrain what a sentence is
    * *about* separately from the phrasing it keys on. Offsets still come from
    * `pattern`. */
-  requiresContext?: RegExp;
+  requiresContext?: (sentence: string) => boolean;
 };
 
 // An availability-negative phrase on its own says nothing about the subject:
@@ -20,27 +20,40 @@ type ClaimMatcher = {
 //
 // Capability context is therefore required alongside the trigger, in one of
 // two forms: gateway vocabulary that only appears when discussing what this
-// agent can reach, or framing that scopes the statement to this agent.
+// agent can reach, or framing that scopes availability to this agent's
+// environment.
 //
 // `tool` and `plugin` are ordinary English and are not gateway vocabulary on
 // their own — "their build tool is not available for Windows" is prose about
-// someone else's product. They count only under agent-scope framing, which is
-// how a real capability claim reads ("I don't have a tool for that").
-// `api`, `endpoint`, `host` and `server` are excluded for the same reason and
-// have no agent-scope form worth admitting.
+// someone else's product. They count only alongside first-person negation,
+// which is how a real capability claim reads ("I don't have a tool for that").
+// First-person negation is likewise not context by itself: without a
+// capability noun, "I don't have direct introspective access to my exact
+// model identifier" is the model describing itself, not a publisher claim
+// (#3687). `api`, `endpoint`, `host` and `server` are excluded for the same
+// reason and have no agent-scope form worth admitting.
 const PUBLISHER_ABSENCE_TRIGGER =
   /\b(unavailable|not available|not exposed|not configured|not enabled|not connected|not supported|could not access|couldn'?t access|cannot access|can'?t access|not found|no access to|do(?: not|n'?t) have)\b|\bno\s+(?:\w+\s+){0,2}(?:publishers?|integrations?|connectors?|gateways?|mcp|tools?|skills?|plugins?)\b/i;
 
 const GATEWAY_VOCABULARY =
   /\b(?:publishers?|integrations?|connectors?|gateways?|mcp|skills?)\b/i;
 
-const AGENT_SCOPE =
-  /\b(?:in|for|during|from) th(?:is|e current) (?:session|conversation|chat)\b|\bavailable to me\b|\bmy (?:tools?|capabilities|access)\b|\bI (?:can'?t|cannot|could not|couldn'?t|do not|don'?t|have no)\b/i;
+const AGENT_ENVIRONMENT_SCOPE =
+  /\b(?:in|for|during|from) th(?:is|e current) (?:session|conversation|chat)\b|\bavailable to me\b|\bmy (?:tools?|capabilities|access)\b/i;
 
-const AGENT_CAPABILITY_CONTEXT = new RegExp(
-  `${GATEWAY_VOCABULARY.source}|${AGENT_SCOPE.source}`,
-  "i",
-);
+const FIRST_PERSON_NEGATION =
+  /\bI (?:can'?t|cannot|could not|couldn'?t|do not|don'?t|have no)\b/i;
+
+const PLAIN_CAPABILITY_NOUN = /\b(?:tools?|plugins?)\b/i;
+
+function hasAgentCapabilityContext(sentence: string): boolean {
+  return (
+    GATEWAY_VOCABULARY.test(sentence) ||
+    AGENT_ENVIRONMENT_SCOPE.test(sentence) ||
+    (FIRST_PERSON_NEGATION.test(sentence) &&
+      PLAIN_CAPABILITY_NOUN.test(sentence))
+  );
+}
 
 const CLAIM_MATCHERS: ClaimMatcher[] = [
   {
@@ -71,7 +84,7 @@ const CLAIM_MATCHERS: ClaimMatcher[] = [
   {
     kind: "publisher_unavailable",
     pattern: PUBLISHER_ABSENCE_TRIGGER,
-    requiresContext: AGENT_CAPABILITY_CONTEXT,
+    requiresContext: hasAgentCapabilityContext,
   },
   {
     kind: "browser_action",
@@ -94,10 +107,7 @@ export function extractClaims(finalText: string): ExtractedClaim[] {
     for (const matcher of CLAIM_MATCHERS) {
       const match = matcher.pattern.exec(sentence.text);
       if (!match) continue;
-      if (
-        matcher.requiresContext &&
-        !matcher.requiresContext.test(sentence.text)
-      ) {
+      if (matcher.requiresContext && !matcher.requiresContext(sentence.text)) {
         continue;
       }
       sentenceClaims.push({

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -456,6 +456,22 @@ describe("#1987 Verified Agent Output", () => {
     expect(report.canStoreMemory).toBe(true);
   });
 
+  it("passes model self-description disclaimers through untouched (#3687)", () => {
+    // This is the complete raw GLM response that was corrupted during the
+    // #3681 walkthrough. First-person negation is framing, not a capability
+    // subject, so it must not manufacture a publisher-unavailability claim.
+    const finalText =
+      "I don't have direct introspective access to my exact model identifier. I can check the private models catalog available through Seren if you'd like — that would tell you what models are configured and which is the default. Want me to look that up?";
+    const report = validateFinalOutput({
+      finalText,
+      evidence: extractEvidenceFromUnifiedMessages([]),
+    });
+    expect(report.claims).toEqual([]);
+    expect(report.safeDisplayText).toBe(finalText);
+    expect(report.safeDisplayText).not.toContain(SUBSTITUTION_MARKER);
+    expect(report.canStoreMemory).toBe(true);
+  });
+
   it("marks substituted sentences without disturbing markdown (#3109)", () => {
     const finalText = [
       "## Findings",


### PR DESCRIPTION
Fixes #3687

## Summary

- stops generic first-person self-description such as `I don't have direct introspective access...` from being classified as a publisher-unavailability claim
- keeps genuine capability statements guarded when they name gateway vocabulary, use explicit session scope, or pair first-person negation with a concrete tool/plugin subject
- covers the complete raw GLM response observed during the #3681 live walkthrough

## Root cause

The `publisher_unavailable` matcher used `I don't have ...` both as the negative trigger and as sufficient agent-capability context. That made the model's self-identification disclaimer satisfy both halves of the rule even though it did not claim that any publisher, integration, connector, gateway, tool, skill, or plugin was unavailable.

The final-output validator then replaced the successful completion with an unrelated `[unverified]` service-outage sentence.

## Safety boundary

This PR changes only deterministic claim classification. It does not change model routing, transport, rendering, tool evidence, or publisher verification.

Existing protected examples remain covered, including:

- `GitHub is unavailable in this session.`
- `The Slack integration is not configured.`
- `I don't have a tool for that.`

## Validation

- `pnpm exec vitest run tests/unit/agent-output-validation.test.ts` — 13 passed
- `pnpm test` — 3,008 passed
- `pnpm check` — passed with pre-existing warnings only
- `pnpm build` — passed
- `pnpm verify:frontend-build` — passed
- `git diff --check` — passed
