### PR TITLE
fix(auth): recover skills and memory after failed key provisioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,6 +299,11 @@ function App() {
     const isAuth = authStore.isAuthenticated;
     // Track the dependency explicitly so createEffect re-runs when auth changes.
     void isAuth;
+    // Also track successful skill-key provisions: a start that failed because
+    // the key was not provisioned yet (offline launch, transient 5xx) can only
+    // retry when the key later lands — `isAuthenticated` stays true across
+    // refreshes and never re-fires this effect on its own. #3690.
+    void authStore.skillKeyEpoch;
 
     untrack(async () => {
       try {

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -1259,6 +1259,25 @@ export async function executeTool(
           return auth.toolResult;
         }
 
+        // An empty skill-key slot means provisioning failed earlier (offline
+        // launch, transient 5xx) and the Rust side would silently spawn the
+        // skill without credentials. One best-effort provision here lets the
+        // first run after connectivity returns carry them. #3690.
+        {
+          const { getSerenSkillApiKey } = await import("@/lib/tauri-bridge");
+          if (!(await getSerenSkillApiKey().catch(() => null))) {
+            const { ensureSkillApiKey } = await import(
+              "@/services/desktop-api-access"
+            );
+            await ensureSkillApiKey().catch((error) => {
+              console.warn(
+                "[ToolExecutor] Skill key provisioning retry failed:",
+                error,
+              );
+            });
+          }
+        }
+
         const invokeArgs: {
           skillSlug: string;
           cwd: string;

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -290,7 +290,7 @@ export function classifyMemoryStartFailure(
     return {
       status,
       message:
-        "Seren is still finishing your account setup, so memory storage isn't ready yet. Sign out and back in, or try again shortly.",
+        "Seren is still finishing your account setup, so memory storage isn't ready yet. It starts automatically once your connection to Seren is back — no sign-out needed.",
     };
   }
 

--- a/src/services/desktop-api-access.ts
+++ b/src/services/desktop-api-access.ts
@@ -338,9 +338,18 @@ let skillKeyInFlight: Promise<void> | null = null;
  * Provision the publisher-invocation-only key that skill child processes and
  * the SerenDB data plane receive. Reconciled the same way as the Desktop key so
  * a key minted by an older build cannot linger with broader scopes.
+ *
+ * `isCurrent` lets the caller invalidate the provisioning mid-flight: a
+ * sign-out (or account switch) that lands between the server-side create and
+ * the local store must not write the old session's live key into the keychain
+ * of whoever is signed in next. When it reports stale, the created key is
+ * revoked instead of stored. #3696.
  */
-export function ensureSkillApiKey(): Promise<void> {
+export function ensureSkillApiKey(options?: {
+  isCurrent?: () => boolean;
+}): Promise<void> {
   if (skillKeyInFlight) return skillKeyInFlight;
+  const isCurrent = options?.isCurrent ?? (() => true);
 
   skillKeyInFlight = (async () => {
     const existing = await getSerenSkillApiKey();
@@ -351,9 +360,20 @@ export function ensureSkillApiKey(): Promise<void> {
       name: SKILL_API_KEY_NAME,
       scopes: SKILL_API_KEY_SCOPES,
     });
-    // Store before revoking so a failed revoke cannot strand skills without a
-    // usable key, matching repairDesktopApiKey.
-    await storeSerenSkillApiKey(created.api_key);
+    if (!isCurrent()) {
+      await revokeKeyRecord(created).catch(() => undefined);
+      return;
+    }
+    try {
+      // Store before revoking so a failed revoke cannot strand skills without
+      // a usable key, matching repairDesktopApiKey.
+      await storeSerenSkillApiKey(created.api_key);
+    } catch (error) {
+      // Do not leave a server-side key orphaned if local secure storage
+      // rejects it — every refresh would mint another live key. #3694.
+      await revokeKeyRecord(created).catch(() => undefined);
+      throw error;
+    }
 
     if (previousKeyId) {
       const { data } = await listDefaultOrgApiKeys({ throwOnError: false });
@@ -361,7 +381,14 @@ export function ensureSkillApiKey(): Promise<void> {
         (candidate) =>
           candidate.key_id === previousKeyId && !candidate.revoked_at,
       );
-      if (stale) await revokeKeyRecord(stale).catch(() => undefined);
+      if (stale) {
+        await revokeKeyRecord(stale).catch((error) => {
+          console.warn(
+            "[Desktop API Access] Stale skill key revoke failed; the old key stays active server-side:",
+            error,
+          );
+        });
+      }
     }
   })().finally(() => {
     skillKeyInFlight = null;

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -53,6 +53,13 @@ interface AuthState {
    * See #1661.
    */
   signInModalRequested: boolean;
+  /**
+   * Counts successful skill-key provisions. Consumers that fail while the
+   * key is absent (the Claude memory interceptor start) track this so a
+   * later successful provisioning re-runs them — `isAuthenticated` alone
+   * never re-fires in-session because refresh sets true over true. #3690.
+   */
+  skillKeyEpoch: number;
 }
 
 const [state, setState] = createStore<AuthState>({
@@ -62,6 +69,7 @@ const [state, setState] = createStore<AuthState>({
   mcpConnected: false,
   privateChatPolicy: null,
   signInModalRequested: false,
+  skillKeyEpoch: 0,
 });
 
 let authBindingsInitialized = false;
@@ -88,12 +96,26 @@ type EnsureApiKeyResult =
  * the blocking sign-in modal. Retries on the next refresh. #3677
  */
 async function provisionSkillApiKey(): Promise<void> {
+  const epoch = authEpoch;
   try {
-    await ensureSkillApiKey();
+    await ensureSkillApiKey({ isCurrent: () => !authEpochChanged(epoch) });
+    setState("skillKeyEpoch", (count) => count + 1);
   } catch (error) {
     console.warn(
       "[Auth Store] Skill API key provisioning failed; skills and Claude memory will retry on next refresh:",
       error,
+    );
+    // Persistent failures (org key policy, quota) never self-heal and
+    // otherwise leave zero telemetry while skills and Claude memory stay
+    // degraded. #3695.
+    const status =
+      typeof (error as { status?: unknown })?.status === "number"
+        ? (error as { status: number }).status
+        : undefined;
+    void reportApiKeyFailure(
+      status,
+      error,
+      "auth.skill_key_provisioning_failure",
     );
   }
 }
@@ -154,6 +176,7 @@ export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
 async function reportApiKeyFailure(
   status: number | undefined,
   error: unknown,
+  kind = "auth.api_key_provisioning_failure",
 ): Promise<void> {
   try {
     const { captureSupportError } = await import("@/lib/support/hook");
@@ -161,7 +184,7 @@ async function reportApiKeyFailure(
     const stack =
       error instanceof Error && error.stack ? error.stack.split("\n") : [];
     void captureSupportError({
-      kind: "auth.api_key_provisioning_failure",
+      kind,
       message,
       stack,
       http: {

--- a/tests/unit/skill-key-lifecycle.test.ts
+++ b/tests/unit/skill-key-lifecycle.test.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Regression coverage for #3690/#3694/#3696 — skill-key provisioning
+// ABOUTME: must roll back orphaned keys and honor session invalidation.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+
+const {
+  getSerenSkillApiKeyMock,
+  storeSerenSkillApiKeyMock,
+  createDefaultOrgApiKeyMock,
+  listDefaultOrgApiKeysMock,
+  revokeDefaultOrgApiKeyMock,
+} = vi.hoisted(() => ({
+  getSerenSkillApiKeyMock: vi.fn(async (): Promise<string | null> => null),
+  storeSerenSkillApiKeyMock: vi.fn(async (_key: string) => {}),
+  createDefaultOrgApiKeyMock: vi.fn(async () => ({
+    data: {
+      data: {
+        id: "00000000-0000-0000-0000-000000000001",
+        key_id: "sknew",
+        api_key: "seren_sknew_secret",
+        name: "Seren Desktop Skills",
+        scopes: ["publisher:*"],
+        key_type: "publisher",
+      },
+    },
+    error: undefined,
+    response: { ok: true },
+  })),
+  listDefaultOrgApiKeysMock: vi.fn(async () => ({ data: { data: [] } })),
+  revokeDefaultOrgApiKeyMock: vi.fn(async () => ({
+    error: undefined,
+    response: { ok: true },
+  })),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getSerenApiKey: vi.fn(async () => null),
+  getSerenSkillApiKey: getSerenSkillApiKeyMock,
+  storeSerenApiKey: vi.fn(async () => {}),
+  storeSerenSkillApiKey: storeSerenSkillApiKeyMock,
+}));
+
+vi.mock("@/api", () => ({
+  createDefaultOrgApiKey: createDefaultOrgApiKeyMock,
+  listDefaultOrgApiKeys: listDefaultOrgApiKeysMock,
+  revokeDefaultOrgApiKey: revokeDefaultOrgApiKeyMock,
+}));
+
+import { ensureSkillApiKey } from "@/services/desktop-api-access";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("skill key lifecycle (#3690)", () => {
+  it("revokes the created key when the local store write fails (#3694)", async () => {
+    storeSerenSkillApiKeyMock.mockRejectedValueOnce(
+      new Error("keychain write denied"),
+    );
+
+    await expect(ensureSkillApiKey()).rejects.toThrow("keychain write denied");
+    expect(revokeDefaultOrgApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("revokes instead of storing when the session went stale mid-flight (#3696)", async () => {
+    await ensureSkillApiKey({ isCurrent: () => false });
+
+    expect(storeSerenSkillApiKeyMock).not.toHaveBeenCalled();
+    expect(revokeDefaultOrgApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores the key for a still-current session", async () => {
+    await ensureSkillApiKey({ isCurrent: () => true });
+
+    expect(storeSerenSkillApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(revokeDefaultOrgApiKeyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("memory interceptor retry wiring (#3690)", () => {
+  it("re-runs the start effect when a later provisioning succeeds", () => {
+    const appSource = readFileSync("src/App.tsx", "utf8");
+    const authSource = readFileSync("src/stores/auth.store.ts", "utf8");
+
+    // The effect must track the provisioning counter — isAuthenticated stays
+    // true across refreshes and never re-fires the effect on its own.
+    expect(appSource).toContain("void authStore.skillKeyEpoch;");
+    expect(authSource).toContain('setState("skillKeyEpoch", (count) => count + 1)');
+    // The counter only advances on success, inside the guarded provisioner.
+    expect(authSource).toContain(
+      "ensureSkillApiKey({ isCurrent: () => !authEpochChanged(epoch) })",
+    );
+  });
+});


### PR DESCRIPTION
Closes #3690. Closes #3694. Closes #3695. Closes #3696.

## Outcome

One failed skill-key provisioning no longer disables Claude memory for the whole session, strands skills without credentials, orphans server-side keys, or writes a live key after sign-out — and the dialog stops telling a signed-in user to sign out.

## Root causes and fixes (one per issue)

- **#3690 (P1)** — the interceptor start effect keyed only on an `isAuthenticated` edge that refresh can never re-fire (`true` over `true` is dropped by Solid's store equality), so the `claudeMemoryStartedForAuth = null` retry reset was unreachable. The effect now also tracks `authStore.skillKeyEpoch`, a counter bumped on each successful provisioning, so the first healed refresh restarts memory. The skill runner (`run_skill_script` path in `src/lib/tools/executor.ts`) re-provisions once when the local slot is empty before spawning, instead of letting Rust silently omit `SEREN_API_KEY`. Dialog copy in `src/services/claudeMemory.ts` no longer instructs sign-out.
- **#3694 (P2)** — `ensureSkillApiKey` now revokes the created record when the local store write fails (mirroring `repairDesktopApiKey`), so a locked/denied keychain cannot mint an orphaned live `publisher:*` key every refresh. The silent stale-key revoke failure now logs.
- **#3695 (P2)** — provisioning failures flow through the existing support capture (`reportApiKeyFailure`) with a distinct kind `auth.skill_key_provisioning_failure`.
- **#3696 (P2)** — `ensureSkillApiKey` accepts an `isCurrent` guard; the auth store passes the auth-epoch check, so a sign-out mid-provisioning revokes the created key instead of storing it into the next session's keychain.

## Critical regression coverage

`tests/unit/skill-key-lifecycle.test.ts`: store-failure → revoke + rethrow; stale session → revoke, no store; current session → store, no revoke; plus source contracts pinning the effect dependency and the success-only epoch bump. Full suite: 3,028 passed. The only secret-looking string in the diff is the fake fixture key in the test.

## Network path

Existing gateway endpoints only: `POST/GET/DELETE https://api.serendb.com/organizations/default/api-keys` (via generated client). No new outbound paths.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com