### PR TITLE
fix(runtime): harden process lifecycle and Windows command resolution

### DIFF
--- a/build/runtime-staging.ts
+++ b/build/runtime-staging.ts
@@ -32,25 +32,25 @@ export function ensureRuntimeShims(nodeDir: string): void {
 }
 
 /**
- * The staged-Node version marker records which Node version was actually
- * extracted into `<outputDir>/node`. The prepare scripts skip the download when
- * that directory exists, and before this marker they had no way to tell a
- * current tree from a stale one — after a NODE_VERSION bump a cached dev
- * staging dir silently shipped the old binary while embedded-runtime.json
- * claimed the new version (#3450).
+ * A staged-component version marker records which version of a runtime
+ * component (node, git, python) was actually extracted into
+ * `<outputDir>/<component>`. The prepare scripts skip the download when that
+ * directory exists, and without a marker they cannot tell a complete tree
+ * from a stale one (#3450) or from an interrupted extraction that left the
+ * directory behind (#3697) — either way the broken tree latches forever.
  *
- * A marker file is used instead of running `<staged node> --version` because
- * the staged binary is not always executable on the staging host (e.g. the
- * linux runtime staged on macOS).
+ * A marker file is used instead of running the staged binary because it is
+ * not always executable on the staging host (e.g. the linux runtime staged
+ * on macOS).
  */
-function stagedNodeVersionPath(outputDir: string): string {
-	return path.join(outputDir, 'staged-node-version');
+function stagedComponentVersionPath(outputDir: string, component: string): string {
+	return path.join(outputDir, `staged-${component}-version`);
 }
 
-/** Read the recorded staged Node version, or null when no marker exists. */
-export function readStagedNodeVersion(outputDir: string): string | null {
+/** Read the recorded staged component version, or null when no marker exists. */
+export function readStagedComponentVersion(outputDir: string, component: string): string | null {
 	try {
-		return fs.readFileSync(stagedNodeVersionPath(outputDir), 'utf8').trim() || null;
+		return fs.readFileSync(stagedComponentVersionPath(outputDir, component), 'utf8').trim() || null;
 	} catch {
 		return null;
 	}
@@ -60,11 +60,33 @@ export function readStagedNodeVersion(outputDir: string): string | null {
  * Remove the marker before (re-)staging begins so an interrupted download or
  * extraction can never leave a marker that matches a broken tree.
  */
+export function clearStagedComponentVersion(outputDir: string, component: string): void {
+	fs.rmSync(stagedComponentVersionPath(outputDir, component), { force: true });
+}
+
+/** Record the staged component version. Call only after staging fully succeeds. */
+export function writeStagedComponentVersion(
+	outputDir: string,
+	component: string,
+	version: string
+): void {
+	fs.writeFileSync(stagedComponentVersionPath(outputDir, component), `${version}\n`);
+}
+
+/** Read the recorded staged Node version, or null when no marker exists. */
+export function readStagedNodeVersion(outputDir: string): string | null {
+	return readStagedComponentVersion(outputDir, 'node');
+}
+
+/**
+ * Remove the marker before (re-)staging begins so an interrupted download or
+ * extraction can never leave a marker that matches a broken tree.
+ */
 export function clearStagedNodeVersion(outputDir: string): void {
-	fs.rmSync(stagedNodeVersionPath(outputDir), { force: true });
+	clearStagedComponentVersion(outputDir, 'node');
 }
 
 /** Record the staged Node version. Call only after staging fully succeeds. */
 export function writeStagedNodeVersion(outputDir: string, version: string): void {
-	fs.writeFileSync(stagedNodeVersionPath(outputDir), `${version}\n`);
+	writeStagedComponentVersion(outputDir, 'node', version);
 }

--- a/build/win32/prepare-embedded-runtime.ts
+++ b/build/win32/prepare-embedded-runtime.ts
@@ -7,8 +7,11 @@ import * as https from 'https';
 import { pipeline } from 'stream/promises';
 import { execSync } from 'child_process';
 import {
+	clearStagedComponentVersion,
 	clearStagedNodeVersion,
+	readStagedComponentVersion,
 	readStagedNodeVersion,
+	writeStagedComponentVersion,
 	writeStagedNodeVersion
 } from '../runtime-staging';
 
@@ -143,10 +146,18 @@ async function prepareGit(options: DownloadOptions): Promise<string> {
 	const gitDir = path.join(outputDir, 'git');
 
 	if (fs.existsSync(gitDir)) {
-		console.log(`Git directory already exists at ${gitDir}, skipping...`);
-		return gitDir;
+		const stagedVersion = readStagedComponentVersion(outputDir, 'git');
+		if (stagedVersion === GIT_VERSION) {
+			console.log(`Git ${GIT_VERSION} already staged at ${gitDir}, skipping download...`);
+			return gitDir;
+		}
+		// A directory without a matching marker is either an interrupted
+		// extraction or a stale version; both must be re-staged (#3697).
+		console.log(`Staged Git at ${gitDir} is ${stagedVersion ?? 'incomplete or of unrecorded version'}, expected ${GIT_VERSION}; re-staging...`);
+		fs.rmSync(gitDir, { recursive: true, force: true });
 	}
 
+	clearStagedComponentVersion(outputDir, 'git');
 	fs.mkdirSync(gitDir, { recursive: true });
 
 	const archivePath = path.join(outputDir, `git-${arch}.7z.exe`);
@@ -157,6 +168,8 @@ async function prepareGit(options: DownloadOptions): Promise<string> {
 
 	// Cleanup
 	fs.unlinkSync(archivePath);
+
+	writeStagedComponentVersion(outputDir, 'git', GIT_VERSION);
 
 	console.log(`Git prepared at ${gitDir}`);
 	return gitDir;

--- a/build/win32/prepare-python-runtime.ts
+++ b/build/win32/prepare-python-runtime.ts
@@ -8,6 +8,11 @@ import * as https from "https";
 import * as path from "path";
 import { pipeline } from "stream/promises";
 import { pathToFileURL } from "node:url";
+import {
+	clearStagedComponentVersion,
+	readStagedComponentVersion,
+	writeStagedComponentVersion,
+} from "../runtime-staging";
 
 // Version configuration — keep this pinned. The Python freshness workflow
 // (.github/workflows/check-python-version.yml) opens a PR to bump the patch
@@ -239,10 +244,20 @@ async function preparePython(
 	const pythonDir = path.join(outputDir, "python");
 
 	if (fs.existsSync(pythonDir)) {
-		console.log(`Python directory already exists at ${pythonDir}, skipping...`);
-		return { pythonDir, getPipSha256: null, pipLauncherSha256: null };
+		const stagedVersion = readStagedComponentVersion(outputDir, "python");
+		if (stagedVersion === PYTHON_VERSION) {
+			console.log(`Python ${PYTHON_VERSION} already staged at ${pythonDir}, skipping download...`);
+			return { pythonDir, getPipSha256: null, pipLauncherSha256: null };
+		}
+		// A directory without a matching marker is either an interrupted
+		// extraction or a stale version; both must be re-staged (#3697).
+		console.log(
+			`Staged Python at ${pythonDir} is ${stagedVersion ?? "incomplete or of unrecorded version"}, expected ${PYTHON_VERSION}; re-staging...`,
+		);
+		fs.rmSync(pythonDir, { recursive: true, force: true });
 	}
 
+	clearStagedComponentVersion(outputDir, "python");
 	fs.mkdirSync(pythonDir, { recursive: true });
 
 	const zipPath = path.join(outputDir, `python-${arch}.zip`);
@@ -289,6 +304,8 @@ async function preparePython(
 	}
 
 	fs.unlinkSync(zipPath);
+
+	writeStagedComponentVersion(outputDir, "python", PYTHON_VERSION);
 
 	console.log(`Python prepared at ${pythonDir}`);
 	return { pythonDir, getPipSha256, pipLauncherSha256 };

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -419,6 +419,34 @@ pub(crate) fn format_playwright_mcp_command(node: &str, script: &std::path::Path
     format!("{} {}", shell_quote(node), shell_quote(&script_str))
 }
 
+/// Candidate file names probed for a bare command, in priority order.
+///
+/// On Windows the executable suffixes must come before the bare name: the
+/// staged win-x64 node directory ships extensionless POSIX `npm`/`npx`
+/// scripts alongside `npm.cmd`/`npx.cmd`, and CreateProcess cannot run a
+/// POSIX shell script — a bare-name-first probe resolves to a file that can
+/// never spawn (#3691).
+fn embedded_command_candidate_names(command: &str, windows: bool) -> Vec<String> {
+    if windows {
+        vec![
+            format!("{}.exe", command),
+            format!("{}.cmd", command),
+            format!("{}.bat", command),
+            command.to_string(),
+        ]
+    } else {
+        vec![command.to_string()]
+    }
+}
+
+/// First candidate name that exists in `dir`, honoring the priority order.
+fn find_command_candidate(dir: &std::path::Path, names: &[String]) -> Option<std::path::PathBuf> {
+    names
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|candidate| candidate.exists())
+}
+
 /// Resolve a bare command name to an absolute path by searching the embedded PATH.
 ///
 /// On macOS/Linux, when the app is launched from Finder or a desktop launcher,
@@ -442,22 +470,11 @@ pub(crate) fn resolve_command_in_embedded_path(command: &str) -> String {
     #[cfg(not(target_os = "windows"))]
     let sep = ":";
 
-    // On Windows, try bare name, then .exe and .cmd suffixes.
-    #[cfg(target_os = "windows")]
-    let names: Vec<String> = vec![
-        command.to_string(),
-        format!("{}.exe", command),
-        format!("{}.cmd", command),
-    ];
-    #[cfg(not(target_os = "windows"))]
-    let names: Vec<String> = vec![command.to_string()];
+    let names = embedded_command_candidate_names(command, cfg!(target_os = "windows"));
 
     for dir in embedded_path.split(sep) {
-        for name in &names {
-            let candidate = std::path::Path::new(dir).join(name);
-            if candidate.exists() {
-                return candidate.to_string_lossy().to_string();
-            }
+        if let Some(candidate) = find_command_candidate(std::path::Path::new(dir), &names) {
+            return candidate.to_string_lossy().to_string();
         }
     }
 
@@ -1987,6 +2004,46 @@ mod playwright_resolver_tests {
         assert_eq!(
             cmd,
             "/usr/local/bin/node /opt/seren/playwright-stealth/dist/index.js"
+        );
+    }
+}
+
+#[cfg(test)]
+mod embedded_command_resolver_tests {
+    use super::*;
+
+    /// #3691: the staged win-x64 runtime ships extensionless POSIX `npm` /
+    /// `npx` scripts alongside `npm.cmd`. A Windows resolve must pick the
+    /// spawnable `.cmd`, never the POSIX script. Exercised through the pure
+    /// candidate list so the ordering is verified on every host OS.
+    #[test]
+    fn windows_probe_prefers_cmd_over_extensionless_posix_script() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("npm"), b"#!/bin/sh\n").unwrap();
+        std::fs::write(tmp.path().join("npm.cmd"), b"@echo off\r\n").unwrap();
+
+        let names = embedded_command_candidate_names("npm", true);
+        let resolved = find_command_candidate(tmp.path(), &names)
+            .expect("candidate must resolve in the fixture dir");
+        assert_eq!(resolved, tmp.path().join("npm.cmd"));
+    }
+
+    #[test]
+    fn windows_probe_still_reaches_the_bare_name_last() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("node"), b"binary\n").unwrap();
+
+        let names = embedded_command_candidate_names("node", true);
+        let resolved = find_command_candidate(tmp.path(), &names)
+            .expect("candidate must resolve in the fixture dir");
+        assert_eq!(resolved, tmp.path().join("node"));
+    }
+
+    #[test]
+    fn unix_probe_uses_only_the_bare_name() {
+        assert_eq!(
+            embedded_command_candidate_names("npm", false),
+            vec!["npm".to_string()]
         );
     }
 }

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -107,8 +107,14 @@ fn gather_repo_context(project_root: &str) -> String {
 
     let mut parts: Vec<String> = Vec::new();
 
+    // Bare "git" resolves against the embedded runtime PATH (#3701): launched
+    // from Finder/desktop the parent PATH is minimal, and Windows ships its
+    // own portable git. The resolver falls back to the bare name when the
+    // embedded PATH is empty or has no match.
+    let git = crate::mcp::resolve_command_in_embedded_path("git");
+
     // Current branch
-    if let Ok(output) = std::process::Command::new("git")
+    if let Ok(output) = std::process::Command::new(&git)
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(root)
         .output()
@@ -120,7 +126,7 @@ fn gather_repo_context(project_root: &str) -> String {
     }
 
     // Dirty file count
-    if let Ok(output) = std::process::Command::new("git")
+    if let Ok(output) = std::process::Command::new(&git)
         .args(["status", "--porcelain"])
         .current_dir(root)
         .output()
@@ -135,7 +141,7 @@ fn gather_repo_context(project_root: &str) -> String {
     }
 
     // Recent commits (last 5)
-    if let Ok(output) = std::process::Command::new("git")
+    if let Ok(output) = std::process::Command::new(&git)
         .args(["log", "--oneline", "-5"])
         .current_dir(root)
         .output()

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -24,6 +24,12 @@ pub struct ProviderRuntimeConfig {
 
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 
+/// Exit-time kill: attempts × delay bounds how long `kill_sync` may block the
+/// RunEvent::Exit handler while waiting out a transient hold on the process
+/// lock (the monitor loop takes it every 5s).
+const KILL_LOCK_ATTEMPTS: u32 = 20;
+const KILL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+
 /// Per-attempt readiness deadlines for the initial spawn sequence
 /// (see GH #1587). Escalating windows absorb the worst observed cold-start
 /// path: first attempt SIGKILL'd instantly (macOS first-touch on the
@@ -174,12 +180,16 @@ impl ProviderRuntimeState {
                     drop(guard);
                     *self.last_config.lock().await = Some(config.clone());
 
-                    // Abort any previous crash monitor before starting a new one
-                    if let Some(old_handle) = self.monitor_handle.lock().await.take() {
-                        old_handle.abort();
-                    }
+                    // Ordering constraint (#3698): the old monitor can be THIS
+                    // task (self-restart via spawn_process_monitor →
+                    // ensure_started). Abort cancels the current task at its
+                    // next yield point, so nothing after the abort is
+                    // guaranteed to run — the new handle must be stored and
+                    // readiness emitted first. The abort itself must still
+                    // happen, or the replaced monitor keeps polling alongside
+                    // the new one.
                     let monitor = spawn_process_monitor(app.clone());
-                    *self.monitor_handle.lock().await = Some(monitor);
+                    let old_monitor = self.monitor_handle.lock().await.replace(monitor);
 
                     // Notify the frontend that the runtime is up. The
                     // agent store subscribes to this event and re-runs
@@ -187,6 +197,10 @@ impl ProviderRuntimeState {
                     // Gemini buttons even when first-attempt readiness
                     // exceeds the store's initial-query backoff budget.
                     let _ = app.emit("provider-runtime://ready", &config);
+
+                    if let Some(old_monitor) = old_monitor {
+                        old_monitor.abort();
+                    }
 
                     return Ok(config);
                 }
@@ -275,35 +289,59 @@ impl ProviderRuntimeState {
             }
         }
 
-        if let Ok(mut guard) = self.process.try_lock() {
-            if let Some(ref process) = *guard {
-                if let Some(pid) = process.child.id() {
-                    log::info!("[ProviderRuntime] Killing process on exit: pid={}", pid);
-                    #[cfg(unix)]
-                    unsafe {
+        // A single `try_lock` can lose the race against the monitor loop,
+        // which takes this lock every 5s. Tauri exits via `process::exit`,
+        // skipping `Drop`/`kill_on_drop`, so a silently missed kill orphans
+        // the runtime and every agent child under it (#3699). Bounded retries
+        // keep RunEvent::Exit from hanging while closing the window.
+        let mut process_guard = None;
+        for _ in 0..KILL_LOCK_ATTEMPTS {
+            if let Ok(guard) = self.process.try_lock() {
+                process_guard = Some(guard);
+                break;
+            }
+            std::thread::sleep(KILL_LOCK_RETRY_DELAY);
+        }
+        let Some(mut guard) = process_guard else {
+            log::warn!(
+                "[ProviderRuntime] Could not acquire process lock on exit; runtime process (pid unknown — lock held) may be orphaned"
+            );
+            return;
+        };
+        if let Some(ref process) = *guard {
+            if let Some(pid) = process.child.id() {
+                log::info!("[ProviderRuntime] Killing process on exit: pid={}", pid);
+                #[cfg(unix)]
+                unsafe {
+                    // The child was spawned with process_group(0), so pid ==
+                    // pgid: killpg reaps the runtime's agent grandchildren
+                    // (claude/codex CLIs) that a single kill(pid) would
+                    // orphan past app exit (#3700). Fall back to the lone
+                    // pid when killpg fails (e.g. the group is already gone).
+                    if libc::killpg(pid as libc::pid_t, libc::SIGKILL) != 0 {
                         libc::kill(pid as i32, libc::SIGKILL);
                     }
-                    #[cfg(windows)]
-                    {
-                        // Use taskkill /T to kill the entire process tree.
-                        // kill_on_drop only terminates the immediate child, leaving
-                        // grandchild node.exe processes (claude CLI) orphaned and
-                        // holding file locks that block the next NSIS install.
-                        // Spawn detached instead of .status(): this runs in the
-                        // RunEvent::Exit handler on the UI thread, and waiting on
-                        // taskkill there freezes "Quit Seren" until the whole tree
-                        // dies (#2508). /F /T is fire-and-forget — taskkill keeps
-                        // running and reaps the tree after we exit.
-                        use std::os::windows::process::CommandExt;
-                        let _ = std::process::Command::new("taskkill")
-                            .args(["/F", "/T", "/PID", &pid.to_string()])
-                            .creation_flags(0x08000000) // CREATE_NO_WINDOW
-                            .spawn();
-                    }
+                }
+                #[cfg(windows)]
+                {
+                    // Use taskkill /T to kill the entire process tree.
+                    // kill_on_drop only terminates the immediate child, leaving
+                    // grandchild node.exe processes (claude CLI) orphaned and
+                    // holding file locks that block the next NSIS install.
+                    // Spawn detached instead of .status(): this runs in the
+                    // RunEvent::Exit handler on the UI thread, and waiting on
+                    // taskkill there freezes "Quit Seren" until the whole tree
+                    // dies (#2508). /F /T is fire-and-forget — taskkill keeps
+                    // running and reaps the tree after we exit.
+                    use std::os::windows::process::CommandExt;
+                    let _ = std::process::Command::new("taskkill")
+                        .args(["/F", "/T", "/PID", &pid.to_string()])
+                        .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                        .spawn();
                 }
             }
-            *guard = None;
         }
+        *guard = None;
     }
 }
 
@@ -544,6 +582,14 @@ fn spawn_node_process(
     #[cfg(windows)]
     {
         command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    #[cfg(unix)]
+    {
+        // Own process group so the exit-time `kill_sync` can killpg the whole
+        // agent tree (#3700): the runtime spawns CLI grandchildren that a
+        // single SIGKILL to the runtime pid would orphan past app quit.
+        command.process_group(0);
     }
 
     let embedded_path = crate::embedded_runtime::get_embedded_path();
@@ -1299,6 +1345,94 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    /// #3699: `kill_sync` runs in RunEvent::Exit, where a single failed
+    /// `try_lock` used to skip the kill silently — the monitor loop takes the
+    /// same lock every 5s, and a missed kill orphans the runtime past app
+    /// exit. The bounded retry must wait out a transient hold and still kill.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn kill_sync_waits_out_a_transient_process_lock_hold() {
+        let state = std::sync::Arc::new(ProviderRuntimeState::new());
+        let child = spawn_hanging_child().await;
+        *state.process.lock().await = Some(ProviderRuntimeProcess {
+            child,
+            config: dummy_config(),
+            spawned_at: Instant::now(),
+            restart_budget_rearmed: false,
+        });
+
+        // Hold the process lock as the monitor loop would, releasing it while
+        // kill_sync is still inside its retry budget.
+        let guard = state.process.lock().await;
+        let killer = {
+            let state = state.clone();
+            std::thread::spawn(move || state.kill_sync())
+        };
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(guard);
+        killer.join().expect("kill_sync thread");
+
+        assert!(
+            state
+                .process
+                .try_lock()
+                .expect("process lock free after kill_sync")
+                .is_none(),
+            "kill_sync must clear the process slot once the lock frees up"
+        );
+    }
+
+    /// #3700: quitting the app must not orphan agent grandchildren. The
+    /// runtime child owns its process group (`spawn_node_process` sets
+    /// `process_group(0)`), so `kill_sync`'s killpg must take down processes
+    /// the runtime spawned, not only the runtime pid itself.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn kill_sync_kills_the_runtime_process_group() {
+        let mut command = test_shell_command("sleep 30 & echo $!; wait");
+        command
+            .process_group(0)
+            .kill_on_drop(true)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut child = command.spawn().expect("spawn group leader");
+
+        let stdout = child.stdout.take().expect("stdout piped");
+        let mut lines = BufReader::new(stdout).lines();
+        let grandchild_pid: libc::pid_t = lines
+            .next_line()
+            .await
+            .expect("read grandchild pid")
+            .expect("grandchild pid line")
+            .trim()
+            .parse()
+            .expect("numeric grandchild pid");
+
+        let state = ProviderRuntimeState::new();
+        *state.process.lock().await = Some(ProviderRuntimeProcess {
+            child,
+            config: dummy_config(),
+            spawned_at: Instant::now(),
+            restart_budget_rearmed: false,
+        });
+
+        state.kill_sync();
+
+        // SIGKILL delivery is immediate; reaping of the re-parented
+        // grandchild by init/launchd can lag a moment.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let alive = unsafe { libc::kill(grandchild_pid, 0) } == 0;
+            if !alive {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "grandchild pid {grandchild_pid} survived kill_sync — process group not killed"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 
     /// Build a stub child process that exits instantly with the requested

--- a/src-tauri/src/run/workspace.rs
+++ b/src-tauri/src/run/workspace.rs
@@ -15,7 +15,17 @@ const SETUP_OUTPUT_LIMIT: usize = 2_000;
 /// Every child this module spawns is background work for a run. Without this
 /// flag Windows opens a console window for each one — setup scripts, evidence
 /// checks, and every git call during provisioning.
+///
+/// Bare `git` resolves against the embedded runtime PATH (#3701): launched
+/// from Finder or a desktop launcher the parent PATH is minimal, and Windows
+/// ships its own portable git. The resolver falls back to the bare name when
+/// the embedded PATH is empty or has no match.
 fn hidden_command(program: &str) -> Command {
+    let program = if program == "git" {
+        crate::mcp::resolve_command_in_embedded_path(program)
+    } else {
+        program.to_string()
+    };
     #[allow(unused_mut)]
     let mut command = Command::new(program);
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Closes #3691. Closes #3697. Closes #3698. Closes #3699. Closes #3700. Closes #3701.

## Fixes (one per issue)

- **#3691 (P1)** — `resolve_command_in_embedded_path` probes `.exe`/`.cmd`/`.bat` before the bare name on Windows. The staged win-x64 node directory ships extensionless POSIX `npm`/`npx` scripts alongside their `.cmd` wrappers, and the bare-name-first probe resolved to a file CreateProcess can never run. The candidate logic is extracted into pure helpers with cross-platform unit tests (fixture dir containing both `npm` and `npm.cmd` → `.cmd` wins).
- **#3697 (P2)** — win32 git/python staging now uses the completeness-marker pattern from the #3450 node fix: a tree without a matching `staged-git-version`/`staged-python-version` marker is deleted and re-staged; the marker is written only after success. One-time cost: existing cached trees have no marker and re-download once.
- **#3698 (P2)** — the crash-restart path stores the new monitor handle and emits `provider-runtime://ready` BEFORE aborting the old handle, which can be the currently executing task; the previous order could cancel the restart mid-success and lose ready/restarted events under lock contention.
- **#3699 (P2)** — `kill_sync` retries the process lock (20 × 25ms, bounded for RunEvent::Exit) instead of a single silent `try_lock`, and warns when the runtime may be orphaned. Regression test holds the lock 100ms and asserts the kill still lands.
- **#3700 (P2)** — the runtime child is spawned as its own process group leader and quit uses `killpg` (with single-pid fallback), so agent CLI grandchildren no longer outlive the app on macOS/Linux. Real end-to-end test: group-leader shell forks a `sleep 30` grandchild; the test polls until the grandchild is actually dead. (`killpg`, not `kill(-pid)`, per the known procps no-op hazard.)
- **#3701 (P2)** — workspace provisioning (`hidden_command`) and chat repo-context `git` calls resolve through the embedded runtime PATH, so the bundled Git for Windows actually applies; the resolver falls back to the bare name when the embedded PATH is empty (dev/test unchanged). PortableGit ships `git.exe` only, so the #3691 ordering is safe here.

## Validation

- `cargo check` — clean (two pre-existing warnings in untouched files)
- `cargo test --lib` — 1,309 passed, 0 failed (4 new tests)
- Staging-adjacent vitest files — 5 files, 11 tests passed
- `pnpm check` — pre-existing warnings only

## Network path

No new outbound paths. The win32 staging change affects build-time downloads only (same PortableGit/python-build-standalone URLs as before).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com