### PR TITLE
fix(agent): survive slow and spaced paths in CLI provisioning

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -400,6 +400,31 @@ function assertAgentCliProvisioningComplete(definitions, provisioning) {
 }
 
 /**
+ * Plain-language reasons for updater outcomes quoted in user-facing spawn
+ * errors, so a raw enum like `skipped:network` never reaches the user. The
+ * structured app log still records the exact outcome enum for support.
+ */
+const CLI_OUTCOME_DESCRIPTIONS = {
+  "skipped:network": "network unavailable",
+  "skipped:unresolved": "the CLI could not be located",
+  "skipped:install_failed": "the install failed",
+  "skipped:integrity_failed": "the download could not be verified",
+  "skipped:scan_rejected": "the download failed Seren's security scan",
+  "skipped:scan_error": "the security scan could not finish",
+  "skipped:verification_required": "the installed version could not be verified",
+  "skipped:error": "an unexpected error occurred",
+};
+
+function describeCliOutcome(outcome) {
+  return (
+    CLI_OUTCOME_DESCRIPTIONS[outcome] ??
+    String(outcome ?? "unknown")
+      .replace(/^skipped:/, "")
+      .replace(/_/g, " ")
+  );
+}
+
+/**
  * Block spawn until the resolved CLI meets its CLI_MIN_VERSION_BASELINE,
  * force-updating through the verified updater when it does not. Shared by
  * the Codex (#2904) and Claude Code (#3443) spawn paths so both degrade
@@ -482,8 +507,9 @@ async function ensureCliBaselineViaUpdater(
       return resolved;
     }
     throw new Error(
-      `Seren could not install ${label} automatically. Seren will retry ` +
-        `automatically. (${outcome.outcome})`,
+      `Seren could not install ${label} automatically ` +
+        `(${describeCliOutcome(outcome.outcome)}). Seren will retry the ` +
+        `next time you start this agent.`,
     );
   }
   if (!isBelowBaseline(installed, baseline)) {
@@ -521,8 +547,8 @@ async function ensureCliBaselineViaUpdater(
   ) {
     throw new Error(
       `${label} CLI is still ${updated ?? "unknown"}; Seren requires ${baseline} ` +
-        `or newer and will retry the verified update automatically. ` +
-        `(${outcome.outcome})`,
+        `or newer and will retry the verified update the next time you start ` +
+        `this agent (${describeCliOutcome(outcome.outcome)}).`,
     );
   }
 
@@ -540,6 +566,10 @@ async function ensureCodexCliViaUpdater(emit) {
     bareCommand: "codex",
     packageName: "@openai/codex",
     resolveBinary: resolveInstalledCodexBinary,
+    // A resolved install whose version probe times out on an IO-starved
+    // machine is usable, not missing — spawn permissively instead of failing
+    // the launch, matching Claude Code (#3471).
+    allowUnprobeableInstall: true,
   });
 }
 
@@ -556,11 +586,10 @@ async function ensureClaudeCodeCli(emit) {
       bareCommand: "claude",
       packageName: "@anthropic-ai/claude-code",
       resolveBinary: resolveInstalledClaudeBinary,
-      // Unlike Codex (a small native binary that answers --version
-      // instantly), this CLI is a large JS package whose cold start can
-      // outlive the probe timeout on a slow machine. An unprobeable version
-      // at a known install location spawns permissively (#3471), matching
-      // the custom-PATH branch below.
+      // This CLI is a large JS package whose cold start can outlive the
+      // probe timeout on a slow machine. An unprobeable version at a known
+      // install location spawns permissively (#3471), matching the
+      // custom-PATH branch below.
       allowUnprobeableInstall: true,
     });
   }
@@ -822,7 +851,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Seren is preparing the Codex CLI automatically.",
+                  "Seren installs the Codex CLI automatically when you start the agent.",
               }),
         };
       },
@@ -859,7 +888,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Seren is preparing the Claude Code CLI automatically.",
+                  "Seren installs the Claude Code CLI automatically when you start the agent.",
               }),
         };
       },
@@ -903,7 +932,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           ...(missing.length === 0
             ? {}
             : {
-                unavailableReason: `Seren is preparing the ${missing.join(" and ")} CLI${missing.length > 1 ? "s" : ""} automatically.`,
+                unavailableReason: `Seren installs the ${missing.join(" and ")} CLI${missing.length > 1 ? "s" : ""} automatically when you start the agent.`,
               }),
         };
       },
@@ -945,7 +974,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Seren is preparing the Antigravity CLI automatically.",
+                  "Seren installs the Antigravity CLI automatically when you start the agent.",
               }),
         };
       },
@@ -961,7 +990,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           emit?.("provider://cli-install-progress", {
             stage: "action_required",
             message:
-              "Seren could not prepare Antigravity yet and will retry automatically.",
+              "Seren could not prepare Antigravity yet and will retry the next time you start this agent.",
           });
           throw error;
         }
@@ -996,7 +1025,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Seren is preparing the Grok CLI automatically.",
+                  "Seren installs the Grok CLI automatically when you start the agent.",
               }),
         };
       },
@@ -1089,7 +1118,13 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   const persistedActions = managedNpmTargets.map((target) => {
     const key = `pendingAction:${target}`;
     const action = persistedUpdaterState[key];
-    if (action?.reason === "installation_required") {
+    // Both reasons were persisted by builds that handed install/update work
+    // to the user; provisioning is Seren-owned now, so a leftover card would
+    // resurface a decision the app no longer asks for. #3708
+    if (
+      action?.reason === "installation_required" ||
+      action?.reason === "update_required"
+    ) {
       persistedUpdaterState[key] = null;
       removedStaleInstallAction = true;
       return null;

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -21,8 +21,27 @@ import {
   verifyTarballIntegrity,
 } from "./cli-scanner.mjs";
 import { serenDataDir } from "./cli-paths.mjs";
+import { composeWindowsShellCommand } from "./windows-shell-args.mjs";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Run a CLI that may resolve to a Windows .cmd shim. Node refuses to exec a
+ * .cmd without a shell, and cmd.exe joins argv with spaces and no per-argument
+ * quoting — an install path containing a space (a Windows username is enough)
+ * splits into two arguments and the command fails. Compose one pre-quoted
+ * command line for the shell case, mirroring the claude-runtime spawn path;
+ * exec directly otherwise.
+ */
+function execCliFile(command, args, { timeout, useShell }) {
+  if (useShell) {
+    return execFileAsync(composeWindowsShellCommand(command, args), [], {
+      timeout,
+      shell: true,
+    });
+  }
+  return execFileAsync(command, args, { timeout });
+}
 
 /** 24h between update checks per CLI. */
 export const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
@@ -197,9 +216,11 @@ export async function runInstalledVersion(resolvedPath, bareCommand) {
   const maxAttempts = 3;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      const { stdout } = await execFileAsync(resolvedPath, ["--version"], {
+      const { stdout } = await execCliFile(resolvedPath, ["--version"], {
         timeout: VERSION_CMD_TIMEOUT_MS,
-        shell: process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd"),
+        useShell:
+          process.platform === "win32" &&
+          resolvedPath.toLowerCase().endsWith(".cmd"),
       });
       return stdout.trim().match(SEMVER_EXTRACT_RE)?.[0] ?? null;
     } catch {
@@ -225,11 +246,10 @@ export async function runNpmView(packageName, { npmCliScript } = {}) {
       return stdout.trim();
     }
     const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-    const { stdout } = await execFileAsync(
+    const { stdout } = await execCliFile(
       npmCommand,
       ["view", packageName, "version"],
-      // Node refuses to exec a .cmd shim without a shell.
-      { timeout: NPM_VIEW_TIMEOUT_MS, shell: process.platform === "win32" },
+      { timeout: NPM_VIEW_TIMEOUT_MS, useShell: process.platform === "win32" },
     );
     return stdout.trim();
   } catch {
@@ -252,11 +272,10 @@ async function runNpmInstallLatest(packageName, { npmCliScript } = {}) {
     return;
   }
   const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-  await execFileAsync(
+  await execCliFile(
     npmCommand,
     ["install", "-g", `${packageName}@latest`],
-    // Node refuses to exec a .cmd shim without a shell.
-    { timeout: NPM_INSTALL_TIMEOUT_MS, shell: process.platform === "win32" },
+    { timeout: NPM_INSTALL_TIMEOUT_MS, useShell: process.platform === "win32" },
   );
 }
 
@@ -284,12 +303,10 @@ async function runNpmInstallFromTarball(
     return;
   }
   const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-  await execFileAsync(
-    npmCommand,
-    installArgs,
-    // Node refuses to exec a .cmd shim without a shell.
-    { timeout: NPM_INSTALL_TIMEOUT_MS, shell: process.platform === "win32" },
-  );
+  await execCliFile(npmCommand, installArgs, {
+    timeout: NPM_INSTALL_TIMEOUT_MS,
+    useShell: process.platform === "win32",
+  });
 }
 
 // All managed npm CLIs share one global prefix. npm mutates that prefix as a
@@ -375,9 +392,9 @@ async function tryCliSelfUpdate(resolvedPath) {
   try {
     const onWindowsCmd =
       process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd");
-    await execFileAsync(resolvedPath, ["update"], {
+    await execCliFile(resolvedPath, ["update"], {
       timeout: NPM_INSTALL_TIMEOUT_MS,
-      shell: onWindowsCmd,
+      useShell: onWindowsCmd,
     });
     return true;
   } catch {
@@ -390,9 +407,9 @@ async function runCliHealthCheck(resolvedPath) {
   try {
     const onWindowsCmd =
       process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd");
-    await execFileAsync(resolvedPath, ["--help"], {
+    await execCliFile(resolvedPath, ["--help"], {
       timeout: VERSION_CMD_TIMEOUT_MS,
-      shell: onWindowsCmd,
+      useShell: onWindowsCmd,
     });
     return true;
   } catch {
@@ -419,10 +436,9 @@ export async function runNpmViewIntegrity(
       : process.platform === "win32"
         ? "npm.cmd"
         : "npm";
-    const { stdout } = await execFileAsync(command, args, {
+    const { stdout } = await execCliFile(command, args, {
       timeout: NPM_VIEW_TIMEOUT_MS,
-      // Node refuses to exec a .cmd shim without a shell.
-      shell: !npmCliScript && process.platform === "win32",
+      useShell: !npmCliScript && process.platform === "win32",
     });
     const trimmed = stdout.trim();
     if (!trimmed) return null;
@@ -663,45 +679,48 @@ async function runBackgroundUpdateCli({
       latest &&
       (installFromMissing || (installed && isNewer(installed, latest)))
     ) {
-      // Native-channel binaries and Codex's package-manager-aware updater must
-      // verify the resulting bytes before success is surfaced. Never fall back
-      // to a downloaded installer script when self-update fails.
+      // Native-channel binaries and Codex's package-manager-aware updater try
+      // their own self-update first and must verify the resulting bytes before
+      // success is surfaced. A failed self-update falls through to the managed
+      // verified npm install below — the same pack-scan-install path a first
+      // install uses — never to a downloaded installer script. The managed
+      // copy leads binary resolution, so the fallback actually unblocks spawn
+      // instead of parking the user on a manual-action card. #3706
       if (
         installed &&
         (channel === "native" || packageName === "@openai/codex")
       ) {
         const selfOk = await selfUpdateFn(resolvedPath);
-        if (!selfOk) {
-          return requireAction("self_update_failed", { channel });
-        }
-        const installedPath = resolveInstalledPath?.() ?? resolvedPath;
-        const verifiedVersion = await installedVersionFn(
-          installedPath,
-          bareCommand,
-        );
-        const healthy = await healthCheckFn(installedPath);
-        if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
-          return requireAction("verification_required", {
-            channel,
+        if (selfOk) {
+          const installedPath = resolveInstalledPath?.() ?? resolvedPath;
+          const verifiedVersion = await installedVersionFn(
+            installedPath,
+            bareCommand,
+          );
+          const healthy = await healthCheckFn(installedPath);
+          if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
+            return requireAction("verification_required", {
+              channel,
+              verifiedVersion,
+            });
+          }
+          persisted[pendingActionKey] = null;
+          if (ownsPersistence) saveState(persisted);
+          onUpdated?.({
+            label,
+            bareCommand,
+            from: installed,
+            to: latest,
+            channel: "self",
+            verifiedVersion,
+          });
+          return report("success", {
+            from: installed,
+            to: latest,
+            channel: "self",
             verifiedVersion,
           });
         }
-        persisted[pendingActionKey] = null;
-        if (ownsPersistence) saveState(persisted);
-        onUpdated?.({
-          label,
-          bareCommand,
-          from: installed,
-          to: latest,
-          channel: "self",
-          verifiedVersion,
-        });
-        return report("success", {
-          from: installed,
-          to: latest,
-          channel: "self",
-          verifiedVersion,
-        });
       }
 
       // npm channel: pack-extract-scan-install-baseline.

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -422,16 +422,38 @@ pub fn configure_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
 }
 
 pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> String {
-    let mut entries: Vec<String> = current_path
-        .split(path_separator)
-        .filter(|p| !p.is_empty())
-        .map(|p| p.to_string())
-        .collect();
+    // Seren's managed CLI directory must LEAD the PATH: terminals spawn bare
+    // `claude`/`codex`, so a stale copy anywhere earlier in the user's PATH
+    // would shadow the verified managed install (#3709).
+    let mut managed_bins: Vec<String> = Vec::new();
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        if !home.is_empty() {
+            managed_bins.push(format!("{}/.seren/cli-tools/bin", home));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let appdata = std::env::var("APPDATA").unwrap_or_default();
+        if !appdata.is_empty() {
+            managed_bins.push(format!("{}\\Seren\\cli-tools", appdata));
+        }
+    }
+
+    let mut entries: Vec<String> = managed_bins.clone();
+    entries.extend(
+        current_path
+            .split(path_separator)
+            .filter(|p| !p.is_empty() && !managed_bins.iter().any(|m| m == p))
+            .map(|p| p.to_string()),
+    );
 
     // Keep the user's order, but append missing common locations.
     // GUI apps don't source shell profiles so CLI install directories
-    // (e.g., Seren's managed CLI directory, ~/.claude/bin, %APPDATA%\npm)
-    // are typically missing from PATH.
+    // (e.g., ~/.claude/bin, %APPDATA%\npm) are typically missing from PATH.
     {
         use std::collections::HashSet;
 
@@ -442,7 +464,6 @@ pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &
         {
             let home = std::env::var("HOME").unwrap_or_default();
             if !home.is_empty() {
-                common_bins.push(format!("{}/.seren/cli-tools/bin", home));
                 common_bins.push(format!("{}/.claude/bin", home));
                 common_bins.push(format!("{}/.local/bin", home));
             }
@@ -481,7 +502,6 @@ pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &
             // npm global installs land here
             let appdata = std::env::var("APPDATA").unwrap_or_default();
             if !appdata.is_empty() {
-                common_bins.push(format!("{}\\Seren\\cli-tools", appdata));
                 common_bins.push(format!("{}\\npm", appdata));
             }
         }
@@ -894,6 +914,71 @@ mod tests {
             !removed,
             "sanitize_spawn_env must preserve PLAYWRIGHT_MCP_PING_TIMEOUT_MS for child MCP spawns"
         );
+    }
+
+    /// Regression guard for #3709.
+    ///
+    /// Terminals spawn bare `claude`/`codex` over this PATH, so the managed
+    /// cli-tools directory has to LEAD it. Appended at the end, a stale CLI
+    /// earlier in the user's PATH shadowed the verified managed copy the
+    /// updater had just installed.
+    #[test]
+    fn extend_path_leads_with_the_managed_cli_dir() {
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            let home = std::env::var("HOME").expect("HOME must be set for this test");
+            let managed = format!("{}/.seren/cli-tools/bin", home);
+
+            // Even when the managed dir is already present at a late
+            // position, it must come back first — exactly once — while the
+            // other entries keep their relative order.
+            let input = format!("/usr/local/bin:/usr/bin:{}", managed);
+            let path = extend_path_with_common_bins(&input, ":");
+            let entries: Vec<&str> = path.split(':').collect();
+
+            assert_eq!(
+                entries.first(),
+                Some(&managed.as_str()),
+                "managed cli dir must lead the PATH, got: {path}"
+            );
+            assert_eq!(
+                entries.iter().filter(|p| **p == managed).count(),
+                1,
+                "managed cli dir must appear exactly once, got: {path}"
+            );
+            let usr_local = entries
+                .iter()
+                .position(|p| *p == "/usr/local/bin")
+                .expect("/usr/local/bin retained");
+            let usr_bin = entries
+                .iter()
+                .position(|p| *p == "/usr/bin")
+                .expect("/usr/bin retained");
+            assert!(
+                usr_local < usr_bin,
+                "existing PATH order must be preserved, got: {path}"
+            );
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let appdata = std::env::var("APPDATA").expect("APPDATA must be set for this test");
+            let managed = format!("{}\\Seren\\cli-tools", appdata);
+            let input = format!("C:\\Windows\\system32;{}", managed);
+            let path = extend_path_with_common_bins(&input, ";");
+            let entries: Vec<&str> = path.split(';').collect();
+
+            assert_eq!(
+                entries.first(),
+                Some(&managed.as_str()),
+                "managed cli dir must lead the PATH, got: {path}"
+            );
+            assert_eq!(
+                entries.iter().filter(|p| **p == managed).count(),
+                1,
+                "managed cli dir must appear exactly once, got: {path}"
+            );
+        }
     }
 }
 

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -941,12 +941,23 @@ export async function getAgentPermissionCatalog(
 }
 
 /**
+ * CLI ensure/retry RPCs cover real install work — an npm install bounded at
+ * three minutes, pack/scan verification, and serialization behind other CLIs
+ * sharing the managed prefix — so the default 30s RPC timeout can expire while
+ * a first install is still succeeding underneath it. Give these calls ten
+ * minutes.
+ */
+const CLI_ENSURE_TIMEOUT_MS = 600_000;
+
+/**
  * Ensure Claude Code CLI is installed through Seren's verified managed path.
  */
 export async function ensureClaudeCli(): Promise<string> {
-  return invokeProvider<string>("provider_ensure_agent_cli", {
-    agentType: "claude-code",
-  });
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "claude-code" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 /**
@@ -954,9 +965,11 @@ export async function ensureClaudeCli(): Promise<string> {
  * Missing installs and upgrades are verified before success is reported.
  */
 export async function ensureCodexCli(): Promise<string> {
-  return invokeProvider<string>("provider_ensure_agent_cli", {
-    agentType: "codex",
-  });
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "codex" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 export type CliUpdateOutcome = {
@@ -983,9 +996,11 @@ export type CliUpdateActionRequired = {
 export async function retryCliUpdate(
   bareCommand: "claude" | "codex" | "grok",
 ): Promise<CliUpdateOutcome> {
-  return invokeProvider<CliUpdateOutcome>("provider_retry_cli_update", {
-    bareCommand,
-  });
+  return invokeProvider<CliUpdateOutcome>(
+    "provider_retry_cli_update",
+    { bareCommand },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 /** Read an updater action that may have fired before the UI subscribed. */
@@ -1001,16 +1016,20 @@ export async function getPendingCliUpdateAction(): Promise<CliUpdateActionRequir
  * The durable service name remains Gemini for saved-session compatibility.
  */
 export async function ensureGeminiCli(): Promise<string> {
-  return invokeProvider<string>("provider_ensure_agent_cli", {
-    agentType: "gemini",
-  });
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "gemini" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 /** Ensure the official Grok Build CLI is installed in Seren's managed prefix. */
 export async function ensureGrokCli(): Promise<string> {
-  return invokeProvider<string>("provider_ensure_agent_cli", {
-    agentType: "grok",
-  });
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "grok" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 /**
@@ -1018,9 +1037,11 @@ export async function ensureGrokCli(): Promise<string> {
  * Returns the bin directory path containing the claude binary.
  */
 export async function ensurePairedCli(): Promise<string> {
-  return invokeProvider<string>("provider_ensure_agent_cli", {
-    agentType: "claude-codex",
-  });
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "claude-codex" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
 }
 
 /**

--- a/tests/unit/claude-cli-baseline-gate.test.ts
+++ b/tests/unit/claude-cli-baseline-gate.test.ts
@@ -122,7 +122,7 @@ describe("#3443 shared baseline gate decision logic", () => {
         _runInstalledVersion: async () => "2.1.100",
         _backgroundUpdateCli: async () => ({ outcome: "skipped:network" }),
       }),
-    ).rejects.toThrow(/requires 2\.1\.197.*skipped:network/s);
+    ).rejects.toThrow(/requires 2\.1\.197.*network unavailable/s);
   });
 
   it("fails closed when the update reports success but the binary is stale", async () => {

--- a/tests/unit/cli-ensure-rpc-timeout.test.ts
+++ b/tests/unit/cli-ensure-rpc-timeout.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Guards #3692 — CLI ensure/retry RPCs must outlive real first-install work.
+// ABOUTME: Pins the extended timeout so the default 30s RPC deadline cannot race npm installs.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@/lib/browser-local-runtime", () => ({
+  isLocalProviderRuntime: () => true,
+  onRuntimeEvent: vi.fn(),
+  runtimeInvoke: vi.fn(async () => "/managed/bin/cli"),
+}));
+vi.mock("@/lib/runtime", () => ({ runtimeHasCapability: () => true }));
+vi.mock("@/lib/tauri-bridge", () => ({ isTauriRuntime: () => false }));
+
+import { runtimeInvoke } from "@/lib/browser-local-runtime";
+import {
+  ensureClaudeCli,
+  ensureCodexCli,
+  ensureGeminiCli,
+  ensureGrokCli,
+  ensurePairedCli,
+  retryCliUpdate,
+} from "@/services/providers";
+
+const runtimeInvokeMock = vi.mocked(runtimeInvoke);
+
+describe("#3692 CLI ensure/retry RPC timeout", () => {
+  it("passes a ten-minute timeout for every install-bound ensure/retry RPC", async () => {
+    await ensureClaudeCli();
+    await ensureCodexCli();
+    await ensureGeminiCli();
+    await ensureGrokCli();
+    await ensurePairedCli();
+    await retryCliUpdate("claude");
+
+    expect(runtimeInvokeMock).toHaveBeenCalledTimes(6);
+    for (const [command, , options] of runtimeInvokeMock.mock.calls) {
+      expect([
+        "provider_ensure_agent_cli",
+        "provider_retry_cli_update",
+      ]).toContain(command);
+      expect(options).toEqual({ timeoutMs: 600_000 });
+    }
+  });
+});

--- a/tests/unit/cli-updater-cmd-quoting.test.ts
+++ b/tests/unit/cli-updater-cmd-quoting.test.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Guards #3693 — Windows .cmd CLI verification must quote paths with spaces.
+// ABOUTME: Pins the composed shell command string and cli-updater's use of the shared helper.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const shellArgsModule = new URL(
+  "../../bin/browser-local/windows-shell-args.mjs",
+  import.meta.url,
+).href;
+const { composeWindowsShellCommand } = await import(
+  /* @vite-ignore */ shellArgsModule
+);
+
+describe("#3693 .cmd verification quoting", () => {
+  it("quotes a .cmd path containing a space so cmd.exe runs one command, not two", () => {
+    const cmdPath =
+      "C:\\Users\\John Smith\\AppData\\Roaming\\Seren\\cli-tools\\claude.cmd";
+
+    const composed = composeWindowsShellCommand(cmdPath, ["--version"]);
+
+    expect(composed).toBe(`"${cmdPath}" "--version"`);
+  });
+
+  it("cli-updater routes every shell exec through the pre-composed command", () => {
+    const updaterSource = readFileSync(
+      new URL("../../bin/browser-local/cli-updater.mjs", import.meta.url),
+      "utf8",
+    );
+
+    expect(updaterSource).toContain("composeWindowsShellCommand");
+    // No exec site may hand an unquoted argv to cmd.exe's space-join.
+    expect(updaterSource).not.toMatch(/shell:\s*process\.platform/);
+    expect(updaterSource).not.toMatch(/shell:\s*onWindowsCmd/);
+  });
+});

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -1007,3 +1007,107 @@ describe("verified fail-closed updates (#3092)", () => {
     expect(store).toContain("https://docs.x.ai/");
   });
 });
+
+describe("failed self-update falls through to the managed install (#3706)", () => {
+  let tempDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "seren-selfupdate-test-"));
+    originalEnv = process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = path.join(
+      tempDir,
+      "cli-update-state.json",
+    );
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    } else {
+      process.env.SEREN_CLI_UPDATER_STATE_PATH = originalEnv;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("native channel + failed self-update attempts the managed verified install instead of parking on an action card", async () => {
+    let selfUpdateCalls = 0;
+    let installCalled = false;
+    let resolved = "/Users/u/.local/bin/claude";
+    const actions: unknown[] = [];
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/Users/u/.local/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      installPrefix: "/managed/cli-tools",
+      resolveInstalledPath: () => resolved,
+      state: {},
+      now: Date.now(),
+      onActionRequired: (event: unknown) => actions.push(event),
+      _versionOverrides: {
+        runInstalledVersion: async (probePath: string) =>
+          probePath === "/managed/cli-tools/bin/claude"
+            ? "2.1.216"
+            : "2.1.200",
+        runNpmView: async () => "2.1.216",
+        runNpmViewIntegrity: async () => "sha512-verified",
+        tryCliSelfUpdate: async () => {
+          selfUpdateCalls++;
+          return false;
+        },
+        runCliHealthCheck: async () => true,
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/claude-2.1.216.tgz",
+        verifyTarballIntegrity: () => true,
+        scanTarball: async () => ({
+          verdict: "pass",
+          flags: [],
+          candidate: {
+            version: "2.1.216",
+            tarballSha512: "verified-claude",
+            installScripts: { postinstall: "node install.cjs" },
+            declaredDependencies: ["@anthropic-ai/claude-code-darwin-arm64"],
+            binEntries: { claude: "bin/claude.exe" },
+            executableFiles: ["bin/claude.exe"],
+            networkHosts: [],
+            files: ["package.json"],
+            fileHashes: { "package.json": "package" },
+          },
+        }),
+        runNpmInstallFromTarball: async (
+          _tarball: string,
+          installOptions: Record<string, unknown>,
+        ) => {
+          expect(installOptions.installPrefix).toBe("/managed/cli-tools");
+          installCalled = true;
+          resolved = "/managed/cli-tools/bin/claude";
+        },
+      },
+    });
+
+    expect(selfUpdateCalls).toBe(1);
+    expect(installCalled).toBe(true);
+    expect(actions).toHaveLength(0);
+    expect(result).toMatchObject({
+      outcome: "success",
+      from: "2.1.200",
+      to: "2.1.216",
+      verifiedVersion: "2.1.216",
+    });
+  });
+});
+
+describe("stale pending-action purge (#3708)", () => {
+  it("purges persisted update_required cards in the same startup sweep as installation_required", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../..");
+    const registry = readFileSync(
+      path.join(repoRoot, "bin/browser-local/agent-registry.mjs"),
+      "utf8",
+    );
+
+    expect(registry).toContain('action?.reason === "installation_required"');
+    expect(registry).toContain('action?.reason === "update_required"');
+  });
+});


### PR DESCRIPTION
Closes #3692. Closes #3693. Closes #3706. Closes #3707. Closes #3708. Closes #3709.

## Fixes (one per issue)

- **#3692 (P1)** — `ensureClaudeCli`/`ensureCodexCli`/`ensureGeminiCli`/`ensureGrokCli`/`ensurePairedCli` and `retryCliUpdate` now pass a 10-minute `timeoutMs` instead of inheriting the 30-second default that raced the first verified install (npm install alone is budgeted 180s, serialized behind the other CLIs' startup installs). `ensureLmStudioCli` keeps the default — it installs nothing.
- **#3693 (P1)** — updater probes (`runInstalledVersion`, `tryCliSelfUpdate`, `runCliHealthCheck`) and the four npm exec sites now compose one pre-quoted command line via `composeWindowsShellCommand` (the established claude-runtime spawn pattern) instead of `shell: true` with unquoted argv join, so a Windows profile path containing a space no longer fails verification forever. Codex's ensure gains `allowUnprobeableInstall: true` so a resolved-but-unprobeable managed install spawns permissively instead of re-downloading on every attempt.
- **#3706 (P2)** — a failed native-channel self-update falls through to the managed verified pack-scan-install path instead of `requireAction("self_update_failed")`. Verification-failure and scan-failure paths stay fail-closed.
- **#3707 (P2)** — spawn-error copy stops promising automatic retries that never run ("the next time you start this agent"), availability text stops implying in-flight work, and raw outcome enums (`skipped:network`) are mapped to plain language in user-facing errors while the structured log keeps the exact enum.
- **#3708 (P2)** — the startup sweep purges legacy `update_required` pending-action cards alongside `installation_required`.
- **#3709 (P2)** — `extend_path_with_common_bins` now puts the managed CLI directory at the HEAD of the constructed PATH (deduped), so terminal quick-launch resolves the same verified binary as agent sessions instead of a stale copy in an earlier PATH entry (npm's global dir class). Rust test pins first-position + exactly-once + preserved ordering.

## Validation

- `pnpm test` — 440 files / 3,030 passed (two new test files: RPC timeout contract, .cmd quoting)
- `cargo test --lib` — 1,305 passed, 0 failed (new PATH-lead test)
- `pnpm check` — clean
- One deliberate assertion update: `claude-cli-baseline-gate.test.ts` error-copy regex follows the #3707 wording change.

## Network path

No new outbound paths — same npm registry and vendor endpoints via the existing verified updater.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com