### PR TITLE
chore(release): curated notes for v3.78.1

### DIFF
--- a/.github/release-notes/v3.78.1.md
+++ b/.github/release-notes/v3.78.1.md
@@ -1,0 +1,39 @@
+## What's New
+
+Maintenance release: bug fixes across chat reliability, the model catalog, sign-in, agent CLI provisioning, and process lifecycle. No new features.
+
+## 💬 Chat Reliability
+
+- A chat turn that hits an upstream streaming error now retries the same model without streaming before rerouting, so a model with a healthy non-streaming route completes instead of failing the turn (#3681, #3685).
+- The non-streaming fallback can no longer corrupt live streaming turns (duplicated text, broken tool arguments) when a provider emits consolidated chunks, and a valid non-streaming completion can no longer end as a silent empty turn (#3702, #3703, #3712).
+- Verified Output no longer rewrites a model's self-description ("I don't have direct introspective access…") into a service-outage sentence (#3687, #3688), while first-person access denials that name a real service ("I cannot access your Gmail account") are guarded again (#3704, #3710).
+
+## 📚 Model Catalog
+
+- Searching the Seren model picker now filters the live SerenModels catalog — the models chat can actually route — instead of expanding into a public catalog where most selections failed with "404 Model not found". The settings model selects share the same source of truth, and a selected model missing from the catalog shows its own ID instead of borrowing another model's name (#3683, #3689).
+
+## 🔑 Sign-in, Skills & Claude Memory
+
+- Skill processes receive a publisher-only key, and a skill key failure no longer signs you out (#3675, #3676, #3677, #3678).
+- A failed skill-key provisioning (offline launch, transient server error) no longer disables Claude memory for the whole session or asks a signed-in user to sign out — memory starts automatically once the key lands, and skills re-provision their key before spawning (#3690, #3711).
+- Interrupted provisioning can no longer orphan server-side keys or store a key after sign-out, and provisioning failures now reach support telemetry (#3694, #3695, #3696, #3711).
+
+## 🤖 Agent CLIs & First Run
+
+- Automatic CLI provisioning restored: a clean install provisions Claude Code, Codex, and Grok through Seren's verified installer with no user action (#3680, #3686).
+- Your first agent click no longer fails with a raw timeout while the first install is still running (#3692), Windows accounts with a space in the profile path install and verify correctly — including Codex (#3693), a failed native self-update falls back to Seren's managed install instead of a manual-action card (#3706), stale update prompts from older builds are cleared (#3708), and install errors read as plain language (#3707, #3714).
+- The terminal quick-launch runs the same verified CLI binary as agent sessions (#3709, #3714).
+
+## 🪟 Windows
+
+- npm-based MCP servers and skills spawn correctly — executable resolution no longer picks the unrunnable POSIX scripts inside the bundled runtime (#3691, #3713).
+- Mission Control workspace provisioning and chat repo context use the bundled Git, so no system Git is required (#3701, #3713).
+- Interrupted Git/Python runtime staging self-heals on the next build instead of shipping a partial tree (#3697, #3713).
+
+## ⚙️ Process Lifecycle
+
+- Quitting the app reliably terminates the provider runtime and all agent child processes on every platform, and a crash-restart can no longer lose the runtime-recovered signal (#3698, #3699, #3700, #3713).
+
+## 🖥️ UI
+
+- The new-agent "Conversation controls" banner can be dismissed per conversation (#3682, #3684).


### PR DESCRIPTION
Curated `.github/release-notes/v3.78.1.md` for the upcoming patch tag. All changes since v3.78.0 are bug fixes (13 merged fix PRs closing 27 issues), so the semver-correct next tag is the patch **v3.78.1** (patch precedent: v3.69.2). The release workflow picks this file up as the What's-New body and appends the standard installation footer.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com