### PR TITLE
fix(agent): survive cold-start registry lookups in CLI provisioning

### DIFF
--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -48,7 +48,10 @@ export const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** Timeouts kept tight so a hung subprocess can't freeze the background task. */
 const VERSION_CMD_TIMEOUT_MS = 5_000;
-const NPM_VIEW_TIMEOUT_MS = 15_000;
+// Budgeted for a COLD registry lookup: on a fresh Windows profile the first
+// npm invocation builds its cache while three CLIs check concurrently during
+// app startup, and 15s was measurably too tight there (#3717).
+const NPM_VIEW_TIMEOUT_MS = 60_000;
 const NPM_INSTALL_TIMEOUT_MS = 180_000;
 
 const SEMVER_EXACT_RE = /^(\d+)\.(\d+)\.(\d+)$/;
@@ -616,7 +619,15 @@ async function runBackgroundUpdateCli({
       return report("skipped:ttl");
     }
 
-    const latest = await npmViewFn(packageName, { npmCliScript });
+    let latest = await npmViewFn(packageName, { npmCliScript });
+    if (!latest) {
+      // On a fresh profile the first view builds npm's cache from scratch
+      // while claude/codex/grok check in parallel during app startup; a cold
+      // Windows machine blows the per-view budget and a swallowed timeout is
+      // indistinguishable from the registry being down. One retry runs
+      // against the now-warm cache in about a second (#3717).
+      latest = await npmViewFn(packageName, { npmCliScript });
+    }
 
     // Record the check timestamp even when we couldn't compare — offline
     // and rate-limited cases should not retry every launch.

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -119,11 +119,41 @@ describe("backgroundUpdateCli TTL gate", () => {
         },
       },
     });
-    expect(npmViewCalls).toBe(1);
+    // Both the initial lookup and the cold-cache retry must fail before the
+    // network skip is reported (#3717).
+    expect(npmViewCalls).toBe(2);
     expect(result).toMatchObject({
       outcome: "skipped:network",
       skipped: "network",
     });
+  });
+
+  it("recovers when the first registry lookup times out cold and the retry succeeds (#3717)", async () => {
+    // A fresh profile's first npm view builds the cache while three CLIs
+    // check in parallel at app startup; on a cold Windows machine the first
+    // attempt times out. The warm retry must carry provisioning instead of
+    // reporting the registry as unreachable.
+    const state = {
+      "lastUpdateCheck:codex": Date.now() - (UPDATE_CHECK_TTL_MS + 1),
+    };
+    let npmViewCalls = 0;
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/nonexistent/codex",
+      packageName: "@seren-test/definitely-not-a-real-package-xyz",
+      state,
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.0.0",
+        runNpmView: async () => {
+          npmViewCalls++;
+          return npmViewCalls === 1 ? null : "1.0.0";
+        },
+      },
+    });
+    expect(npmViewCalls).toBe(2);
+    expect(result).toMatchObject({ outcome: "skipped:up_to_date" });
   });
 
   it("skips when resolver returned the bare command — never creates a shadow install", async () => {


### PR DESCRIPTION
Closes #3717.

## Outcome

First-run CLI provisioning no longer aborts on cold machines: the npm version-check budget covers a cold-cache lookup, and a failed view retries once against the warm cache before anything is classified as a network failure.

## Live evidence (release gate + real-box probes)

The v3.78.1 release run failed at windows-app-e2e with all three CLIs reporting `skipped:network` exactly 15s after provider-runtime start. SSM probes on the same box immediately after: registry HEAD **200**, shipped `npm-cli.js` present and working, one **cold** `npm view` = **8.2s**, warm = 1.3s. Three parallel cold views at app startup exceed the old 15s budget; the timeout was swallowed and misread as the registry being down.

## Changes

- `NPM_VIEW_TIMEOUT_MS` 15s → 60s with the cold-start constraint documented.
- `runBackgroundUpdateCli` retries a null view once before reporting `skipped:network`.
- Tests: new case pinning fail-then-succeed → provisioning proceeds; the existing network-skip case now asserts both attempts fail first.

## Validation

- `pnpm vitest run tests/unit/cli-updater.test.ts` — 53 passed
- `pnpm test` — 3,036 passed
- `pnpm check` — clean

The real-world validation is the retagged v3.78.1 release run's windows-app-e2e gate, which exercises this exact path on the real box.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com