### PR TITLE
feat(models): match model search words in any order

### DIFF
--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -13,6 +13,7 @@ import {
   untrack,
 } from "solid-js";
 import { ProviderIcon } from "@/components/chat/ProviderIcon";
+import { filterModelsByQuery } from "@/lib/model-search";
 import {
   PROVIDER_CONFIGS,
   type ProviderId,
@@ -218,34 +219,17 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
 
   // Filter models: show the live list when no search, filter it when typing
   const filteredModels = createMemo(() => {
-    const query = searchQuery().toLowerCase().trim();
+    const query = searchQuery().trim();
 
     if (isPrivateChat()) {
-      const models = privateModels();
-      if (!query) {
-        return models;
-      }
-      return models.filter(
-        (model) =>
-          model.name.toLowerCase().includes(query) ||
-          model.id.toLowerCase().includes(query),
-      );
-    }
-
-    // No search query - show curated defaults
-    if (!query) {
-      return defaultModels();
+      return filterModelsByQuery(privateModels(), query);
     }
 
     // Search filters the same live list the empty picker shows. For Seren
     // that list is the publisher's advertised catalog — the only IDs
     // `POST /publishers/seren-models/chat/completions` routes. A broader
     // discovery catalog let search surface IDs that 404 on send (#3683).
-    return defaultModels().filter(
-      (model) =>
-        model.name.toLowerCase().includes(query) ||
-        model.id.toLowerCase().includes(query),
-    );
+    return filterModelsByQuery(defaultModels(), query);
   });
 
   const currentModel = () => {

--- a/src/components/settings/SearchableModelSelect.tsx
+++ b/src/components/settings/SearchableModelSelect.tsx
@@ -9,6 +9,7 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
+import { filterModelsByQuery } from "@/lib/model-search";
 import { type Model, modelsService } from "@/services/models";
 
 interface SearchableModelSelectProps {
@@ -51,16 +52,7 @@ export const SearchableModelSelect: Component<SearchableModelSelectProps> = (
   }
 
   // Filter models based on search
-  const filteredModels = () => {
-    const query = search().toLowerCase();
-    if (!query) return models();
-    return models().filter(
-      (m) =>
-        m.name.toLowerCase().includes(query) ||
-        m.id.toLowerCase().includes(query) ||
-        m.provider.toLowerCase().includes(query),
-    );
-  };
+  const filteredModels = () => filterModelsByQuery(models(), search());
 
   // Get display name for current value
   const selectedModelName = () => {

--- a/src/lib/model-search.ts
+++ b/src/lib/model-search.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Shared model-search matching for the chat picker and the settings model select.
+// ABOUTME: Matches whitespace-separated query words in any order across a model's searchable text.
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  google: "Google",
+  "meta-llama": "Meta",
+  meta: "Meta",
+  mistralai: "Mistral AI",
+  mistral: "Mistral AI",
+  cohere: "Cohere",
+  perplexity: "Perplexity",
+  deepseek: "DeepSeek",
+  qwen: "Qwen",
+  minimax: "MiniMax",
+  moonshotai: "MoonshotAI",
+  "x-ai": "xAI",
+  "z-ai": "Z.ai",
+  microsoft: "Microsoft",
+  nvidia: "NVIDIA",
+  amazon: "Amazon",
+  inflection: "Inflection",
+};
+
+/** Human vendor name for a `vendor/model` slug. */
+export function providerLabel(modelId: string): string {
+  const slug = modelId.split("/")[0]?.toLowerCase() || "";
+  return PROVIDER_LABELS[slug] || slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+export interface SearchableModel {
+  id: string;
+  name: string;
+  provider?: string;
+}
+
+/**
+ * Every whitespace-separated word in the query must appear somewhere in the
+ * model's name, slug, or vendor label. Word order is not significant: the
+ * vendor lives in the slug and the family lives in the name, so a query naming
+ * both ("anthropic opus") spans two fields and can never match contiguously.
+ */
+export function matchesModelQuery(
+  model: SearchableModel,
+  query: string,
+): boolean {
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return true;
+
+  const haystack =
+    `${model.name} ${model.id} ${model.provider ?? providerLabel(model.id)}`.toLowerCase();
+  return words.every((word) => haystack.includes(word));
+}
+
+/** Filter a model list with {@link matchesModelQuery}; an empty query keeps every entry. */
+export function filterModelsByQuery<T extends SearchableModel>(
+  models: T[],
+  query: string,
+): T[] {
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return models;
+  return models.filter((model) => matchesModelQuery(model, query));
+}

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Models service for fetching the searchable AI model catalog.
 // ABOUTME: Serves the live SerenModels publisher catalog — the set chat can route.
 
+import { providerLabel } from "@/lib/model-search";
 import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 
 export interface Model {
@@ -23,39 +24,8 @@ export const modelsService = {
     return models.map((model) => ({
       id: model.id,
       name: model.name,
-      provider: extractProvider(model.id),
+      provider: providerLabel(model.id),
       contextWindow: model.contextWindow,
     }));
   },
 };
-
-function extractProvider(modelId: string): string {
-  const providerMap: Record<string, string> = {
-    anthropic: "Anthropic",
-    openai: "OpenAI",
-    google: "Google",
-    "meta-llama": "Meta",
-    meta: "Meta",
-    mistralai: "Mistral AI",
-    mistral: "Mistral AI",
-    cohere: "Cohere",
-    perplexity: "Perplexity",
-    deepseek: "DeepSeek",
-    qwen: "Qwen",
-    minimax: "MiniMax",
-    moonshotai: "MoonshotAI",
-    "x-ai": "xAI",
-    "z-ai": "Z.ai",
-    microsoft: "Microsoft",
-    nvidia: "NVIDIA",
-    amazon: "Amazon",
-    inflection: "Inflection",
-  };
-
-  const providerSlug = modelId.split("/")[0]?.toLowerCase() || "";
-  return providerMap[providerSlug] || capitalize(providerSlug);
-}
-
-function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}

--- a/tests/unit/model-search.test.ts
+++ b/tests/unit/model-search.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Protects order-independent model search across the picker and settings select.
+// ABOUTME: Guards the vendor-in-slug plus family-in-name case that no substring can span.
+
+import { describe, expect, it } from "vitest";
+import { filterModelsByQuery, providerLabel } from "@/lib/model-search";
+
+// Shapes taken from the live SerenModels catalog, including OpenRouter's
+// inconsistent naming: some entries carry the vendor, some do not.
+const CATALOG = [
+  { id: "anthropic/claude-opus-5", name: "Claude Opus 5" },
+  { id: "anthropic/claude-sonnet-5", name: "Anthropic Claude Sonnet 5" },
+  { id: "anthropic/claude-haiku-4.5", name: "Anthropic: Claude Haiku 4.5" },
+  { id: "google/gemini-3.6-flash", name: "Google Gemini 3.6 Flash" },
+  { id: "openai/gpt-5-mini", name: "GPT-5 Mini" },
+];
+
+const ids = (query: string) =>
+  filterModelsByQuery(CATALOG, query).map((model) => model.id);
+
+describe("filterModelsByQuery", () => {
+  it("matches words in any order", () => {
+    expect(ids("claude opus")).toEqual(["anthropic/claude-opus-5"]);
+    expect(ids("opus claude")).toEqual(["anthropic/claude-opus-5"]);
+  });
+
+  it("spans the vendor in the slug and the family in the name", () => {
+    // "anthropic opus" appears contiguously in neither field: the vendor is
+    // only in the slug, the family only in the name.
+    expect(ids("anthropic opus")).toEqual(["anthropic/claude-opus-5"]);
+    expect(ids("mini gpt")).toEqual(["openai/gpt-5-mini"]);
+  });
+
+  it("keeps every model for an empty or whitespace-only query", () => {
+    expect(filterModelsByQuery(CATALOG, "")).toHaveLength(CATALOG.length);
+    expect(filterModelsByQuery(CATALOG, "   ")).toHaveLength(CATALOG.length);
+  });
+
+  it("still excludes models when any word matches nothing", () => {
+    expect(ids("claude gemini")).toEqual([]);
+    expect(ids("nonexistent")).toEqual([]);
+  });
+
+  it("matches the derived vendor label when it is absent from slug and name", () => {
+    // "Z.ai" is the label for the `z-ai` slug prefix; neither field spells it.
+    expect(
+      filterModelsByQuery([{ id: "z-ai/glm-5.2", name: "GLM 5.2" }], "z.ai glm"),
+    ).toHaveLength(1);
+  });
+});
+
+describe("providerLabel", () => {
+  it("maps known vendor slugs and capitalizes unknown ones", () => {
+    expect(providerLabel("anthropic/claude-opus-5")).toBe("Anthropic");
+    expect(providerLabel("meta-llama/llama-3.3-70b-instruct")).toBe("Meta");
+    expect(providerLabel("acme/some-model")).toBe("Acme");
+  });
+});


### PR DESCRIPTION
Closes #3731

## Outcome

Model search now splits the query on whitespace and requires every word to appear in the model's name, slug, or vendor label, in any order. `opus claude` and `anthropic opus` find the Claude Opus family that `claude opus` already found. Single-word queries and the empty-query full list are unchanged.

## Why now

Contiguous-substring matching was fine when the SerenModels catalog advertised 7 models. serenorg/seren-router#86 restored the full routable catalog (395 models, 58 vendors), and at that size a wrong word order returns an empty list with no hint the model is right there.

Measured against the live catalog, comparing the shipped substring match with this change over the same fields:

| Query | Before | After |
| --- | ---: | ---: |
| `claude opus` | 17 | 17 |
| `opus claude` | **0** | 17 |
| `anthropic opus` | **0** | 17 |
| `sonnet anthropic` | **0** | 8 |
| `gemini google` | **0** | 30 |
| `google flash` | **0** | 20 |
| `mini gpt` | **0** | 13 |
| `4.5 haiku` | **0** | 2 |
| `claude` | 32 | 32 |

`anthropic opus` is the case that motivated this: the vendor is only in the slug (`anthropic/claude-opus-5`) and the family is only in the name (`Claude Opus 5`), so no single substring can span both.

## Implementation boundary

Filtering only. No change to what the catalog contains, how it is fetched, or how a model is selected and committed. No fuzzy matching, ranking, or scoring — order-independence and one shared field set are the whole change.

## Second defect fixed in the same change

The two surfaces searched different fields: `SearchableModelSelect` matched the vendor label, `ModelSelector` did not. Typing `Anthropic` in Settings worked while the same query in the chat picker returned nothing. Both now use one matcher, so they behave identically.

## File walkthrough

| File | What changed |
| --- | --- |
| `src/lib/model-search.ts` | New. `matchesModelQuery` / `filterModelsByQuery` do the word-wise match; `providerLabel` is the vendor map, moved here from `services/models.ts` so one implementation serves both surfaces. |
| `src/components/chat/ModelSelector.tsx` | `filteredModels` delegates to `filterModelsByQuery` for both the private-models and public branches. Net -16 lines. |
| `src/components/settings/SearchableModelSelect.tsx` | Same delegation; its three-field filter collapses to the shared call. |
| `src/services/models.ts` | Private `extractProvider`/`capitalize` removed in favour of the shared `providerLabel`. Net -26 lines. |
| `tests/unit/model-search.test.ts` | New. Order-independence, the vendor-in-slug/family-in-name span, empty and whitespace-only queries, exclusion when any word misses, derived-label matching, and the label map itself. |

The change removes 62 lines and adds 8 across the three existing files.

## Checks

```
pnpm vitest run tests/unit/model-search.test.ts     6 passed
pnpm test                                           443 files, 3057 tests passed
pnpm check                                          0 errors (48 warnings, 1 info — matches main baseline)
```

Per Taariq's instruction on this ticket, no live walkthrough was required.

## Network path

None added, removed, or re-pointed. Both surfaces already read the same list through `getLiveSerenModelCatalog()` → `GET /publishers/seren-models/models`; this change only alters how an already-fetched list is filtered client-side.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com