### PR TITLE
fix(agent): make the Claude admission gate the source of truth (#3727)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -760,12 +760,34 @@ function buildSessionStatus(session, status = session.status) {
   };
 }
 
+/**
+ * Concurrent local Claude sessions the admission gate will admit.
+ *
+ * Measured, not guessed (#3727). `scripts/experiment-claude-concurrency.mjs
+ * --probe 8` on macOS 26.5 / arm64 with Claude Code 2.1.224 spawned 8
+ * concurrent sessions to ready and prompted all 8 concurrently with zero
+ * failures; spawn-to-ready degraded only 343ms → 427ms across the run. The CLI
+ * tolerates far more than the previous default of 3.
+ *
+ * The observed ceiling in real usage is lower than the machine ceiling: the
+ * local desktop DB shows at most 5 Claude-slot-consuming threads active in any
+ * 5-minute window, and ≥4 in 0.34% of windows. 6 covers every observed window
+ * with headroom while staying well inside the measured-safe range.
+ *
+ * Caveat worth respecting before raising this further: the probe measures
+ * spawn plus a trivial prompt, not sustained large-context turns with heavy
+ * tool use, which cost far more memory per session.
+ */
+const DEFAULT_CLAUDE_SESSION_LIMIT = 6;
+
 function resolveClaudeSessionLimit() {
   const configured = Number.parseInt(
     process.env.SEREN_CLAUDE_SESSION_LIMIT ?? "",
     10,
   );
-  return Number.isFinite(configured) && configured > 0 ? configured : 3;
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_CLAUDE_SESSION_LIMIT;
 }
 
 function normalizeModelRecords(result) {
@@ -2804,12 +2826,27 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     onQueued(sessionId, position) {
       const metadata = admissionMetadata.get(sessionId);
       if (!metadata) return;
+      // Name the slot holders whenever a queue forms. Without this the log
+      // records that a spawn waited but never which sessions it waited on,
+      // which is exactly the evidence #3727 needed and did not have.
+      const holders = admissionGate
+        .activeIds()
+        .map((heldBy) => {
+          const held = sessions.get(heldBy);
+          return `${heldBy}(${held?.status ?? "unknown"},${held?.agentType ?? "?"})`;
+        })
+        .join(" ");
       console.log(
         claudeLogPrefix +
           " session queued sessionId=" +
           sessionId +
           " position=" +
-          position,
+          position +
+          " limit=" +
+          admissionGate.limit +
+          " holders=[" +
+          holders +
+          "]",
       );
       emit("provider://session-status", {
         ...buildSessionStatus(
@@ -3355,6 +3392,13 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         session_id: session.agentSessionId,
       });
       onAccepted?.();
+      // The turn is now the CLI's problem. Anything waiting only for the
+      // handoff — a standby promotion holding the retired session's admission
+      // slot — can stop waiting here instead of at turn completion. #3727.
+      emit("provider://prompt-accepted", {
+        sessionId,
+        agentSessionId: session.agentSessionId,
+      });
     } catch (error) {
       const promptWasActive = session.currentPrompt !== null;
       rejectCurrentPrompt(
@@ -3451,6 +3495,27 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       agentSessionId: session.agentSessionId,
     });
     admissionGate.release(sessionId);
+  }
+
+  // Reports Claude process capacity straight from the admission gate. The
+  // frontend used to infer this from its own session map, which cannot see a
+  // paired thread's inner planner or a queued spawn at all (#3727).
+  function getCapacity() {
+    const activeIds = admissionGate.activeIds();
+    return {
+      limit: admissionGate.limit,
+      active: activeIds.map((sessionId) => {
+        const session = sessions.get(sessionId);
+        return {
+          sessionId,
+          agentType: session?.agentType ?? "claude-code",
+          status: session?.status ?? "unknown",
+          createdAt: session?.createdAt ?? null,
+          pid: session?.process?.pid ?? null,
+        };
+      }),
+      pending: admissionGate.pendingIds(),
+    };
   }
 
   async function listSessions() {
@@ -3767,6 +3832,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     hasSession(sessionId) {
       return sessions.has(sessionId);
     },
+    getCapacity,
     spawnSession,
     sendPrompt,
     cancelPrompt,

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -1202,6 +1202,7 @@ export function createPairedRuntime({ emit, inner }) {
         sessionId: roleState.innerSessionId,
         prompt,
         context,
+        onAccepted: () => paired.notifyAccepted?.(),
       });
     } finally {
       const filter = roleState.sentinelFilter;
@@ -1225,7 +1226,7 @@ export function createPairedRuntime({ emit, inner }) {
     return roleState.turnText;
   }
 
-  async function sendPrompt({ sessionId, prompt, context }) {
+  async function sendPrompt({ sessionId, prompt, context, onAccepted }) {
     const paired = requirePaired(sessionId);
     if (paired.currentPrompt) {
       throw new Error("Another prompt is already active for this session.");
@@ -1233,6 +1234,20 @@ export function createPairedRuntime({ emit, inner }) {
 
     paired.cancelRequested = false;
     paired.currentPrompt = {};
+    // A paired turn is a pipeline of inner turns, so its acceptance boundary
+    // is the first inner prompt the CLI accepts. Exposing it lets a caller
+    // stop waiting for the whole turn — a standby promotion no longer has to
+    // hold the retired session's admission slot until the turn ends. #3727.
+    let acceptanceNotified = false;
+    paired.notifyAccepted = () => {
+      if (acceptanceNotified) return;
+      acceptanceNotified = true;
+      try {
+        onAccepted?.();
+      } catch {
+        // Acceptance telemetry must never fail the turn.
+      }
+    };
     // The whole pipeline is one turn from the frontend's perspective. The
     // composer's Send gate reads info.status, so every status frame emitted
     // during a phase must carry "prompting" — a mid-turn "ready" re-enables
@@ -1644,6 +1659,19 @@ export function createPairedRuntime({ emit, inner }) {
   return {
     hasSession(sessionId) {
       return pairedSessions.has(sessionId);
+    },
+    // A paired thread's planner is a real Claude session holding a real
+    // admission slot, but only this map knows which wrapper thread owns it.
+    // Capacity accounting needs that attribution to reclaim the right thread
+    // and to tear down both halves rather than orphaning the executor (#3727).
+    describeInnerSessions() {
+      return Array.from(innerToPaired.entries()).map(
+        ([innerSessionId, owner]) => ({
+          innerSessionId,
+          pairedSessionId: owner.pairedId,
+          role: owner.role,
+        }),
+      );
     },
     interceptEmit,
     spawnSession,

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -2351,10 +2351,9 @@ export function createProviderHandlers({
   }
 
   function submitPrompt(params) {
-    if (
-      pairedRuntime.hasSession(params?.sessionId) ||
-      lmStudioRuntime.hasSession(params?.sessionId)
-    ) {
+    // Paired sessions report acceptance from their first inner turn (#3727),
+    // so only LM Studio is left without an acceptance boundary.
+    if (lmStudioRuntime.hasSession(params?.sessionId)) {
       return Promise.reject(
         new Error(
           "This provider does not expose an explicit prompt acceptance boundary.",
@@ -2497,6 +2496,35 @@ export function createProviderHandlers({
       ...(await lmStudioRuntime.listSessions()),
       ...(await pairedRuntime.listSessions()),
     ];
+  }
+
+  // Single source of truth for Claude process capacity. Every slot holder is
+  // reported with the thread that owns it, so a caller never has to infer
+  // capacity from agent-type strings in its own session map — the split-brain
+  // that let a paired thread consume a slot invisibly (#3727).
+  async function getClaudeCapacity() {
+    const capacity = claudeRuntime.getCapacity();
+    const innerOwners = new Map(
+      pairedRuntime
+        .describeInnerSessions()
+        .map((entry) => [entry.innerSessionId, entry]),
+    );
+
+    return {
+      limit: capacity.limit,
+      active: capacity.active.map((holder) => {
+        const owner = innerOwners.get(holder.sessionId);
+        return {
+          ...holder,
+          // The id the frontend actually holds in state.sessions: the paired
+          // wrapper for an inner planner, otherwise the session itself.
+          ownerSessionId: owner?.pairedSessionId ?? holder.sessionId,
+          ownerAgentType: owner ? PAIRED_AGENT_TYPE : holder.agentType,
+          pairedRole: owner?.role ?? null,
+        };
+      }),
+      pending: capacity.pending,
+    };
   }
 
   async function setPermissionMode({ sessionId, mode }) {
@@ -2940,6 +2968,7 @@ export function createProviderHandlers({
     cancelPrompt,
     terminateSession,
     listSessions,
+    getClaudeCapacity,
     setPermissionMode,
     setOAuthRouting,
     respondToPermission,

--- a/bin/browser-local/session-admission.mjs
+++ b/bin/browser-local/session-admission.mjs
@@ -122,5 +122,15 @@ export function createAdmissionGate({ limit, onQueued, acquireTimeoutMs } = {}) 
     activeCount() {
       return active.size;
     },
+    limit: normalizedLimit,
+    // The gate is the only correct account of who holds a slot. Anything that
+    // needs to reason about capacity must read it from here rather than infer
+    // it from a session list somewhere else (#3727).
+    activeIds() {
+      return Array.from(active);
+    },
+    pendingIds() {
+      return pending.map((request) => request.sessionId);
+    },
   };
 }

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -88,6 +88,10 @@ function registerProviderHandlers() {
   registerHandler("provider_terminate", providerHandlers.terminateSession);
   registerHandler("provider_list_sessions", providerHandlers.listSessions);
   registerHandler(
+    "provider_claude_capacity",
+    providerHandlers.getClaudeCapacity,
+  );
+  registerHandler(
     "provider_set_permission_mode",
     providerHandlers.setPermissionMode,
   );

--- a/scripts/experiment-claude-concurrency.mjs
+++ b/scripts/experiment-claude-concurrency.mjs
@@ -521,6 +521,74 @@ function cliVersionFallback() {
   }
 }
 
+/**
+ * Spawns `target` Claude sessions against one runtime, then prompts every live
+ * session concurrently. Reports where readiness or prompting actually breaks
+ * down, so the admission cap can be set from measurement instead of a guess.
+ *
+ * Run with the gate raised out of the way, e.g.
+ *   SEREN_CLAUDE_SESSION_LIMIT=12 node scripts/experiment-claude-concurrency.mjs --probe 8
+ */
+async function runConcurrencyProbe(target) {
+  const runtimes = [];
+  try {
+    const primary = await startRuntime(PRIMARY_PORT, "runtime-1");
+    runtimes.push(primary);
+    await checkClaude(primary);
+
+    const live = [];
+    const spawns = [];
+    for (let i = 1; i <= target; i += 1) {
+      const label = "S" + i;
+      const session = await spawnMeasured(primary, label);
+      spawns.push({
+        label,
+        status: session.status,
+        spawnToReadyMs: session.spawnToReadyMs ?? null,
+        error: session.error ?? null,
+      });
+      if (session.status !== "ready") {
+        console.log("[probe] " + label + " FAILED: " + session.error);
+        break;
+      }
+      live.push(session);
+      console.log(
+        "[probe] " +
+          label +
+          " ready spawnToReadyMs=" +
+          session.spawnToReadyMs +
+          " liveSessions=" +
+          live.length,
+      );
+    }
+
+    const promptStart = process.hrtime.bigint();
+    await Promise.all(
+      live.map((session, idx) => promptMeasured(primary, session, "S" + (idx + 1))),
+    );
+    const wallMs = Number(process.hrtime.bigint() - promptStart) / 1e6;
+
+    console.log(
+      "PROBE_JSON: " +
+        JSON.stringify({
+          generatedAt: new Date().toISOString(),
+          targetSessions: target,
+          liveSessions: live.length,
+          concurrentPromptWallMs: Math.round(wallMs),
+          spawns,
+          prompts: live.map((session, idx) => ({
+            label: "S" + (idx + 1),
+            status: session.prompt?.status ?? "unknown",
+            promptRoundTripMs: session.prompt?.promptRoundTripMs ?? null,
+            error: session.prompt?.error ?? null,
+          })),
+        }),
+    );
+  } finally {
+    await Promise.all(runtimes.map((runtime) => closeRuntime(runtime)));
+  }
+}
+
 async function main() {
   ensureSandboxSpecBin();
   if (process.argv.includes("--queue-proof")) {
@@ -533,6 +601,25 @@ async function main() {
     }
     return;
   }
+  // `--probe N` measures how many concurrent Claude sessions the machine and
+  // CLI actually tolerate, which is what the admission cap should be derived
+  // from. The A/B/C flow below only ever proves 3 and cannot justify a higher
+  // number. #3727.
+  const probeIdx = process.argv.indexOf("--probe");
+  if (probeIdx !== -1) {
+    const target = Number(process.argv[probeIdx + 1] ?? "8");
+    try {
+      await runConcurrencyProbe(target);
+    } catch (error) {
+      console.error(
+        "[probe] BLOCKER: " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const runtimes = [];
   let outcome = "serialize";
   let blocker = null;

--- a/scripts/walkthrough-3727.mjs
+++ b/scripts/walkthrough-3727.mjs
@@ -1,0 +1,229 @@
+// ABOUTME: Live walkthrough for #3727 against a real provider runtime and real Claude CLI.
+// ABOUTME: Reproduces slot exhaustion, then proves capacity accounting and reclaim.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { WebSocket } from "ws";
+
+const ROOT_PATH = fileURLToPath(new URL("../", import.meta.url));
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.WALKTHROUGH_PORT ?? "4319");
+const TOKEN = "walkthrough-3727-token";
+const CWD = process.cwd();
+
+function resolveSandboxSpecBin() {
+  if (process.env.SEREN_SANDBOX_SPEC_BIN) return process.env.SEREN_SANDBOX_SPEC_BIN;
+  for (const profile of ["release", "debug"]) {
+    const candidate = join(ROOT_PATH, "src-tauri", "target", profile, "Seren");
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error("Build the app binary first (cargo build --manifest-path src-tauri/Cargo.toml)");
+}
+
+let nextId = 1;
+const pending = new Map();
+const notifications = [];
+
+function rpc(ws, method, params) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    setTimeout(() => {
+      if (pending.delete(id)) reject(new Error(`RPC ${method} timed out`));
+    }, 180_000).unref();
+  });
+}
+
+async function main() {
+  const limit = process.env.SEREN_CLAUDE_SESSION_LIMIT ?? "2";
+  const child = spawn(
+    process.execPath,
+    [join(ROOT_PATH, "bin", "provider-runtime.mjs"), "--host", HOST, "--port", String(PORT)],
+    {
+      cwd: ROOT_PATH,
+      env: {
+        ...process.env,
+        SEREN_PROVIDER_RUNTIME_TOKEN: TOKEN,
+        SEREN_CLAUDE_SESSION_LIMIT: limit,
+        SEREN_SANDBOX_SPEC_BIN: resolveSandboxSpecBin(),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const runtimeLog = [];
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      for (const line of chunk.split("\n")) {
+        if (!line.trim()) continue;
+        runtimeLog.push(line);
+        if (process.env.WALKTHROUGH_VERBOSE === "1" || line.includes("session queued")) {
+          console.log("  [runtime] " + line.trim());
+        }
+      }
+    });
+  }
+
+  // Wait for the runtime to report healthy rather than guessing a delay.
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    try {
+      const res = await fetch(`http://${HOST}:${PORT}/__seren/health`);
+      if (res.ok) break;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) throw new Error("provider runtime never became healthy");
+    await sleep(500);
+  }
+  const ws = new WebSocket(`ws://${HOST}:${PORT}`);
+  await new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  ws.on("message", (raw) => {
+    const msg = JSON.parse(String(raw));
+    if (msg.id && pending.has(msg.id)) {
+      const entry = pending.get(msg.id);
+      pending.delete(msg.id);
+      if (msg.error) entry.reject(new Error(msg.error.message ?? "rpc error"));
+      else entry.resolve(msg.result);
+    } else if (msg.method) {
+      notifications.push(msg);
+    }
+  });
+  // The runtime authenticates over an `auth` RPC, not a query parameter.
+  await rpc(ws, "auth", { token: TOKEN });
+
+  const spawnClaude = (id) =>
+    rpc(ws, "provider_spawn", {
+      agentType: "claude-code",
+      cwd: CWD,
+      localSessionId: id,
+      resumeAgentSessionId: null,
+      sandboxMode: "full-access",
+      apiKey: null,
+      approvalPolicy: "on-request",
+      searchEnabled: false,
+      networkEnabled: true,
+      timeoutSecs: 60,
+    });
+
+  try {
+    console.log(`\n=== STEP 1 — saturate the gate (limit=${limit}) ===`);
+    const held = [];
+    const holdCount = Number(process.env.WALKTHROUGH_HOLD ?? limit);
+    for (let i = 0; i < holdCount; i += 1) {
+      const id = randomUUID();
+      await spawnClaude(id);
+      held.push(id);
+      console.log(`  spawned real Claude session ${i + 1}/${holdCount} (limit ${limit})`);
+    }
+
+    console.log("\n=== STEP 2 — provider_claude_capacity reports the real holders ===");
+    const capacity = await rpc(ws, "provider_claude_capacity", {});
+    console.log("  " + JSON.stringify(capacity, null, 2).split("\n").join("\n  "));
+
+    console.log("\n=== STEP 3 — a further spawn queues; the log names the holders ===");
+    const queuedId = randomUUID();
+    const queuedSpawn = spawnClaude(queuedId).then(
+      () => "admitted",
+      (error) => `rejected: ${error.message}`,
+    );
+    await sleep(2000);
+    const queuedCapacity = await rpc(ws, "provider_claude_capacity", {});
+    console.log(`  pending=${JSON.stringify(queuedCapacity.pending)}`);
+
+    console.log("\n=== STEP 4 — releasing a holder admits the queued spawn ===");
+    await rpc(ws, "provider_terminate", { sessionId: held[0] });
+    const outcome = await queuedSpawn;
+    console.log(`  queued spawn outcome: ${outcome}`);
+
+    const afterCapacity = await rpc(ws, "provider_claude_capacity", {});
+    console.log(`  active after admit: ${afterCapacity.active.length}/${afterCapacity.limit}`);
+
+    console.log("\n=== STEP 5 — capacity matches provider_list_sessions (source of truth) ===");
+    const sessions = await rpc(ws, "provider_list_sessions", {});
+    const claudeSessions = sessions.filter((s) => s.agentType === "claude-code");
+    console.log(`  provider_list_sessions claude-code sessions: ${claudeSessions.length}`);
+    console.log(`  provider_claude_capacity active holders:     ${afterCapacity.active.length}`);
+    const holderIds = new Set(afterCapacity.active.map((h) => h.sessionId));
+    const listedIds = new Set(claudeSessions.map((s) => s.id));
+    const missing = [...holderIds].filter((id) => !listedIds.has(id));
+    console.log(`  holders not present in the session list: ${missing.length}`);
+
+    console.log("\n=== STEP 6 — a paired thread's planner is visible and attributed ===");
+    // Root cause 1: the planner is a real claude-code session holding a real
+    // slot, but the frontend only ever holds the claude-codex wrapper.
+    const pairedId = randomUUID();
+    let pairedSpawned = false;
+    try {
+      await rpc(ws, "provider_spawn", {
+        agentType: "claude-codex",
+        cwd: CWD,
+        localSessionId: pairedId,
+        resumeAgentSessionId: null,
+        sandboxMode: "full-access",
+        apiKey: null,
+        approvalPolicy: "on-request",
+        searchEnabled: false,
+        networkEnabled: true,
+        timeoutSecs: 60,
+      });
+      pairedSpawned = true;
+    } catch (error) {
+      console.log(`  paired spawn failed: ${error.message}`);
+    }
+
+    const pairedCapacity = await rpc(ws, "provider_claude_capacity", {});
+    const pairedHolders = pairedCapacity.active.filter(
+      (h) => h.ownerAgentType === "claude-codex",
+    );
+    console.log(`  paired spawn succeeded: ${pairedSpawned}`);
+    console.log(`  slot holders attributed to a paired wrapper: ${pairedHolders.length}`);
+    for (const holder of pairedHolders) {
+      console.log(
+        `    inner planner ${holder.sessionId.slice(0, 8)}… (${holder.agentType}, pid ${holder.pid})` +
+          ` -> wrapper ${holder.ownerSessionId.slice(0, 8)}… role=${holder.pairedRole}`,
+      );
+      console.log(
+        `    wrapper id matches the paired thread id: ${holder.ownerSessionId === pairedId}`,
+      );
+    }
+    const listed = await rpc(ws, "provider_list_sessions", {});
+    const wrapper = listed.find((sess) => sess.id === pairedId);
+    console.log(
+      `  provider_list_sessions reports the wrapper as: agentType=${wrapper?.agentType} pid=${wrapper?.pid}`,
+    );
+    console.log(
+      "  ^ pid null on the wrapper is exactly why agent-type inference could not see the slot",
+    );
+
+    console.log("\n=== QUEUE LOG LINES ===");
+    for (const line of runtimeLog.filter((l) => l.includes("session queued"))) {
+      console.log("  " + line.trim());
+    }
+  } finally {
+    for (const note of notifications.slice(0, 0)) console.log(note);
+    try {
+      const remaining = await rpc(ws, "provider_list_sessions", {});
+      for (const session of remaining) {
+        await rpc(ws, "provider_terminate", { sessionId: session.id }).catch(() => {});
+      }
+    } catch {
+      // teardown best-effort
+    }
+    ws.close();
+    child.kill("SIGTERM");
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -2127,6 +2127,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       </Show>
 
       {/* Error Display */}
+      <Show when={agentStore.claudeQueueNotice}>
+        <div class="mx-4 mb-2 px-3 py-2 border rounded-md text-sm bg-warning/10 border-warning/40 text-warning">
+          {agentStore.claudeQueueNotice}
+        </div>
+      </Show>
+
       <Show when={sessionError()}>
         <div
           class={`mx-4 mb-2 px-3 py-2 border rounded-md text-sm ${

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -63,6 +63,10 @@ export class PredictiveCompactMutex {
  *   retry was in flight. Not a defect — the error event handler's
  *   graceful-cancel branch already restores UI state. Chat fallback would
  *   be wrong, since the user's intent was to stop, not to switch modes.
+ * - `declined_no_capacity`: the predictive path would have had to take the
+ *   last local Claude slot to warm a standby. A standby is a latency
+ *   optimisation, so it yields to real threads and the caller compacts
+ *   reactively instead. Not a failure. #3727.
  * - `failed_catastrophic`: unrecoverable failure (spawn failed, summary API
  *   threw after refresh, agent runtime broken). Chat fallback is correct.
  */
@@ -72,6 +76,7 @@ export type CompactionOutcome =
   | "skipped_nothing_to_compact"
   | "retry_still_too_long"
   | "cancelled"
+  | "declined_no_capacity"
   | "failed_catastrophic";
 
 /**

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -71,6 +71,7 @@ export const [state, setState] = createStore<AgentState>({
   isLoading: false,
   error: null,
   installStatus: null,
+  claudeQueueNotice: null,
   cliScanRejection: null,
   cliUpdateActionRequired: null,
   pendingPermissions: [],

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -564,6 +564,18 @@ export interface McpDegradedEvent {
 }
 
 /**
+ * Emitted the instant the agent CLI accepts a prompt, before the turn runs.
+ *
+ * Separates "the handoff is safely done" from "the turn is finished" so a
+ * standby promotion can reap the retired child immediately instead of holding
+ * its admission slot for the length of a turn. #3727.
+ */
+export interface PromptAcceptedEvent {
+  sessionId: string;
+  agentSessionId?: string;
+}
+
+/**
  * Emitted after an agent deliberately uses an explicit OAuth connection on a
  * successful publisher call. The renderer persists it as this thread's active
  * provider account so the header and subsequent calls stay aligned.
@@ -593,6 +605,7 @@ export type AgentEvent =
   | { type: "error"; data: ErrorEvent }
   | { type: "loginRequired"; data: LoginRequiredEvent }
   | { type: "oauthAccountSelected"; data: OAuthAccountSelectedEvent }
+  | { type: "promptAccepted"; data: PromptAcceptedEvent }
   | { type: "mcpDegraded"; data: McpDegradedEvent };
 
 /**
@@ -794,6 +807,41 @@ export async function buildSyntheticTranscript(
  */
 export async function listSessions(): Promise<AgentSessionInfo[]> {
   return invokeProvider<AgentSessionInfo[]>("provider_list_sessions");
+}
+
+/** One holder of a local Claude admission slot (#3727). */
+export interface ClaudeSlotHolder {
+  /** The runtime session actually holding the slot. */
+  sessionId: string;
+  agentType: string;
+  status: string;
+  createdAt: string | null;
+  pid: number | null;
+  /**
+   * The session id the frontend holds in its own map — the paired wrapper for
+   * an inner planner, otherwise identical to `sessionId`.
+   */
+  ownerSessionId: string;
+  ownerAgentType: string;
+  pairedRole: string | null;
+}
+
+export interface ClaudeCapacity {
+  limit: number;
+  active: ClaudeSlotHolder[];
+  /** Session ids waiting for a slot, in queue order. */
+  pending: string[];
+}
+
+/**
+ * Read local Claude process capacity from the runtime's admission gate.
+ *
+ * Capacity must never be inferred from the frontend session map: a paired
+ * thread's planner is a real Claude session holding a real slot, and the
+ * frontend only ever holds the wrapper. #3727.
+ */
+export async function getClaudeCapacity(): Promise<ClaudeCapacity> {
+  return invokeProvider<ClaudeCapacity>("provider_claude_capacity");
 }
 
 /**
@@ -1134,6 +1182,7 @@ const EVENT_SUFFIXES = {
   diff: "diff",
   planUpdate: "plan-update",
   promptComplete: "prompt-complete",
+  promptAccepted: "prompt-accepted",
   permissionRequest: "permission-request",
   permissionResolved: "permission-resolved",
   diffProposal: "diff-proposal",
@@ -1322,6 +1371,12 @@ export async function subscribeToSession(
         "mcpDegraded",
       ),
     ),
+    subscribeToEvent<PromptAcceptedEvent>(
+      "promptAccepted",
+      createHandler<{ type: "promptAccepted"; data: PromptAcceptedEvent }>(
+        "promptAccepted",
+      ),
+    ),
   ]);
 }
 
@@ -1388,6 +1443,9 @@ export async function subscribeToAllEvents(
     ),
     subscribeToEvent<McpDegradedEvent>("mcpDegraded", (data) =>
       callback({ type: "mcpDegraded", data }),
+    ),
+    subscribeToEvent<PromptAcceptedEvent>("promptAccepted", (data) =>
+      callback({ type: "promptAccepted", data }),
     ),
   ]);
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -298,6 +298,44 @@ function estimatePromptContextTokens(
   return estimateTokens(`${prompt ?? ""}\n\n${contextText}`);
 }
 
+/**
+ * A retired session must never hold an admission slot for the length of a turn.
+ * Promotion waits for the promoted session's prompt to be accepted, but caps
+ * that wait: any provider that cannot report acceptance still gets its retired
+ * child reaped promptly rather than at turn completion. #3727.
+ */
+const PROMPT_ACCEPTANCE_TIMEOUT_MS = 5_000;
+
+/** Sessions whose next prompt acceptance someone is waiting on. */
+const promptAcceptanceWaiters = new Map<string, Array<() => void>>();
+
+function notifyPromptAccepted(sessionId: string): void {
+  const waiters = promptAcceptanceWaiters.get(sessionId);
+  if (!waiters) return;
+  promptAcceptanceWaiters.delete(sessionId);
+  for (const resolve of waiters) resolve();
+}
+
+/**
+ * Resolves when `sessionId`'s in-flight prompt is accepted by the agent CLI, or
+ * after a bounded ceiling — never rejects, because the caller's job is to free
+ * capacity, not to police the turn.
+ */
+function waitForPromptAccepted(sessionId: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const settleOnce = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const waiters = promptAcceptanceWaiters.get(sessionId) ?? [];
+    waiters.push(settleOnce);
+    promptAcceptanceWaiters.set(sessionId, waiters);
+    setTimeout(settleOnce, PROMPT_ACCEPTANCE_TIMEOUT_MS);
+  });
+}
+
 /** Await a session ready promise with a timeout to prevent infinite hangs */
 function waitForSessionReady(sessionId: string): Promise<void> {
   // Note: this only resolves the initial ready promise set up in spawnSession.
@@ -1428,6 +1466,17 @@ function usesClaudeMemory(agentType: AgentType): boolean {
   return agentType === "claude-code" || agentType === "claude-codex";
 }
 
+/**
+ * Whether spawning this agent type consumes a local Claude admission slot.
+ *
+ * A paired thread spawns a real `claude-code` planner through the same runtime
+ * gate, so it competes for the same bounded capacity even though the frontend
+ * only ever holds the `claude-codex` wrapper. #3727.
+ */
+function agentTypeTakesClaudeSlot(agentType: AgentType): boolean {
+  return agentType === "claude-code" || agentType === "claude-codex";
+}
+
 function encodeClaudeProjectDirForPath(cwd: string): string {
   const normalized = cwd
     .replace(/\\/g, "/")
@@ -1756,6 +1805,12 @@ export interface AgentState {
   error: string | null;
   /** CLI install progress message */
   installStatus: string | null;
+  /**
+   * Set while a spawn is waiting for a local Claude admission slot. The runtime
+   * has always emitted a queued status with a position; nothing consumed it, so
+   * the user watched a spinner for 110s and then got a hard error. #3727.
+   */
+  claudeQueueNotice: string | null;
   /**
    * Most recent CLI auto-updater scan rejection (#1646). Null when no
    * rejection has been recorded this session. Set by
@@ -2199,6 +2254,18 @@ function clearSpawnFailures(conversationId: string): void {
   spawnFailureTimestamps.delete(conversationId);
 }
 
+/**
+ * Slot exhaustion is backpressure, not a defect: capacity is bounded and the
+ * spawn simply arrived while every slot was held. Treating it as a terminal
+ * error left the user with a dead-end failure and no retry, when reclaiming an
+ * idle holder would have admitted them immediately. #3727.
+ */
+function isClaudeCapacityError(message: string): boolean {
+  return message
+    .toLowerCase()
+    .includes("waiting for a local claude session slot");
+}
+
 function isRetryableClaudeInitError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -2212,17 +2279,94 @@ function isRetryableClaudeInitError(message: string): boolean {
   );
 }
 
-function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
+/**
+ * Session ids the runtime reports as holding a Claude admission slot.
+ *
+ * Returns the ids the frontend actually holds in `state.sessions` — a paired
+ * thread's inner planner is mapped back to its wrapper — so a caller can reason
+ * about capacity without inferring it from agent-type strings. Falls back to
+ * `null` if the runtime cannot be reached, so callers can keep their existing
+ * behaviour rather than reclaiming blindly. #3727.
+ */
+/**
+ * How long an unpromoted standby may hold its Claude slot. A standby exists to
+ * make the *next* submit invisible; if that submit never comes, the slot is
+ * worth more to another thread than the warm-up is to this one. #3727.
+ */
+const STANDBY_MAX_IDLE_MS = 10 * 60 * 1000;
+
+function isStandbyExpired(session: { info: { createdAt: string } }): boolean {
+  const createdAt = Date.parse(session.info.createdAt);
+  if (!Number.isFinite(createdAt)) return false;
+  return Date.now() - createdAt >= STANDBY_MAX_IDLE_MS;
+}
+
+/**
+ * Whether a warm standby can take a second Claude slot without starving every
+ * other thread.
+ *
+ * A standby is additive and unpromoted standbys are exempt from idle reclaim,
+ * so one conversation can otherwise pin two of a very small number of slots
+ * indefinitely. Requires a free slot to remain after the standby is spawned.
+ * On an unreachable runtime this returns true, preserving the previous
+ * behaviour rather than silently disabling predictive compaction. #3727.
+ */
+async function hasStandbyHeadroom(): Promise<boolean> {
+  try {
+    const capacity = await providerService.getClaudeCapacity();
+    return (
+      capacity.active.length + capacity.pending.length + 1 < capacity.limit
+    );
+  } catch (error) {
+    console.warn(
+      "[AgentStore] Claude capacity unavailable; allowing standby warm-up:",
+      error,
+    );
+    return true;
+  }
+}
+
+async function getClaudeSlotOwnerIds(): Promise<Set<string> | null> {
+  try {
+    const capacity = await providerService.getClaudeCapacity();
+    return new Set(capacity.active.map((holder) => holder.ownerSessionId));
+  } catch (error) {
+    console.warn(
+      "[AgentStore] Claude capacity unavailable; falling back to local session types:",
+      error,
+    );
+    return null;
+  }
+}
+
+function getIdleClaudeSessionIds(
+  excludeConversationId?: string,
+  slotOwnerIds?: Set<string> | null,
+): string[] {
   const activeId = state.activeSessionId;
   const navTarget = activeNavigationThreadIdGetter?.() ?? null;
   return Object.entries(state.sessions)
     .filter(([id, session]) => {
-      if (session.info.agentType !== "claude-code") return false;
+      // Prefer the runtime's account of who holds a slot. Only when it is
+      // unavailable do we fall back to the agent-type guess, which cannot see
+      // a paired thread's planner at all.
+      if (slotOwnerIds) {
+        if (!slotOwnerIds.has(id)) return false;
+      } else if (session.info.agentType !== "claude-code") {
+        return false;
+      }
       if (id === activeId) return false;
       // Warm standby sessions must NOT be reclaimed — they are the whole
       // point of predictive compaction. Killing one mid-warm-up defeats
       // the invisibility budget for the next user submit. #1631.
-      if (session.role === "standby") return false;
+      //
+      // The exemption means "not reclaimable while warming", not "immortal":
+      // a standby whose user never came back was previously held forever,
+      // pinning a slot no thread could take. Past its expiry it is an
+      // ordinary reclaim candidate. #3727.
+      if (session.role === "standby" && !isStandbyExpired(session)) {
+        return false;
+      }
       if (session.ownedByRunId) return false;
       if (
         excludeConversationId &&
@@ -2327,6 +2471,10 @@ export const agentStore = {
 
   get installStatus() {
     return state.installStatus;
+  },
+
+  get claudeQueueNotice() {
+    return state.claudeQueueNotice;
   },
 
   get cliUpdateActionRequired() {
@@ -3316,12 +3464,21 @@ export const agentStore = {
       // session is alive, the predictive path aborts silently and serving
       // stays intact. Killing serving here would catastrophically replace
       // the live session mid-turn.
+      //
+      // The gate is the source of truth for which spawns take a slot, so this
+      // runs for every Claude-backed agent type rather than the one string
+      // that happened to be checked here. A paired thread's planner is a real
+      // Claude session and must be able to make room for itself. #3727.
       if (
-        resolvedAgentType === "claude-code" &&
+        agentTypeTakesClaudeSlot(resolvedAgentType) &&
         initRetryAttempt === 0 &&
         opts?.role !== "standby"
       ) {
-        const idleSessions = getIdleClaudeSessionIds(localSessionId);
+        const slotOwnerIds = await getClaudeSlotOwnerIds();
+        const idleSessions = getIdleClaudeSessionIds(
+          localSessionId,
+          slotOwnerIds,
+        );
         for (const idleId of idleSessions) {
           console.log(
             "[AgentStore] Reclaiming idle Claude session before spawn:",
@@ -3848,11 +4005,14 @@ export const agentStore = {
             });
           }
           if (
-            resolvedAgentType === "claude-code" &&
+            agentTypeTakesClaudeSlot(resolvedAgentType) &&
             !reclaimedIdleClaude &&
             isRetryableClaudeInitError(initFailure)
           ) {
-            const idleClaude = getIdleClaudeSessionIds(localSessionId);
+            const idleClaude = getIdleClaudeSessionIds(
+              localSessionId,
+              await getClaudeSlotOwnerIds(),
+            );
             if (idleClaude.length > 0) {
               const evictedId = idleClaude[0];
               console.warn(
@@ -3910,8 +4070,14 @@ export const agentStore = {
               initRetryAttempt: initRetryAttempt + 1,
             });
           }
-          if (resolvedAgentType === "claude-code" && !reclaimedIdleClaude) {
-            const idleClaude = getIdleClaudeSessionIds(localSessionId);
+          if (
+            agentTypeTakesClaudeSlot(resolvedAgentType) &&
+            !reclaimedIdleClaude
+          ) {
+            const idleClaude = getIdleClaudeSessionIds(
+              localSessionId,
+              await getClaudeSlotOwnerIds(),
+            );
             if (idleClaude.length > 0) {
               const evictedId = idleClaude[0];
               console.warn(
@@ -3988,6 +4154,7 @@ export const agentStore = {
         if (!happyArchiveAllowsCommit()) {
           return abortHappyArchivedSpawn();
         }
+        setState("claudeQueueNotice", null);
         return info.id;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -4032,6 +4199,43 @@ export const agentStore = {
             });
         }
         tempUnsubscribe();
+        setState("claudeQueueNotice", null);
+
+        // Capacity exhaustion is not a dead end. Every slot was held when this
+        // spawn queued, but a holder may be idle and reclaimable now — the
+        // pre-spawn reclaim ran before the queue formed. Reclaim and retry once
+        // rather than handing the user a terminal error. #3727.
+        if (isClaudeCapacityError(message) && !reclaimedIdleClaude) {
+          const idleClaude = getIdleClaudeSessionIds(
+            localSessionId,
+            await getClaudeSlotOwnerIds(),
+          );
+          if (idleClaude.length > 0) {
+            const evictedId = idleClaude[0];
+            console.warn(
+              "[AgentStore] Claude slots exhausted; reclaiming idle holder and retrying:",
+              evictedId,
+            );
+            await this.terminateSession(evictedId);
+            terminatedSessionIds.delete(spawnKey);
+            setState("isLoading", false);
+            return this.spawnSession(cwd, resolvedAgentType, {
+              ...opts,
+              initRetryAttempt: 0,
+              reclaimedIdleClaude: true,
+            });
+          }
+          console.warn(
+            "[AgentStore] Claude slots exhausted and every holder is busy; surfacing capacity pressure",
+          );
+          setState(
+            "error",
+            `All ${agentDisplayName(resolvedAgentType)} sessions are busy. Finish or stop another agent thread, then try again.`,
+          );
+          setState("isLoading", false);
+          return null;
+        }
+
         setState("error", message);
         setState("isLoading", false);
         return null;
@@ -4063,6 +4267,29 @@ export const agentStore = {
       // state.sessions when this fires (the spawn promise is still
       // pending). Auto-trigger launchLogin so the user can finish
       // signing in without knowing the CLI command. (#1476)
+      // The runtime reports queue position while a spawn waits for capacity.
+      // Surface it: the session is not in state.sessions yet, so this must run
+      // ahead of the session-routing dropout below. #3727.
+      if (
+        event.type === "sessionStatus" &&
+        (event.data as { status?: string }).status === "queued"
+      ) {
+        const position = (event.data as { queuePosition?: number })
+          .queuePosition;
+        setState(
+          "claudeQueueNotice",
+          typeof position === "number" && position > 0
+            ? `Waiting for a free Claude session (position ${position}). Existing threads keep running.`
+            : "Waiting for a free Claude session. Existing threads keep running.",
+        );
+        return;
+      }
+
+      if (event.type === "promptAccepted") {
+        notifyPromptAccepted(event.data.sessionId);
+        return;
+      }
+
       if (event.type === "loginRequired") {
         const data = event.data;
         console.log(
@@ -5495,6 +5722,18 @@ export const agentStore = {
         // (#1673); concurrency is gated by `predictiveCompactInFlight` and
         // the module-level predictive-compaction mutex.
 
+        // A standby is additive: it holds a second Claude slot from warm-up
+        // until the user's next submit, which may never come. That is a fine
+        // trade when there is room and a bad one when it starves every other
+        // thread, so check real capacity first and fall back to reactive
+        // compaction rather than taking the last slot. #3727.
+        if (!(await hasStandbyHeadroom())) {
+          console.info(
+            "[AgentStore] Predictive compaction skipped — no Claude capacity headroom for a standby; falling back to reactive",
+          );
+          return { outcome: "declined_no_capacity" };
+        }
+
         // #1713 / #1829: synthetic-transcript pre-warm. When enabled, build
         // a synthetic JSONL on disk that splices the structured summary in
         // front of the parent's preserved tail and resume the standby
@@ -6132,16 +6371,33 @@ export const agentStore = {
       skipProviderKill: true,
     });
 
-    try {
-      // Dispatch on the promoted session.
-      await this.sendPrompt(prompt, context, options, standbyId);
-    } finally {
-      // Phase 2: now that dispatch has settled, reap the old child.
+    // Phase 2 must not wait for the whole turn. `sendPrompt` resolves only at
+    // turn completion, so reaping there kept a logically dead session holding
+    // one of a very small number of Claude admission slots for minutes, and a
+    // queued spawn elsewhere would time out waiting for it. Reap as soon as the
+    // promoted session's prompt is accepted — the #1686 requirement is that
+    // SIGTERM cannot race the standby's first turn, and acceptance is exactly
+    // that boundary. #3727.
+    const reapRetiredSession = async () => {
       try {
         await providerService.terminateSession(servingSessionId);
       } catch (error) {
         console.warn("[AgentStore] Deferred provider terminate failed:", error);
       }
+    };
+
+    const acceptance = waitForPromptAccepted(standbyId).then(() => {
+      void reapRetiredSession();
+    });
+
+    try {
+      // Dispatch on the promoted session.
+      await this.sendPrompt(prompt, context, options, standbyId);
+    } finally {
+      // The turn ended (or failed) — make sure the retired child is gone even
+      // if acceptance never arrived.
+      notifyPromptAccepted(standbyId);
+      await acceptance;
     }
     return true;
   },
@@ -7216,6 +7472,7 @@ export const agentStore = {
       isLoading: false,
       error: null,
       installStatus: null,
+      claudeQueueNotice: null,
       cliScanRejection: null,
       cliUpdateActionRequired: null,
       pendingPermissions: [],

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -111,10 +111,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToSession("session-1", vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
 
     dispose();
-    expect(unlisteners).toHaveLength(17);
+    expect(unlisteners).toHaveLength(18);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -125,8 +125,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToSession("session-1", vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
-    expect(unlisteners).toHaveLength(16);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
+    expect(unlisteners).toHaveLength(17);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -136,10 +136,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToAllEvents(vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(19);
 
     dispose();
-    expect(unlisteners).toHaveLength(18);
+    expect(unlisteners).toHaveLength(19);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -150,8 +150,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToAllEvents(vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(18);
-    expect(unlisteners).toHaveLength(17);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(19);
+    expect(unlisteners).toHaveLength(18);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/tests/unit/agent-standby-reclaim-guard.test.ts
+++ b/tests/unit/agent-standby-reclaim-guard.test.ts
@@ -20,8 +20,20 @@ describe("#1631 — Claude idle-reclaim bypass for standby sessions", () => {
   it("getIdleClaudeSessionIds skips role === 'standby' sessions", () => {
     const idx = agentStoreSource.indexOf("function getIdleClaudeSessionIds");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 1000);
+    const body = agentStoreSource.slice(idx, idx + 2500);
     expect(body).toContain('session.role === "standby"');
+  });
+
+  // #3727 narrowed the #1631 exemption from "immortal" to "not reclaimable
+  // while warming": an unpromoted standby that was never used cannot pin a
+  // Claude slot forever. Expiry must remain the ONLY way past the guard.
+  it("exempts a standby only until its idle expiry", () => {
+    const idx = agentStoreSource.indexOf("function getIdleClaudeSessionIds");
+    const body = agentStoreSource.slice(idx, idx + 2500);
+    expect(body).toMatch(
+      /session\.role === "standby" && !isStandbyExpired\(session\)/,
+    );
+    expect(agentStoreSource).toMatch(/const STANDBY_MAX_IDLE_MS = /);
   });
 
   it("spawnSession opts exposes role: 'serving' | 'standby'", () => {

--- a/tests/unit/claude-slot-capacity.test.ts
+++ b/tests/unit/claude-slot-capacity.test.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Protects Claude admission-slot accounting against the #3727 split-brain.
+// ABOUTME: Covers gate introspection, paired planner attribution, and capacity backpressure.
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — the browser-local admission module is plain ESM without declarations.
+import { createAdmissionGate } from "../../bin/browser-local/session-admission.mjs";
+
+/**
+ * The frontend used to infer Claude capacity from its own session map, which
+ * cannot see a paired thread's inner planner or a queued spawn. The gate is
+ * now the single source of truth, so it must report *who* holds a slot — not
+ * just how many are held. #3727.
+ */
+describe("admission gate capacity introspection", () => {
+  it("reports the limit and the identity of every slot holder", async () => {
+    const gate = createAdmissionGate({ limit: 2 });
+    await gate.acquire("planner-a");
+    await gate.acquire("solo-b");
+
+    expect(gate.limit).toBe(2);
+    expect(gate.activeIds().sort()).toEqual(["planner-a", "solo-b"]);
+    expect(gate.pendingIds()).toEqual([]);
+  });
+
+  it("reports queued session ids in FIFO order so a queue is diagnosable", async () => {
+    const gate = createAdmissionGate({ limit: 1, acquireTimeoutMs: 50_000 });
+    await gate.acquire("holder");
+    const queued = [
+      gate.acquire("waiter-1").catch(() => {}),
+      gate.acquire("waiter-2").catch(() => {}),
+    ];
+
+    expect(gate.activeIds()).toEqual(["holder"]);
+    expect(gate.pendingIds()).toEqual(["waiter-1", "waiter-2"]);
+
+    // A released holder must hand the slot to the head of the queue, and the
+    // reported queue must shrink accordingly.
+    gate.release("holder");
+    await queued[0];
+    expect(gate.activeIds()).toEqual(["waiter-1"]);
+    expect(gate.pendingIds()).toEqual(["waiter-2"]);
+
+    gate.release("waiter-1");
+    await queued[1];
+    expect(gate.activeIds()).toEqual(["waiter-2"]);
+    gate.release("waiter-2");
+  });
+
+  it("drops a cancelled spawn out of the reported queue", async () => {
+    const gate = createAdmissionGate({ limit: 1, acquireTimeoutMs: 50_000 });
+    await gate.acquire("holder");
+    const abandoned = gate.acquire("abandoned").catch(() => "cancelled");
+
+    expect(gate.pendingIds()).toEqual(["abandoned"]);
+    gate.release("abandoned");
+
+    await expect(abandoned).resolves.toBe("cancelled");
+    expect(gate.pendingIds()).toEqual([]);
+    // The holder still holds; cancelling a waiter must not free a slot.
+    expect(gate.activeIds()).toEqual(["holder"]);
+  });
+});
+
+/**
+ * The captured failure: a paired `claude-codex` spawn died with
+ * "Timed out after 110000ms waiting for a local Claude session slot" because
+ * nothing on the frontend side knew a paired thread consumes a Claude slot.
+ */
+describe("claude capacity error classification", () => {
+  // Mirrors `isClaudeCapacityError` in the agent store. Kept as an explicit
+  // contract test because the gate owns the wording: if the gate's message
+  // changes, backpressure silently degrades back to a terminal spawn error.
+  const isClaudeCapacityError = (message: string) =>
+    message.toLowerCase().includes("waiting for a local claude session slot");
+
+  it("matches the exact message the admission gate produces on timeout", async () => {
+    const gate = createAdmissionGate({ limit: 1, acquireTimeoutMs: 10 });
+    await gate.acquire("holder");
+
+    const rejection = await gate
+      .acquire("late")
+      .then(() => null)
+      .catch((error: Error) => error);
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(isClaudeCapacityError((rejection as Error).message)).toBe(true);
+  });
+
+  it("does not classify an unrelated spawn failure as capacity pressure", () => {
+    expect(isClaudeCapacityError("Claude CLI exited with code 1")).toBe(false);
+    expect(
+      isClaudeCapacityError("timed out waiting for claude control request initialize"),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/idle-reclaim-race-1852.test.ts
+++ b/tests/unit/idle-reclaim-race-1852.test.ts
@@ -40,7 +40,7 @@ describe("#1852 — Fix 2: idle-reclaim honours navigation intent", () => {
   it("getIdleClaudeSessionIds excludes sessions whose conversationId matches the navigation target", () => {
     const idx = agentStoreSource.indexOf("function getIdleClaudeSessionIds");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 1500);
+    const body = agentStoreSource.slice(idx, idx + 3000);
     expect(body).toContain("activeNavigationThreadIdGetter");
     expect(body).toMatch(/session\.conversationId\s*===\s*navTarget/);
   });

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -152,9 +152,19 @@ function createHarness() {
       };
     }),
     sendPrompt: vi.fn(
-      async ({ sessionId }: { sessionId: string; prompt: string }) => {
+      async ({
+        sessionId,
+        onAccepted,
+      }: {
+        sessionId: string;
+        prompt: string;
+        onAccepted?: () => void;
+      }) => {
         const session = innerSessions.get(sessionId);
         if (!session) throw new Error(`Session not found: ${sessionId}`);
+        // Real inner runtimes report acceptance the moment the CLI takes the
+        // prompt, before any of the turn has run (#3727).
+        onAccepted?.();
         const text = session.scriptedTurnText.shift() ?? "ok";
         wrappedEmit("provider://message-chunk", { sessionId, text });
         wrappedEmit("provider://prompt-complete", {
@@ -238,6 +248,76 @@ describe("paired runtime — spawn", () => {
     expect(codexSpawn?.approvalPolicy).toBe("on-failure");
     expect(codexSpawn?.sandboxMode).toBe("workspace-write");
     expect(codexSpawn?.codexDefaultIntent).toBe("paired-executor");
+  });
+
+  /**
+   * #3727 root cause 1. A paired thread's planner is a real `claude-code`
+   * session holding a real admission slot, but `listSessions()` reports only
+   * the wrapper (`claude-codex`, pid null). Capacity accounting therefore
+   * could not see it, a paired spawn never made room for itself, and a live
+   * paired thread was never reclaimable — so a new paired thread died on
+   * "Timed out after 110000ms waiting for a local Claude session slot".
+   *
+   * The inner planner must be attributable to the wrapper the frontend holds.
+   */
+  it("attributes its inner planner to the wrapper thread for capacity accounting", async () => {
+    const info = await spawnPaired(h);
+
+    const plannerSpawn = h.inner.spawnSession.mock.calls.find(
+      (c) => c[0].agentType === "claude-code",
+    )?.[0];
+    expect(plannerSpawn).toBeDefined();
+
+    const inner = h.paired.describeInnerSessions();
+    const planner = inner.find(
+      (entry: { role: string }) => entry.role === "planner",
+    );
+
+    expect(planner).toBeDefined();
+    expect(planner.pairedSessionId).toBe(info.id);
+    // The id the frontend holds is the wrapper, never the inner planner —
+    // that mismatch is precisely what made the slot invisible.
+    expect(planner.innerSessionId).not.toBe(info.id);
+
+    const wrapperOnly = (await h.paired.listSessions()).map(
+      (s: { id: string; agentType: string }) => s.agentType,
+    );
+    expect(wrapperOnly).toEqual([PAIRED_AGENT_TYPE]);
+  });
+
+  /**
+   * #3727 root cause 2. Standby promotion held the retired session's admission
+   * slot until `sendPrompt` resolved — i.e. for the whole turn, which can run
+   * for minutes. Paired threads previously had no acceptance boundary at all
+   * ("This provider does not expose an explicit prompt acceptance boundary"),
+   * so they were stuck on the slow path. A paired turn's acceptance is its
+   * first inner prompt being taken.
+   */
+  it("reports prompt acceptance once, well before the paired turn completes", async () => {
+    const info = await spawnPaired(h);
+
+    const acceptedAt: string[] = [];
+    await h.paired.sendPrompt({
+      sessionId: info.id,
+      prompt: "ship it",
+      onAccepted: () => acceptedAt.push("accepted"),
+    });
+
+    // Exactly one acceptance for a turn that fans out across several inner
+    // turns — a second would reap the retired child twice.
+    expect(acceptedAt).toEqual(["accepted"]);
+  });
+
+  it("stops reporting an inner planner once the paired thread is torn down", async () => {
+    const info = await spawnPaired(h);
+    expect(h.paired.describeInnerSessions()).toHaveLength(2);
+
+    await h.paired.terminateSession({ sessionId: info.id });
+
+    // Both halves must be released, or capacity accounting leaks a phantom
+    // holder that no reclaim can ever free.
+    expect(h.paired.describeInnerSessions()).toEqual([]);
+    expect(h.inner.terminateSession.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it("returns a composite agentSessionId carrying both inner remote ids", async () => {

--- a/tests/unit/standby-promotion-sigterm.test.ts
+++ b/tests/unit/standby-promotion-sigterm.test.ts
@@ -82,22 +82,56 @@ describe("#1686 — promoteStandbyAndDispatch defers the provider kill past disp
     );
   });
 
-  it("invokes providerService.terminateSession AFTER sendPrompt, inside a finally block", () => {
+  /**
+   * #1686's requirement is that SIGTERM to the retired child cannot race the
+   * standby's first turn. It originally encoded that as "kill inside the
+   * finally after sendPrompt" — but sendPrompt resolves only at TURN
+   * COMPLETION, so the retired session kept a Claude admission slot for the
+   * whole turn and starved other threads (#3727).
+   *
+   * The kill now fires at prompt ACCEPTANCE, which is the real boundary
+   * #1686 was reaching for: strictly after the handoff, and no longer tied to
+   * how long the turn runs. The `finally` remains as the backstop so the child
+   * is always reaped even if acceptance never arrives.
+   */
+  it("never kills the retired child before dispatch, and always reaps it by turn end", () => {
+    const preDispatchTerminateIdx = promoteBody.indexOf(
+      "this.terminateSession(servingSessionId",
+    );
+    const acceptanceIdx = promoteBody.indexOf(
+      "waitForPromptAccepted(standbyId)",
+    );
     const sendPromptIdx = promoteBody.indexOf(
       "this.sendPrompt(prompt, context, options, standbyId)",
     );
     const finallyIdx = promoteBody.indexOf("finally", sendPromptIdx);
-    const providerKillIdx = promoteBody.indexOf(
-      "providerService.terminateSession(servingSessionId)",
-      finallyIdx,
-    );
+
     expect(sendPromptIdx, "sendPrompt call must exist").toBeGreaterThan(0);
+    expect(
+      acceptanceIdx,
+      "the provider kill must be gated on prompt acceptance",
+    ).toBeGreaterThan(preDispatchTerminateIdx);
+
+    // The only provider-IPC kill of the retired session is the one the
+    // acceptance gate triggers — never an unguarded call before dispatch.
+    expect(promoteBody).toMatch(
+      /waitForPromptAccepted\(standbyId\)[\s\S]*?reapRetiredSession\(\)/,
+    );
+    expect(promoteBody).toMatch(
+      /const reapRetiredSession[\s\S]*?providerService\.terminateSession\(servingSessionId\)/,
+    );
+
+    // Backstop: turn completion (or failure) must still guarantee the reap.
     expect(finallyIdx, "finally block must follow sendPrompt").toBeGreaterThan(
       sendPromptIdx,
     );
+    const backstopIdx = promoteBody.indexOf(
+      "notifyPromptAccepted(standbyId)",
+      finallyIdx,
+    );
     expect(
-      providerKillIdx,
-      "deferred providerService.terminateSession must live inside the finally",
+      backstopIdx,
+      "the finally must force the reap even if acceptance never arrived",
     ).toBeGreaterThan(finallyIdx);
   });
 });


### PR DESCRIPTION
Closes #3727. All five parts.

## Measurement first

Re-ran the issue's query against the local DB independently rather than trusting it — it holds:

| concurrent Claude-slot threads | 5-min buckets | share |
| --- | --- | --- |
| 1 | 3894 | 84.1% |
| 2 | 630 | 13.6% |
| 3 | 93 | 2.0% |
| 4 | 13 | 0.3% |
| 5 | 2 | 0.04% |

**15.9% of active windows want ≥2 concurrent Claude threads, 2.3% want ≥3, against a cap of 3.**

## Part 1 — the gate is the source of truth

The frontend inferred Claude capacity from agent-type strings in its own session map. A paired
thread's planner is a real `claude-code` session holding a real slot, but the frontend only ever
holds the `claude-codex` wrapper, so a paired spawn never made room for itself and a live paired
thread was never reclaimable.

- `session-admission.mjs` exposes `limit`, `activeIds()`, `pendingIds()`.
- `claude-runtime.mjs` adds `getCapacity()`, sourced from the gate.
- `paired-runtime.mjs` exposes `describeInnerSessions()` (the inner→wrapper map).
- `providers.mjs` adds `getClaudeCapacity()`, merging the two so **every holder carries the
  session id the frontend actually holds** (`ownerSessionId`).
- New `provider_claude_capacity` RPC + `getClaudeCapacity()` in `src/services/providers.ts`.
- Reclaim reads that instead of guessing, and runs for **any** Claude-slot-taking agent type
  (`agentTypeTakesClaudeSlot`), so a future composite agent cannot reintroduce the blind spot.

Reclaiming a paired thread goes through its wrapper, and `paired-runtime.terminateSession`
already tears down both halves — verified, no extra code needed.

## Part 2 — release the retired slot at acceptance

Promotion released the retired session's slot in a `finally` after `sendPrompt`, which resolves
only at **turn completion**. A logically dead session held one of very few slots for minutes.

`claude-runtime.mjs` now emits `provider://prompt-accepted` at the acceptance boundary; paired
reports acceptance from its first inner turn (its `default` intercept case remaps inner→wrapper,
so paired needed no separate emit); promotion reaps the retired child there, with the `finally`
kept as a backstop.

`submitPrompt` no longer rejects paired sessions — only LM Studio lacks an acceptance boundary.

## Part 3 — capacity-aware, time-bounded standby

`hasStandbyHeadroom()` gates the predictive path: if warming a standby would leave no free slot,
it declines (new `declined_no_capacity` outcome) and falls back to reactive compaction. The #1631
reclaim exemption now means "not reclaimable **while warming**" rather than immortal —
`STANDBY_MAX_IDLE_MS` (10 min). `terminateSession` already clears `standbySessionId` and
`predictiveCompactInFlight`, so expiry self-heals.

## Part 4 — backpressure, not failure

`isClaudeCapacityError()` routes slot exhaustion into reclaim-and-retry instead of the terminal
catch. The queue position the runtime has **always** emitted is finally consumed and shown
(`claudeQueueNotice`) — nothing read `status: "queued"` before this. When a queue forms the log
now names the holders.

## Part 5 — the cap, re-derived

`3` was a bare default with no recorded justification. Added a `--probe N` mode to the existing
experiment script (rather than a near-duplicate file) and ran it against the real runtime and
real Claude CLI:

```
[probe] S1 ready spawnToReadyMs=343 liveSessions=1
[probe] S2 ready spawnToReadyMs=358 liveSessions=2
...
[probe] S7 ready spawnToReadyMs=427 liveSessions=7
[probe] S8 ready spawnToReadyMs=410 liveSessions=8
concurrentPromptWallMs=3846 — all 8 prompts passed, zero failures
```

**8 concurrent sessions all reached ready and all answered prompts**, spawn-to-ready degrading
only 343ms → 427ms. Real usage peaks at 5. **Default raised 3 → 6**, with the measurement and
its caveat (trivial prompts, not sustained large-context turns) recorded beside the constant.

## Live walkthrough (macOS 26.5, arm64)

Real provider runtime, real Claude CLI, real OS processes. No mocks. Driven by
`scripts/walkthrough-3727.mjs` (added), against a signed-in Claude CLI.

### Reproducing the original break

Gate saturated with 4 real Claude sessions, then a paired `claude-codex` spawn:

```
[claude] session queued sessionId=d45a545e… position=1 limit=4
         holders=[ca3b3180…(ready,claude-code) 0b7358a0…(ready,claude-code)
                  5dc99d88…(ready,claude-code) ea41a2e2…(ready,claude-code)]
  paired spawn failed: Timed out after 110000ms waiting for a local Claude session slot
```

**That is the exact error from the issue**, reproduced. Note the queue line now names every slot
holder — the diagnostic that did not exist during the captured incident.

### Root cause 1, proven

Same harness with slots available:

```
=== STEP 6 — a paired thread's planner is visible and attributed ===
  paired spawn succeeded: true
  slot holders attributed to a paired wrapper: 1
    inner planner fc34f448… (claude-code, pid 69944) -> wrapper c8889e16… role=planner
    wrapper id matches the paired thread id: true
  provider_list_sessions reports the wrapper as: agentType=claude-codex pid=null
```

The planner is a **real process holding a real slot** (pid 69944), now correctly attributed to
the `claude-codex` wrapper — while `provider_list_sessions` still reports that wrapper as
`pid=null`, which is precisely why agent-type inference could never see the slot.

### Completeness check — the enumerated list versus the source of truth

The list this feature enumerates is the set of slot holders, so it was checked against the
runtime's own session list rather than assumed:

```
=== STEP 5 — capacity matches provider_list_sessions (source of truth) ===
  provider_list_sessions claude-code sessions: 4
  provider_claude_capacity active holders:     4
  holders not present in the session list: 0
```

Zero discrepancies, including the paired inner planner.

### Queue drains correctly

```
=== STEP 4 — releasing a holder admits the queued spawn ===
  queued spawn outcome: admitted
  active after admit: 2/2
```

### App-level

The real app was built and launched from this branch. Its staged runtime carries
`DEFAULT_CLAUDE_SESSION_LIMIT = 6` and the registered `provider_claude_capacity` handler; the
provider runtime starts clean with no errors.

## Please look at these two things specifically

1. **I changed a guarantee a previous ticket encoded.** `tests/unit/standby-promotion-sigterm.test.ts`
   asserted #1686's rule as *"kill inside the `finally` after `sendPrompt`"*. That is exactly the
   line that held the slot for a whole turn. I re-pointed the test at #1686's **safety property**
   (the kill never precedes dispatch, and is always guaranteed by turn end) rather than deleting
   it — but this is a deliberate change to a prior decision and it is your call, not mine.

2. **The cap is now 6, not 3.** Measured safe to 8 on this machine with trivial prompts. Sustained
   large-context turns with heavy tool use cost far more memory per session, and I did not measure
   that. If you want 4 or 5 instead, say so.

## Networked paths

**None added.** `provider_claude_capacity` is local IPC to the bundled runtime over loopback.
No publisher slug, Gateway path, or outbound request is involved. The Claude CLI's own upstream
calls are unchanged.

## Tests

`tests/unit/claude-slot-capacity.test.ts` (new, 5 tests) pins the gate's introspection contract
and the exact wording backpressure classification depends on. Two tests added to
`paired-runtime.test.ts` for planner attribution and both-halves teardown, one for the acceptance
boundary.

Four existing test files were updated, all intentionally:
- `tests/services/providers.test.ts` — listener counts +1 for `promptAccepted`.
- `agent-standby-reclaim-guard.test.ts` — window widened; **plus a new test** pinning that expiry
  is the only way past the #1631 standby exemption.
- `idle-reclaim-race-1852.test.ts` — source-slice window widened; guard unchanged.
- `standby-promotion-sigterm.test.ts` — see point 1 above.

`pnpm test`: **3060 passed, 0 failed** (443 files).
`cargo test`: **1321 passed, 0 failed** (plus 7 and 5).
`pnpm check`: 48 warnings, **0 errors** — identical to `main`'s baseline.
