### PR TITLE
feat(happy): surface Claude and Codex terminal panes as remote sessions

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -7,13 +7,16 @@ import {
   createProviderSource,
   validateBridgeConfig,
 } from "./happy-bridge/provider-source.mjs";
+import { createCompositeSource } from "./happy-bridge/composite-source.mjs";
 import { createHappyLayer } from "./happy-bridge/happy-layer.mjs";
 import { createSupervisorChannel } from "./happy-bridge/supervisor-channel.mjs";
+import { createTerminalSource } from "./happy-bridge/terminal-source.mjs";
 
 let client = null;
 let input = null;
 let supervisorChannel = null;
 let happyLayer = null;
+let source = null;
 let shuttingDown = false;
 
 function startInputReader() {
@@ -67,6 +70,7 @@ async function shutdown(exitCode = 0) {
     // Keep the provider RPC socket open until Happy has unwound any in-flight
     // remote spawn; that cleanup may still need provider terminate/list calls.
     await Promise.allSettled([happyLayer?.close()]);
+    source?.close();
     await Promise.allSettled([client?.close()]);
   })();
   await Promise.race([
@@ -100,10 +104,11 @@ try {
     },
   });
   await client.connect();
-  const source = createProviderSource({
-    client,
-    config,
-    debugLog: (message) => console.error(`happy-bridge: ${message}`),
+  const debugLog = (message) => console.error(`happy-bridge: ${message}`);
+  source = createCompositeSource({
+    provider: createProviderSource({ client, config, debugLog }),
+    terminal: createTerminalSource({ supervisorChannel, debugLog }),
+    debugLog,
   });
   const sessions = await source.listSessions();
   console.error(`happy-bridge: config ok, ${sessions.length} sessions`);

--- a/bin/happy-bridge/composite-source.mjs
+++ b/bin/happy-bridge/composite-source.mjs
@@ -1,0 +1,66 @@
+// ABOUTME: Routes one session-source facade across the provider runtime and terminal panes.
+// ABOUTME: Ownership is learned from listings and events; the provider stays the default.
+
+/**
+ * The Happy layer holds exactly one source. Terminal panes and provider
+ * sessions have disjoint id spaces, so this fans out the collection calls and
+ * routes every per-session call to whichever source claimed that id.
+ *
+ * The provider is the fallback for an unknown id: it owns spawning, so a
+ * session this has never listed is always one the provider just created.
+ *
+ * @param {{provider: object, terminal: object, debugLog?: (message: string) => void}} options
+ */
+export function createCompositeSource({ provider, terminal, debugLog = () => {} }) {
+  const terminalSessionIds = new Set();
+
+  const sourceFor = (sessionId) =>
+    terminalSessionIds.has(sessionId) ? terminal : provider;
+
+  return {
+    async listSessions() {
+      const [providerSessions, terminalSessions] = await Promise.all([
+        provider.listSessions(),
+        terminal.listSessions().catch((error) => {
+          // A terminal listing failure must not blank the provider sessions the
+          // phone is already using.
+          debugLog(`terminal session listing failed: ${error}`);
+          return [];
+        }),
+      ]);
+      terminalSessionIds.clear();
+      for (const session of terminalSessions) terminalSessionIds.add(session.sessionId);
+      return [...providerSessions, ...terminalSessions];
+    },
+
+    subscribe(onEvent) {
+      const unsubscribeProvider = provider.subscribe(onEvent);
+      const unsubscribeTerminal = terminal.subscribe((event) => {
+        terminalSessionIds.add(event.sessionId);
+        onEvent(event);
+      });
+      return () => {
+        unsubscribeProvider?.();
+        unsubscribeTerminal?.();
+      };
+    },
+
+    sendPrompt: (sessionId, text) => sourceFor(sessionId).sendPrompt(sessionId, text),
+    cancel: (sessionId) => sourceFor(sessionId).cancel(sessionId),
+    terminate: (sessionId) => sourceFor(sessionId).terminate(sessionId),
+    respondToPermission: (sessionId, requestId, optionId) =>
+      sourceFor(sessionId).respondToPermission(sessionId, requestId, optionId),
+    respondToDiffProposal: (sessionId, proposalId, accepted) =>
+      sourceFor(sessionId).respondToDiffProposal(sessionId, proposalId, accepted),
+    setPermissionMode: (sessionId, mode) => sourceFor(sessionId).setPermissionMode(sessionId, mode),
+
+    // Spawning and machine capabilities are the provider's alone: a terminal
+    // pane is opened from the desktop, never from the phone.
+    spawn: (spec) => provider.spawn(spec),
+    advertise: () => provider.advertise(),
+
+    close() {
+      terminal.close?.();
+    },
+  };
+}

--- a/bin/happy-bridge/terminal-source.mjs
+++ b/bin/happy-bridge/terminal-source.mjs
@@ -1,0 +1,280 @@
+// ABOUTME: Exposes the desktop's Claude/Codex terminal panes as neutral remote sessions.
+// ABOUTME: Reads their CLI transcripts; the panes themselves stay owned by the desktop.
+
+import { open, stat } from "node:fs/promises";
+
+import { transcriptParserFor } from "./terminal-transcript.mjs";
+
+const POLL_INTERVAL_MS = 2_000;
+// A pane's transcript can be megabytes of history. Replay enough to make the
+// thread readable on a phone, not the whole file.
+const HISTORY_EVENT_LIMIT = 40;
+const READ_CHUNK_BYTES = 1024 * 1024;
+
+const REMOTE_UNSUPPORTED =
+  "This is a terminal pane on the desktop. Type into it there — remote prompting is not available yet.";
+
+function normalizeSession(session) {
+  return {
+    sessionId: session.sessionId,
+    agentType: session.agentType,
+    cwd: session.cwd,
+    title: typeof session.title === "string" && session.title.length > 0 ? session.title : undefined,
+    status: "idle",
+    ...(typeof session.agentSessionId === "string" && session.agentSessionId.length > 0
+      ? { agentSessionId: session.agentSessionId }
+      : {}),
+  };
+}
+
+/**
+ * A terminal pane is driven from the desktop keyboard, so this source is
+ * read-only. Every write-shaped method rejects rather than silently succeeding:
+ * a remote peer must learn its prompt went nowhere.
+ *
+ * @param {{supervisorChannel: {call: (method: string, params?: object) => Promise<any>}, debugLog?: (message: string) => void}} options
+ */
+export function createTerminalSource({ supervisorChannel, debugLog = () => {} }) {
+  /** @type {Map<string, {summary: object, path: string|null, offset: number, pending: string, replayed: boolean, announced: boolean, busy: boolean}>} */
+  const tracked = new Map();
+  let listeners = new Set();
+  let pollTimer = null;
+  let polling = false;
+  let closed = false;
+
+  async function listRaw() {
+    const response = await supervisorChannel.call("terminal_list_sessions", {});
+    const sessions = Array.isArray(response?.sessions) ? response.sessions : [];
+    return sessions.filter(
+      (session) =>
+        typeof session?.sessionId === "string" &&
+        typeof session?.cwd === "string" &&
+        typeof transcriptParserFor(session?.agentType) === "function",
+    );
+  }
+
+  function emit(event) {
+    for (const listener of listeners) listener(event);
+  }
+
+  async function resolveTranscriptPath(sessionId) {
+    try {
+      const response = await supervisorChannel.call("terminal_transcript_path", { sessionId });
+      return typeof response?.path === "string" && response.path.length > 0 ? response.path : null;
+    } catch {
+      // The pane left the advertised roots, or the CLI has not written its
+      // transcript yet. Both resolve on a later tick.
+      return null;
+    }
+  }
+
+  /** Read from `offset` to end of file, returning whole lines plus any partial tail. */
+  async function readNewLines(entry) {
+    const info = await stat(entry.path);
+    if (info.size < entry.offset) {
+      // Truncated or replaced underneath us. Re-anchor rather than replay a
+      // file whose earlier bytes are already published.
+      entry.offset = info.size;
+      entry.pending = "";
+      return [];
+    }
+    if (info.size === entry.offset) return [];
+
+    const handle = await open(entry.path, "r");
+    try {
+      let text = entry.pending;
+      let position = entry.offset;
+      while (position < info.size) {
+        const length = Math.min(READ_CHUNK_BYTES, info.size - position);
+        const buffer = Buffer.alloc(length);
+        const { bytesRead } = await handle.read(buffer, 0, length, position);
+        if (bytesRead <= 0) break;
+        position += bytesRead;
+        text += buffer.subarray(0, bytesRead).toString("utf8");
+      }
+      entry.offset = position;
+      const lines = text.split("\n");
+      // A live CLI flushes mid-line; hold the remainder for the next read.
+      entry.pending = lines.pop() ?? "";
+      return lines;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  function parseLines(entry, lines) {
+    const parse = transcriptParserFor(entry.summary.agentType);
+    const events = [];
+    for (const line of lines) {
+      for (const event of parse(line)) events.push(event);
+    }
+    return events;
+  }
+
+  /**
+   * Publish parsed events, tracking the busy/idle state the transcript implies
+   * so the phone's activity indicator matches the pane.
+   */
+  function publish(sessionId, entry, events, { includeStatus }) {
+    for (const event of events) {
+      if (event.kind === "status") {
+        entry.busy = event.payload?.status === "busy";
+        if (!includeStatus) continue;
+      }
+      if (event.kind === "turn-complete") entry.busy = false;
+      emit({ kind: event.kind, sessionId, payload: { ...event.payload } });
+    }
+  }
+
+  async function replayHistory(sessionId, entry) {
+    const lines = await readNewLines(entry);
+    const events = parseLines(entry, lines);
+    // Status events during replay would post a turn-start/turn-end pair for
+    // every historical turn. Track the state, publish only the final one.
+    const publishable = events.filter((event) => event.kind !== "status");
+    const trimmed = publishable.slice(-HISTORY_EVENT_LIMIT);
+    for (const event of events) {
+      if (event.kind === "status") entry.busy = event.payload?.status === "busy";
+      if (event.kind === "turn-complete") entry.busy = false;
+    }
+    for (const event of trimmed) {
+      emit({ kind: event.kind, sessionId, payload: { ...event.payload, replay: true } });
+    }
+    entry.replayed = true;
+    emit({
+      kind: "status",
+      sessionId,
+      payload: { status: entry.busy ? "busy" : "idle" },
+    });
+  }
+
+  async function advance(sessionId, entry) {
+    if (!entry.path) {
+      entry.path = await resolveTranscriptPath(sessionId);
+      if (!entry.path) return;
+    }
+    if (!entry.replayed) {
+      await replayHistory(sessionId, entry);
+      return;
+    }
+    const lines = await readNewLines(entry);
+    if (lines.length === 0) return;
+    const wasBusy = entry.busy;
+    const events = parseLines(entry, lines);
+    publish(sessionId, entry, events, { includeStatus: true });
+    // A turn that ended without an explicit completion still has to clear the
+    // phone's spinner.
+    if (wasBusy && !entry.busy) {
+      emit({ kind: "status", sessionId, payload: { status: "idle" } });
+    }
+  }
+
+  async function poll() {
+    if (polling || closed) return;
+    polling = true;
+    try {
+      const listed = await listRaw();
+      const seen = new Set();
+      for (const raw of listed) {
+        const summary = normalizeSession(raw);
+        seen.add(summary.sessionId);
+        let entry = tracked.get(summary.sessionId);
+        if (!entry) {
+          entry = {
+            summary,
+            path: null,
+            offset: 0,
+            pending: "",
+            replayed: false,
+            announced: false,
+            busy: false,
+          };
+          tracked.set(summary.sessionId, entry);
+          // Announce first and read on the next tick. The layer resolves a
+          // session's summary lazily; letting that resolution happen before
+          // history is emitted keeps the replay in order.
+          entry.announced = true;
+          emit({ kind: "status", sessionId: summary.sessionId, payload: { status: "idle" } });
+          continue;
+        }
+        entry.summary = { ...summary, status: entry.busy ? "busy" : "idle" };
+        try {
+          await advance(summary.sessionId, entry);
+        } catch (error) {
+          debugLog(`terminal transcript read failed: ${error}`);
+        }
+      }
+      for (const [sessionId, entry] of tracked) {
+        if (seen.has(sessionId)) continue;
+        tracked.delete(sessionId);
+        // The pane exited or left the advertised roots. Either way the remote
+        // session is over.
+        if (entry.announced) {
+          emit({ kind: "status", sessionId, payload: { status: "terminated" } });
+        }
+      }
+    } catch (error) {
+      debugLog(`terminal session poll failed: ${error}`);
+    } finally {
+      polling = false;
+    }
+  }
+
+  function rejectRemoteWrite() {
+    return Promise.reject(new Error(REMOTE_UNSUPPORTED));
+  }
+
+  return {
+    async listSessions() {
+      const listed = await listRaw();
+      return listed.map((session) => {
+        const summary = normalizeSession(session);
+        const entry = tracked.get(summary.sessionId);
+        return entry ? { ...summary, status: entry.busy ? "busy" : "idle" } : summary;
+      });
+    },
+
+    subscribe(onEvent) {
+      listeners.add(onEvent);
+      if (!pollTimer && !closed) {
+        void poll();
+        pollTimer = setInterval(() => void poll(), POLL_INTERVAL_MS);
+        // The bridge must still exit when nothing else is pending.
+        pollTimer.unref?.();
+      }
+      return () => listeners.delete(onEvent);
+    },
+
+    sendPrompt: rejectRemoteWrite,
+    respondToPermission: rejectRemoteWrite,
+    respondToDiffProposal: rejectRemoteWrite,
+    spawn: rejectRemoteWrite,
+
+    async cancel() {
+      // Interrupting a pane means sending it a signal, which is a write.
+      throw new Error(REMOTE_UNSUPPORTED);
+    },
+
+    async terminate(sessionId) {
+      // Detach only. A phone dismissing a thread must never kill a terminal the
+      // user is working in on the desktop.
+      tracked.delete(sessionId);
+    },
+
+    async setPermissionMode() {
+      // A running TUI owns its own permission mode; nothing to change remotely.
+    },
+
+    async advertise() {
+      return { machineName: "", agents: [], roots: [] };
+    },
+
+    close() {
+      closed = true;
+      if (pollTimer) clearInterval(pollTimer);
+      pollTimer = null;
+      listeners = new Set();
+      tracked.clear();
+    },
+  };
+}

--- a/bin/happy-bridge/terminal-transcript.mjs
+++ b/bin/happy-bridge/terminal-transcript.mjs
@@ -1,0 +1,196 @@
+// ABOUTME: Parses Claude Code and Codex CLI transcript lines into neutral session events.
+// ABOUTME: Pure functions only — the terminal source owns all file I/O and ordering.
+
+// Mobile bubbles are not a place to reproduce a 200KB tool payload. Bounding
+// here rather than in the source keeps both CLIs on one limit.
+const TEXT_MAX_CHARS = 8_000;
+const TRUNCATION_MARKER = "\n… [truncated for Happy Mobile]";
+
+function boundedText(value) {
+  const text = typeof value === "string" ? value : "";
+  if (text.length <= TEXT_MAX_CHARS) return text;
+  const prefixLength = Math.max(0, TEXT_MAX_CHARS - TRUNCATION_MARKER.length);
+  let prefix = text.slice(0, prefixLength);
+  const finalCodeUnit = prefix.charCodeAt(prefix.length - 1);
+  // Never split a surrogate pair; a lone half is not valid UTF-16 on the wire.
+  if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) prefix = prefix.slice(0, -1);
+  return `${prefix}${TRUNCATION_MARKER}`;
+}
+
+function parseLine(line) {
+  const trimmed = typeof line === "string" ? line.trim() : "";
+  if (!trimmed) return null;
+  try {
+    const value = JSON.parse(trimmed);
+    return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+  } catch {
+    // A partially flushed final line is normal while tailing a live CLI.
+    return null;
+  }
+}
+
+function timestampOf(entry) {
+  const parsed = Date.parse(entry?.timestamp ?? "");
+  return Number.isFinite(parsed) ? { timestamp: parsed } : {};
+}
+
+/**
+ * One line of a Claude Code transcript (`~/.claude/projects/<dir>/<id>.jsonl`).
+ *
+ * `thinking` blocks are deliberately dropped: they outnumber assistant text
+ * roughly three to one in real transcripts, and the phone already learns the
+ * agent is working from the busy status this emits.
+ *
+ * @param {string} line
+ * @returns {Array<{kind: string, payload: Record<string, unknown>}>}
+ */
+export function parseClaudeTranscriptLine(line) {
+  const entry = parseLine(line);
+  if (!entry) return [];
+  // Sub-agent traffic belongs to its own conversation, and meta lines are
+  // bookkeeping the user never typed.
+  if (entry.isSidechain === true || entry.isMeta === true) return [];
+  const time = timestampOf(entry);
+  const content = entry.message?.content;
+
+  if (entry.type === "user") {
+    if (typeof content === "string") {
+      const text = boundedText(content);
+      if (!text) return [];
+      return [
+        { kind: "user-message", payload: { text, ...time } },
+        { kind: "status", payload: { status: "busy", ...time } },
+      ];
+    }
+    if (!Array.isArray(content)) return [];
+    return content
+      .filter((block) => block?.type === "tool_result")
+      .map((block) => ({
+        kind: "tool-end",
+        payload: {
+          toolCallId: typeof block.tool_use_id === "string" ? block.tool_use_id : undefined,
+          output: boundedText(
+            typeof block.content === "string" ? block.content : JSON.stringify(block.content),
+          ),
+          isError: block.is_error === true,
+          ...time,
+        },
+      }));
+  }
+
+  if (entry.type !== "assistant" || !Array.isArray(content)) return [];
+  // Every block of one assistant message shares its id, so the coalescer joins
+  // them into a single bubble instead of one per block.
+  const messageId =
+    typeof entry.message?.id === "string" && entry.message.id.length > 0
+      ? entry.message.id
+      : undefined;
+  const events = [];
+  for (const block of content) {
+    if (block?.type === "text") {
+      const text = boundedText(block.text);
+      if (text) events.push({ kind: "assistant-delta", payload: { text, messageId, ...time } });
+    } else if (block?.type === "tool_use") {
+      events.push({
+        kind: "tool-start",
+        payload: {
+          toolCallId: typeof block.id === "string" ? block.id : undefined,
+          toolName: typeof block.name === "string" ? block.name : undefined,
+          input: block.input,
+          ...time,
+        },
+      });
+    }
+  }
+  // `tool_use` means the model is handing off and will speak again this turn.
+  if (entry.message?.stop_reason === "end_turn") {
+    events.push({ kind: "turn-complete", payload: { stopReason: "end_turn", ...time } });
+  }
+  return events;
+}
+
+const CODEX_TOOL_CALL_TYPES = new Set(["function_call", "custom_tool_call"]);
+const CODEX_TOOL_OUTPUT_TYPES = new Set(["function_call_output", "custom_tool_call_output"]);
+
+/**
+ * One line of a Codex rollout transcript
+ * (`~/.codex/sessions/**\/rollout-*-<id>.jsonl`).
+ *
+ * Codex records the same turn twice: `event_msg` entries are the user-facing
+ * stream and `response_item` entries are the raw model exchange. Text is read
+ * from `event_msg` only, so nothing is published twice; tool calls have no
+ * `event_msg` equivalent and are read from `response_item`.
+ *
+ * @param {string} line
+ * @returns {Array<{kind: string, payload: Record<string, unknown>}>}
+ */
+export function parseCodexTranscriptLine(line) {
+  const entry = parseLine(line);
+  if (!entry) return [];
+  const payload = entry.payload;
+  if (!payload || typeof payload !== "object") return [];
+  const time = timestampOf(entry);
+
+  if (entry.type === "event_msg") {
+    switch (payload.type) {
+      case "user_message": {
+        const text = boundedText(payload.message);
+        return text
+          ? [
+              { kind: "user-message", payload: { text, ...time } },
+              { kind: "status", payload: { status: "busy", ...time } },
+            ]
+          : [];
+      }
+      case "agent_message": {
+        const text = boundedText(payload.message);
+        return text ? [{ kind: "assistant-delta", payload: { text, ...time } }] : [];
+      }
+      case "task_started":
+        return [{ kind: "status", payload: { status: "busy", ...time } }];
+      case "task_complete":
+        return [{ kind: "turn-complete", payload: { stopReason: "completed", ...time } }];
+      default:
+        return [];
+    }
+  }
+
+  if (entry.type !== "response_item") return [];
+  if (CODEX_TOOL_CALL_TYPES.has(payload.type)) {
+    return [
+      {
+        kind: "tool-start",
+        payload: {
+          toolCallId: typeof payload.call_id === "string" ? payload.call_id : undefined,
+          toolName: typeof payload.name === "string" ? payload.name : undefined,
+          input: payload.arguments ?? payload.input,
+          ...time,
+        },
+      },
+    ];
+  }
+  if (CODEX_TOOL_OUTPUT_TYPES.has(payload.type)) {
+    return [
+      {
+        kind: "tool-end",
+        payload: {
+          toolCallId: typeof payload.call_id === "string" ? payload.call_id : undefined,
+          output: boundedText(
+            typeof payload.output === "string" ? payload.output : JSON.stringify(payload.output),
+          ),
+          ...time,
+        },
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * @param {"claude-code" | "codex"} agentType
+ */
+export function transcriptParserFor(agentType) {
+  if (agentType === "claude-code") return parseClaudeTranscriptLine;
+  if (agentType === "codex") return parseCodexTranscriptLine;
+  return null;
+}

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -1171,6 +1171,24 @@ fn is_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -> bool 
         .any(|root| root == candidate)
 }
 
+/// Visibility scope for an already-running session, mirroring
+/// `isWithinAdvertisedRoots` in `validate.mjs`: spawning requires a path to *be*
+/// an advertised root, but a session already running inside one is in scope
+/// because the user shared that folder. Both sides are canonicalized first so a
+/// symlink cannot smuggle a path in. `Path::starts_with` matches whole
+/// components, so `/srv/project-secret` is not treated as inside
+/// `/srv/project` — the same boundary `validate.mjs` gets from its explicit
+/// separator check.
+fn is_within_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -> bool {
+    let Ok(candidate) = std::fs::canonicalize(cwd) else {
+        return false;
+    };
+    crate::commands::happy_bridge::saved_advertised_roots(app)
+        .iter()
+        .filter_map(|root| std::fs::canonicalize(root).ok())
+        .any(|root| candidate.starts_with(&root))
+}
+
 /// Serialize an already-canonical path in the same form Node's `realpath`
 /// returns. Windows' Rust canonicalizer uses verbatim paths (`\\?\C:\...` or
 /// `\\?\UNC\...`), while Node returns ordinary DOS/UNC paths. This conversion
@@ -1273,6 +1291,8 @@ fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
             | "conversation_owner_lookup"
             | "provider_session_archive"
             | "provider_session_archive_lookup"
+            | "terminal_list_sessions"
+            | "terminal_transcript_path"
             | "identity_store"
     ) {
         return Err(error_response(id, -32601, "unknown supervisor method"));
@@ -1569,6 +1589,40 @@ async fn dispatch_supervisor_request(
             let conversation_id = required_uuid(&request.params, "conversationId")?;
             crate::commands::chat::delete_conversation(app.clone(), conversation_id).await?;
             Ok(json!({ "deleted": true }))
+        }
+        "terminal_list_sessions" => {
+            // Re-checked here rather than trusted: the bridge is the process
+            // parsing relay traffic, and the terminal source it feeds hands
+            // these paths straight back as session scope.
+            let sessions = crate::terminal::happy_terminal_sessions(app)
+                .into_iter()
+                .filter(|session| is_within_advertised_root(app, &session.cwd))
+                .collect::<Vec<_>>();
+            Ok(json!({ "sessions": sessions }))
+        }
+        "terminal_transcript_path" => {
+            let session_id = required_string(&request.params, "sessionId")?;
+            // A pane that left the advertised roots stops yielding a transcript
+            // as well as a listing, so revoking a folder also stops the reads.
+            let authorized = crate::terminal::happy_terminal_sessions(app)
+                .into_iter()
+                .any(|session| {
+                    session.session_id == session_id
+                        && is_within_advertised_root(app, &session.cwd)
+                });
+            if !authorized {
+                return Err("terminal session is not in an advertised root".to_string());
+            }
+            // Built by joining the home directory, never canonicalized, so it
+            // carries no Windows verbatim prefix Node would fail to open.
+            Ok(
+                match crate::terminal::happy_terminal_transcript_path(app, &session_id)
+                    .and_then(|path| path.to_str().map(ToOwned::to_owned))
+                {
+                    Some(path) => json!({ "path": path }),
+                    None => json!({}),
+                },
+            )
         }
         "identity_store" => {
             let identity = request
@@ -2078,6 +2132,55 @@ mod tests {
                 .expect_err("stale generations stay rejected"),
             "stale Happy bridge process",
         );
+    }
+
+    #[test]
+    fn terminal_session_scope_covers_subdirectories_but_not_prefix_siblings() {
+        // Terminal panes are listed by visibility, not spawn authority: a pane
+        // running inside a shared folder is in scope, while a sibling that
+        // merely shares a name prefix is a different folder entirely.
+        let consented = tempfile::tempdir().expect("temp dir");
+        let nested = consented.path().join("packages/app");
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        let sibling_root = tempfile::tempdir().expect("temp dir");
+        let shared_prefix = sibling_root.path().join("project-secret");
+        std::fs::create_dir(&shared_prefix).expect("sibling dir");
+
+        let app = mock_app_with_roots(Some(vec![
+            consented.path().to_string_lossy().to_string(),
+            sibling_root.path().join("project").to_string_lossy().to_string(),
+        ]));
+
+        assert!(
+            super::is_within_advertised_root(app.handle(), &nested.to_string_lossy()),
+            "a pane inside a shared folder is visible"
+        );
+        assert!(
+            !super::is_within_advertised_root(app.handle(), &shared_prefix.to_string_lossy()),
+            "a shared name prefix is not containment"
+        );
+    }
+
+    #[test]
+    fn terminal_session_scope_fails_closed_without_roots() {
+        let candidate = tempfile::tempdir().expect("temp dir");
+        let app = mock_app_with_roots(None);
+        assert!(
+            !super::is_within_advertised_root(app.handle(), &candidate.path().to_string_lossy()),
+            "nothing is visible until the user shares a folder"
+        );
+    }
+
+    #[test]
+    fn supervisor_channel_accepts_terminal_session_methods() {
+        let listing =
+            parse_supervisor_line("{\"id\":1,\"method\":\"terminal_list_sessions\"}").expect("listing");
+        assert_eq!(listing.method, "terminal_list_sessions");
+        let transcript = parse_supervisor_line(
+            "{\"id\":2,\"method\":\"terminal_transcript_path\",\"params\":{\"sessionId\":\"a\"}}",
+        )
+        .expect("transcript");
+        assert_eq!(transcript.method, "terminal_transcript_path");
     }
 
     #[test]

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -226,6 +226,7 @@ impl HappyBridgeManager {
                 None,
             )
             .await,
+            crate::terminal::happy_terminal_project_roots(app),
         )?;
         let advertised_roots =
             crate::commands::happy_bridge::effective_advertised_roots(app, discovered_roots);
@@ -1234,14 +1235,22 @@ fn canonical_happy_restoration_root<R: tauri::Runtime>(
 /// order they were seen. A failed lookup is reported rather than absorbed: an
 /// empty set is also what a user with no projects has, so absorbing it started a
 /// bridge that reported connected and then refused every remote spawn.
+/// `terminal_roots` are the folders holding CLI terminal panes. They are not
+/// conversations, so a folder used only for `claude` / `codex` panes had no row
+/// here and was filtered out of the consented set, leaving its panes
+/// unshareable. `HappyRemoteSettings` offers checkboxes for the same two
+/// sources, so #3144's invariant holds: nothing is advertised that the user was
+/// not shown and cannot withdraw.
 fn discovered_project_roots(
     conversations: Result<Vec<crate::commands::chat::UnifiedConversationRow>, String>,
+    terminal_roots: Vec<String>,
 ) -> Result<Vec<String>, String> {
     let conversations =
         conversations.map_err(|error| format!("Failed to read Happy project folders: {error}"))?;
     Ok(conversations
         .into_iter()
         .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
+        .chain(terminal_roots)
         .fold(Vec::<String>::new(), |mut roots, root| {
             if !roots.iter().any(|existing| existing == &root) {
                 roots.push(root);
@@ -2635,7 +2644,8 @@ mod tests {
         // Regression: the lookup was absorbed with `unwrap_or_default()`. On a
         // busy database the bridge started, advertised zero folders, reported
         // itself connected, and then refused every remote spawn silently.
-        let failure = discovered_project_roots(Err("database is locked".to_string()));
+        let failure =
+            discovered_project_roots(Err("database is locked".to_string()), Vec::new());
 
         assert!(
             failure.is_err_and(|error| error.contains("database is locked")),
@@ -2645,19 +2655,45 @@ mod tests {
 
     #[test]
     fn project_root_discovery_keeps_first_seen_distinct_roots() {
-        let roots = discovered_project_roots(Ok(conversations(vec![
-            conversation(Some("/workspace/alpha"), None),
-            // A conversation with no project falls back to where the agent ran.
-            conversation(None, Some("/workspace/beta")),
-            conversation(Some("/workspace/alpha"), Some("/workspace/gamma")),
-            conversation(None, None),
-        ])));
+        let roots = discovered_project_roots(
+            Ok(conversations(vec![
+                conversation(Some("/workspace/alpha"), None),
+                // A conversation with no project falls back to where the agent ran.
+                conversation(None, Some("/workspace/beta")),
+                conversation(Some("/workspace/alpha"), Some("/workspace/gamma")),
+                conversation(None, None),
+            ])),
+            Vec::new(),
+        );
 
         assert_eq!(
             roots.expect("a successful lookup yields roots"),
             vec![
                 "/workspace/alpha".to_string(),
                 "/workspace/beta".to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn project_root_discovery_offers_folders_that_only_hold_terminal_panes() {
+        // A folder used only for `claude` / `codex` panes has no conversation
+        // row. Deriving candidates from conversations alone left it with no
+        // consent checkbox, so its panes could never reach the phone.
+        let roots = discovered_project_roots(
+            Ok(conversations(vec![conversation(Some("/workspace/alpha"), None)])),
+            vec![
+                "/workspace/terminal-only".to_string(),
+                // A folder holding both must not be offered twice.
+                "/workspace/alpha".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            roots.expect("a successful lookup yields roots"),
+            vec![
+                "/workspace/alpha".to_string(),
+                "/workspace/terminal-only".to_string(),
             ],
         );
     }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -2958,6 +2958,103 @@ pub fn terminal_list_agent_descriptors(app: AppHandle) -> Vec<TerminalAgentDescr
     read_descriptor_store(&app).agents
 }
 
+/// A running CLI-agent terminal pane, described for the Happy bridge's terminal
+/// session source.
+///
+/// Panes with no `cli_kind` are deliberately absent. A plain shell reachable
+/// from the relay is the unscoped `bash` exposure revoked in #3578, and it must
+/// not return through the terminal source.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HappyTerminalSession {
+    /// The terminal buffer id. Stable across app restarts — `restoreAgents`
+    /// reuses it — so a Happy relay binding keyed on it survives too.
+    pub session_id: String,
+    pub agent_type: &'static str,
+    pub cwd: String,
+    pub title: String,
+    /// The CLI's own session UUID, which names its transcript on disk.
+    pub agent_session_id: Option<String>,
+    pub launch_mode: TerminalLaunchMode,
+    pub created_at: i64,
+}
+
+/// Describe every *running* CLI-agent pane. Exited panes are omitted: the
+/// bridge reports a pane that leaves this list as terminated, which both ends a
+/// live remote session and keeps a long-dead pane from being republished on
+/// every bridge start.
+pub fn happy_terminal_sessions(app: &AppHandle) -> Vec<HappyTerminalSession> {
+    let state = app.state::<TerminalState>();
+    let Ok(buffers) = state.buffers.lock() else {
+        log::warn!("[Terminal] Failed to lock buffers while listing Happy terminal sessions");
+        return Vec::new();
+    };
+    buffers
+        .values()
+        .filter_map(|process| happy_terminal_session(&process.info))
+        .collect()
+}
+
+fn happy_terminal_session(info: &TerminalBufferInfo) -> Option<HappyTerminalSession> {
+    if !matches!(info.status, TerminalStatus::Running) {
+        return None;
+    }
+    let cli_kind = info.cli_kind?;
+    let cwd = info.cwd.clone()?;
+    Some(HappyTerminalSession {
+        session_id: info.id.clone(),
+        agent_type: match cli_kind {
+            TerminalCliKind::Claude => "claude-code",
+            TerminalCliKind::Codex => "codex",
+        },
+        cwd,
+        title: info.title.clone(),
+        agent_session_id: info.session_id.clone(),
+        launch_mode: info.launch_mode,
+        created_at: info.created_at,
+    })
+}
+
+/// Resolve the on-disk transcript a CLI-agent pane is writing, so the bridge can
+/// read its conversation. `None` until the CLI has materialized the session —
+/// Claude creates its file on first activity, and Codex does not even choose a
+/// session id until then.
+///
+/// Codex resolution walks the whole rollout tree, so the bridge caches the
+/// answer and only asks again while it is still `None`.
+pub fn happy_terminal_transcript_path(app: &AppHandle, session_id: &str) -> Option<PathBuf> {
+    let (cli_kind, cwd, agent_session_id) = {
+        let state = app.state::<TerminalState>();
+        let buffers = state.buffers.lock().ok()?;
+        let info = &buffers.get(session_id)?.info;
+        (
+            info.cli_kind?,
+            info.cwd.clone()?,
+            info.session_id.clone()?,
+        )
+    };
+    // Doubles as path-injection defense: neither branch touches the filesystem
+    // with an id that is not a UUID.
+    let agent_session_id = canonical_session_uuid(&agent_session_id).ok()?;
+    match cli_kind {
+        TerminalCliKind::Claude => {
+            let root = crate::claude_memory::claude_projects_root().ok()?;
+            let path = crate::claude_memory::session_jsonl_path(
+                &root,
+                Path::new(&cwd),
+                &agent_session_id,
+            );
+            path.is_file().then_some(path)
+        }
+        TerminalCliKind::Codex => {
+            let root = codex_sessions_root()?;
+            codex_transcripts_for_session(&root, &agent_session_id)
+                .into_iter()
+                .next()
+        }
+    }
+}
+
 #[tauri::command]
 pub fn terminal_forget_agent(app: AppHandle, state: State<'_, TerminalState>, buffer_id: String) {
     mutate_descriptors(&app, &state, |agents| {
@@ -3829,6 +3926,88 @@ pub fn terminal_claude_version() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn buffer_info(
+        cli_kind: Option<TerminalCliKind>,
+        status: TerminalStatus,
+        cwd: Option<&str>,
+    ) -> TerminalBufferInfo {
+        TerminalBufferInfo {
+            id: TEST_UUID.to_string(),
+            instance_id: "instance".to_string(),
+            title: "Claude Code".to_string(),
+            cwd: cwd.map(ToOwned::to_owned),
+            command: None,
+            cli_kind,
+            launch_mode: TerminalLaunchMode::Normal,
+            session_id: Some(TEST_UUID.to_string()),
+            session_resumable: true,
+            cols: 100,
+            rows: 28,
+            status,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn happy_terminal_sessions_exclude_plain_shells() {
+        // A relay-reachable plain shell is the unscoped `bash` exposure revoked
+        // in #3578. It must not return through the terminal session source.
+        assert_eq!(
+            happy_terminal_session(&buffer_info(None, TerminalStatus::Running, Some("/tmp"))),
+            None,
+        );
+        assert!(
+            happy_terminal_session(&buffer_info(
+                Some(TerminalCliKind::Claude),
+                TerminalStatus::Running,
+                Some("/tmp"),
+            ))
+            .is_some(),
+            "a running Claude pane is exposed"
+        );
+    }
+
+    #[test]
+    fn happy_terminal_sessions_exclude_exited_and_rootless_panes() {
+        assert_eq!(
+            happy_terminal_session(&buffer_info(
+                Some(TerminalCliKind::Claude),
+                TerminalStatus::Exited,
+                Some("/tmp"),
+            )),
+            None,
+            "an exited pane leaves the list so the bridge reports it terminated"
+        );
+        assert_eq!(
+            happy_terminal_session(&buffer_info(
+                Some(TerminalCliKind::Codex),
+                TerminalStatus::Running,
+                None,
+            )),
+            None,
+            "a pane with no cwd cannot be scope-checked, so it is not exposed"
+        );
+    }
+
+    #[test]
+    fn happy_terminal_sessions_map_cli_kind_to_agent_type() {
+        let claude = happy_terminal_session(&buffer_info(
+            Some(TerminalCliKind::Claude),
+            TerminalStatus::Running,
+            Some("/tmp"),
+        ))
+        .expect("claude pane");
+        let codex = happy_terminal_session(&buffer_info(
+            Some(TerminalCliKind::Codex),
+            TerminalStatus::Running,
+            Some("/tmp"),
+        ))
+        .expect("codex pane");
+        assert_eq!(claude.agent_type, "claude-code");
+        assert_eq!(codex.agent_type, "codex");
+    }
 
     #[test]
     fn terminal_title_uses_first_command_word() {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -3015,6 +3015,25 @@ fn happy_terminal_session(info: &TerminalBufferInfo) -> Option<HappyTerminalSess
     })
 }
 
+/// The project folders the user has run CLI-agent panes in, for the Happy
+/// advertised-root candidate set.
+///
+/// Read from the persisted descriptors rather than live buffers so a folder
+/// keeps offering its consent checkbox between app runs, matching how agent
+/// conversations keep offering theirs.
+pub fn happy_terminal_project_roots(app: &AppHandle) -> Vec<String> {
+    read_descriptor_store(app)
+        .agents
+        .into_iter()
+        .filter_map(|descriptor| descriptor.cwd)
+        .fold(Vec::<String>::new(), |mut roots, root| {
+            if !roots.iter().any(|existing| existing == &root) {
+                roots.push(root);
+            }
+            roots
+        })
+}
+
 /// Resolve the on-disk transcript a CLI-agent pane is writing, so the bridge can
 /// read its conversation. `None` until the CLI has materialized the session —
 /// Claude creates its file on first activity, and Codex does not even choose a

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -25,6 +25,10 @@ import {
   startPairing,
   updateAdvertisedRoots,
 } from "@/services/happyRemote";
+import {
+  type TerminalAgentDescriptor,
+  terminalStore,
+} from "@/stores/terminal.store";
 
 const DESCRIPTION =
   "Use your phone to monitor and control agents running in Seren Desktop. Sessions are end-to-end encrypted and only reachable while this app is open.";
@@ -74,14 +78,24 @@ const StoreMark: Component<{ platform: "apple" | "google" }> = (props) => (
   </Show>
 );
 
+/**
+ * The project folders a user can share, from both places one exists: agent
+ * conversations and CLI terminal panes. A folder used only for `claude` /
+ * `codex` panes has no conversation row, so listing conversations alone offered
+ * it no checkbox and its panes could never be shared. The Rust bridge derives
+ * its advertised set from the same two sources, so nothing is advertised that
+ * is not offered here to withdraw (#3144).
+ */
 function uniqueRoots(
   rows: Awaited<ReturnType<typeof listConversations>>,
+  terminalAgents: TerminalAgentDescriptor[],
 ): string[] {
   const roots: string[] = [];
-  for (const row of rows) {
-    const root = row.project_root ?? row.agent_cwd;
+  const add = (root: string | null | undefined) => {
     if (root && !roots.includes(root)) roots.push(root);
-  }
+  };
+  for (const row of rows) add(row.project_root ?? row.agent_cwd);
+  for (const agent of terminalAgents) add(agent.cwd);
   return roots;
 }
 
@@ -122,11 +136,12 @@ export const HappyRemoteSettings: Component = () => {
 
   const loadRoots = async () => {
     try {
-      const [rows, saved] = await Promise.all([
+      const [rows, terminalAgents, saved] = await Promise.all([
         listConversations({ kind: "agent" }),
+        terminalStore.listAgentDescriptors(),
         getAdvertisedRoots(),
       ]);
-      const discovered = uniqueRoots(rows);
+      const discovered = uniqueRoots(rows, terminalAgents);
       setRoots(discovered);
       setAdvertisedRoots(
         saved === null ? [] : saved.filter((root) => discovered.includes(root)),

--- a/tests/unit/happy-composite-source.test.ts
+++ b/tests/unit/happy-composite-source.test.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Verifies the composite session source routes per-session calls to the owning source.
+// ABOUTME: Protects provider sessions from a failing terminal listing.
+
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { createCompositeSource } from "../../bin/happy-bridge/composite-source.mjs";
+
+function stubSource(sessions: Array<{ sessionId: string }>) {
+  return {
+    listSessions: vi.fn(async () => sessions),
+    subscribe: vi.fn(() => () => {}),
+    sendPrompt: vi.fn(async () => ({ accepted: true })),
+    cancel: vi.fn(async () => {}),
+    terminate: vi.fn(async () => {}),
+    respondToPermission: vi.fn(async () => ({ ok: true })),
+    respondToDiffProposal: vi.fn(async () => ({ ok: true })),
+    setPermissionMode: vi.fn(async () => {}),
+    spawn: vi.fn(async () => ({ sessionId: "spawned" })),
+    advertise: vi.fn(async () => ({ machineName: "mac", agents: [], roots: [] })),
+    close: vi.fn(),
+  };
+}
+
+describe("composite session source", () => {
+  it("lists provider and terminal sessions together", async () => {
+    const provider = stubSource([{ sessionId: "provider-1" }]);
+    const terminal = stubSource([{ sessionId: "terminal-1" }]);
+    const source = createCompositeSource({ provider, terminal });
+
+    await expect(source.listSessions()).resolves.toEqual([
+      { sessionId: "provider-1" },
+      { sessionId: "terminal-1" },
+    ]);
+  });
+
+  it("keeps provider sessions when the terminal listing fails", async () => {
+    const provider = stubSource([{ sessionId: "provider-1" }]);
+    const terminal = stubSource([]);
+    terminal.listSessions.mockRejectedValue(new Error("supervisor RPC timed out"));
+    const source = createCompositeSource({ provider, terminal });
+
+    await expect(source.listSessions()).resolves.toEqual([{ sessionId: "provider-1" }]);
+  });
+
+  it("routes a prompt to the source that owns the session", async () => {
+    const provider = stubSource([{ sessionId: "provider-1" }]);
+    const terminal = stubSource([{ sessionId: "terminal-1" }]);
+    const source = createCompositeSource({ provider, terminal });
+    await source.listSessions();
+
+    await source.sendPrompt("terminal-1", "hello");
+    await source.sendPrompt("provider-1", "hello");
+
+    expect(terminal.sendPrompt).toHaveBeenCalledWith("terminal-1", "hello");
+    expect(provider.sendPrompt).toHaveBeenCalledWith("provider-1", "hello");
+    expect(terminal.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(provider.sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("claims ownership from an event before the session is ever listed", async () => {
+    const provider = stubSource([]);
+    const terminal = stubSource([]);
+    let publish: ((event: { sessionId: string }) => void) | null = null;
+    terminal.subscribe.mockImplementation((onEvent: (event: { sessionId: string }) => void) => {
+      publish = onEvent;
+      return () => {};
+    });
+    const source = createCompositeSource({ provider, terminal });
+    source.subscribe(() => {});
+
+    publish?.({ sessionId: "terminal-late" });
+    await source.terminate("terminal-late");
+
+    expect(terminal.terminate).toHaveBeenCalledWith("terminal-late");
+    expect(provider.terminate).not.toHaveBeenCalled();
+  });
+
+  it("always spawns through the provider — panes are opened on the desktop", async () => {
+    const provider = stubSource([]);
+    const terminal = stubSource([]);
+    const source = createCompositeSource({ provider, terminal });
+
+    await source.spawn({ agentType: "claude-code", cwd: "/tmp" });
+
+    expect(provider.spawn).toHaveBeenCalledTimes(1);
+    expect(terminal.spawn).not.toHaveBeenCalled();
+  });
+
+  it("sends an unknown session to the provider, which owns spawning", async () => {
+    const provider = stubSource([]);
+    const terminal = stubSource([]);
+    const source = createCompositeSource({ provider, terminal });
+
+    await source.cancel("just-spawned");
+
+    expect(provider.cancel).toHaveBeenCalledWith("just-spawned");
+    expect(terminal.cancel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/happy-terminal-transcript.test.ts
+++ b/tests/unit/happy-terminal-transcript.test.ts
@@ -1,0 +1,117 @@
+// ABOUTME: Verifies Claude and Codex CLI transcript lines map to neutral session events.
+// ABOUTME: Fixtures mirror the real on-disk shapes both CLIs write.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import {
+  parseClaudeTranscriptLine,
+  parseCodexTranscriptLine,
+} from "../../bin/happy-bridge/terminal-transcript.mjs";
+
+const line = (value: unknown) => JSON.stringify(value);
+
+describe("Claude Code transcript parsing", () => {
+  it("publishes a typed prompt and marks the session busy", () => {
+    const events = parseClaudeTranscriptLine(
+      line({ type: "user", message: { role: "user", content: "run the tests" } }),
+    );
+    expect(events).toEqual([
+      { kind: "user-message", payload: { text: "run the tests" } },
+      { kind: "status", payload: { status: "busy" } },
+    ]);
+  });
+
+  it("shares one message id across the blocks of a reply so they render as one bubble", () => {
+    const events = parseClaudeTranscriptLine(
+      line({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "msg_1",
+          stop_reason: "end_turn",
+          content: [
+            { type: "thinking", thinking: "internal" },
+            { type: "text", text: "first" },
+            { type: "text", text: " second" },
+          ],
+        },
+      }),
+    );
+    // Thinking blocks outnumber assistant text three to one in real
+    // transcripts and are deliberately dropped.
+    expect(events.map((event: { kind: string }) => event.kind)).toEqual([
+      "assistant-delta",
+      "assistant-delta",
+      "turn-complete",
+    ]);
+    expect(events[0].payload.messageId).toBe("msg_1");
+    expect(events[1].payload.messageId).toBe("msg_1");
+  });
+
+  it("does not end the turn while the model is still calling tools", () => {
+    const events = parseClaudeTranscriptLine(
+      line({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "msg_2",
+          stop_reason: "tool_use",
+          content: [{ type: "tool_use", id: "call_1", name: "Bash", input: { command: "ls" } }],
+        },
+      }),
+    );
+    expect(events.map((event: { kind: string }) => event.kind)).toEqual(["tool-start"]);
+  });
+
+  it("drops sub-agent and bookkeeping lines that the user never typed", () => {
+    const prompt = { role: "user", content: "sub-agent work" };
+    expect(parseClaudeTranscriptLine(line({ type: "user", isSidechain: true, message: prompt })))
+      .toEqual([]);
+    expect(parseClaudeTranscriptLine(line({ type: "user", isMeta: true, message: prompt })))
+      .toEqual([]);
+    expect(parseClaudeTranscriptLine(line({ type: "ai-title", aiTitle: "x" }))).toEqual([]);
+  });
+
+  it("ignores a half-written final line rather than throwing", () => {
+    expect(parseClaudeTranscriptLine('{"type":"user","mess')).toEqual([]);
+    expect(parseClaudeTranscriptLine("")).toEqual([]);
+  });
+});
+
+describe("Codex transcript parsing", () => {
+  it("publishes user and agent messages from the user-facing stream", () => {
+    expect(
+      parseCodexTranscriptLine(
+        line({ type: "event_msg", payload: { type: "user_message", message: "ship it" } }),
+      ).map((event: { kind: string }) => event.kind),
+    ).toEqual(["user-message", "status"]);
+
+    expect(
+      parseCodexTranscriptLine(
+        line({ type: "event_msg", payload: { type: "agent_message", message: "done" } }),
+      ),
+    ).toEqual([{ kind: "assistant-delta", payload: { text: "done" } }]);
+  });
+
+  it("does not publish the raw model exchange a second time", () => {
+    // Codex records every turn twice. `response_item/message` is the same text
+    // already published from `event_msg`, so reading both would double it.
+    expect(
+      parseCodexTranscriptLine(
+        line({
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ text: "done" }] },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("ends the turn on task completion", () => {
+    expect(
+      parseCodexTranscriptLine(
+        line({ type: "event_msg", payload: { type: "task_complete", turn_id: "t1" } }),
+      ).map((event: { kind: string }) => event.kind),
+    ).toEqual(["turn-complete"]);
+  });
+});


### PR DESCRIPTION
Closes #3732. Ticket **1 of 3** — the read path.

## What was broken

Happy listed provider-runtime sessions only. The Claude Code and Codex chats started from the launcher's **Command line** section are PTY buffers: `createTerminalThread` → `terminal_create_buffer`, no `conversations` row. Confirmed against the live desktop database:

```
sqlite3 -readonly chat.db \
  "select kind, agent_type, count(*) from conversations where deleted_at is null group by 1,2;"
agent|claude-code|750  agent|codex|621  chat||226  agent|claude-codex|34
agent|lmstudio|10      agent|gemini|7   agent|grok|3
```

No `terminal` kind exists. `bin/happy-bridge.mjs` held one source, `createProviderSource`, whose `listSessions` is `provider_list_sessions`. A PTY buffer is not registered with the provider runtime, so **no configuration could have surfaced these panes** — this was a missing capability, not a regression.

## What changed

**Rust — two supervisor methods.** `terminal_list_sessions` returns running CLI panes; `terminal_transcript_path` resolves the file one is writing. Transcript resolution is a separate call because the Codex lookup walks the rollout tree — 1,239 files on the audited machine — so the bridge caches the answer and only re-asks while it is still unresolved.

**Security.** Panes with no `cli_kind` are never returned. A relay-reachable plain shell is exactly the unscoped `bash` exposure revoked in #3578. Both methods re-check the pane against the advertised roots with a new `is_within_advertised_root` mirroring `isWithinAdvertisedRoots` in `validate.mjs` — visibility semantics (a pane inside a shared folder is in scope), not spawn semantics.

**Bridge.** `terminal-transcript.mjs` maps both CLI formats onto the neutral event kinds already in `provider-source.mjs`, so `translate.mjs` and the publish path are reused unchanged. `terminal-source.mjs` replays bounded history then tails. `composite-source.mjs` routes per-session calls to the owning source.

**Read-only in this ticket.** `sendPrompt` rejects with a message the phone can read. `terminate` detaches — a phone dismissing a thread must never kill a terminal being worked in on the desktop.

## Evidence

### Parsers run against real production transcripts

Not fixtures — the actual files three live panes were writing during the audit, plus a real Codex rollout.

| Source | Lines | Events produced |
| --- | --- | --- |
| Claude pane A | 1,034 | 9 user · 47 assistant · 243 tool pairs · 10 turn-complete |
| Claude pane B | 504 | 1 user · 18 assistant · 121 tool pairs |
| Claude pane C | 1,451 | 3 user · 91 assistant · 368 tool pairs · 2 turn-complete |
| Codex rollout | 2,772 | 4 user · 62 assistant · 617 tool pairs · 3 turn-complete |

8,761 real lines across both formats. Mobile text bounding engaged on 80 events; no event exceeded the 8,000-char bound. Tool starts and ends balanced on every file.

Two format details this surfaced, both handled:
- Codex records every turn twice (`event_msg` *and* `response_item`). Text is read from `event_msg` only, or every message would post twice.
- Claude `thinking` blocks outnumber assistant text roughly 3:1 and are dropped; all blocks of one assistant message share `message.id` so they coalesce into one bubble instead of one per block.

### Tests

6 Rust + 14 unit, all passing. Scoped to the behavior that was broken and the exposure that must not regress:

```
test terminal::tests::happy_terminal_sessions_exclude_plain_shells ... ok
test terminal::tests::happy_terminal_sessions_exclude_exited_and_rootless_panes ... ok
test terminal::tests::happy_terminal_sessions_map_cli_kind_to_agent_type ... ok
test happy_bridge::tests::terminal_session_scope_covers_subdirectories_but_not_prefix_siblings ... ok
test happy_bridge::tests::terminal_session_scope_fails_closed_without_roots ... ok
test happy_bridge::tests::supervisor_channel_accepts_terminal_session_methods ... ok
```

Full suite: **444 files, 3,065 tests, 0 failures.** `cargo check` clean.

### Integration points verified by reading, not assumed

- `retirePersistedSession` resolves no conversation owner for a terminal id, so it takes the `archiveProviderOnly` branch rather than failing on `conversation_archive`.
- `restorePersistedProviderSessions` and `migrateLegacyHappyProviderBindings` iterate DB-backed conversations only; terminal panes are absent and untouched.
- Terminal buffer ids are v4 UUIDs reused across restarts by `restoreAgents`, which is what `sessionKeyStore` needs for a durable relay binding.
- `scripts/build-provider-runtime.ts:88` copies `bin/happy-bridge/` recursively, so the three new modules ship without a manifest change.

## Live walkthrough — NOT YET RUN

**This PR is not ready to merge.** The device-side confirmation is outstanding and needs Taariq's hardware:

- The only paired Happy device is Taariq's phone. Pairing is QR-based, so no automated harness can stand in for it, and building a headless relay client would be a fake phone — not evidence.
- The app under test is the one hosting the agent session that wrote this change: three of its live panes are the Claude terminals in the table above. Restarting it to load this branch ends that session.

What needs to be observed on device, per the acceptance list in #3732: a Claude pane and a Codex pane appearing in the phone's folder list with their real titles; tapping either showing the actual conversation rather than an empty screen; a desktop-typed message arriving without a manual refresh; a plain `Terminal` pane staying absent; and existing agent conversations unaffected.
