### PR TITLE
fix(codex): surface invalidated credentials and offer sign-in (#3729)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -9,6 +9,7 @@ import {
   existsSync,
   openSync,
   readSync,
+  statSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -249,6 +250,46 @@ async function isCommandAvailable(command) {
   }
 }
 
+/**
+ * Agents whose stored credentials the upstream service has rejected.
+ *
+ * A credential file survives server-side invalidation intact — same keys, same
+ * shape, still parseable — so file existence alone reports an agent as
+ * authenticated forever while every request 401s. Recording an observed
+ * rejection is what makes the state reachable by the UI. Cleared when a
+ * credential file is rewritten (i.e. the user signed in again). #3729.
+ */
+const invalidatedAgentCredentials = new Map();
+
+export function markAgentCredentialsInvalid(agentType) {
+  invalidatedAgentCredentials.set(agentType, Date.now());
+}
+
+export function clearAgentCredentialsInvalid(agentType) {
+  invalidatedAgentCredentials.delete(agentType);
+}
+
+/**
+ * True when a rejection has been observed and no credential file has been
+ * written since. Deliberately does NOT call upstream — availability is polled
+ * often and must stay free.
+ */
+function hasObservedInvalidCredentials(agentType, paths) {
+  const invalidatedAt = invalidatedAgentCredentials.get(agentType);
+  if (invalidatedAt === undefined) return false;
+  for (const candidate of paths) {
+    try {
+      if (statSync(candidate).mtimeMs > invalidatedAt) {
+        invalidatedAgentCredentials.delete(agentType);
+        return false;
+      }
+    } catch {
+      // Missing or unreadable candidate cannot clear the flag.
+    }
+  }
+  return true;
+}
+
 function hasAnyCredentialPath(paths) {
   return paths.some((candidate) => {
     try {
@@ -295,10 +336,10 @@ function hasClaudeCredentials() {
   ]);
 }
 
-function hasCodexCredentials() {
+function codexCredentialPaths() {
   const home = os.homedir();
   const appData = process.env.APPDATA;
-  return Boolean(process.env.OPENAI_API_KEY) || hasAnyCredentialPath([
+  return [
     path.join(home, ".codex", "auth.json"),
     path.join(home, ".codex", "credentials.json"),
     ...(appData
@@ -307,7 +348,16 @@ function hasCodexCredentials() {
           path.join(appData, "OpenAI", "Codex", "auth.json"),
         ]
       : []),
-  ]);
+  ];
+}
+
+function hasCodexCredentials() {
+  if (process.env.OPENAI_API_KEY) return true;
+  const paths = codexCredentialPaths();
+  // An invalidated ChatGPT token leaves auth.json on disk and syntactically
+  // valid, so presence alone is not evidence of a usable credential. #3729.
+  if (hasObservedInvalidCredentials("codex", paths)) return false;
+  return hasAnyCredentialPath(paths);
 }
 
 function hasGrokCredentials() {
@@ -1317,3 +1367,6 @@ export { AGENT_CLI_PROVISIONING as _AGENT_CLI_PROVISIONING };
 export {
   assertAgentCliProvisioningComplete as _assertAgentCliProvisioningComplete,
 };
+// Exported so the #3729 regression can assert that an observed credential
+// rejection actually flips reported auth status, against the real filesystem.
+export { isAgentAuthenticated as _isAgentAuthenticated };

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import readline from "node:readline";
 import {
   createBrowserLocalAgentRegistry,
+  markAgentCredentialsInvalid,
   resolveInstalledCodexBinary,
 } from "./agent-registry.mjs";
 import {
@@ -333,7 +334,20 @@ function isAuthError(message) {
     lower.includes("auth required") ||
     lower.includes("please run /login") ||
     lower.includes("login required") ||
-    lower.includes("not logged in")
+    lower.includes("not logged in") ||
+    // Server-side credential invalidation is the most common real Codex auth
+    // failure and none of the phrases above appear in it. Match the
+    // machine-readable code first so upstream wording changes cannot silently
+    // un-fix this, and keep the prose forms as a fallback. #3729.
+    lower.includes("token_invalidated") ||
+    lower.includes("token has been invalidated") ||
+    // A bare 401 from Codex's own API endpoints is the failure the user
+    // actually hits: the prompt cannot connect and they see only
+    // "Reconnecting... 2/5". 401 means unauthorized by definition — rate
+    // limiting is 429 — so this is always a credential problem. Found by
+    // driving the real CLI with an invalid credential; the wording above
+    // covers only the background models refresh. #3729
+    lower.includes("401 unauthorized")
   );
 }
 
@@ -1564,6 +1578,29 @@ function handleLine(emit, session, line) {
   }
 }
 
+/**
+ * Raises Codex credential invalidation exactly once per session.
+ *
+ * The upstream 401 repeats every few seconds for as long as the session lives,
+ * so this must be idempotent or it would bury the log it is trying to make
+ * useful and re-open the login flow on a loop.
+ */
+function reportCodexAuthInvalidated(emit, session, detail) {
+  if (session.authInvalidatedReported) return;
+  session.authInvalidatedReported = true;
+  markAgentCredentialsInvalid("codex");
+  emit("provider://login-required", {
+    sessionId: session.id,
+    agentType: "codex",
+    reason: detail,
+  });
+  emit("provider://error", {
+    sessionId: session.id,
+    error:
+      "Codex sign-in expired. Finish the login in the Terminal window, then send your message again.",
+  });
+}
+
 function attachProcessListeners(
   emit,
   sessions,
@@ -1576,6 +1613,14 @@ function attachProcessListeners(
     const message = String(chunk).trim();
     if (message.length > 0) {
       console.log(`${logPrefix} ${message}`);
+      // Codex reports server-side credential invalidation only here, as a log
+      // line on its own stderr — the models refresh keeps serving a cached
+      // catalog and no RPC ever fails, so nothing downstream could notice. The
+      // user was left with a thread that looked healthy and silently degraded.
+      // This is the only place the signal exists, so recovery starts here. #3729
+      if (isAuthError(message)) {
+        reportCodexAuthInvalidated(emit, session, message);
+      }
     }
   });
 
@@ -1673,6 +1718,10 @@ function attachProcessListeners(
   });
 }
 
+// Exported so the #3729 regression can drive the real stderr listener with a
+// real child process emitting the real upstream invalidation line.
+export { attachProcessListeners as _attachProcessListeners };
+
 export function createProviderHandlers({
   emit: rawEmit,
   runtimeMode = "provider-runtime",
@@ -1764,11 +1813,16 @@ export function createProviderHandlers({
       return await callback(session);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        isAuthError(message)
-          ? "Agent authentication required. Run the login flow and try again."
-          : message,
-      );
+      if (isAuthError(message)) {
+        // The model-list refresh is the first thing to notice an invalidated
+        // token, and it runs long before the user tries to spawn. Record it so
+        // availability stops reporting a stale `authenticated: true`. #3729.
+        markAgentCredentialsInvalid("codex");
+        throw new Error(
+          "Codex sign-in required. Finish the login, then reload the model list.",
+        );
+      }
+      throw new Error(message);
     } finally {
       tempSessions.delete(session.id);
       try {
@@ -2191,10 +2245,23 @@ export function createProviderHandlers({
       sessions.delete(sessionId);
       killChildTree(processHandle);
       await serenMcpProxy?.close();
+      const authFailed = isAuthError(message);
+      if (authFailed) {
+        // Codex is the only agent with a launchLogin() and, until now, no way
+        // to reach it: every other runtime emits this event and agent.store
+        // answers it by auto-opening the login flow. Emit before the error so
+        // the ordering matches acp-runtime.mjs. #3729.
+        markAgentCredentialsInvalid("codex");
+        emit("provider://login-required", {
+          sessionId,
+          agentType: "codex",
+          reason: message,
+        });
+      }
       emit("provider://error", {
         sessionId,
-        error: isAuthError(message)
-          ? "Agent authentication required. Run the login flow and try again."
+        error: authFailed
+          ? "Codex sign-in required. Finish the login, then start the agent again."
           : message,
       });
       throw error;

--- a/scripts/walkthrough-3729.mjs
+++ b/scripts/walkthrough-3729.mjs
@@ -1,0 +1,214 @@
+// ABOUTME: Live walkthrough for #3729 against a real provider runtime and the real Codex CLI.
+// ABOUTME: Exercises invalidated-token detection, auth status, and login-required recovery.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { WebSocket } from "ws";
+
+const ROOT_PATH = fileURLToPath(new URL("../", import.meta.url));
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.WALKTHROUGH_PORT ?? "4321");
+const TOKEN = "walkthrough-3729-token";
+const CWD = process.cwd();
+
+function resolveSandboxSpecBin() {
+  if (process.env.SEREN_SANDBOX_SPEC_BIN) return process.env.SEREN_SANDBOX_SPEC_BIN;
+  for (const profile of ["release", "debug"]) {
+    const candidate = join(ROOT_PATH, "src-tauri", "target", profile, "Seren");
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error("Build the app binary first (cargo build --manifest-path src-tauri/Cargo.toml)");
+}
+
+let nextId = 1;
+const pending = new Map();
+const notifications = [];
+
+function rpc(ws, method, params) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    setTimeout(() => {
+      if (pending.delete(id)) reject(new Error(`RPC ${method} timed out`));
+    }, 180_000).unref();
+  });
+}
+
+async function main() {
+  const limit = process.env.SEREN_CLAUDE_SESSION_LIMIT ?? "2";
+  const child = spawn(
+    process.execPath,
+    [join(ROOT_PATH, "bin", "provider-runtime.mjs"), "--host", HOST, "--port", String(PORT)],
+    {
+      cwd: ROOT_PATH,
+      env: {
+        ...process.env,
+        SEREN_PROVIDER_RUNTIME_TOKEN: TOKEN,
+        SEREN_CLAUDE_SESSION_LIMIT: limit,
+        SEREN_SANDBOX_SPEC_BIN: resolveSandboxSpecBin(),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const runtimeLog = [];
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      for (const line of chunk.split("\n")) {
+        if (!line.trim()) continue;
+        runtimeLog.push(line);
+        if (process.env.WALKTHROUGH_VERBOSE === "1" || line.includes("session queued")) {
+          console.log("  [runtime] " + line.trim());
+        }
+      }
+    });
+  }
+
+  // Wait for the runtime to report healthy rather than guessing a delay.
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    try {
+      const res = await fetch(`http://${HOST}:${PORT}/__seren/health`);
+      if (res.ok) break;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) throw new Error("provider runtime never became healthy");
+    await sleep(500);
+  }
+  const ws = new WebSocket(`ws://${HOST}:${PORT}`);
+  await new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  ws.on("message", (raw) => {
+    const msg = JSON.parse(String(raw));
+    if (msg.id && pending.has(msg.id)) {
+      const entry = pending.get(msg.id);
+      pending.delete(msg.id);
+      if (msg.error) entry.reject(new Error(msg.error.message ?? "rpc error"));
+      else entry.resolve(msg.result);
+    } else if (msg.method) {
+      notifications.push(msg);
+    }
+  });
+  // The runtime authenticates over an `auth` RPC, not a query parameter.
+  await rpc(ws, "auth", { token: TOKEN });
+
+  const spawnClaude = (id) =>
+    rpc(ws, "provider_spawn", {
+      agentType: "claude-code",
+      cwd: CWD,
+      localSessionId: id,
+      resumeAgentSessionId: null,
+      sandboxMode: "full-access",
+      apiKey: null,
+      approvalPolicy: "on-request",
+      searchEnabled: false,
+      networkEnabled: true,
+      timeoutSecs: 60,
+    });
+
+  try {
+    console.log("\n=== STEP 1 — codex availability BEFORE any observed rejection ===");
+    const before = await rpc(ws, "provider_get_available_agents", {});
+    const codexBefore = before.find((a) => a.type === "codex");
+    console.log(`  codex authenticated: ${codexBefore?.authenticated}`);
+    console.log(`  (auth.json exists on disk, so file-presence alone says "yes")`);
+
+    console.log("\n=== STEP 2 — ask Codex for its model catalog (real upstream call) ===");
+    let catalogError = null;
+    try {
+      const models = await rpc(ws, "provider_get_model_catalog", {
+        agentType: "codex",
+        cwd: CWD,
+      });
+      console.log(`  model catalog returned ${models.length} models — token is valid`);
+    } catch (error) {
+      catalogError = error.message;
+      console.log(`  model catalog FAILED with:`);
+      console.log(`    ${catalogError}`);
+    }
+
+    console.log("\n=== STEP 3 — availability AFTER the observed rejection ===");
+    const after = await rpc(ws, "provider_get_available_agents", {});
+    const codexAfter = after.find((a) => a.type === "codex");
+    console.log(`  codex authenticated: ${codexAfter?.authenticated}`);
+
+    console.log("\n=== STEP 4 — spawn Codex and watch for login-required ===");
+    const codexId = randomUUID();
+    let spawnError = null;
+    try {
+      await rpc(ws, "provider_spawn", {
+        agentType: "codex",
+        cwd: CWD,
+        localSessionId: codexId,
+        resumeAgentSessionId: null,
+        sandboxMode: "full-access",
+        apiKey: null,
+        approvalPolicy: "on-request",
+        searchEnabled: false,
+        networkEnabled: true,
+        timeoutSecs: 60,
+      });
+      console.log("  codex spawn succeeded");
+      console.log("  sending a real prompt (this must reach upstream)...");
+      try {
+        await rpc(ws, "provider_prompt", {
+          sessionId: codexId,
+          prompt: "Reply with exactly: PONG",
+          context: [],
+        });
+        console.log("  prompt completed — credential is valid");
+      } catch (error) {
+        console.log(`  prompt failed: ${error.message}`);
+      }
+      await sleep(3000);
+      await rpc(ws, "provider_terminate", { sessionId: codexId }).catch(() => {});
+    } catch (error) {
+      spawnError = error.message;
+      console.log(`  codex spawn failed: ${spawnError}`);
+    }
+    const loginEvents = notifications.filter(
+      (n) => n.method === "provider://login-required",
+    );
+    console.log(`  provider://login-required events observed: ${loginEvents.length}`);
+    for (const evt of loginEvents) {
+      console.log(`    agentType=${evt.params?.agentType} sessionId=${evt.params?.sessionId?.slice(0, 8)}…`);
+    }
+
+    console.log("\n=== STEP 5 — availability after a REAL observed rejection ===");
+    const final = await rpc(ws, "provider_get_available_agents", {});
+    const codexFinal = final.find((a) => a.type === "codex");
+    console.log(`  codex authenticated: ${codexFinal?.authenticated}`);
+    console.log(
+      `  unavailableReason: ${codexFinal?.unavailableReason ?? "(none)"}`,
+    );
+
+    console.log("\n=== SUMMARY ===");
+    console.log(`  catalog error classified as auth: ${catalogError ? catalogError.includes("sign-in required") : "n/a (token valid)"}`);
+    console.log(`  authenticated before -> after: ${codexBefore?.authenticated} -> ${codexAfter?.authenticated}`);
+  } finally {
+    for (const note of notifications.slice(0, 0)) console.log(note);
+    try {
+      const remaining = await rpc(ws, "provider_list_sessions", {});
+      for (const session of remaining) {
+        await rpc(ws, "provider_terminate", { sessionId: session.id }).catch(() => {});
+      }
+    } catch {
+      // teardown best-effort
+    }
+    ws.close();
+    child.kill("SIGTERM");
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/tests/unit/codex-token-invalidated.test.ts
+++ b/tests/unit/codex-token-invalidated.test.ts
@@ -1,0 +1,227 @@
+// ABOUTME: Protects Codex auth-failure detection and recovery for invalidated tokens (#3729).
+// ABOUTME: Pins the real upstream error text and the login-required wiring it must reach.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain-JS runtime module without type declarations.
+import {
+  clearAgentCredentialsInvalid,
+  markAgentCredentialsInvalid,
+} from "../../bin/browser-local/agent-registry.mjs";
+
+const providersSource = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+const registrySource = readFileSync(
+  resolve("bin/browser-local/agent-registry.mjs"),
+  "utf-8",
+);
+
+/**
+ * Captured verbatim from a real failing session. `isAuthError` matched none of
+ * it, so a Codex thread 401'd continuously with no user-facing signal at all.
+ */
+const REAL_CODEX_INVALIDATION =
+  "failed to refresh available models: unexpected status 401 Unauthorized: " +
+  "Your authentication token has been invalidated. Please try signing in again., " +
+  "url: https://chatgpt.com/backend-api/codex/models?client_version=0.146.1, " +
+  "auth error: 401, auth error code: token_invalidated";
+
+// Mirrors `isAuthError` in providers.mjs. That function is module-private, so
+// the contract is pinned here and cross-checked against the source below.
+function isAuthError(message: string): boolean {
+  const lower = String(message).toLowerCase();
+  return (
+    lower.includes("invalid api key") ||
+    lower.includes("authentication required") ||
+    lower.includes("auth required") ||
+    lower.includes("please run /login") ||
+    lower.includes("login required") ||
+    lower.includes("not logged in") ||
+    lower.includes("token_invalidated") ||
+    lower.includes("token has been invalidated") ||
+    lower.includes("401 unauthorized")
+  );
+}
+
+describe("#3729 — Codex invalidated-token classification", () => {
+  it("classifies the real upstream invalidation message as an auth error", () => {
+    expect(isAuthError(REAL_CODEX_INVALIDATION)).toBe(true);
+  });
+
+  it("matches the machine-readable code on its own", () => {
+    // Preferred over prose: upstream wording changes must not silently un-fix
+    // this the way they would if only the sentence were matched.
+    expect(isAuthError("auth error code: token_invalidated")).toBe(true);
+  });
+
+  it("classifies the websocket 401 the user actually hits when prompting", () => {
+    // Captured by driving the real Codex CLI with an invalid credential. This
+    // is the failure the user sees ("Reconnecting... 2/5"), and it carries
+    // none of the invalidation prose above.
+    expect(
+      isAuthError(
+        "failed to connect to websocket: HTTP error: 401 Unauthorized, " +
+          "url: wss://api.openai.com/v1/responses",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated failures as auth errors", () => {
+    expect(isAuthError("Codex exited with code 1")).toBe(false);
+    expect(isAuthError("unexpected status 500 Internal Server Error")).toBe(
+      false,
+    );
+    // Rate limiting is 429, not 401 — it must not open a sign-in flow.
+    expect(isAuthError("unexpected status 429 Too Many Requests")).toBe(false);
+  });
+
+  it("keeps providers.mjs in step with the classifier pinned here", () => {
+    for (const token of [
+      "token_invalidated",
+      "token has been invalidated",
+      "401 unauthorized",
+    ]) {
+      expect(providersSource).toContain(token);
+    }
+  });
+});
+
+/**
+ * The actual failure mode, found by driving the real Codex CLI with an invalid
+ * credential: the invalidation NEVER surfaces as an RPC error. `model/list`
+ * keeps serving a cached catalog and every RPC succeeds. The 401 exists only as
+ * a log line on the Codex child's stderr — which `attachProcessListeners` read
+ * and threw away with a bare console.log. That is why the user saw nothing.
+ */
+describe("#3729 — invalidation is detected on the Codex child's stderr", () => {
+  it("raises login-required once from a real child emitting the real 401 line", async () => {
+    const { spawn } = await import("node:child_process");
+    const readline = await import("node:readline");
+    const providers = await import(
+      // @ts-expect-error — plain-JS runtime module without type declarations.
+      "../../bin/browser-local/providers.mjs"
+    );
+
+    // A real child process writing the real captured line to a real stderr
+    // pipe, four times — the live failure repeats every few seconds.
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        `let n=0;const t=setInterval(()=>{n++;process.stderr.write(${JSON.stringify(
+          REAL_CODEX_INVALIDATION,
+        )}+"\n");if(n>=4){clearInterval(t);process.exit(0);}},50);`,
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    const emitted: Array<{ channel: string; payload: Record<string, string> }> = [];
+    const session = {
+      id: "codex-auth-regression",
+      process: child,
+      output: readline.createInterface({ input: child.stdout! }),
+      serenMcpProxy: null,
+      currentPrompt: null,
+      pendingRequests: new Map(),
+      status: "ready",
+    };
+
+    providers._attachProcessListeners(
+      (channel: string, payload: Record<string, string>) =>
+        emitted.push({ channel, payload }),
+      new Map([[session.id, session]]),
+      session,
+      "[test][codex]",
+    );
+
+    await new Promise((resolve) => child.once("exit", resolve));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const loginRequired = emitted.filter(
+      (e) => e.channel === "provider://login-required",
+    );
+    // Exactly one: the 401 repeats for the life of the session, so a
+    // per-line emit would bury the log and reopen the login flow on a loop.
+    expect(loginRequired).toHaveLength(1);
+    expect(loginRequired[0]?.payload.agentType).toBe("codex");
+    expect(loginRequired[0]?.payload.sessionId).toBe("codex-auth-regression");
+
+    const errors = emitted.filter((e) => e.channel === "provider://error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload.error).toMatch(/sign-in expired/i);
+
+    clearAgentCredentialsInvalid("codex");
+  });
+});
+
+describe("#3729 — the native Codex path reaches the login-required flow", () => {
+  it("emits provider://login-required before provider://error on an auth failure", () => {
+    // Every other runtime emits this; providers.mjs previously emitted none,
+    // so agent.store's auto-launch-login handler was unreachable for Codex.
+    const loginIdx = providersSource.indexOf('"provider://login-required"');
+    expect(loginIdx, "Codex path must emit login-required").toBeGreaterThan(0);
+
+    const authBranch = providersSource.indexOf("const authFailed = isAuthError(");
+    expect(authBranch).toBeGreaterThan(0);
+    const errorIdx = providersSource.indexOf(
+      '"provider://error"',
+      authBranch,
+    );
+    const loginInBranch = providersSource.indexOf(
+      '"provider://login-required"',
+      authBranch,
+    );
+    expect(loginInBranch).toBeGreaterThan(0);
+    expect(
+      loginInBranch,
+      "login-required must precede the error event, matching acp-runtime",
+    ).toBeLessThan(errorIdx);
+  });
+
+  it("carries agentType codex so the auto-login targets the right CLI", () => {
+    expect(providersSource).toMatch(
+      /provider:\/\/login-required"[\s\S]{0,160}agentType: "codex"/,
+    );
+  });
+});
+
+describe("#3729 — Codex auth status reflects validity, not file presence", () => {
+  it("stops reporting codex as authenticated after an observed invalidation", async () => {
+    // Real module, real filesystem check — the credential file on this machine
+    // is untouched, which is the whole point: presence alone is not evidence.
+    const registry = await import(
+      // @ts-expect-error — plain-JS runtime module without type declarations.
+      "../../bin/browser-local/agent-registry.mjs"
+    );
+
+    clearAgentCredentialsInvalid("codex");
+    const before = registry._isAgentAuthenticated("codex");
+
+    markAgentCredentialsInvalid("codex");
+    const after = registry._isAgentAuthenticated("codex");
+
+    clearAgentCredentialsInvalid("codex");
+    const restored = registry._isAgentAuthenticated("codex");
+
+    // Only meaningful when a credential actually exists on this machine; when
+    // it does, an observed rejection must flip the answer.
+    if (before) {
+      expect(after, "an observed rejection must clear authenticated").toBe(
+        false,
+      );
+      expect(restored, "clearing the flag must restore it").toBe(true);
+    }
+  });
+
+  it("does not call upstream to decide availability", () => {
+    const idx = registrySource.indexOf("function hasObservedInvalidCredentials");
+    expect(idx).toBeGreaterThan(0);
+    const body = registrySource.slice(idx, idx + 900);
+    // Availability is polled often; a network call here would be a hot-path
+    // regression, not a fix.
+    expect(body).not.toMatch(/fetch\(|https?:\/\//);
+  });
+});

--- a/tests/unit/spawn-binary-validation.test.ts
+++ b/tests/unit/spawn-binary-validation.test.ts
@@ -53,11 +53,15 @@ describe("#1735 A2 — codex spawn attaches an 'error' listener so missing binar
     // structured per-session error event the UI can show.
     const fnIdx = providersRuntime.indexOf("function attachProcessListeners(");
     expect(fnIdx).toBeGreaterThan(0);
-    const fn = providersRuntime.slice(fnIdx, fnIdx + 2000);
+    const fn = providersRuntime.slice(fnIdx, fnIdx + 3000);
     expect(fn).toMatch(/session\.process\.on\(\s*"error"/);
     // The listener must emit a provider://error so the UI surfaces a
     // recoverable per-session failure rather than the runtime dying
-    // silently from the user's POV.
-    expect(fn).toMatch(/emit\([\s\S]*?provider:\/\/error/);
+    // silently from the user's POV. Anchored to the 'error' listener so a
+    // provider://error emitted elsewhere in the function cannot satisfy it.
+    const errorListenerIdx = fn.search(/session\.process\.on\(\s*"error"/);
+    expect(fn.slice(errorListenerIdx)).toMatch(
+      /emit\([\s\S]*?provider:\/\/error/,
+    );
   });
 });


### PR DESCRIPTION
Closes #3729.

## The issue's premise was wrong, and the live walkthrough is what caught it

#3729 assumed the invalidation arrives as an error `isAuthError()` could classify on the spawn
and model-catalog paths. Driving the **real Codex CLI with an invalid credential** showed it
does not:

- `model/list` **succeeded** and returned a cached catalog.
- `provider_spawn` **succeeded**.
- Every RPC succeeded. There was no error anywhere for anything to classify.

The 401 exists **only as a log line on the Codex child's stderr** — which
`providers.mjs:1583-1588` read and threw away with a bare `console.log`. That is the whole
reason the user saw nothing, and it is not what the issue described. Fixed at the real source.

## What changed

### 1. Detect it where the signal actually is

The stderr listener now recognises an auth failure and raises it **once per session**. The 401
repeats every few seconds for the life of the session, so a per-line emit would bury the log it
is meant to make useful and reopen the login flow on a loop.

### 2. `isAuthError()` matched none of the real forms

It now matches the machine-readable `token_invalidated` code (preferred, so upstream wording
changes cannot silently un-fix it), the invalidation prose, and a **bare `401 Unauthorized`**.

That last one was the second thing the walkthrough caught. Prompting against an invalidated
credential does not fail with any invalidation prose — it fails on the responses websocket:

```
ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket:
HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses
prompt failed: Reconnecting... 2/5
```

`Reconnecting... 2/5` is the entire user-facing signal today. My first pass would still have
missed this — the most common way a user actually hits the bug. Rate limiting is 429, so a 401
is always a credential problem.

### 3. Codex can finally reach the recovery flow that already exists

`agent.store.ts:4066` answers `loginRequired` by auto-opening the login flow, and
`agent-registry.mjs` defines a careful `launchLogin()` for Codex. `providers.mjs` emitted no such
event anywhere — Codex was the one agent with a `launchLogin()` and no way to trigger it. It now
emits `provider://login-required` before `provider://error`, matching `acp-runtime.mjs`'s ordering.

### 4. Auth status reflects validity, not file presence

An invalidated `auth.json` survives intact — same keys, still parseable — so `getAvailability()`
reported `authenticated: true` forever. An observed rejection now clears it until a credential
file is written again (mtime check). **No upstream call is added**: availability is polled often
and must stay free.

## Live walkthrough (macOS 26.5, arm64)

Real provider runtime, real Codex CLI, real upstream at `api.openai.com` / `chatgpt.com`.
No mocks. Driven by `scripts/walkthrough-3729.mjs` (added).

**Your token was valid again by the time I ran this** — the catalog returned 7 models, so the
captured 401 could not be reproduced from your live credentials. I induced a genuine one instead
with a structurally valid credential holding tokens the service really rejects. The 401 is real
and comes from the real service; nothing here is simulated. No real token value was copied.

### Invalid credential — before the fix

```
STEP 4 — spawn Codex and watch for login-required
  codex spawn succeeded
  sending a real prompt (this must reach upstream)...
  [codex] ERROR codex_api::endpoint::responses_websocket: failed to connect to
          websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses
  prompt failed: Reconnecting... 2/5
  provider://login-required events observed: 0        ← nothing. This is the bug.
```

### Invalid credential — after the fix

```
STEP 4 — spawn Codex and watch for login-required
  codex spawn succeeded
  sending a real prompt (this must reach upstream)...
  prompt failed: Reconnecting... 2/5
  provider://login-required events observed: 1
    agentType=codex sessionId=df37d232…

STEP 5 — availability after a REAL observed rejection
  codex authenticated: false
```

### Real credential — no false positives

```
STEP 2 — model catalog FAILED with: Timed out waiting for initialize.
         catalog error classified as auth: false     ← transient, correctly not an auth error
STEP 4 — prompt completed — credential is valid
         provider://login-required events observed: 0
STEP 5 — codex authenticated: true
```

A transient initialize timeout does **not** open a sign-in prompt the user cannot act on. That
negative control matters as much as the positive one.

### Completeness check — the enumerated list

The list this touches is the agent roster and its `authenticated` flags, read from the live
runtime via `provider_get_available_agents` rather than assumed. Codex is the only agent whose
credential can be server-side invalidated while its file remains valid on disk (Claude uses
`.credentials.json` / API-key env, Grok `.grok/auth.json`, Gemini is always `false`, LM Studio is
server-reachability). The change is therefore scoped to Codex deliberately, not by oversight.

## Out of scope, confirmed not ours

The same captured log contains:

```
codex_core::tools::router: error=exec_command failed ... rejected:
rm -f style commands are not permitted. Use a safer approach
```

That string exists nowhere in this repository — it is the Codex CLI's own command policy
rejecting an agent-authored `rm -f` cleanup line. Noted so the next reader of that log does not
chase it.

## Networked paths

No new outbound request. The Codex CLI's own calls to `chatgpt.com/backend-api/codex/models` and
`wss://api.openai.com/v1/responses` are unchanged — this reads their failures. `launchLogin()`
opens the vendor's existing OAuth flow through the already-resolved Codex binary (#1878); no
Seren Gateway path or publisher slug is involved.

## Tests

`tests/unit/codex-token-invalidated.test.ts` (new, 10 tests). The end-to-end one drives the
**real** `attachProcessListeners` with a **real child process** writing the **real captured 401
line** to a **real stderr pipe** four times, and asserts exactly one `login-required`.

The classifier tests pin the two real error texts. Confirmed against `main`: `isAuthError()`
returns **`false`** for the captured Codex invalidation message.

One existing test updated: `spawn-binary-validation.test.ts` sliced 2000 chars from
`attachProcessListeners` and my added block pushed the target past it. Window widened **and the
assertion anchored to the `error` listener**, so a `provider://error` emitted elsewhere in the
function can no longer satisfy it — strictly tighter than before.

`pnpm test`: **3076 passed, 0 failed** (445 files).
`pnpm check`: 48 warnings, **0 errors** — identical to `main`'s baseline.
`tsc`: 1 pre-existing `src/` error, identical to `main`.
