### PR TITLE
feat(happy): let a paired phone prompt a Claude or Codex terminal pane

### DIFF
--- a/bin/happy-bridge/terminal-source.mjs
+++ b/bin/happy-bridge/terminal-source.mjs
@@ -10,9 +10,14 @@ const POLL_INTERVAL_MS = 2_000;
 // thread readable on a phone, not the whole file.
 const HISTORY_EVENT_LIMIT = 40;
 const READ_CHUNK_BYTES = 1024 * 1024;
+// A prompt sent from a phone comes back in the CLI transcript with nothing to
+// say where it came from. Remember it just long enough to recognize the echo;
+// past this the CLI clearly never wrote it and the entry is dead weight.
+const ECHO_TTL_MS = 5 * 60_000;
+const MAX_TRACKED_ECHOES = 16;
 
 const REMOTE_UNSUPPORTED =
-  "This is a terminal pane on the desktop. Type into it there — remote prompting is not available yet.";
+  "This is a terminal pane on the desktop. Type into it there.";
 
 function normalizeSession(session) {
   return {
@@ -35,8 +40,31 @@ function normalizeSession(session) {
  * @param {{supervisorChannel: {call: (method: string, params?: object) => Promise<any>}, debugLog?: (message: string) => void}} options
  */
 export function createTerminalSource({ supervisorChannel, debugLog = () => {} }) {
-  /** @type {Map<string, {summary: object, path: string|null, offset: number, pending: string, replayed: boolean, announced: boolean, busy: boolean}>} */
+  /** @type {Map<string, {summary: object, path: string|null, offset: number, pending: string, replayed: boolean, announced: boolean, busy: boolean, echoes: Array<{text: string, at: number}>}>} */
   const tracked = new Map();
+
+  /**
+   * Happy renders the peer's own prompt the moment it is sent, and the CLI then
+   * writes that same text into its transcript. Marking the echo as remote lets
+   * `translate.mjs` drop it, which is the difference between one bubble and two.
+   */
+  function claimEcho(entry, text) {
+    const now = Date.now();
+    let claimed = false;
+    entry.echoes = entry.echoes.filter((echo) => {
+      if (now - echo.at > ECHO_TTL_MS) return false;
+      if (claimed || echo.text !== text) return true;
+      claimed = true;
+      return false;
+    });
+    return claimed;
+  }
+
+  function rememberEcho(entry, text) {
+    entry.echoes.push({ text, at: Date.now() });
+    // A prompt whose echo never arrives must not pin the list forever.
+    if (entry.echoes.length > MAX_TRACKED_ECHOES) entry.echoes.shift();
+  }
   let listeners = new Set();
   let pollTimer = null;
   let polling = false;
@@ -122,8 +150,25 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
         if (!includeStatus) continue;
       }
       if (event.kind === "turn-complete") entry.busy = false;
-      emit({ kind: event.kind, sessionId, payload: { ...event.payload } });
+      emitTranscriptEvent(sessionId, entry, event);
     }
+  }
+
+  /**
+   * Every transcript-derived event leaves through here so echo suppression can
+   * never be bypassed by a second emit path — including history replay, which a
+   * prompt sent moments earlier can still land in.
+   */
+  function emitTranscriptEvent(sessionId, entry, event, extra = {}) {
+    const origin =
+      event.kind === "user-message" && claimEcho(entry, event.payload?.text)
+        ? { origin: "remote" }
+        : {};
+    emit({
+      kind: event.kind,
+      sessionId,
+      payload: { ...event.payload, ...extra, ...origin },
+    });
   }
 
   async function replayHistory(sessionId, entry) {
@@ -138,7 +183,7 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
       if (event.kind === "turn-complete") entry.busy = false;
     }
     for (const event of trimmed) {
-      emit({ kind: event.kind, sessionId, payload: { ...event.payload, replay: true } });
+      emitTranscriptEvent(sessionId, entry, event, { replay: true });
     }
     entry.replayed = true;
     emit({
@@ -188,6 +233,7 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
             replayed: false,
             announced: false,
             busy: false,
+            echoes: [],
           };
           tracked.set(summary.sessionId, entry);
           // Announce first and read on the next tick. The layer resolves a
@@ -245,7 +291,23 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
       return () => listeners.delete(onEvent);
     },
 
-    sendPrompt: rejectRemoteWrite,
+    async sendPrompt(sessionId, text) {
+      const entry = tracked.get(sessionId);
+      if (!entry) throw new Error("terminal session is no longer available");
+      const response = await supervisorChannel.call("terminal_submit_prompt", {
+        sessionId,
+        prompt: text,
+      });
+      if (response?.accepted !== true) {
+        throw new Error("The terminal pane did not accept the prompt.");
+      }
+      // Track what was actually typed, not what was sent: sanitization may have
+      // changed it, and the transcript will echo the typed form.
+      rememberEcho(entry, typeof response.prompt === "string" ? response.prompt : text);
+      entry.busy = true;
+      return { accepted: true, sessionId };
+    },
+
     respondToPermission: rejectRemoteWrite,
     respondToDiffProposal: rejectRemoteWrite,
     spawn: rejectRemoteWrite,

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -1302,6 +1302,7 @@ fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
             | "provider_session_archive_lookup"
             | "terminal_list_sessions"
             | "terminal_transcript_path"
+            | "terminal_submit_prompt"
             | "identity_store"
     ) {
         return Err(error_response(id, -32601, "unknown supervisor method"));
@@ -1632,6 +1633,24 @@ async fn dispatch_supervisor_request(
                     None => json!({}),
                 },
             )
+        }
+        "terminal_submit_prompt" => {
+            let session_id = required_string(&request.params, "sessionId")?;
+            let prompt = required_string(&request.params, "prompt")?;
+            // Same fail-closed scope check the listing uses. A pane that left
+            // the advertised roots stops accepting remote prompts at the same
+            // moment it stops being visible.
+            let authorized = crate::terminal::happy_terminal_sessions(app)
+                .into_iter()
+                .any(|session| {
+                    session.session_id == session_id
+                        && is_within_advertised_root(app, &session.cwd)
+                });
+            if !authorized {
+                return Err("terminal session is not in an advertised root".to_string());
+            }
+            let typed = crate::terminal::happy_terminal_submit_prompt(app, &session_id, &prompt)?;
+            Ok(json!({ "accepted": true, "prompt": typed }))
         }
         "identity_store" => {
             let identity = request

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -3034,6 +3034,106 @@ pub fn happy_terminal_project_roots(app: &AppHandle) -> Vec<String> {
         })
 }
 
+/// Bracketed-paste terminator. Stripped from remote text so a payload cannot
+/// close its own paste bracket and have the remainder read as keystrokes.
+const PASTE_END: &str = "\x1b[201~";
+const PASTE_START: &str = "\x1b[200~";
+
+/// Reduce remote text to something a CLI pane can only read as typing.
+///
+/// Drops the paste terminator first, then every C0 control character except
+/// `\n` and `\t` plus `DEL`. Without this a paired device could send `\x03` to
+/// interrupt the agent, or an escape sequence to drive the emulator — the
+/// unscoped-`bash` shape revoked in #3578 arriving as a prompt.
+fn sanitize_remote_prompt(text: &str) -> String {
+    text.replace(PASTE_END, "")
+        .chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\t')
+        .collect()
+}
+
+/// Type a prompt into a CLI-agent pane on behalf of a paired device and submit
+/// it.
+///
+/// Bracketed paste (when the TUI has the mode on) is what keeps a multi-line
+/// prompt one prompt: the CLI takes the whole payload as literal text instead of
+/// submitting at each newline. The trailing `\r` is the submit, sent outside the
+/// bracket so it is the only key the TUI ever sees from a remote peer.
+///
+/// Plain shells are refused here as well as in the listing: a pane the bridge
+/// cannot see must also be a pane it cannot type into.
+/// Returns the text actually typed into the pane. The caller stores that rather
+/// than what it sent, so echo matching compares against one authority on what
+/// sanitization produced instead of reimplementing the rules.
+pub fn happy_terminal_submit_prompt(
+    app: &AppHandle,
+    session_id: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    let prompt = sanitize_remote_prompt(prompt);
+    if prompt.trim().is_empty() {
+        return Err("prompt is empty after sanitization".to_string());
+    }
+
+    let state = app.state::<TerminalState>();
+    let (writer, bracketed) = {
+        let buffers = state
+            .buffers
+            .lock()
+            .map_err(|err| format!("Terminal state mutex poisoned: {err}"))?;
+        let process = buffers
+            .get(session_id)
+            .ok_or_else(|| "terminal session not found".to_string())?;
+        if process.info.cli_kind.is_none() {
+            return Err("terminal session is not a CLI agent".to_string());
+        }
+        if !matches!(process.info.status, TerminalStatus::Running) {
+            return Err("terminal session is not running".to_string());
+        }
+        let bracketed = process
+            .grid
+            .lock()
+            .map(|grid| grid.bracketed_paste)
+            .unwrap_or(false);
+        (Arc::clone(&process.writer), bracketed)
+    };
+
+    let payload = if bracketed {
+        format!("{PASTE_START}{prompt}{PASTE_END}\r")
+    } else {
+        format!("{prompt}\r")
+    };
+
+    let mut writer = writer
+        .lock()
+        .map_err(|err| format!("Terminal writer mutex poisoned: {err}"))?;
+    writer
+        .write_all(payload.as_bytes())
+        .map_err(|err| format!("Failed to write remote prompt: {err}"))?;
+    writer
+        .flush()
+        .map_err(|err| format!("Failed to flush remote prompt: {err}"))?;
+    drop(writer);
+
+    // A submitted prompt is what makes the session resumable, exactly as it is
+    // for input typed on this machine.
+    let descriptor = {
+        let mut buffers = state
+            .buffers
+            .lock()
+            .map_err(|err| format!("Terminal state mutex poisoned: {err}"))?;
+        buffers.get_mut(session_id).and_then(|process| {
+            record_terminal_input_for_resume(process, &payload)
+                .then(|| descriptor_from_info(&process.info))
+                .flatten()
+        })
+    };
+    if let Some(descriptor) = descriptor {
+        upsert_descriptor(app, &state, descriptor);
+    }
+    Ok(prompt)
+}
+
 /// Resolve the on-disk transcript a CLI-agent pane is writing, so the bridge can
 /// read its conversation. `None` until the CLI has materialized the session —
 /// Claude creates its file on first activity, and Codex does not even choose a
@@ -3967,6 +4067,41 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         }
+    }
+
+    #[test]
+    fn remote_prompt_sanitization_strips_signals_and_escapes() {
+        // A raw write would let a paired device interrupt the agent or drive the
+        // emulator. Only text a user could have typed may survive.
+        assert_eq!(sanitize_remote_prompt("run tests\u{3}"), "run tests");
+        assert_eq!(
+            sanitize_remote_prompt("look\u{1b}[2Jhere"),
+            "look[2Jhere",
+            "the ESC introducing a control sequence is removed"
+        );
+        assert_eq!(sanitize_remote_prompt("a\u{7f}b"), "ab");
+        assert_eq!(sanitize_remote_prompt("submit\rnow"), "submitnow");
+    }
+
+    #[test]
+    fn remote_prompt_sanitization_cannot_escape_its_paste_bracket() {
+        // Closing the bracket early would make the remainder keystrokes again.
+        // The terminator goes first, then the interrupt it was smuggling.
+        assert_eq!(
+            sanitize_remote_prompt("hi\u{1b}[201~\u{3}rm -rf /"),
+            "hirm -rf /"
+        );
+        assert!(!sanitize_remote_prompt("hi\u{1b}[201~ping").contains(PASTE_END));
+    }
+
+    #[test]
+    fn remote_prompt_sanitization_keeps_multi_line_text() {
+        // Newlines survive because bracketed paste delivers them as text; that
+        // is what keeps a multi-line phone prompt a single prompt.
+        assert_eq!(
+            sanitize_remote_prompt("first line\nsecond line\twith tab"),
+            "first line\nsecond line\twith tab"
+        );
     }
 
     #[test]

--- a/tests/unit/happy-terminal-prompting.test.ts
+++ b/tests/unit/happy-terminal-prompting.test.ts
@@ -1,0 +1,138 @@
+// ABOUTME: Verifies remote prompts reach a terminal pane and echo back exactly once.
+// ABOUTME: Drives the real terminal source against a scripted supervisor channel.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { createTerminalSource } from "../../bin/happy-bridge/terminal-source.mjs";
+
+const SESSION = "11111111-1111-4111-8111-111111111111";
+const INTERRUPT = String.fromCharCode(3);
+
+function claudeUserLine(text: string) {
+  return `${JSON.stringify({
+    type: "user",
+    message: { role: "user", content: text },
+  })}\n`;
+}
+
+/** Mirrors the Rust sanitizer: control characters never reach the pane. */
+function typedForm(prompt: string): string {
+  return [...prompt]
+    .filter((ch) => {
+      const code = ch.charCodeAt(0);
+      return (code >= 32 && code !== 127) || ch === "\n" || ch === "\t";
+    })
+    .join("");
+}
+
+/**
+ * A supervisor channel backed by a real transcript file on disk, so the source
+ * exercises its actual read path rather than a stubbed one.
+ */
+function supervisor(transcriptPath: string | null) {
+  const submitted: Array<{ sessionId: string; prompt: string }> = [];
+  return {
+    submitted,
+    call: vi.fn(async (method: string, params: Record<string, string>) => {
+      if (method === "terminal_list_sessions") {
+        return {
+          sessions: [
+            {
+              sessionId: SESSION,
+              agentType: "claude-code",
+              cwd: "/workspace/project",
+              title: "Claude Code CLI",
+            },
+          ],
+        };
+      }
+      if (method === "terminal_transcript_path") {
+        return transcriptPath ? { path: transcriptPath } : {};
+      }
+      if (method === "terminal_submit_prompt") {
+        submitted.push({ sessionId: params.sessionId, prompt: params.prompt });
+        // Rust answers with the text it actually typed. Returning the sanitized
+        // form is what proves the source matches echoes against what was typed
+        // rather than against what the phone sent.
+        return { accepted: true, prompt: typedForm(params.prompt) };
+      }
+      throw new Error(`unexpected supervisor method: ${method}`);
+    }),
+  };
+}
+
+describe("remote prompting a terminal pane", () => {
+  it("types the prompt into the pane and reports acceptance", async () => {
+    const channel = supervisor(null);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string }> = [];
+    source.subscribe((event: { kind: string }) => events.push(event));
+    await vi.waitFor(() => expect(events.length).toBeGreaterThan(0));
+
+    await expect(source.sendPrompt(SESSION, "run the tests")).resolves.toEqual({
+      accepted: true,
+      sessionId: SESSION,
+    });
+    expect(channel.submitted).toEqual([
+      { sessionId: SESSION, prompt: "run the tests" },
+    ]);
+    source.close();
+  });
+
+  it("refuses a prompt for a pane it is not tracking", async () => {
+    const channel = supervisor(null);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    await expect(
+      source.sendPrompt("22222222-2222-4222-8222-222222222222", "hi"),
+    ).rejects.toThrow(/no longer available/);
+    expect(channel.submitted).toEqual([]);
+    source.close();
+  });
+
+  it("marks the transcript echo of its own prompt as remote so it renders once", async () => {
+    // Happy already showed the peer its prompt; the CLI then writes the same
+    // text into its transcript. `translate.mjs` drops a remote-origin
+    // user-message, which is what stops the second bubble.
+    const dir = mkdtempSync(path.join(tmpdir(), "seren-echo-"));
+    const transcript = path.join(dir, "session.jsonl");
+    writeFileSync(transcript, "");
+
+    const channel = supervisor(transcript);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    source.subscribe(
+      (event: { kind: string; payload: Record<string, unknown> }) =>
+        events.push(event),
+    );
+    await vi.waitFor(() => expect(events.length).toBeGreaterThan(0));
+
+    // The interrupt byte is stripped before typing, so the transcript records
+    // the sanitized text — the echo must still be recognized.
+    await source.sendPrompt(SESSION, `remote${INTERRUPT} prompt`);
+    writeFileSync(
+      transcript,
+      claudeUserLine("remote prompt") + claudeUserLine("typed on the desktop"),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(
+          events.filter((event) => event.kind === "user-message").length,
+        ).toBe(2);
+      },
+      { timeout: 10_000 },
+    );
+
+    const users = events.filter((event) => event.kind === "user-message");
+    expect(users[0].payload.text).toBe("remote prompt");
+    expect(users[0].payload.origin).toBe("remote");
+    // A prompt the desktop user typed has no echo to claim and stays visible.
+    expect(users[1].payload.text).toBe("typed on the desktop");
+    expect(users[1].payload.origin).toBeUndefined();
+    source.close();
+  }, 20_000);
+});


### PR DESCRIPTION
Closes #3737. Ticket **2 of 3**, following #3735.

Terminal panes were listed and readable but refused every write. Prompts from a paired phone now type into the pane and submit.

## How the pane is driven

The desktop already has one correct way to insert text into a pane — `writePromptText` (`TerminalBuffer.tsx:1812`) — and this reuses its shape rather than inventing a second one: bracketed paste with the terminator stripped, when the TUI has the mode on. That is what keeps a multi-line phone prompt **one** prompt instead of one submission per newline. The trailing carriage return is sent outside the bracket, so it is the only key a remote peer can produce.

A raw `terminal_write` to the relay would have been the unscoped shell revoked in #3578 wearing a different hat, so text is sanitized first: the paste terminator, then every C0 control character except newline and tab, plus DEL. Plain shells stay refused, exactly as in the listing.

## Echo suppression

`translate.mjs` drops a `user-message` carrying `origin: "remote"` (#3141/#3142) because Happy already rendered the peer's own prompt. The provider path gets that flag from the runtime; a terminal pane has no such channel — the prompt simply reappears in the CLI transcript. Without suppression **every phone-sent prompt would render twice.**

Two details that decide whether this actually works:

- Rust answers with the text it *typed*, and the bridge remembers that instead of what it sent. Sanitization can change the text, and the transcript echoes the typed form; matching on the sent form would miss.
- Every transcript-derived event now leaves through a single emit path. The first draft left `replayHistory` emitting directly, so a prompt sent moments before history replay was published unsuppressed. The echo test caught it.

## Live evidence — macOS arm64, real build of this branch

Run in a validation instance alongside the normal app (separate bundle identifier, real `HOME` so the CLIs stay authenticated). **No production code was changed to enable testing.**

**The plain shell is excluded by the real bridge, not just by a unit test.** Three panes created from the launcher in one folder:

```
cliKind=None    title='Terminal'                <- plain shell
cliKind=claude  title='✳ Claude Code'
cliKind=codex   title='issue-3737-happy-term…'
total panes: 3
```

The real bridge process, spawned by the real app and talking over the real supervisor channel, reported:

```
[HappyBridge] happy-bridge: config ok, 1 sessions   <- Claude pane only
[HappyBridge] happy-bridge: config ok, 2 sessions   <- after the Codex pane was added
```

**Three panes, two sessions.** The shell is present as a pane and absent from what the relay can reach, and both CLI kinds are picked up. This instance had no provider sessions, so the count is unambiguously the terminal source.

The folder used was consented through the real Settings checkbox and written to disk as exactly one root:

```
consented: ['issue-3737-happy-terminal-prompting']
```

That folder has zero conversations of any kind — it is offered purely on the CLI-pane descriptors added in #3735.

## Tests

3 Rust + 3 unit, scoped to the security surface and the double-render bug:

```
remote_prompt_sanitization_strips_signals_and_escapes ... ok
remote_prompt_sanitization_cannot_escape_its_paste_bracket ... ok
remote_prompt_sanitization_keeps_multi_line_text ... ok
```

The echo test drives the real terminal source against a real transcript file on disk and asserts a phone-sent prompt is marked remote while a desktop-typed one stays visible.

Full suites: **448 files / 3,093 unit tests**, **1,331 Rust tests**, 0 failures.

## Not demonstrated

Sending an actual prompt from a phone. That requires a paired device, and at the repo owner's direction this moves to release testing rather than blocking the merge.

## Next

**#3** — approval prompts. A non-YOLO pane still stops at a TUI approval that is never written to the transcript, so the phone sees the turn go quiet with no explanation until that ticket lands.
