### PR TITLE
feat(happy): answer terminal approval prompts from a phone

### DIFF
--- a/bin/happy-bridge/terminal-source.mjs
+++ b/bin/happy-bridge/terminal-source.mjs
@@ -19,6 +19,37 @@ const MAX_TRACKED_ECHOES = 16;
 const REMOTE_UNSUPPORTED =
   "This is a terminal pane on the desktop. Type into it there.";
 
+/**
+ * Approval options are numbered on screen, so their ids are digits and match
+ * none of the layer's affirmative/deny vocabularies. Classifying the label
+ * gives `selectApprovalOption` something to reason about when a phone answers
+ * with a plain approve/deny rather than naming an option.
+ */
+export function classifyApprovalOption(label) {
+  const text = String(label ?? "").toLowerCase();
+  if (/^(no|don't|do not|cancel|reject|deny)\b/.test(text)) return "reject_once";
+  if (/don't ask again|allow all|remember|this session|future|always/.test(text)) {
+    return "allow_always";
+  }
+  return "allow_once";
+}
+
+function approvalEventPayload(approval) {
+  const options = (Array.isArray(approval?.options) ? approval.options : []).map(
+    (option) => ({
+      optionId: option.optionId,
+      name: option.label,
+      kind: classifyApprovalOption(option.label),
+    }),
+  );
+  return {
+    requestId: approval.requestId,
+    toolName: "Terminal approval",
+    description: approval.question,
+    options,
+  };
+}
+
 function normalizeSession(session) {
   return {
     sessionId: session.sessionId,
@@ -193,6 +224,44 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
     });
   }
 
+  /**
+   * Approvals are drawn on screen and never written to either CLI's transcript,
+   * so they are polled from the rendered grid rather than read from the tail.
+   */
+  async function syncApproval(sessionId, entry) {
+    let approval = null;
+    try {
+      const response = await supervisorChannel.call("terminal_pending_approval", {
+        sessionId,
+      });
+      approval = response?.approval ?? null;
+    } catch (error) {
+      debugLog(`terminal approval poll failed: ${error}`);
+      return;
+    }
+
+    const requestId = approval?.requestId ?? null;
+    if (requestId === entry.approvalRequestId) return;
+
+    if (entry.approvalRequestId) {
+      // Answered on the desktop, or replaced by a different prompt. Either way
+      // the card the phone is showing is no longer actionable.
+      emit({
+        kind: "permission-resolved",
+        sessionId,
+        payload: { requestId: entry.approvalRequestId },
+      });
+    }
+    entry.approvalRequestId = requestId;
+    if (approval) {
+      emit({
+        kind: "permission-request",
+        sessionId,
+        payload: approvalEventPayload(approval),
+      });
+    }
+  }
+
   async function advance(sessionId, entry) {
     if (!entry.path) {
       entry.path = await resolveTranscriptPath(sessionId);
@@ -234,6 +303,7 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
             announced: false,
             busy: false,
             echoes: [],
+            approvalRequestId: null,
           };
           tracked.set(summary.sessionId, entry);
           // Announce first and read on the next tick. The layer resolves a
@@ -249,6 +319,7 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
         } catch (error) {
           debugLog(`terminal transcript read failed: ${error}`);
         }
+        await syncApproval(summary.sessionId, entry);
       }
       for (const [sessionId, entry] of tracked) {
         if (seen.has(sessionId)) continue;
@@ -308,7 +379,21 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
       return { accepted: true, sessionId };
     },
 
-    respondToPermission: rejectRemoteWrite,
+    async respondToPermission(sessionId, requestId, optionId) {
+      const entry = tracked.get(sessionId);
+      if (!entry) throw new Error("terminal session is no longer available");
+      // Rust re-reads the screen and refuses if the prompt changed, so a stale
+      // answer cannot land on whatever replaced it.
+      await supervisorChannel.call("terminal_respond_to_approval", {
+        sessionId,
+        requestId,
+        optionId,
+      });
+      entry.approvalRequestId = null;
+      emit({ kind: "permission-resolved", sessionId, payload: { requestId } });
+      return { ok: true };
+    },
+
     respondToDiffProposal: rejectRemoteWrite,
     spawn: rejectRemoteWrite,
 

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -1190,6 +1190,18 @@ fn is_within_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -
         .any(|root| candidate.starts_with(&root))
 }
 
+/// A terminal pane is reachable only while it is a live CLI pane inside a
+/// folder the user still shares. Re-checked on every supervisor call rather
+/// than once at listing time, so revoking a folder revokes reads, prompts, and
+/// approval answers at the same moment.
+fn terminal_session_is_authorized(app: &AppHandle, session_id: &str) -> bool {
+    crate::terminal::happy_terminal_sessions(app)
+        .into_iter()
+        .any(|session| {
+            session.session_id == session_id && is_within_advertised_root(app, &session.cwd)
+        })
+}
+
 /// Serialize an already-canonical path in the same form Node's `realpath`
 /// returns. Windows' Rust canonicalizer uses verbatim paths (`\\?\C:\...` or
 /// `\\?\UNC\...`), while Node returns ordinary DOS/UNC paths. This conversion
@@ -1303,6 +1315,8 @@ fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
             | "terminal_list_sessions"
             | "terminal_transcript_path"
             | "terminal_submit_prompt"
+            | "terminal_pending_approval"
+            | "terminal_respond_to_approval"
             | "identity_store"
     ) {
         return Err(error_response(id, -32601, "unknown supervisor method"));
@@ -1614,13 +1628,7 @@ async fn dispatch_supervisor_request(
             let session_id = required_string(&request.params, "sessionId")?;
             // A pane that left the advertised roots stops yielding a transcript
             // as well as a listing, so revoking a folder also stops the reads.
-            let authorized = crate::terminal::happy_terminal_sessions(app)
-                .into_iter()
-                .any(|session| {
-                    session.session_id == session_id
-                        && is_within_advertised_root(app, &session.cwd)
-                });
-            if !authorized {
+            if !terminal_session_is_authorized(app, &session_id) {
                 return Err("terminal session is not in an advertised root".to_string());
             }
             // Built by joining the home directory, never canonicalized, so it
@@ -1640,17 +1648,38 @@ async fn dispatch_supervisor_request(
             // Same fail-closed scope check the listing uses. A pane that left
             // the advertised roots stops accepting remote prompts at the same
             // moment it stops being visible.
-            let authorized = crate::terminal::happy_terminal_sessions(app)
-                .into_iter()
-                .any(|session| {
-                    session.session_id == session_id
-                        && is_within_advertised_root(app, &session.cwd)
-                });
-            if !authorized {
+            if !terminal_session_is_authorized(app, &session_id) {
                 return Err("terminal session is not in an advertised root".to_string());
             }
             let typed = crate::terminal::happy_terminal_submit_prompt(app, &session_id, &prompt)?;
             Ok(json!({ "accepted": true, "prompt": typed }))
+        }
+        "terminal_pending_approval" => {
+            let session_id = required_string(&request.params, "sessionId")?;
+            if !terminal_session_is_authorized(app, &session_id) {
+                return Err("terminal session is not in an advertised root".to_string());
+            }
+            Ok(
+                match crate::terminal::happy_terminal_pending_approval(app, &session_id) {
+                    Some(approval) => json!({ "approval": approval }),
+                    None => json!({}),
+                },
+            )
+        }
+        "terminal_respond_to_approval" => {
+            let session_id = required_string(&request.params, "sessionId")?;
+            let request_id = required_string(&request.params, "requestId")?;
+            let option_id = required_string(&request.params, "optionId")?;
+            if !terminal_session_is_authorized(app, &session_id) {
+                return Err("terminal session is not in an advertised root".to_string());
+            }
+            crate::terminal::happy_terminal_respond_to_approval(
+                app,
+                &session_id,
+                &request_id,
+                &option_id,
+            )?;
+            Ok(json!({ "ok": true }))
         }
         "identity_store" => {
             let identity = request

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, VecDeque},
     env,
+    hash::{DefaultHasher, Hash, Hasher},
     io::{Read, Write},
     path::{Path, PathBuf},
     sync::{
@@ -3034,6 +3035,135 @@ pub fn happy_terminal_project_roots(app: &AppHandle) -> Vec<String> {
         })
 }
 
+/// One selectable answer on a CLI approval prompt. `option_id` is the digit the
+/// TUI expects, so answering never needs cursor movement.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalApprovalOption {
+    pub option_id: String,
+    pub label: String,
+}
+
+/// An approval the CLI is currently drawing and waiting on.
+///
+/// These are rendered UI, never written to either CLI's transcript, which is
+/// why the transcript reader cannot see them and this has to read the screen.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalApproval {
+    /// Digest of the rendered question and options. Answering re-derives it and
+    /// refuses on a mismatch, so a stale reply cannot land on the prompt that
+    /// replaced the one the phone saw.
+    pub request_id: String,
+    pub question: String,
+    pub options: Vec<TerminalApprovalOption>,
+}
+
+/// Modals that share the numbered-option shape but must never be answered by a
+/// remote peer. Granting filesystem trust is not an agent approval, and a phone
+/// tapping "Yes" would authorize a folder the user never opened.
+const NON_APPROVAL_MODAL_MARKERS: [&str; 2] = ["trust this folder", "do you trust the files"];
+
+/// Lead-ins observed on the real TUIs: Claude asks `Do you want to …?`, Codex
+/// asks `Allow Codex to run \`…\``. A bare question mark also qualifies so a
+/// reworded prompt still registers.
+fn is_approval_question(line: &str) -> bool {
+    let lowered = line.to_lowercase();
+    lowered.starts_with("do you want")
+        || lowered.starts_with("allow codex to run")
+        || lowered.starts_with("allow ")
+        || lowered.ends_with('?')
+}
+
+/// Parse `1. Yes` / `❯2. No` / `  3. Yes, and don't ask again`, returning the
+/// digit and its label.
+fn parse_approval_option(line: &str) -> Option<(u32, String)> {
+    let trimmed = line.trim_start_matches(['❯', '>', '*', ' ', '\t']);
+    let (digits, rest) = trimmed.split_at(trimmed.find(|c: char| !c.is_ascii_digit())?);
+    let index: u32 = digits.parse().ok()?;
+    if index == 0 {
+        return None;
+    }
+    let label = rest.strip_prefix('.').or_else(|| rest.strip_prefix(')'))?;
+    let label = label.trim();
+    (!label.is_empty()).then(|| (index, label.to_string()))
+}
+
+fn approval_request_id(question: &str, options: &[TerminalApprovalOption]) -> String {
+    let mut hasher = DefaultHasher::new();
+    question.hash(&mut hasher);
+    for option in options {
+        option.option_id.hash(&mut hasher);
+        option.label.hash(&mut hasher);
+    }
+    format!("terminal-approval-{:016x}", hasher.finish())
+}
+
+/// Recover the approval a pane is waiting on from its rendered screen.
+///
+/// Reads bottom-up because a TUI draws the live prompt last, so the newest
+/// numbered block is the one awaiting an answer.
+pub(crate) fn detect_terminal_approval(lines: &[String]) -> Option<TerminalApproval> {
+    let mut end = lines.len();
+    while end > 0 {
+        // Find the last line that looks like an option, then walk up while the
+        // indices stay contiguous.
+        let Some(last) = (0..end).rev().find(|i| parse_approval_option(&lines[*i]).is_some())
+        else {
+            return None;
+        };
+        let mut first = last;
+        while first > 0 && parse_approval_option(&lines[first - 1]).is_some() {
+            first -= 1;
+        }
+
+        let mut options = Vec::new();
+        let mut expected = 1;
+        for line in &lines[first..=last] {
+            let (index, label) = parse_approval_option(line)?;
+            if index != expected {
+                options.clear();
+                break;
+            }
+            expected += 1;
+            options.push(TerminalApprovalOption {
+                option_id: index.to_string(),
+                label,
+            });
+        }
+
+        if options.len() >= 2 {
+            let question = lines[..first]
+                .iter()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .map(|line| line.trim().to_string())
+                .unwrap_or_default();
+            if is_approval_question(&question) {
+                let haystack = format!("{question} {}", options
+                    .iter()
+                    .map(|option| option.label.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" "))
+                .to_lowercase();
+                if NON_APPROVAL_MODAL_MARKERS
+                    .iter()
+                    .any(|marker| haystack.contains(marker))
+                {
+                    return None;
+                }
+                return Some(TerminalApproval {
+                    request_id: approval_request_id(&question, &options),
+                    question,
+                    options,
+                });
+            }
+        }
+        end = first;
+    }
+    None
+}
+
 /// Bracketed-paste terminator. Stripped from remote text so a payload cannot
 /// close its own paste bracket and have the remainder read as keystrokes.
 const PASTE_END: &str = "\x1b[201~";
@@ -3062,6 +3192,94 @@ fn sanitize_remote_prompt(text: &str) -> String {
 ///
 /// Plain shells are refused here as well as in the listing: a pane the bridge
 /// cannot see must also be a pane it cannot type into.
+/// Render a pane's visible screen as plain text lines, one per grid row.
+fn rendered_grid_lines(grid: &TerminalGrid) -> Vec<String> {
+    let snapshot = grid.snapshot();
+    let cols = snapshot.cols as usize;
+    if cols == 0 {
+        return Vec::new();
+    }
+    snapshot
+        .cells
+        .chunks(cols)
+        .map(|row| {
+            row.iter()
+                .map(|cell| char::from_u32(cell.ch).filter(|ch| *ch != '\0').unwrap_or(' '))
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+/// The approval a CLI pane is currently waiting on, if any.
+pub fn happy_terminal_pending_approval(
+    app: &AppHandle,
+    session_id: &str,
+) -> Option<TerminalApproval> {
+    let state = app.state::<TerminalState>();
+    let grid = {
+        let buffers = state.buffers.lock().ok()?;
+        let process = buffers.get(session_id)?;
+        process.info.cli_kind?;
+        if !matches!(process.info.status, TerminalStatus::Running) {
+            return None;
+        }
+        Arc::clone(&process.grid)
+    };
+    let lines = grid.lock().ok().map(|grid| rendered_grid_lines(&grid))?;
+    detect_terminal_approval(&lines)
+}
+
+/// Answer a pending approval on behalf of a paired device.
+///
+/// The screen is re-read here rather than trusted from when the phone was told
+/// about it: between the two, the desktop user may have answered, the CLI may
+/// have moved on, or a different prompt may now occupy the same rows. Requiring
+/// the same `request_id` — a digest of the rendered prompt — means a stale reply
+/// is refused instead of landing on whatever replaced it.
+pub fn happy_terminal_respond_to_approval(
+    app: &AppHandle,
+    session_id: &str,
+    request_id: &str,
+    option_id: &str,
+) -> Result<(), String> {
+    let approval = happy_terminal_pending_approval(app, session_id)
+        .ok_or_else(|| "no approval is pending on this terminal".to_string())?;
+    if approval.request_id != request_id {
+        return Err("the approval prompt changed before the answer arrived".to_string());
+    }
+    let option = approval
+        .options
+        .iter()
+        .find(|option| option.option_id == option_id)
+        .ok_or_else(|| "approval option was not offered".to_string())?;
+
+    let state = app.state::<TerminalState>();
+    let writer = {
+        let buffers = state
+            .buffers
+            .lock()
+            .map_err(|err| format!("Terminal state mutex poisoned: {err}"))?;
+        let process = buffers
+            .get(session_id)
+            .ok_or_else(|| "terminal session not found".to_string())?;
+        Arc::clone(&process.writer)
+    };
+    // Only the digit. Never arbitrary bytes, and never a newline the TUI could
+    // read as a second answer.
+    let mut writer = writer
+        .lock()
+        .map_err(|err| format!("Terminal writer mutex poisoned: {err}"))?;
+    writer
+        .write_all(option.option_id.as_bytes())
+        .map_err(|err| format!("Failed to answer approval: {err}"))?;
+    writer
+        .flush()
+        .map_err(|err| format!("Failed to flush approval answer: {err}"))?;
+    Ok(())
+}
+
 /// Returns the text actually typed into the pane. The caller stores that rather
 /// than what it sent, so echo matching compares against one authority on what
 /// sanitization produced instead of reimplementing the rules.
@@ -4067,6 +4285,103 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         }
+    }
+
+    fn screen(lines: &[&str]) -> Vec<String> {
+        lines.iter().map(|line| line.to_string()).collect()
+    }
+
+    #[test]
+    fn detects_a_real_claude_approval_screen() {
+        // Captured from claude 2.1.224 driven through a PTY.
+        let approval = detect_terminal_approval(&screen(&[
+            " Create file",
+            "approval-test.txt",
+            "  1 banana",
+            "",
+            " Do you want to create approval-test.txt?",
+            "❯1. Yes",
+            "   2. Yes, allow all edits during this session (shift+tab)",
+            "  3. No",
+            "",
+            "Esc to cancel · Tab to amend",
+        ]))
+        .expect("a pending approval");
+
+        assert_eq!(approval.question, "Do you want to create approval-test.txt?");
+        assert_eq!(
+            approval.options,
+            vec![
+                TerminalApprovalOption { option_id: "1".into(), label: "Yes".into() },
+                TerminalApprovalOption {
+                    option_id: "2".into(),
+                    label: "Yes, allow all edits during this session (shift+tab)".into(),
+                },
+                TerminalApprovalOption { option_id: "3".into(), label: "No".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn detects_a_codex_exec_approval_screen() {
+        // Wording taken from the shipped codex binary's own strings.
+        let approval = detect_terminal_approval(&screen(&[
+            "Allow Codex to run `rm -rf build`?",
+            "❯ 1. Yes",
+            "  2. Yes, and don't ask again for commands that start with `rm`",
+            "  3. No",
+        ]))
+        .expect("a pending approval");
+
+        assert_eq!(approval.options.len(), 3);
+        assert_eq!(approval.options[1].option_id, "2");
+    }
+
+    #[test]
+    fn refuses_to_treat_the_folder_trust_modal_as_an_approval() {
+        // Same numbered shape, but answering it from a phone would grant
+        // filesystem trust to a folder the user never opened.
+        assert_eq!(
+            detect_terminal_approval(&screen(&[
+                "Quick safety check: Is this a project you created or one you trust?",
+                "❯1. Yes, I trust this folder",
+                "  2. No, exit",
+                "Enter to confirm · Esc to cancel",
+            ])),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_screens_with_no_pending_prompt() {
+        assert_eq!(detect_terminal_approval(&screen(&[])), None);
+        assert_eq!(
+            detect_terminal_approval(&screen(&[
+                "Ran 1 shell command",
+                "  1 banana",
+                "hello-from-approval",
+            ])),
+            None,
+            "a numbered diff line is not an option list"
+        );
+    }
+
+    #[test]
+    fn request_id_changes_when_the_prompt_changes() {
+        // The id is what stops a late answer landing on a different prompt.
+        let first = detect_terminal_approval(&screen(&[
+            "Do you want to create a.txt?",
+            "❯1. Yes",
+            "  2. No",
+        ]))
+        .expect("first");
+        let second = detect_terminal_approval(&screen(&[
+            "Do you want to create b.txt?",
+            "❯1. Yes",
+            "  2. No",
+        ]))
+        .expect("second");
+        assert_ne!(first.request_id, second.request_id);
     }
 
     #[test]

--- a/tests/unit/happy-terminal-approvals.test.ts
+++ b/tests/unit/happy-terminal-approvals.test.ts
@@ -1,0 +1,177 @@
+// ABOUTME: Verifies terminal approval prompts reach the phone and can be answered.
+// ABOUTME: Drives the real terminal source against a scripted supervisor channel.
+
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import {
+  classifyApprovalOption,
+  createTerminalSource,
+} from "../../bin/happy-bridge/terminal-source.mjs";
+
+const SESSION = "11111111-1111-4111-8111-111111111111";
+
+const APPROVAL = {
+  requestId: "terminal-approval-abc123",
+  question: "Do you want to create approval-test.txt?",
+  options: [
+    { optionId: "1", label: "Yes" },
+    { optionId: "2", label: "Yes, allow all edits during this session" },
+    { optionId: "3", label: "No" },
+  ],
+};
+
+function supervisor(state: { approval: unknown }) {
+  const answered: Array<Record<string, string>> = [];
+  return {
+    answered,
+    call: vi.fn(async (method: string, params: Record<string, string>) => {
+      if (method === "terminal_list_sessions") {
+        return {
+          sessions: [
+            {
+              sessionId: SESSION,
+              agentType: "claude-code",
+              cwd: "/workspace/project",
+              title: "Claude Code CLI",
+            },
+          ],
+        };
+      }
+      if (method === "terminal_transcript_path") return {};
+      if (method === "terminal_pending_approval") {
+        return state.approval ? { approval: state.approval } : {};
+      }
+      if (method === "terminal_respond_to_approval") {
+        answered.push(params);
+        return { ok: true };
+      }
+      throw new Error(`unexpected supervisor method: ${method}`);
+    }),
+  };
+}
+
+describe("terminal approval prompts", () => {
+  it("classifies option labels so a plain approve or deny picks the right one", () => {
+    expect(classifyApprovalOption("Yes")).toBe("allow_once");
+    expect(classifyApprovalOption("Yes, allow all edits during this session")).toBe(
+      "allow_always",
+    );
+    expect(
+      classifyApprovalOption("Yes, and don't ask again for commands that start with `rm`"),
+    ).toBe("allow_always");
+    expect(classifyApprovalOption("No")).toBe("reject_once");
+    expect(classifyApprovalOption("No, and tell Codex what to do differently")).toBe(
+      "reject_once",
+    );
+  });
+
+  it("publishes a pending approval as an actionable request", async () => {
+    const state = { approval: APPROVAL };
+    const channel = supervisor(state);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    source.subscribe(
+      (event: { kind: string; payload: Record<string, unknown> }) => events.push(event),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(events.some((event) => event.kind === "permission-request")).toBe(true);
+      },
+      { timeout: 8000 },
+    );
+
+    const request = events.find((event) => event.kind === "permission-request");
+    expect(request?.payload.requestId).toBe(APPROVAL.requestId);
+    expect(request?.payload.description).toBe(APPROVAL.question);
+    expect(request?.payload.options).toEqual([
+      { optionId: "1", name: "Yes", kind: "allow_once" },
+      {
+        optionId: "2",
+        name: "Yes, allow all edits during this session",
+        kind: "allow_always",
+      },
+      { optionId: "3", name: "No", kind: "reject_once" },
+    ]);
+    source.close();
+  }, 15000);
+
+  it("publishes exactly one request while the same prompt stays on screen", async () => {
+    const state = { approval: APPROVAL };
+    const channel = supervisor(state);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string }> = [];
+    source.subscribe((event: { kind: string }) => events.push(event));
+
+    await vi.waitFor(
+      () => {
+        expect(events.filter((e) => e.kind === "permission-request").length).toBe(1);
+      },
+      { timeout: 8000 },
+    );
+    // Several more polls must not re-announce the same prompt.
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    expect(events.filter((e) => e.kind === "permission-request").length).toBe(1);
+    source.close();
+  }, 20000);
+
+  it("resolves the card when the approval is answered on the desktop", async () => {
+    const state: { approval: unknown } = { approval: APPROVAL };
+    const channel = supervisor(state);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    source.subscribe(
+      (event: { kind: string; payload: Record<string, unknown> }) => events.push(event),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(events.some((e) => e.kind === "permission-request")).toBe(true);
+      },
+      { timeout: 8000 },
+    );
+    state.approval = null;
+    await vi.waitFor(
+      () => {
+        expect(events.some((e) => e.kind === "permission-resolved")).toBe(true);
+      },
+      { timeout: 8000 },
+    );
+    expect(
+      events.find((e) => e.kind === "permission-resolved")?.payload.requestId,
+    ).toBe(APPROVAL.requestId);
+    source.close();
+  }, 20000);
+
+  it("answers the approval through the supervisor and clears the card", async () => {
+    const state = { approval: APPROVAL };
+    const channel = supervisor(state);
+    const source = createTerminalSource({ supervisorChannel: channel });
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    source.subscribe(
+      (event: { kind: string; payload: Record<string, unknown> }) => events.push(event),
+    );
+    await vi.waitFor(
+      () => {
+        expect(events.some((e) => e.kind === "permission-request")).toBe(true);
+      },
+      { timeout: 8000 },
+    );
+
+    await expect(
+      source.respondToPermission(SESSION, APPROVAL.requestId, "3"),
+    ).resolves.toEqual({ ok: true });
+
+    expect(channel.answered).toEqual([
+      { sessionId: SESSION, requestId: APPROVAL.requestId, optionId: "3" },
+    ]);
+    expect(
+      events.some(
+        (e) =>
+          e.kind === "permission-resolved" && e.payload.requestId === APPROVAL.requestId,
+      ),
+    ).toBe(true);
+    source.close();
+  }, 15000);
+});


### PR DESCRIPTION
Closes #3739. Ticket **3 of 3**, completing #3732 (#3735) and #3737 (#3738).

A non-YOLO pane stopped dead at a TUI approval. Approvals are rendered UI and are **never written to either CLI's transcript**, so the reader added in #3735 had no signal — the phone watched the turn go silent with no explanation and no way to answer.

## Read the grid, not the byte stream

`TerminalGrid` (`terminal.rs:137`) is already a real terminal emulator, and it is the only thing that can reconstruct these screens: both CLIs redraw incrementally, and Codex repaints character by character. Detection reads rendered rows from its snapshot.

Detection is structural rather than a table of vendor strings — a question line followed by a contiguous run of numbered options — so a reworded prompt still registers.

## Grounded in real output, not assumption

**Claude**, captured from a live 2.1.224 TUI driven through a PTY:

```
 Do you want to create approval-test.txt?
❯1. Yes
   2. Yes, allow all edits during this session (shift+tab)
  3. No
```

**Codex**, taken from the shipped binary's own strings (`strings $(command -v codex)`) rather than by burning account quota:

```
Allow Codex to run `…`
Yes, and don't ask again for commands that start with `…`
```

Both are pinned as tests.

## The trap this audit caught

The folder-trust gate wears the **same numbered shape**:

```
❯1. Yes, I trust this folder
  2. No, exit
```

A naive detector would let a phone tap grant filesystem trust to a folder the user never opened. It is excluded explicitly, with a test.

## Safety

- **Stale answers are refused.** `requestId` is a digest of the rendered question and options. Answering re-reads the screen and requires the same digest, so a tap that arrives after the desktop user already answered — or after a different prompt took the same rows — is rejected rather than applied to whatever replaced it.
- **Only the option digit is written.** Never arbitrary bytes, and no newline the TUI could read as a second answer.
- CLI panes only; advertised-root re-check on every call. That check was repeated in four places and is now one `terminal_session_is_authorized` helper.

Option ids are digits, which match none of the layer's affirmative/deny vocabularies, so each label is classified (`allow_once` / `allow_always` / `reject_once`). That is what lets `selectApprovalOption` resolve a plain approve/deny from the phone to the right row.

## Tests

5 Rust + 5 unit, all passing — the real Claude screen, the Codex screen, folder-trust exclusion, request-id change detection, label classification, single-announce while a prompt persists, desktop-side resolution, and answering through the supervisor.

Full suites: **449 files / 3,098 unit tests**, **1,336 Rust tests**, 0 failures.

## Watch this one in production

Answering writes the digit alone, on the expectation that these numbered menus select on keypress. **If a TUI turns out to need digit-then-Enter, the answer will select but not confirm and the pane will stay blocked** — a visible, benign failure rather than a wrong action. I chose that over sending Enter, which would submit a stray empty prompt if the digit already confirmed. Confirming this needs a live approval, which costs account quota; per the repo owner's direction it is being verified in the release instead.

Per the same direction, no walkthrough was run for this ticket.
