### PR TITLE
fix(happy): fix transcript decoding and pane ownership (#3743, #3744)

### DIFF
--- a/bin/happy-bridge/composite-source.mjs
+++ b/bin/happy-bridge/composite-source.mjs
@@ -25,12 +25,17 @@ export function createCompositeSource({ provider, terminal, debugLog = () => {} 
           // A terminal listing failure must not blank the provider sessions the
           // phone is already using.
           debugLog(`terminal session listing failed: ${error}`);
-          return [];
+          // Distinguished from an empty listing below: a user with no panes
+          // returns the same `[]`, and forgetting who owns what on a transient
+          // failure sends every later call for those panes to the provider.
+          return null;
         }),
       ]);
-      terminalSessionIds.clear();
-      for (const session of terminalSessions) terminalSessionIds.add(session.sessionId);
-      return [...providerSessions, ...terminalSessions];
+      if (terminalSessions) {
+        terminalSessionIds.clear();
+        for (const session of terminalSessions) terminalSessionIds.add(session.sessionId);
+      }
+      return [...providerSessions, ...(terminalSessions ?? [])];
     },
 
     subscribe(onEvent) {

--- a/bin/happy-bridge/terminal-source.mjs
+++ b/bin/happy-bridge/terminal-source.mjs
@@ -71,7 +71,7 @@ function normalizeSession(session) {
  * @param {{supervisorChannel: {call: (method: string, params?: object) => Promise<any>}, debugLog?: (message: string) => void}} options
  */
 export function createTerminalSource({ supervisorChannel, debugLog = () => {} }) {
-  /** @type {Map<string, {summary: object, path: string|null, offset: number, pending: string, replayed: boolean, announced: boolean, busy: boolean, echoes: Array<{text: string, at: number}>}>} */
+  /** @type {Map<string, {summary: object, path: string|null, offset: number, pending: string, decoder: TextDecoder, replayed: boolean, announced: boolean, busy: boolean, echoes: Array<{text: string, at: number}>}>} */
   const tracked = new Map();
 
   /**
@@ -135,6 +135,8 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
       // file whose earlier bytes are already published.
       entry.offset = info.size;
       entry.pending = "";
+      // Any bytes the decoder was holding belong to the discarded file.
+      entry.decoder = new TextDecoder("utf-8");
       return [];
     }
     if (info.size === entry.offset) return [];
@@ -149,7 +151,13 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
         const { bytesRead } = await handle.read(buffer, 0, length, position);
         if (bytesRead <= 0) break;
         position += bytesRead;
-        text += buffer.subarray(0, bytesRead).toString("utf8");
+        // Streaming decode: a multi-byte character split across a chunk — or
+        // across a poll, when a live CLI flushes mid-character — is held as
+        // bytes until the rest arrives. Decoding each chunk on its own turned
+        // both halves into U+FFFD and corrupted the message.
+        text += entry.decoder.decode(buffer.subarray(0, bytesRead), {
+          stream: true,
+        });
       }
       entry.offset = position;
       const lines = text.split("\n");
@@ -299,6 +307,7 @@ export function createTerminalSource({ supervisorChannel, debugLog = () => {} })
             path: null,
             offset: 0,
             pending: "",
+            decoder: new TextDecoder("utf-8"),
             replayed: false,
             announced: false,
             busy: false,

--- a/tests/unit/happy-composite-source.test.ts
+++ b/tests/unit/happy-composite-source.test.ts
@@ -87,6 +87,43 @@ describe("composite session source", () => {
     expect(terminal.spawn).not.toHaveBeenCalled();
   });
 
+  it("keeps terminal ownership when a later listing fails", async () => {
+    // A failed listing used to be absorbed into `[]`, which is also what a user
+    // with no panes returns. Forgetting ownership sent every later call for a
+    // live pane to the provider, and an idle pane emits no event to restore it.
+    const provider = stubSource([{ sessionId: "provider-1" }]);
+    const terminal = stubSource([{ sessionId: "terminal-1" }]);
+    const source = createCompositeSource({ provider, terminal });
+    await source.listSessions();
+
+    terminal.listSessions.mockRejectedValueOnce(
+      new Error("supervisor RPC timed out"),
+    );
+    await source.listSessions();
+
+    await source.sendPrompt("terminal-1", "still mine");
+
+    expect(terminal.sendPrompt).toHaveBeenCalledWith("terminal-1", "still mine");
+    expect(provider.sendPrompt).not.toHaveBeenCalled();
+  });
+
+  it("drops terminal ownership when the listing succeeds and the pane is gone", async () => {
+    // The other half of the same invariant: a real empty listing means the pane
+    // exited, and its id must stop routing to the terminal source.
+    const provider = stubSource([]);
+    const terminal = stubSource([{ sessionId: "terminal-1" }]);
+    const source = createCompositeSource({ provider, terminal });
+    await source.listSessions();
+
+    terminal.listSessions.mockResolvedValueOnce([]);
+    await source.listSessions();
+
+    await source.cancel("terminal-1");
+
+    expect(provider.cancel).toHaveBeenCalledWith("terminal-1");
+    expect(terminal.cancel).not.toHaveBeenCalled();
+  });
+
   it("sends an unknown session to the provider, which owns spawning", async () => {
     const provider = stubSource([]);
     const terminal = stubSource([]);

--- a/tests/unit/happy-terminal-transcript-decode.test.ts
+++ b/tests/unit/happy-terminal-transcript-decode.test.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Verifies transcript text survives a multi-byte character on a read boundary.
+// ABOUTME: Drives the real terminal source against a real file written to disk.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { createTerminalSource } from "../../bin/happy-bridge/terminal-source.mjs";
+
+const SESSION = "33333333-3333-4333-8333-333333333333";
+/** Mirrors READ_CHUNK_BYTES in terminal-source.mjs. */
+const READ_CHUNK_BYTES = 1024 * 1024;
+
+function supervisor(transcriptPath: string) {
+  return {
+    call: vi.fn(async (method: string) => {
+      if (method === "terminal_list_sessions") {
+        return {
+          sessions: [
+            {
+              sessionId: SESSION,
+              agentType: "claude-code",
+              cwd: "/workspace/project",
+              title: "Claude Code CLI",
+            },
+          ],
+        };
+      }
+      if (method === "terminal_transcript_path") return { path: transcriptPath };
+      if (method === "terminal_pending_approval") return {};
+      throw new Error(`unexpected supervisor method: ${method}`);
+    }),
+  };
+}
+
+describe("terminal transcript decoding", () => {
+  it("keeps a multi-byte character that straddles a read boundary intact", async () => {
+    // Measured on real data: 16 of 716 Codex transcripts larger than one chunk
+    // have a UTF-8 continuation byte sitting exactly on a 1 MiB boundary.
+    // Decoding each chunk on its own turned both halves into U+FFFD.
+    const dir = mkdtempSync(path.join(tmpdir(), "seren-decode-"));
+    const transcript = path.join(dir, "session.jsonl");
+
+    // `isMeta` lines publish nothing, so they pad the file to the boundary
+    // without adding events the assertions would have to skip.
+    const metaPrefix =
+      '{"isMeta":true,"type":"user","message":{"role":"user","content":"';
+    const metaSuffix = '"}}\n';
+    const targetPrefix = '{"type":"user","message":{"role":"user","content":"';
+
+    // Land the first byte of a 3-byte character one byte before the boundary so
+    // the read splits it. Written unescaped, because it is the raw bytes on
+    // disk that get split — a `…` escape would be plain ASCII and prove
+    // nothing.
+    const padBytes = READ_CHUNK_BYTES - 1 - targetPrefix.length;
+    const padding =
+      metaPrefix +
+      "a".repeat(padBytes - metaPrefix.length - metaSuffix.length) +
+      metaSuffix;
+    const text = "… boundary survived";
+    const contents = `${padding}${targetPrefix}${text}"}}\n`;
+    writeFileSync(transcript, contents);
+
+    // The character must genuinely straddle the boundary, or this test proves
+    // nothing about the bug it guards.
+    const bytes = Buffer.from(contents, "utf8");
+    expect(bytes.length).toBeGreaterThan(READ_CHUNK_BYTES);
+    expect(bytes[READ_CHUNK_BYTES] & 0xc0).toBe(0x80);
+
+    const source = createTerminalSource({
+      supervisorChannel: supervisor(transcript),
+    });
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    source.subscribe(
+      (event: { kind: string; payload: Record<string, unknown> }) =>
+        events.push(event),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(
+          events.filter((event) => event.kind === "user-message").length,
+        ).toBe(1);
+      },
+      { timeout: 10_000 },
+    );
+
+    const [message] = events.filter((event) => event.kind === "user-message");
+    expect(message.payload.text).toBe(text);
+    expect(String(message.payload.text)).not.toContain("�");
+    source.close();
+  }, 20_000);
+});


### PR DESCRIPTION
Closes #3743 and #3744.

Two defects in the terminal session source, both found by auditing the read
path added alongside the phone-approval work.

readNewLines decoded each read chunk on its own, so a multi-byte character
straddling a boundary became U+FFFD on both sides. Two boundaries hit this: the
1 MiB chunk boundary inside a read, and the read/EOF boundary between polls,
where the trailing partial line was carried forward as an already-decoded
string. Scanning real transcripts, 16 of 716 Codex files larger than one chunk
have a continuation byte sitting exactly on a boundary. The replacement lands
inside a JSON string, so parsing still succeeds and no events are lost — the
effect is one mangled character in one message. A streaming TextDecoder held on
the entry closes both boundaries, matching the invariant LineFramer already
enforces on the Rust side.

createCompositeSource absorbed a failed terminal listing into an empty array,
which is also what a user with no panes returns, and cleared the ownership set
either way. Every later per-session call for a live pane then routed to the
provider. listSessions is not polled — it runs at registration and on a cache
miss — and an idle pane emits no event to restore ownership, so the window is
unbounded. Failure is now distinguished from emptiness and ownership is kept.

Both fixes are covered by regression tests that fail without them: the decode
test drives the real source against a real file whose character genuinely
straddles the boundary, and asserts the byte layout so it cannot silently stop
testing the bug.

A bounded tail read was considered for the full-file replay and rejected on
measurement: across 567 real transcripts over 2 MB, the last 40 publishable
events can span 13.78 MB of a 14.2 MB file, so any useful cap would truncate
replay.


## Checks

- `pnpm test` — 3101 passed, 0 failed (450 files)
- `pnpm check` — clean
- Both fixes verified to fail without the change: reverting the decoder yields `\ufffd\ufffd\ufffd boundary survived`; reverting the routing guard sends the prompt to the provider.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
