### PR TITLE
chore(release): curated notes for v3.79.0

### DIFF
--- a/.github/release-notes/v3.79.0.md
+++ b/.github/release-notes/v3.79.0.md
@@ -1,0 +1,49 @@
+## What's New
+
+Your Claude Code and Codex terminal panes are now reachable from a paired phone — read the conversation, send a prompt, and answer approval prompts without walking back to the desk. Plus local-model fixes that restore Seren publisher access on LM Studio, and a Claude session-capacity gate that stops turning a busy moment into a dead end.
+
+## 📱 Terminal Panes on Your Phone
+
+The Claude Code and Codex chats you start from the launcher's **Command line** section are terminal panes, not agent conversations, and Happy Remote could not see them at all. All three parts of that gap are closed.
+
+- Running Claude and Codex panes now appear as remote sessions, with their conversation read from the CLI's own transcript. Plain shells are never exposed, and a pane is reachable only while it lives in a folder you have shared — re-checked on every call, so withdrawing a folder revokes access immediately (#3732, #3735).
+- A prompt sent from your phone is typed into the pane and submitted, arriving as one prompt even when it spans several lines. Your own prompt renders once, not twice (#3737, #3738).
+- A pane stopped at an approval no longer goes silent. Approvals are rendered UI that neither CLI writes to its transcript, so they are read from the pane's screen; a stale answer is refused rather than landing on whatever replaced the prompt (#3739, #3740).
+- Folders used only for CLI panes now offer their own sharing checkbox in Happy Remote settings — previously they had no agent conversation, so they could never be shared (#3735).
+
+Approvals from a phone are limited to agent actions. A folder-trust prompt is never offered remotely, on either CLI (#3739, #3741).
+
+## 🧠 Local Models (LM Studio)
+
+- LM Studio models now load at a 200K context window instead of inheriting whatever LM Studio last used — often 8K, which culled the Seren tool catalog down to a handful and left the agent unable to discover any publisher. The window is bounded by the model's trained maximum and by what actually fits in memory, read from the model's own attention geometry, with a load-backoff when the target does not fit (#3725, #3726).
+- Publisher discovery, enumeration, and execution tools are now prioritized when a large tool catalog has to be trimmed to fit, so Seren publisher routing survives on a small local model instead of disappearing (#3719, #3720).
+
+## 🤖 Claude Session Capacity
+
+- Running out of local Claude session slots is treated as backpressure rather than a fatal error: an idle holder is reclaimed and the spawn retried instead of handing you a dead end (#3727, #3734).
+- While a spawn waits for a slot, the queue position is shown instead of an unexplained spinner followed by a timeout (#3727, #3734).
+- Paired threads are counted correctly. A paired thread's planner is a real Claude session holding a real slot, which the capacity accounting previously could not see (#3727, #3734).
+- A warm standby no longer takes the last slot, and one whose user never returned no longer holds a slot indefinitely (#3727, #3734).
+- Promoting a standby now releases the retired session as soon as the new prompt is accepted, rather than holding its slot for the length of the turn (#3727, #3734).
+
+## 🔑 Codex Sign-in
+
+- Server-side credential invalidation is now surfaced and offers sign-in. Codex reports this only as a line on its own stderr — every RPC keeps succeeding and the model list keeps serving a cached catalog — so the thread previously looked healthy while silently failing (#3729, #3736).
+
+## 💬 Chat
+
+- A non-Claude gateway model is now told which model it is and is no longer handed the private-models catalog tools, so it stops looking itself up, concluding it does not exist, and offering to re-run your task on a different model (#3721, #3722).
+
+## 📚 Model Search
+
+- Model search now matches words in any order, so `opus claude` and `anthropic opus` find the same models as `claude opus` (#3731, #3733).
+
+## ⚙️ Reliability
+
+- Provider runtime diagnostics can no longer be silenced by the child process. A child writing without ever ending a line used to park the reader indefinitely — no output, no error, and unbounded memory growth — and a single non-UTF-8 byte used to end the channel permanently. Output is now framed with a hard per-line cap, survives bad bytes, and a stalled or dead channel on a live child is reported (#3728, #3730).
+- Terminal transcript text is no longer corrupted when a multi-byte character falls on a read boundary (#3743, #3745).
+- A transient failure listing terminal panes no longer misroutes later calls for those panes to the provider runtime (#3744, #3745).
+
+## 🖥️ UI
+
+- Folder headers in the thread sidebar no longer show an "active" dot beside the folder's total thread count — the two meant different things, so a folder with one running thread out of three read as "3 active" (#3723, #3724).


### PR DESCRIPTION
Curated release notes for v3.79.0.

Minor bump: four `feat` commits add user-facing capability since v3.78.1 — phone-paired terminal panes (three tickets) and order-independent model search.

Notes cover all 13 commits in `v3.78.1..main`, grouped by what a user would notice rather than by subsystem.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
