### PR TITLE
feat(agent): Planner + Runner — pick any planner + any runner (#3748)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -381,6 +381,8 @@ function isAgentAuthenticated(agentType) {
       return false;
     case "claude-codex":
       return hasClaudeCredentials() && hasCodexCredentials();
+    case "planner-runner":
+      return hasClaudeCredentials() && hasCodexCredentials();
     default:
       return false;
   }
@@ -420,6 +422,10 @@ const AGENT_CLI_PROVISIONING = Object.freeze({
   codex: { kind: "npm", target: "codex" },
   "claude-code": { kind: "npm", target: "claude" },
   "claude-codex": {
+    kind: "derived",
+    dependencies: ["claude-code", "codex"],
+  },
+  "planner-runner": {
     kind: "derived",
     dependencies: ["claude-code", "codex"],
   },
@@ -1000,6 +1006,46 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         // agent type, so automatic login targets the right CLI. A manual
         // paired login starts with the planner; the executor's own
         // login-required event follows if Codex also needs auth.
+        definitions["claude-code"].launchLogin();
+      },
+    },
+    "planner-runner": {
+      type: "planner-runner",
+      name: "Planner + Runner",
+      description: "Paired workflow — pick any agent to plan and any to run",
+      command: "claude",
+      async getAvailability() {
+        const claudeInstalled = resolveInstalledClaudeBinary() !== "claude";
+        const codexInstalled = resolveInstalledCodexBinary() !== "codex";
+        const missing = [
+          ...(claudeInstalled ? [] : ["Claude Code"]),
+          ...(codexInstalled ? [] : ["Codex"]),
+        ];
+        return {
+          type: "planner-runner",
+          name: "Planner + Runner",
+          description: "Paired workflow — pick any agent to plan and any to run",
+          command: "claude",
+          available: true,
+          authenticated: isAgentAuthenticated("planner-runner"),
+          ...(missing.length === 0
+            ? {}
+            : {
+                unavailableReason: `Seren installs the ${missing.join(" and ")} CLI${missing.length > 1 ? "s" : ""} automatically when you start the agent.`,
+              }),
+        };
+      },
+      async canSpawn() {
+        return true;
+      },
+      async ensureCli() {
+        // The default pairing spawns Claude + Codex; a swapped role's CLI is
+        // ensured by the frontend before the swap reaches the runtime.
+        const claudeBin = await definitions["claude-code"].ensureCli();
+        await definitions.codex.ensureCli();
+        return claudeBin;
+      },
+      launchLogin() {
         definitions["claude-code"].launchLogin();
       },
     },

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -39,7 +39,7 @@ import {
 
 const DEFAULT_BASE_URL = "http://localhost:1234";
 const LMSTUDIO_AGENT_TYPE = "lmstudio";
-const MAX_TOOL_ITERATIONS = 25;
+export const MAX_TOOL_ITERATIONS = 25;
 const DEFAULT_CONTEXT_LENGTH = 4096;
 const RESERVED_OUTPUT_TOKENS = 1024;
 const REQUEST_INPUT_OVERHEAD_TOKENS = 128;
@@ -522,7 +522,7 @@ async function parseMcpResponse(response) {
   return { sessionId, result: payload.result ?? null };
 }
 
-function createMcpGatewayClient({ capability, url } = {}) {
+export function createMcpGatewayClient({ capability, url } = {}) {
   let nextId = 1;
   let sessionId = null;
   let initialized = false;
@@ -675,7 +675,7 @@ export function schemaFromMcpTool(tool) {
   };
 }
 
-async function buildToolCatalog(session) {
+export async function buildToolCatalog(session) {
   const used = new Set();
   const tools = [];
   const handlers = new Map();
@@ -1220,7 +1220,10 @@ export function isToolIncompatibilityError(message) {
 }
 
 async function streamOpenAiResponse({ session, body, signal, onContent }) {
-  const response = await fetch(`${openAiBaseUrl(session.baseUrl)}/chat/completions`, {
+  const chatUrl =
+    session.chatCompletionsUrl ??
+    `${openAiBaseUrl(session.baseUrl)}/chat/completions`;
+  const response = await fetch(chatUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -1323,7 +1326,7 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
  * tools for that model and retry, so the user always gets a reply instead of a
  * silent empty response.
  */
-async function runChatCompletion({ session, tools, signal, onContent }) {
+export async function runChatCompletion({ session, tools, signal, onContent }) {
   const requestModelId = session.currentModelId;
   const useTools =
     tools.length > 0 &&
@@ -1487,7 +1490,7 @@ function buildPermissionRequestEvent(
   };
 }
 
-function listPendingPermissions(session) {
+export function listPendingPermissions(session) {
   return Array.from(session.pendingPermissions.values()).map(
     (pending) => pending.permissionRequest,
   );
@@ -1537,7 +1540,7 @@ async function requestPermission(session, toolCall, args, fileAccess) {
   return permission;
 }
 
-async function executeToolCall(session, toolCall, handlers) {
+export async function executeToolCall(session, toolCall, handlers) {
   const args = safeJsonParse(toolCall.function.arguments, {});
   const handler = handlers.get(toolCall.function.name);
   const title = handler?.displayName ?? toolCall.function.name;

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -808,6 +808,7 @@ export function createPairedRuntime({ emit, inner }) {
       paired: {
         state: paired.state,
         activeRole: paired.activeRole,
+        agentType: paired.agentType,
         planner: roleStatusView(paired.roles.planner),
         executor: roleStatusView(paired.roles.executor),
         ledger: ledgerStatusView(paired),

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -1,9 +1,14 @@
-// ABOUTME: Paired Claude + Codex coordinator — Claude plans/reviews, Codex executes (#2368).
+// ABOUTME: Paired planner/executor coordinator — one agent plans/reviews, another executes (#2368, #3748).
 // ABOUTME: Presents one paired session to the frontend; inner runtime events are remapped with role attribution.
 
 import { randomUUID } from "node:crypto";
 
 export const PAIRED_AGENT_TYPE = "claude-codex";
+export const GENERAL_PAIRED_AGENT_TYPE = "planner-runner";
+export const PAIRED_AGENT_TYPES = new Set([
+  PAIRED_AGENT_TYPE,
+  GENERAL_PAIRED_AGENT_TYPE,
+]);
 
 const PAIRED_LEDGER_VERSION = 1;
 const DEFAULT_EXECUTOR_MAX_ATTEMPTS = 3;
@@ -91,20 +96,29 @@ export function resolvePlannerModel(explicitModelId, availableModels) {
   return { modelId: null, reason: "default", name: null };
 }
 
-const ROLE_DEFS = {
-  planner: {
-    role: "planner",
-    label: "Claude",
-    agentType: "claude-code",
-    defaultModelLabel: "Claude Default",
-  },
-  executor: {
-    role: "executor",
-    label: "Codex",
-    agentType: "codex",
-    defaultModelLabel: "Codex Recommended",
+// Fixed pairing for the legacy `claude-codex` wrapper; also the default
+// pairing a new `planner-runner` thread opens with (#3748).
+const ROLE_AGENT_DEFAULTS = { planner: "claude-code", executor: "codex" };
+
+// Per-agent presentation for either role. Labels feed the setup declaration,
+// handoffs, and role prompts; defaultModelLabel is the float-forward text the
+// selectors show until the user pins a model.
+const AGENT_IDENTITIES = {
+  "claude-code": { label: "Claude", defaultModelLabel: "Claude Default" },
+  codex: { label: "Codex", defaultModelLabel: "Codex Recommended" },
+  gemini: { label: "Antigravity", defaultModelLabel: "Antigravity Default" },
+  grok: { label: "Grok", defaultModelLabel: "Grok Default" },
+  lmstudio: { label: "LM Studio", defaultModelLabel: "LM Studio Default" },
+  seren: { label: "Seren", defaultModelLabel: "Seren Default" },
+  "seren-private": {
+    label: "Seren Private",
+    defaultModelLabel: "Private Default",
   },
 };
+
+export function pairedRoleAgentTypes() {
+  return Object.keys(AGENT_IDENTITIES);
+}
 
 function modelDisplayName(roleState) {
   const id = roleState.models?.currentModelId;
@@ -127,7 +141,7 @@ function describeRoleModel(roleState) {
     ? (modelDisplayName(roleState) ??
         MODEL_DISPLAY_LABELS[roleState.pinnedModelId] ??
         roleState.pinnedModelId)
-    : ROLE_DEFS[roleState.role].defaultModelLabel;
+    : roleState.defaultModelLabel;
   const current = modelDisplayName(roleState);
   return current && current !== base ? `${base} · currently ${current}` : base;
 }
@@ -137,13 +151,15 @@ export function buildPairedDeclaration(paired) {
   const executor = paired.roles.executor;
   const plannerEffort = effortDisplayValue(planner) ?? "runtime default";
   const executorEffort = effortDisplayValue(executor) ?? "runtime default";
+  const runnerWord = paired.runnerWord ?? "executor";
+  const runnerTitle = runnerWord === "runner" ? "Runner" : "Executor";
   return [
     "**Setup**",
     "",
-    "- Claude is planner and reviewer.",
-    "- Codex is executor for code edits, commands, and tests.",
+    `- ${planner.label} is planner and reviewer.`,
+    `- ${executor.label} is ${runnerWord} for code edits, commands, and tests.`,
     `- Planner: ${describeRoleModel(planner)} · ${plannerEffort} effort.`,
-    `- Executor: ${describeRoleModel(executor)} · ${executorEffort} effort.`,
+    `- ${runnerTitle}: ${describeRoleModel(executor)} · ${executorEffort} effort.`,
     "- Handoffs appear inline when ownership changes.",
   ].join("\n");
 }
@@ -195,10 +211,10 @@ function createSentinelFilter(sentinel) {
   };
 }
 
-function buildPlannerPrompt(userPrompt) {
+function buildPlannerPrompt(userPrompt, executorLabel) {
   return [
     "You are the PLANNER in a paired workflow. A separate executor agent",
-    "(Codex) will make all code edits, run commands, and run tests — you do",
+    `(${executorLabel}) will make all code edits, run commands, and run tests — you do`,
     "not. Read only the files you need to write an accurate plan.",
     "",
     "If the user is not ready for execution — they asked you to discuss,",
@@ -230,12 +246,12 @@ function buildPlannerPrompt(userPrompt) {
   ].join("\n");
 }
 
-function buildExecutorPrompt(userPrompt, planText, phase) {
+function buildExecutorPrompt(userPrompt, planText, phase, plannerLabel) {
   const assertionLines = phase.assertions
     .map((assertion) => `${assertion.id}: ${assertion.description}`)
     .join("\n");
   return [
-    "You are the EXECUTOR in a paired workflow. Claude's plan is approved",
+    `You are the EXECUTOR in a paired workflow. ${plannerLabel}'s plan is approved`,
     "guidance, but the repository is the source of truth. Inspect the",
     "relevant files, callers, tests, and config before editing. If the plan",
     "conflicts with the code, adapt and report the deviation.",
@@ -289,14 +305,14 @@ function buildExecutorPrompt(userPrompt, planText, phase) {
     "Original user request:",
     userPrompt,
     "",
-    "Approved plan from Claude:",
+    `Approved plan from ${plannerLabel}:`,
     planText || "(The planner did not produce plan text; use the user request directly.)",
   ].join("\n");
 }
 
-function buildRepairPrompt(userPrompt, planText, phase, diagnostics) {
+function buildRepairPrompt(userPrompt, planText, phase, diagnostics, plannerLabel) {
   return [
-    buildExecutorPrompt(userPrompt, planText, phase),
+    buildExecutorPrompt(userPrompt, planText, phase, plannerLabel),
     "",
     `This is bounded repair attempt ${phase.attempts.length + 1}.`,
     "Repair only the failed or missing assertions below, then re-run their",
@@ -309,9 +325,14 @@ function buildRepairPrompt(userPrompt, planText, phase, diagnostics) {
   ].join("\n");
 }
 
-function buildReviewPrompt(userPrompt, executorReport, checkpointSummary) {
+function buildReviewPrompt(
+  userPrompt,
+  executorReport,
+  checkpointSummary,
+  executorLabel,
+) {
   return [
-    "You are the REVIEWER in a paired workflow. Codex (the executor) just",
+    `You are the REVIEWER in a paired workflow. ${executorLabel} (the executor) just`,
     "implemented your plan. Review the work below against the user's request.",
     "Do NOT edit files. Verify the changes look correct, call out any gaps or",
     "risks, and finish with a short summary for the user: who planned, what",
@@ -325,7 +346,7 @@ function buildReviewPrompt(userPrompt, executorReport, checkpointSummary) {
     "Original user request:",
     userPrompt,
     "",
-    "Executor report from Codex:",
+    `Executor report from ${executorLabel}:`,
     executorReport || "(The executor did not produce a report.)",
   ].join("\n");
 }
@@ -626,9 +647,16 @@ export function createPairedRuntime({ emit, inner }) {
   const pairedSessions = new Map();
   const innerToPaired = new Map();
 
-  function createRoleState(role) {
+  function createRoleState(role, agentType) {
+    const identity = AGENT_IDENTITIES[agentType] ?? {
+      label: agentType,
+      defaultModelLabel: "Default",
+    };
     return {
-      ...ROLE_DEFS[role],
+      role,
+      agentType,
+      label: identity.label,
+      defaultModelLabel: identity.defaultModelLabel,
       innerSessionId: null,
       agentSessionId: null,
       models: undefined,
@@ -653,6 +681,17 @@ export function createPairedRuntime({ emit, inner }) {
     return JSON.stringify({
       planner,
       executor,
+      // The chosen pairing rides in the composite so a resumed thread spawns
+      // the same agents even if the conversation row's pairedConfig is stale.
+      // The legacy claude-codex composite stays byte-compatible (#3748).
+      ...(paired.agentType === GENERAL_PAIRED_AGENT_TYPE
+        ? {
+            agents: {
+              planner: paired.roles.planner.agentType,
+              executor: paired.roles.executor.agentType,
+            },
+          }
+        : {}),
       ledger: persistedLedger(paired.ledger),
     });
   }
@@ -765,7 +804,7 @@ export function createPairedRuntime({ emit, inner }) {
       sessionId: paired.id,
       status,
       agentSessionId: compositeAgentSessionId(paired),
-      agentInfo: { name: "Claude + Codex", version: "paired" },
+      agentInfo: { name: paired.displayName, version: "paired" },
       paired: {
         state: paired.state,
         activeRole: paired.activeRole,
@@ -989,12 +1028,36 @@ export function createPairedRuntime({ emit, inner }) {
     if (role === "planner") {
       const info = await inner.spawnSession({
         ...base,
-        agentType: ROLE_DEFS.planner.agentType,
+        agentType: roleState.agentType,
         approvalPolicy: params.approvalPolicy,
-        reasoningEffort: config.effort ?? params.reasoningEffort,
+        // The global claudeReasoningEffort default only applies to a Claude
+        // planner; other planner agents keep their own runtime default unless
+        // the user pinned an effort (#3748).
+        reasoningEffort:
+          config.effort ??
+          (roleState.agentType === "claude-code"
+            ? params.reasoningEffort
+            : undefined),
         initialModelId: config.modelId ?? undefined,
       });
       roleState.agentSessionId = info?.agentSessionId ?? roleState.agentSessionId;
+
+      if (roleState.agentType !== "claude-code") {
+        // Non-Claude planners float on their own runtime default (#3748
+        // decision: no cross-agent auto-pin). Honor an explicit user pin only.
+        if (config.modelId) {
+          try {
+            await inner.setSessionModel({
+              sessionId: innerSessionId,
+              modelId: config.modelId,
+            });
+          } catch {
+            roleState.pinnedModelId = null;
+            roleState.notice = `Pinned model ${config.modelId} is no longer available. Using the ${roleState.label} default instead.`;
+          }
+        }
+        return info;
+      }
 
       // Pin the planner/reviewer model. Prefer the user's explicit choice, then
       // Fable 5 (#2825), then the newest Opus when the account has no Fable
@@ -1034,13 +1097,16 @@ export function createPairedRuntime({ emit, inner }) {
 
     const info = await inner.spawnSession({
       ...base,
-      agentType: ROLE_DEFS.executor.agentType,
+      agentType: roleState.agentType,
       // Match direct Codex sessions: paired executor work should start in
-      // Permission Mode: Auto, not inherit Claude's default on-request policy.
+      // Permission Mode: Auto, not inherit the planner's default on-request
+      // policy. Runtimes without an equivalent mode map or ignore it.
       approvalPolicy: "on-failure",
       initialModelId: config.modelId ?? undefined,
       reasoningEffort: config.effort ?? undefined,
-      codexDefaultIntent: "paired-executor",
+      ...(roleState.agentType === "codex"
+        ? { codexDefaultIntent: "paired-executor" }
+        : {}),
     });
     roleState.agentSessionId = info?.agentSessionId ?? roleState.agentSessionId;
 
@@ -1083,14 +1149,39 @@ export function createPairedRuntime({ emit, inner }) {
     return info;
   }
 
+  function resolveRoleAgent(role, wrapperType, pairedConfig, resumeAgents) {
+    if (wrapperType !== GENERAL_PAIRED_AGENT_TYPE) {
+      return ROLE_AGENT_DEFAULTS[role];
+    }
+    const candidate =
+      resumeAgents?.[role] ?? pairedConfig?.[role]?.agentType ?? null;
+    return candidate && AGENT_IDENTITIES[candidate]
+      ? candidate
+      : ROLE_AGENT_DEFAULTS[role];
+  }
+
   async function spawnSession(params) {
     const pairedId = params.localSessionId ?? randomUUID();
     const resumeState = parseResumeState(params.resumeAgentSessionId);
     const resumeIds = resumeState.resumeIds;
 
+    const wrapperType =
+      params.agentType === GENERAL_PAIRED_AGENT_TYPE
+        ? GENERAL_PAIRED_AGENT_TYPE
+        : PAIRED_AGENT_TYPE;
+    const resumeAgents = resumeIds?.agents ?? null;
+
     const paired = {
       id: pairedId,
       cwd: params.cwd,
+      agentType: wrapperType,
+      displayName:
+        wrapperType === GENERAL_PAIRED_AGENT_TYPE
+          ? "Planner + Runner"
+          : "Claude + Codex",
+      runnerWord:
+        wrapperType === GENERAL_PAIRED_AGENT_TYPE ? "runner" : "executor",
+      spawnParams: params,
       status: "initializing",
       createdAt: new Date().toISOString(),
       timeoutSecs: params.timeoutSecs ?? undefined,
@@ -1098,8 +1189,14 @@ export function createPairedRuntime({ emit, inner }) {
       state: "idle",
       activeRole: null,
       roles: {
-        planner: createRoleState("planner"),
-        executor: createRoleState("executor"),
+        planner: createRoleState(
+          "planner",
+          resolveRoleAgent("planner", wrapperType, params.paired, resumeAgents),
+        ),
+        executor: createRoleState(
+          "executor",
+          resolveRoleAgent("executor", wrapperType, params.paired, resumeAgents),
+        ),
       },
       ledger: resumeState.ledger,
       resumeIds,
@@ -1137,7 +1234,7 @@ export function createPairedRuntime({ emit, inner }) {
 
       return {
         id: paired.id,
-        agentType: PAIRED_AGENT_TYPE,
+        agentType: paired.agentType,
         cwd: paired.cwd,
         status: paired.status,
         createdAt: paired.createdAt,
@@ -1294,7 +1391,7 @@ export function createPairedRuntime({ emit, inner }) {
         planText = await runRoleTurn(
           paired,
           "planner",
-          buildPlannerPrompt(prompt),
+          buildPlannerPrompt(prompt, paired.roles.executor.label),
           context,
         );
         collectMeta("planner", phase);
@@ -1335,11 +1432,11 @@ export function createPairedRuntime({ emit, inner }) {
       if (phase.status !== "reviewing" || !executorReport || !checkpoint) {
         emitHandoff(
           paired,
-          resumable ? "Ledger" : "Claude",
-          "Codex",
+          resumable ? "Ledger" : paired.roles.planner.label,
+          paired.roles.executor.label,
           resumable
-            ? `${phase.id} resumed directly with Codex; planner re-entry was blocked.`
-            : "Claude handed off to Codex to make the approved code changes.",
+            ? `${phase.id} resumed directly with ${paired.roles.executor.label}; planner re-entry was blocked.`
+            : `${paired.roles.planner.label} handed off to ${paired.roles.executor.label} to make the approved code changes.`,
         );
         phase.status = "executing";
         setPhase(paired, "executing", "executor");
@@ -1356,8 +1453,14 @@ export function createPairedRuntime({ emit, inner }) {
                       `Attempt ${attempt.number}: ${attempt.diagnostics}`,
                   )
                   .join("\n"),
+                paired.roles.planner.label,
               )
-            : buildExecutorPrompt(phase.userPrompt, planText, phase);
+            : buildExecutorPrompt(
+                phase.userPrompt,
+                planText,
+                phase,
+                paired.roles.planner.label,
+              );
         while (phase.attempts.length < phase.budget.maxAttempts) {
           executorReport = await runRoleTurn(
             paired,
@@ -1420,15 +1523,16 @@ export function createPairedRuntime({ emit, inner }) {
                   `Attempt ${attempt.number}: ${attempt.diagnostics}`,
               )
               .join("\n"),
+            paired.roles.planner.label,
           );
         }
       }
 
       emitHandoff(
         paired,
-        "Codex",
-        "Claude",
-        "Codex handed back to Claude at the declared ledger checkpoint.",
+        paired.roles.executor.label,
+        paired.roles.planner.label,
+        `${paired.roles.executor.label} handed back to ${paired.roles.planner.label} at the declared ledger checkpoint.`,
       );
       phase.status = "reviewing";
       setPhase(paired, "reviewing", "planner");
@@ -1440,6 +1544,7 @@ export function createPairedRuntime({ emit, inner }) {
           phase.userPrompt,
           executorReport,
           checkpointContext(paired.ledger, phase),
+          paired.roles.executor.label,
         ),
       );
       collectMeta("planner", phase);
@@ -1542,7 +1647,7 @@ export function createPairedRuntime({ emit, inner }) {
   async function listSessions() {
     return Array.from(pairedSessions.values()).map((paired) => ({
       id: paired.id,
-      agentType: PAIRED_AGENT_TYPE,
+      agentType: paired.agentType,
       cwd: paired.cwd,
       status: paired.status,
       createdAt: paired.createdAt,
@@ -1560,6 +1665,45 @@ export function createPairedRuntime({ emit, inner }) {
       );
     }
     return paired.roles[role];
+  }
+
+  /**
+   * Swap one role to a different agent mid-thread (#3748). The old inner leg
+   * is terminated and a fresh leg spawns with the new agent's defaults; the
+   * other role and the ledger are untouched. Pins do not carry across agents —
+   * a model pinned on Codex means nothing to Antigravity.
+   */
+  async function setRoleAgent({ sessionId, role, agentType }) {
+    const paired = requirePaired(sessionId);
+    if (paired.agentType !== GENERAL_PAIRED_AGENT_TYPE) {
+      throw new Error("Role agents are fixed for Claude + Codex threads.");
+    }
+    if (!AGENT_IDENTITIES[agentType]) {
+      throw new Error(`Unknown paired role agent: ${agentType}`);
+    }
+    if (paired.currentPrompt) {
+      throw new Error("Wait for the current turn to finish before changing agents.");
+    }
+    const previous = requireRole(paired, role);
+    if (previous.agentType === agentType) return;
+
+    if (previous.innerSessionId) {
+      try {
+        await inner.terminateSession({ sessionId: previous.innerSessionId });
+      } catch {
+        // Best-effort: the old leg may already be gone.
+      }
+      innerToPaired.delete(previous.innerSessionId);
+    }
+    if (paired.resumeIds?.[role]) {
+      // A fresh agent cannot resume the retired agent's provider session.
+      paired.resumeIds = { ...paired.resumeIds, [role]: null };
+    }
+
+    paired.roles[role] = createRoleState(role, agentType);
+    await spawnRole(paired, role, paired.spawnParams, { [role]: {} });
+    refreshDeclaration(paired);
+    emitPairedStatus(paired);
   }
 
   async function setSessionModel({ sessionId, modelId, role }) {
@@ -1670,6 +1814,11 @@ export function createPairedRuntime({ emit, inner }) {
           innerSessionId,
           pairedSessionId: owner.pairedId,
           role: owner.role,
+          pairedAgentType:
+            pairedSessions.get(owner.pairedId)?.agentType ?? PAIRED_AGENT_TYPE,
+          roleAgentType:
+            pairedSessions.get(owner.pairedId)?.roles?.[owner.role]?.agentType ??
+            null,
         }),
       );
     },
@@ -1679,6 +1828,7 @@ export function createPairedRuntime({ emit, inner }) {
     cancelPrompt,
     terminateSession,
     listSessions,
+    setRoleAgent,
     setSessionModel,
     updateSessionConfigOption,
     setPermissionMode,

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -63,6 +63,9 @@ const pairedRuntimeModule = await loadAgentRuntimeModule(
 // still recognizes the type and routes it to the unavailable stub.
 const PAIRED_AGENT_TYPE =
   pairedRuntimeModule.module?.PAIRED_AGENT_TYPE ?? "claude-codex";
+const PAIRED_AGENT_TYPES =
+  pairedRuntimeModule.module?.PAIRED_AGENT_TYPES ??
+  new Set(["claude-codex", "planner-runner"]);
 
 const CODEX_DEFAULT_INTENTS = new Set(["direct", "paired-executor"]);
 const CODEX_DIRECT_PREFERRED_MODELS = ["gpt-5.6-sol", "gpt-5.6"];
@@ -1920,7 +1923,7 @@ export function createProviderHandlers({
   }) {
     const settings = { approvalPolicy, sandboxMode, networkEnabled };
 
-    if (agentType === "codex" || agentType === PAIRED_AGENT_TYPE) {
+    if (agentType === "codex" || PAIRED_AGENT_TYPES.has(agentType)) {
       // Direct Codex and the paired executor both intentionally start with
       // Codex's on-failure policy, independent of Claude's global default.
       const defaultModeId = modeFromApprovalPolicy("on-failure");
@@ -1982,7 +1985,7 @@ export function createProviderHandlers({
       codexDefaultIntent,
     } = params;
 
-    if (agentType === PAIRED_AGENT_TYPE) {
+    if (PAIRED_AGENT_TYPES.has(agentType)) {
       return pairedRuntime.spawnSession(params);
     }
 
@@ -2586,7 +2589,9 @@ export function createProviderHandlers({
           // The id the frontend actually holds in state.sessions: the paired
           // wrapper for an inner planner, otherwise the session itself.
           ownerSessionId: owner?.pairedSessionId ?? holder.sessionId,
-          ownerAgentType: owner ? PAIRED_AGENT_TYPE : holder.agentType,
+          ownerAgentType: owner
+            ? (owner.pairedAgentType ?? PAIRED_AGENT_TYPE)
+            : holder.agentType,
           pairedRole: owner?.role ?? null,
         };
       }),

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -53,6 +53,11 @@ const lmStudioRuntimeModule = await loadAgentRuntimeModule(
   "lmstudio",
   () => import("./lmstudio-runtime.mjs"),
 );
+const serenRuntimeModule = await loadAgentRuntimeModule(
+  "seren-hosted",
+  () => import("./seren-runtime.mjs"),
+);
+
 const pairedRuntimeModule = await loadAgentRuntimeModule(
   "claude-codex",
   () => import("./paired-runtime.mjs"),
@@ -66,6 +71,9 @@ const PAIRED_AGENT_TYPE =
 const PAIRED_AGENT_TYPES =
   pairedRuntimeModule.module?.PAIRED_AGENT_TYPES ??
   new Set(["claude-codex", "planner-runner"]);
+const SEREN_HOSTED_AGENT_TYPES =
+  serenRuntimeModule.module?.SEREN_HOSTED_AGENT_TYPES ??
+  new Set(["seren", "seren-private"]);
 
 const CODEX_DEFAULT_INTENTS = new Set(["direct", "paired-executor"]);
 const CODEX_DIRECT_PREFERRED_MODELS = ["gpt-5.6-sol", "gpt-5.6"];
@@ -1796,6 +1804,13 @@ export function createProviderHandlers({
     { emit, runtimeMode },
   );
 
+  const serenRuntime = instantiateAgentRuntime(
+    "seren-hosted",
+    serenRuntimeModule,
+    "createSerenHostedRuntime",
+    { emit, runtimeMode },
+  );
+
   async function withTemporaryCodexSession(cwd, callback) {
     const processHandle = spawnCodex(cwd);
     const session = createCodexSessionRecord({
@@ -2003,6 +2018,10 @@ export function createProviderHandlers({
 
     if (agentType === "lmstudio") {
       return lmStudioRuntime.spawnSession(params);
+    }
+
+    if (SEREN_HOSTED_AGENT_TYPES.has(agentType)) {
+      return serenRuntime.spawnSession(params);
     }
 
     if (agentType !== "codex") {
@@ -2343,6 +2362,20 @@ export function createProviderHandlers({
           onAccepted,
         });
       }
+      if (serenRuntime.hasSession(sessionId)) {
+        emit("provider://user-message", {
+          sessionId,
+          text: prompt,
+          origin: source,
+        });
+        return serenRuntime.sendPrompt({
+          sessionId,
+          prompt,
+          context,
+          origin: source,
+          onAccepted,
+        });
+      }
       emit("provider://user-message", {
         sessionId,
         text: prompt,
@@ -2469,6 +2502,9 @@ export function createProviderHandlers({
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.cancelPrompt({ sessionId });
       }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.cancelPrompt({ sessionId });
+      }
       return claudeRuntime.cancelPrompt({ sessionId });
     }
     if (session.activeTurnId) {
@@ -2525,6 +2561,9 @@ export function createProviderHandlers({
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.terminateSession({ sessionId });
       }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.terminateSession({ sessionId });
+      }
       return claudeRuntime.terminateSession({ sessionId });
     }
 
@@ -2564,6 +2603,7 @@ export function createProviderHandlers({
       ...(await geminiRuntime.listSessions()),
       ...(await grokRuntime.listSessions()),
       ...(await lmStudioRuntime.listSessions()),
+      ...(await serenRuntime.listSessions()),
       ...(await pairedRuntime.listSessions()),
     ];
   }
@@ -2614,6 +2654,9 @@ export function createProviderHandlers({
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setPermissionMode({ sessionId, mode });
       }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.setPermissionMode({ sessionId, mode });
+      }
       return claudeRuntime.setPermissionMode({ sessionId, mode });
     }
 
@@ -2638,6 +2681,9 @@ export function createProviderHandlers({
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setOAuthRouting({ sessionId, routing });
+      }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.setOAuthRouting({ sessionId, routing });
       }
       return claudeRuntime.setOAuthRouting({ sessionId, routing });
     }
@@ -2683,6 +2729,16 @@ export function createProviderHandlers({
         return runPermissionResolution({
           sessionId, requestId, optionId, source,
           action: () => lmStudioRuntime.respondToPermission({
+            sessionId,
+            requestId,
+            optionId,
+          }),
+        });
+      }
+      if (serenRuntime.hasSession(sessionId)) {
+        return runPermissionResolution({
+          sessionId, requestId, optionId, source,
+          action: () => serenRuntime.respondToPermission({
             sessionId,
             requestId,
             optionId,
@@ -2878,6 +2934,9 @@ export function createProviderHandlers({
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setSessionModel({ sessionId, modelId });
       }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.setSessionModel({ sessionId, modelId });
+      }
       return claudeRuntime.setModel({ sessionId, modelId });
     }
 
@@ -2957,6 +3016,14 @@ export function createProviderHandlers({
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.updateSessionConfigOption({
+          sessionId,
+          configId,
+          valueId,
+          role,
+        });
+      }
+      if (serenRuntime.hasSession(sessionId)) {
+        return serenRuntime.updateSessionConfigOption({
           sessionId,
           configId,
           valueId,

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -3100,6 +3100,13 @@ export function createProviderHandlers({
     },
   );
 
+  async function setRoleAgent({ sessionId, role, agentType }) {
+    if (pairedRuntime.hasSession(sessionId)) {
+      return pairedRuntime.setRoleAgent({ sessionId, role, agentType });
+    }
+    throw new Error("Role agents can only be changed on a paired session.");
+  }
+
   return {
     spawnSession,
     sendPrompt,
@@ -3124,6 +3131,7 @@ export function createProviderHandlers({
     listRemoteSessions,
     nativeForkSession,
     buildSyntheticTranscript,
+    setRoleAgent,
     setSessionModel,
     setSessionMode,
     updateSessionConfigOption,

--- a/bin/browser-local/seren-runtime.mjs
+++ b/bin/browser-local/seren-runtime.mjs
@@ -1,0 +1,414 @@
+// ABOUTME: Hosted Seren runtime — SerenModels and Private Models as paired-role sessions (#3748).
+// ABOUTME: OpenAI-compatible streaming through the Rust credential broker's loopback publisher proxy.
+
+import { randomUUID } from "node:crypto";
+import {
+  buildLmStudioPromptForContextBudget,
+  buildToolCatalog,
+  createMcpGatewayClient,
+  executeToolCall,
+  listPendingPermissions,
+  MAX_TOOL_ITERATIONS,
+  runChatCompletion,
+} from "./lmstudio-runtime.mjs";
+import { providerLogPrefix } from "./logging.mjs";
+import { resolveBrokeredSerenCredential } from "./mcp-config.mjs";
+import {
+  createOAuthSelectionEventEmitter,
+  createSerenMcpOAuthProxy,
+} from "./seren-mcp-oauth-proxy.mjs";
+
+export const SEREN_HOSTED_AGENT_TYPES = new Set(["seren", "seren-private"]);
+
+const PUBLISHER_SLUGS = {
+  seren: "seren-models",
+  "seren-private": "seren-private-models",
+};
+
+const AGENT_DISPLAY_NAMES = {
+  seren: "Seren",
+  "seren-private": "Seren Private Models",
+};
+
+// Hosted SerenModels run with large native contexts; the shared context-budget
+// trimming only engages on very long paired sessions.
+const HOSTED_CONTEXT_LENGTH = 200_000;
+
+function publisherBaseUrl(apiBaseUrl, agentType) {
+  const base = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
+  return `${base}publishers/${PUBLISHER_SLUGS[agentType]}`;
+}
+
+function normalizeHostedModels(payload) {
+  const records = Array.isArray(payload?.data)
+    ? payload.data
+    : Array.isArray(payload?.models)
+      ? payload.models
+      : [];
+  return records
+    .map((model) => {
+      const modelId = String(model?.id ?? model?.modelId ?? "").trim();
+      if (!modelId) return null;
+      return {
+        modelId,
+        name: String(model?.name ?? modelId),
+        ...(model?.description ? { description: String(model.description) } : {}),
+      };
+    })
+    .filter(Boolean);
+}
+
+async function fetchHostedModels(session) {
+  const response = await fetch(`${session.publisherBaseUrl}/models`, {
+    headers: { Authorization: `Bearer ${session.apiKey}` },
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `${session.displayName} model catalog HTTP ${response.status}: ${detail}`,
+    );
+  }
+  return normalizeHostedModels(await response.json());
+}
+
+function buildHostedSessionStatus(session, status = session.status) {
+  return {
+    sessionId: session.id,
+    status,
+    agentSessionId: session.agentSessionId,
+    agentInfo: { name: session.displayName, version: "hosted" },
+    models: {
+      currentModelId: session.currentModelId,
+      availableModels: session.availableModelRecords,
+    },
+    modes: {
+      currentModeId: session.currentModeId,
+      availableModes: [
+        {
+          modeId: "ask",
+          name: "Review First",
+          description: "Local edits and commands pause for review.",
+        },
+        {
+          modeId: "auto",
+          name: "Auto",
+          description: "Approve safe local operations automatically.",
+        },
+      ],
+    },
+    configOptions: [],
+  };
+}
+
+async function sendPromptToSeren(session, prompt, context) {
+  if (session.currentPrompt) {
+    throw new Error(
+      `Another prompt is already active for this ${session.displayName} session.`,
+    );
+  }
+
+  session.status = "prompting";
+  session.emit(
+    "provider://session-status",
+    buildHostedSessionStatus(session, "prompting"),
+  );
+
+  const abortController = new AbortController();
+  session.currentPrompt = { abortController };
+
+  try {
+    const builtPrompt = buildLmStudioPromptForContextBudget(
+      prompt,
+      context,
+      session.contextLength,
+    );
+    session.messages.push({ role: "user", content: builtPrompt.prompt });
+
+    for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
+      const { tools, handlers } = await buildToolCatalog(session);
+      const result = await runChatCompletion({
+        session,
+        tools,
+        signal: abortController.signal,
+        onContent: (text, options) => {
+          session.emit("provider://message-chunk", {
+            sessionId: session.id,
+            text,
+            ...(options?.isThought ? { isThought: true } : {}),
+          });
+        },
+      });
+
+      if (!result.toolCalls || result.toolCalls.length === 0) {
+        session.messages.push({ role: "assistant", content: result.content });
+        session.status = "ready";
+        session.currentPrompt = null;
+        session.emit("provider://prompt-complete", {
+          sessionId: session.id,
+          stopReason: result.stopReason ?? "stop",
+        });
+        session.emit(
+          "provider://session-status",
+          buildHostedSessionStatus(session, "ready"),
+        );
+        return;
+      }
+
+      session.messages.push({
+        role: "assistant",
+        content: result.content || null,
+        tool_calls: result.toolCalls,
+      });
+
+      for (const toolCall of result.toolCalls) {
+        const toolResult = await executeToolCall(session, toolCall, handlers);
+        session.messages.push(toolResult);
+      }
+    }
+
+    throw new Error(
+      `${session.displayName} stopped after too many tool iterations.`,
+    );
+  } catch (error) {
+    session.status = "ready";
+    session.currentPrompt = null;
+    const message =
+      error?.name === "AbortError"
+        ? "Task cancelled"
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    session.emit("provider://error", { sessionId: session.id, error: message });
+    session.emit(
+      "provider://session-status",
+      buildHostedSessionStatus(session, "ready"),
+    );
+    throw error;
+  }
+}
+
+export function createSerenHostedRuntime({
+  emit,
+  runtimeMode = "provider-runtime",
+}) {
+  const sessions = new Map();
+  const logPrefix = providerLogPrefix("seren-hosted", runtimeMode);
+
+  function hasSession(sessionId) {
+    return sessions.has(sessionId);
+  }
+
+  function requireSession(sessionId) {
+    const session = sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown hosted Seren session: ${sessionId}`);
+    return session;
+  }
+
+  async function spawnSession(params) {
+    const agentType = params.agentType;
+    if (!SEREN_HOSTED_AGENT_TYPES.has(agentType)) {
+      throw new Error(`Not a hosted Seren agent type: ${agentType}`);
+    }
+    const serenCredential = resolveBrokeredSerenCredential(params);
+    if (!serenCredential) {
+      throw new Error(
+        "Sign in to Seren to use hosted Seren models in this thread.",
+      );
+    }
+
+    const sessionId = params.localSessionId ?? randomUUID();
+    const displayName = AGENT_DISPLAY_NAMES[agentType];
+
+    let serenMcpProxy = null;
+    if (serenCredential.mcpUrl) {
+      serenMcpProxy = await createSerenMcpOAuthProxy({
+        gatewayUrl: serenCredential.mcpUrl,
+        apiUrl: serenCredential.apiBaseUrl,
+        onConnectionSelected: createOAuthSelectionEventEmitter(emit, sessionId),
+      });
+    }
+
+    let session;
+    try {
+      session = {
+        id: sessionId,
+        agentType,
+        displayName,
+        cwd: params.cwd,
+        status: "initializing",
+        createdAt: new Date().toISOString(),
+        agentSessionId: sessionId,
+        timeoutSecs: params.timeoutSecs ?? undefined,
+        baseUrl: serenCredential.apiBaseUrl,
+        apiKey: serenCredential.capability,
+        publisherBaseUrl: publisherBaseUrl(
+          serenCredential.apiBaseUrl,
+          agentType,
+        ),
+        chatCompletionsUrl: `${publisherBaseUrl(serenCredential.apiBaseUrl, agentType)}/chat/completions`,
+        mcpGateway: createMcpGatewayClient({
+          capability: serenCredential.capability,
+          url: serenMcpProxy?.url,
+        }),
+        serenMcpConfigured: serenMcpProxy != null,
+        serenMcpProxy,
+        availableModelRecords: [],
+        currentModelId: null,
+        currentModeId: params.approvalPolicy === "never" ? "auto" : "ask",
+        sandboxMode: params.sandboxMode ?? "workspace-write",
+        approvalPolicy: params.approvalPolicy ?? "on-request",
+        autoApproveReads: params.autoApproveReads !== false,
+        currentPrompt: null,
+        pendingPermissions: new Map(),
+        approvedForSession: new Set(),
+        fileAccessGrants: [],
+        messages: [],
+        toolIncompatibleModelIds: new Set(),
+        contextLength: HOSTED_CONTEXT_LENGTH,
+        logPrefix,
+        emit,
+      };
+
+      session.availableModelRecords = await fetchHostedModels(session);
+      if (session.availableModelRecords.length === 0) {
+        throw new Error(
+          agentType === "seren-private"
+            ? "No private models are enabled for this organization."
+            : "The Seren model catalog is empty for this account.",
+        );
+      }
+      session.currentModelId =
+        session.availableModelRecords.find(
+          (model) => model.modelId === params.initialModelId,
+        )?.modelId ?? session.availableModelRecords[0].modelId;
+
+      sessions.set(sessionId, session);
+      session.status = "ready";
+      emit(
+        "provider://session-status",
+        buildHostedSessionStatus(session, "ready"),
+      );
+    } catch (error) {
+      sessions.delete(sessionId);
+      await serenMcpProxy?.close().catch(() => {});
+      throw error;
+    }
+
+    return {
+      id: session.id,
+      agentType: session.agentType,
+      cwd: session.cwd,
+      status: session.status,
+      createdAt: session.createdAt,
+      agentSessionId: session.agentSessionId,
+      timeoutSecs: session.timeoutSecs,
+      serenMcpConfigured: session.serenMcpConfigured,
+      pid: null,
+    };
+  }
+
+  async function sendPrompt({ sessionId, prompt, context, onAccepted }) {
+    const session = requireSession(sessionId);
+    try {
+      onAccepted?.();
+    } catch {
+      // Acceptance telemetry must never fail the turn.
+    }
+    return sendPromptToSeren(session, prompt, context);
+  }
+
+  async function cancelPrompt({ sessionId }) {
+    const session = requireSession(sessionId);
+    session.currentPrompt?.abortController?.abort();
+    session.currentPrompt = null;
+    session.status = "ready";
+    emit("provider://error", { sessionId, error: "Task cancelled" });
+    emit(
+      "provider://session-status",
+      buildHostedSessionStatus(session, "ready"),
+    );
+  }
+
+  async function terminateSession({ sessionId }) {
+    const session = requireSession(sessionId);
+    sessions.delete(sessionId);
+    session.currentPrompt?.abortController?.abort();
+    await session.serenMcpProxy?.close().catch(() => {});
+    emit("provider://session-status", {
+      sessionId,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  }
+
+  async function listSessions() {
+    return Array.from(sessions.values()).map((session) => ({
+      id: session.id,
+      agentType: session.agentType,
+      cwd: session.cwd,
+      status: session.status,
+      createdAt: session.createdAt,
+      agentSessionId: session.agentSessionId,
+      timeoutSecs: session.timeoutSecs,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      pendingPermissions: listPendingPermissions(session),
+      serenMcpConfigured: session.serenMcpConfigured,
+      pid: null,
+    }));
+  }
+
+  function listSessionModels(sessionId) {
+    return sessions.get(sessionId)?.availableModelRecords ?? [];
+  }
+
+  async function setSessionModel({ sessionId, modelId }) {
+    const session = requireSession(sessionId);
+    const target = session.availableModelRecords.find(
+      (model) => model.modelId === modelId,
+    );
+    if (!target) {
+      throw new Error(`Unknown ${session.displayName} model: ${modelId}`);
+    }
+    session.currentModelId = target.modelId;
+    emit("provider://session-status", buildHostedSessionStatus(session));
+  }
+
+  async function setPermissionMode({ sessionId, mode }) {
+    const session = requireSession(sessionId);
+    session.currentModeId = mode === "auto" ? "auto" : "ask";
+    emit("provider://session-status", buildHostedSessionStatus(session));
+  }
+
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = requireSession(sessionId);
+    session.serenMcpProxy?.setRouting(routing);
+  }
+
+  async function respondToPermission({ sessionId, requestId, optionId }) {
+    const session = requireSession(sessionId);
+    const pending = session.pendingPermissions.get(requestId);
+    if (!pending) throw new Error(`No pending permission request: ${requestId}`);
+    session.pendingPermissions.delete(requestId);
+    pending.resolve(optionId);
+  }
+
+  async function updateSessionConfigOption() {
+    return null;
+  }
+
+  return {
+    hasSession,
+    spawnSession,
+    sendPrompt,
+    cancelPrompt,
+    terminateSession,
+    listSessions,
+    listSessionModels,
+    setSessionModel,
+    setPermissionMode,
+    setOAuthRouting,
+    respondToPermission,
+    updateSessionConfigOption,
+  };
+}

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -143,6 +143,10 @@ function registerProviderHandlers() {
     providerHandlers.buildSyntheticTranscript,
   );
   registerHandler(
+    "provider_set_role_agent",
+    providerHandlers.setRoleAgent,
+  );
+  registerHandler(
     "provider_set_session_model",
     providerHandlers.setSessionModel,
   );

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -298,6 +298,10 @@ function registerBrowserLocalHandlers() {
     providerHandlers.buildSyntheticTranscript,
   );
   registerHandler(
+    "provider_set_role_agent",
+    providerHandlers.setRoleAgent,
+  );
+  registerHandler(
     "provider_set_session_model",
     providerHandlers.setSessionModel,
   );

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -162,19 +162,52 @@ fn delete_agent_transcripts_best_effort(targets: &[AgentTranscriptTarget]) {
 fn split_paired_session_ids(
     agent_type: &str,
     session_id: &str,
-) -> (Option<String>, Option<String>) {
+) -> (Vec<String>, Vec<String>) {
     let non_empty = |value: &str| (!value.is_empty()).then(|| value.to_string());
     match agent_type {
-        "claude-code" => (non_empty(session_id), None),
-        "codex" => (None, non_empty(session_id)),
+        "claude-code" => (non_empty(session_id).into_iter().collect(), Vec::new()),
+        "codex" => (Vec::new(), non_empty(session_id).into_iter().collect()),
         "claude-codex" => match serde_json::from_str::<PairedSessionIds>(session_id) {
             Ok(ids) => (
-                ids.planner.filter(|id| !id.is_empty()),
-                ids.executor.filter(|id| !id.is_empty()),
+                ids.planner
+                    .filter(|id| !id.is_empty())
+                    .into_iter()
+                    .collect(),
+                ids.executor
+                    .filter(|id| !id.is_empty())
+                    .into_iter()
+                    .collect(),
             ),
-            Err(_) => (None, None),
+            Err(_) => (Vec::new(), Vec::new()),
         },
-        _ => (None, None),
+        // A planner-runner composite names each role's agent; either role can
+        // be a Claude or Codex leg (including both the same), and legs backed
+        // by other agents keep no local transcript this cleanup owns (#3748).
+        "planner-runner" => match serde_json::from_str::<PairedSessionIds>(session_id) {
+            Ok(ids) => {
+                let mut claude = Vec::new();
+                let mut codex = Vec::new();
+                let agents = ids.agents.unwrap_or_default();
+                let mut route = |session: Option<String>, agent: Option<&str>| {
+                    let Some(id) = session.filter(|id| !id.is_empty()) else {
+                        return;
+                    };
+                    match agent {
+                        Some("claude-code") => claude.push(id),
+                        Some("codex") => codex.push(id),
+                        _ => {}
+                    }
+                };
+                route(
+                    ids.planner,
+                    agents.planner.as_deref().or(Some("claude-code")),
+                );
+                route(ids.executor, agents.executor.as_deref().or(Some("codex")));
+                (claude, codex)
+            }
+            Err(_) => (Vec::new(), Vec::new()),
+        },
+        _ => (Vec::new(), Vec::new()),
     }
 }
 
@@ -182,6 +215,16 @@ fn split_paired_session_ids(
 /// conversation's composite `agent_session_id`. The trailing ledger is ignored.
 #[derive(Deserialize)]
 struct PairedSessionIds {
+    planner: Option<String>,
+    executor: Option<String>,
+    #[serde(default)]
+    agents: Option<PairedSessionAgents>,
+}
+
+/// The per-role agent types a `planner-runner` composite records so transcript
+/// cleanup routes each leg to the right provider's on-disk format.
+#[derive(Default, Deserialize)]
+struct PairedSessionAgents {
     planner: Option<String>,
     executor: Option<String>,
 }
@@ -196,10 +239,10 @@ fn remove_agent_transcripts(
     codex_root: Option<&std::path::Path>,
 ) {
     for target in targets {
-        let (claude_id, codex_id) =
+        let (claude_ids, codex_ids) =
             split_paired_session_ids(&target.agent_type, &target.session_id);
 
-        if let Some(claude_id) = claude_id {
+        for claude_id in claude_ids {
             if let (Some(root), Some(cwd)) = (claude_root, target.agent_cwd.as_deref()) {
                 if uuid::Uuid::parse_str(&claude_id).is_ok() {
                     let path = crate::claude_memory::session_jsonl_path(
@@ -211,7 +254,7 @@ fn remove_agent_transcripts(
                 }
             }
         }
-        if let Some(codex_id) = codex_id {
+        for codex_id in codex_ids {
             if let Some(root) = codex_root {
                 for path in crate::terminal::codex_transcripts_for_session(root, &codex_id) {
                     remove_transcript_file(&path);
@@ -2959,7 +3002,7 @@ mod tests {
         is_happy_provider_session_archived_in_db, list_legacy_happy_restoration_candidates_in_db,
         lookup_agent_conversation_owner_in_db, lookup_happy_restoration_candidate_in_db,
         lookup_happy_session_id_by_conversation_in_db, migrate_happy_restoration_relay_in_db,
-        remove_agent_transcripts,
+        remove_agent_transcripts, split_paired_session_ids,
         set_agent_conversation_session_id_in_db,
         upsert_agent_conversation_in_db, vacuum_database,
     };
@@ -3352,6 +3395,42 @@ mod tests {
 
         // Idempotent: a second pass over now-missing files must not panic.
         remove_agent_transcripts(&targets, Some(claude_root.path()), Some(codex_root.path()));
+    }
+
+    #[test]
+    fn split_planner_runner_composite_routes_legs_by_agent_type() {
+        // Roles route to the provider that owns their on-disk transcript
+        // format — either bucket can hold either role, including both (#3748).
+        let swapped = serde_json::json!({
+            "planner": "11111111-1111-4111-8111-111111111111",
+            "executor": "22222222-2222-4222-8222-222222222222",
+            "agents": { "planner": "codex", "executor": "claude-code" },
+        })
+        .to_string();
+        let (claude, codex) = split_paired_session_ids("planner-runner", &swapped);
+        assert_eq!(claude, vec!["22222222-2222-4222-8222-222222222222"]);
+        assert_eq!(codex, vec!["11111111-1111-4111-8111-111111111111"]);
+
+        // Hosted and other-provider legs keep no local transcript here.
+        let hosted = serde_json::json!({
+            "planner": "33333333-3333-4333-8333-333333333333",
+            "executor": "44444444-4444-4444-8444-444444444444",
+            "agents": { "planner": "seren", "executor": "gemini" },
+        })
+        .to_string();
+        let (claude, codex) = split_paired_session_ids("planner-runner", &hosted);
+        assert!(claude.is_empty());
+        assert!(codex.is_empty());
+
+        // A composite without an agents map is the default pairing.
+        let default_pairing = serde_json::json!({
+            "planner": "55555555-5555-4555-8555-555555555555",
+            "executor": "66666666-6666-4666-8666-666666666666",
+        })
+        .to_string();
+        let (claude, codex) = split_paired_session_ids("planner-runner", &default_pairing);
+        assert_eq!(claude, vec!["55555555-5555-4555-8555-555555555555"]);
+        assert_eq!(codex, vec!["66666666-6666-4666-8666-666666666666"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/provider_runtime.rs
+++ b/src-tauri/src/commands/provider_runtime.rs
@@ -282,6 +282,7 @@ pub(crate) const NATIVE_AGENT_PROVIDERS: &[&str] = &[
     "gemini",
     "grok",
     "claude-codex",
+    "planner-runner",
     "lmstudio",
 ];
 
@@ -295,7 +296,7 @@ pub(crate) const NATIVE_AGENT_PROVIDERS: &[&str] = &[
 /// test in this module asserts that invariant.
 pub(crate) const DERIVED_KIND_CASE_SQL: &str = "CASE \
      WHEN psr.provider IS NULL THEN c.kind \
-     WHEN psr.provider IN ('claude-code', 'codex', 'gemini', 'grok', 'claude-codex', 'lmstudio') THEN 'agent' \
+     WHEN psr.provider IN ('claude-code', 'codex', 'gemini', 'grok', 'claude-codex', 'planner-runner', 'lmstudio') THEN 'agent' \
      ELSE 'chat' \
      END";
 

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -120,6 +120,7 @@ import { DataDestinationsPanel } from "./DataDestinationsPanel";
 import { DiffCard } from "./DiffCard";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { OAuthAccountSwitcher } from "./OAuthAccountSwitcher";
+import { PairedAgentSelector } from "./PairedAgentSelector";
 import { PairedEffortSelector } from "./PairedEffortSelector";
 import { PairedFastModeSelector } from "./PairedFastModeSelector";
 import { PairedModelSelector } from "./PairedModelSelector";
@@ -590,6 +591,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       threadType === "gemini" ||
       threadType === "grok" ||
       threadType === "claude-codex" ||
+      threadType === "planner-runner" ||
       threadType === "lmstudio"
     ) {
       return threadType;
@@ -601,23 +603,32 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       sessionAgent === "gemini" ||
       sessionAgent === "grok" ||
       sessionAgent === "claude-codex" ||
+      sessionAgent === "planner-runner" ||
       sessionAgent === "lmstudio"
     ) {
       return sessionAgent;
     }
     return agentStore.selectedAgentType;
   });
-  const isPairedThread = createMemo(() => lockedAgentType() === "claude-codex");
-  // Compact paired-workflow stage for the thread header (#2368).
+  const isPairedThread = createMemo(
+    () =>
+      lockedAgentType() === "claude-codex" ||
+      lockedAgentType() === "planner-runner",
+  );
+  // Compact paired-workflow stage for the thread header (#2368). Labels come
+  // from the live role status so a swapped pairing names its own agents.
   const pairedHeaderState = createMemo(() => {
     if (!isPairedThread()) return null;
-    switch (threadSession()?.paired?.state) {
+    const paired = threadSession()?.paired;
+    const plannerLabel = paired?.planner?.label ?? "Claude";
+    const executorLabel = paired?.executor?.label ?? "Codex";
+    switch (paired?.state) {
       case "planning":
-        return "Claude planning";
+        return `${plannerLabel} planning`;
       case "executing":
-        return "Codex editing";
+        return `${executorLabel} editing`;
       case "reviewing":
-        return "Claude reviewing";
+        return `${plannerLabel} reviewing`;
       case "waiting-approval":
         return "Waiting for approval";
       default:
@@ -634,6 +645,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         return "Grok";
       case "claude-codex":
         return "Claude + Codex";
+      case "planner-runner":
+        return "Planner + Runner";
       case "lmstudio":
         return "LM Studio";
       default:
@@ -1754,7 +1767,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           data-testid="paired-thread-header"
         >
           <span class="text-xs font-medium text-foreground">
-            {"\u{1F91D}"} Claude + Codex
+            {lockedAgentType() === "planner-runner"
+              ? `${"\u{1F9ED}"} Planner + Runner`
+              : `${"\u{1F91D}"} Claude + Codex`}
           </span>
           <span class="text-[11px] text-muted-foreground">
             {pairedHeaderState()}
@@ -2080,9 +2095,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   ? "Grok"
                   : agentType === "claude-codex"
                     ? "Claude + Codex"
-                    : agentType === "lmstudio"
-                      ? "LM Studio"
-                      : "Claude Code";
+                    : agentType === "planner-runner"
+                      ? "Planner + Runner"
+                      : agentType === "lmstudio"
+                        ? "LM Studio"
+                        : "Claude Code";
           const reason = agentStore.agentFallbackReason;
           const title =
             reason === "prompt_too_long"
@@ -2356,6 +2373,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     </>
                   }
                 >
+                  <PairedAgentSelector
+                    session={threadSession()}
+                    pairedRole="planner"
+                  />
+                  <PairedAgentSelector
+                    session={threadSession()}
+                    pairedRole="executor"
+                  />
                   <PairedModelSelector
                     session={threadSession()}
                     pairedRole="planner"

--- a/src/components/chat/PairedAgentSelector.tsx
+++ b/src/components/chat/PairedAgentSelector.tsx
@@ -1,0 +1,185 @@
+// ABOUTME: Role-scoped agent dropdown for Planner + Runner threads (#3748).
+// ABOUTME: Lists every offered agent from live availability and swaps that role's inner session.
+
+import type { Component } from "solid-js";
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
+import {
+  allowsClaudeAgent,
+  allowsCodexAgent,
+  allowsGeminiAgent,
+  allowsGrokAgent,
+  allowsLmStudioAgent,
+  allowsSerenPrivateAgent,
+  allowsSerenPublicModels,
+} from "@/services/organization-policy";
+import type { PairedRole, PairedRoleAgentType } from "@/services/providers";
+import { type ActiveSession, agentStore } from "@/stores/agent.store";
+import { authStore } from "@/stores/auth.store";
+
+interface Props {
+  session: ActiveSession | null;
+  pairedRole: PairedRole;
+}
+
+const ROLE_LABELS: Record<PairedRole, string> = {
+  planner: "Planner",
+  executor: "Runner",
+};
+
+interface RoleAgentOption {
+  id: PairedRoleAgentType;
+  label: string;
+  glyph: string;
+}
+
+const ROLE_AGENT_OPTIONS: readonly RoleAgentOption[] = [
+  { id: "claude-code", label: "Claude Code", glyph: "\u{1F916}" },
+  { id: "codex", label: "Codex", glyph: "⚡" },
+  { id: "gemini", label: "Antigravity", glyph: "✨" },
+  { id: "grok", label: "Grok", glyph: "\u{1D54F}" },
+  { id: "lmstudio", label: "LM Studio", glyph: "\u{1F5A5}️" },
+  { id: "seren", label: "Seren Agent", glyph: "\u{1F4AC}" },
+  { id: "seren-private", label: "Seren Private Models", glyph: "\u{1F512}" },
+];
+
+export const PairedAgentSelector: Component<Props> = (props) => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let dropdownRef: HTMLDivElement | undefined;
+
+  const paired = () => props.session?.paired ?? null;
+  const roleStatus = () => paired()?.[props.pairedRole] ?? null;
+
+  // The Claude + Codex wrapper keeps its fixed pairing; only the general
+  // Planner + Runner thread offers the swap.
+  const isSwappable = () => paired()?.agentType === "planner-runner";
+  const isIdle = () => (paired()?.state ?? "idle") === "idle";
+
+  const offeredOptions = createMemo(() => {
+    const policy = authStore.privateChatPolicy;
+    const nativeAvailable = new Map(
+      agentStore.availableAgents.map((agent) => [agent.type, agent.available]),
+    );
+    return ROLE_AGENT_OPTIONS.filter((option) => {
+      switch (option.id) {
+        case "claude-code":
+          return allowsClaudeAgent(policy);
+        case "codex":
+          return allowsCodexAgent(policy);
+        case "gemini":
+          return allowsGeminiAgent(policy);
+        case "grok":
+          return allowsGrokAgent(policy);
+        case "lmstudio":
+          return (
+            allowsLmStudioAgent(policy) &&
+            nativeAvailable.get("lmstudio") !== false
+          );
+        case "seren":
+          return authStore.isAuthenticated && allowsSerenPublicModels(policy);
+        case "seren-private":
+          return authStore.isAuthenticated && allowsSerenPrivateAgent(policy);
+      }
+    });
+  });
+
+  const currentOption = () => {
+    const agentType = roleStatus()?.agentType;
+    return ROLE_AGENT_OPTIONS.find((option) => option.id === agentType) ?? null;
+  };
+
+  const selectAgent = (agentType: PairedRoleAgentType) => {
+    setIsOpen(false);
+    if (agentType === roleStatus()?.agentType) return;
+    void agentStore.setPairedAgent(
+      props.pairedRole,
+      agentType,
+      props.session?.info.id,
+    );
+  };
+
+  return (
+    <Show when={isSwappable()}>
+      <div class="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          data-testid={`paired-agent-selector-${props.pairedRole}`}
+          class="flex items-center gap-1.5 px-2 py-1 bg-surface-2 border border-surface-3 rounded-md text-xs text-foreground cursor-pointer hover:bg-surface-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={() => setIsOpen(!isOpen())}
+          disabled={!isIdle()}
+          title={
+            isIdle()
+              ? `Change ${ROLE_LABELS[props.pairedRole].toLowerCase()} agent`
+              : "Wait for the current turn to finish before changing agents"
+          }
+        >
+          <span class="font-medium max-w-[200px] truncate">
+            {ROLE_LABELS[props.pairedRole]} ·{" "}
+            {currentOption()?.label ?? roleStatus()?.label ?? "Agent"}
+          </span>
+          <svg
+            class={`w-3 h-3 text-muted-foreground transition-transform ${isOpen() ? "rotate-180" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            role="img"
+            aria-label="Toggle dropdown"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <FloatingSelectorMenu
+          open={isOpen()}
+          anchor={() => dropdownRef}
+          onRequestClose={() => setIsOpen(false)}
+          class="w-64 max-w-[calc(100vw-2rem)]"
+        >
+          <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            {ROLE_LABELS[props.pairedRole]} Agent
+          </div>
+          <For each={offeredOptions()}>
+            {(option) => (
+              <button
+                type="button"
+                class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
+                  option.id === roleStatus()?.agentType ? "bg-surface-2" : ""
+                }`}
+                onClick={() => selectAgent(option.id)}
+              >
+                <div class="flex items-center gap-2">
+                  <span class="text-[14px] w-[20px] text-center shrink-0">
+                    {option.glyph}
+                  </span>
+                  <span class="text-sm text-foreground font-medium flex-1">
+                    {option.label}
+                  </span>
+                  <Show when={option.id === roleStatus()?.agentType}>
+                    <svg
+                      class="w-4 h-4 text-green-500 flex-shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      role="img"
+                      aria-label="Selected"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </Show>
+                </div>
+              </button>
+            )}
+          </For>
+        </FloatingSelectorMenu>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/chat/PairedAgentSelector.tsx
+++ b/src/components/chat/PairedAgentSelector.tsx
@@ -147,6 +147,7 @@ export const PairedAgentSelector: Component<Props> = (props) => {
             {(option) => (
               <button
                 type="button"
+                data-testid={`paired-agent-option-${props.pairedRole}-${option.id}`}
                 class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
                   option.id === roleStatus()?.agentType ? "bg-surface-2" : ""
                 }`}

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -956,9 +956,11 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                                       ? "𝕏"
                                       : thread.agentType === "claude-codex"
                                         ? "\u{1F91D}"
-                                        : thread.agentType === "lmstudio"
-                                          ? "\u{1F5A5}\uFE0F"
-                                          : "\u{1F916}"}
+                                        : thread.agentType === "planner-runner"
+                                          ? "\u{1F9ED}"
+                                          : thread.agentType === "lmstudio"
+                                            ? "\u{1F5A5}\uFE0F"
+                                            : "\u{1F916}"}
                               </span>
                             </Show>
                           </div>

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -94,7 +94,13 @@ export const ThreadTabBar: Component = () => {
   };
 
   const handleNewAgent = async (
-    agentType: "claude-code" | "codex" | "gemini" | "grok" | "claude-codex",
+    agentType:
+      | "claude-code"
+      | "codex"
+      | "gemini"
+      | "grok"
+      | "claude-codex"
+      | "planner-runner",
   ) => {
     setShowNewMenu(false);
     const cwd = fileTreeState.rootPath;
@@ -120,6 +126,7 @@ export const ThreadTabBar: Component = () => {
     if (thread.agentType === "gemini") return "✨";
     if (thread.agentType === "grok") return "𝕏";
     if (thread.agentType === "claude-codex") return "🤝";
+    if (thread.agentType === "planner-runner") return "🧭";
     return "🤖";
   };
 
@@ -341,6 +348,31 @@ export const ThreadTabBar: Component = () => {
                   🤝
                 </span>
                 <div class="flex-1 min-w-0 font-medium">Claude + Codex</div>
+                <Chip variant="subscription">Subscription</Chip>
+              </button>
+            </Show>
+            <Show
+              when={
+                allowsClaudeAgent(authStore.privateChatPolicy) &&
+                allowsCodexAgent(authStore.privateChatPolicy)
+              }
+            >
+              <button
+                type="button"
+                data-testid="new-planner-runner-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
+                onClick={() => handleNewAgent("planner-runner")}
+                disabled={!fileTreeState.rootPath}
+                title={
+                  !fileTreeState.rootPath
+                    ? "Open a folder first to use agents"
+                    : undefined
+                }
+              >
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  🧭
+                </span>
+                <div class="flex-1 min-w-0 font-medium">Planner + Runner</div>
                 <Chip variant="subscription">Subscription</Chip>
               </button>
             </Show>

--- a/src/components/layout/native-agent-launchers.ts
+++ b/src/components/layout/native-agent-launchers.ts
@@ -46,6 +46,13 @@ export const NATIVE_AGENT_LAUNCHER_METADATA = {
     testId: "new-claude-codex-agent",
     chip: { label: "Subscription", variant: "subscription" },
   },
+  "planner-runner": {
+    label: "Planner + Runner",
+    description: "Pick any planner + any runner",
+    glyph: "🧭",
+    testId: "new-planner-runner-agent",
+    chip: { label: "Subscription", variant: "subscription" },
+  },
   gemini: {
     label: "Antigravity",
     description: "Google · Antigravity coding agent",
@@ -79,6 +86,10 @@ function isAllowedByOrganizationPolicy(
     case "codex":
       return allowsCodexAgent(policy);
     case "claude-codex":
+      return allowsClaudeAgent(policy) && allowsCodexAgent(policy);
+    case "planner-runner":
+      // The default pairing is Claude + Codex; a swapped role re-checks its
+      // own agent's policy gate at swap time.
       return allowsClaudeAgent(policy) && allowsCodexAgent(policy);
     case "gemini":
       return allowsGeminiAgent(policy);

--- a/src/lib/agent/bootstrap-context.ts
+++ b/src/lib/agent/bootstrap-context.ts
@@ -17,6 +17,8 @@ export function agentDisplayName(agentType?: string): string {
       return "Grok";
     case "claude-codex":
       return "Claude + Codex";
+    case "planner-runner":
+      return "Planner + Runner";
     case "lmstudio":
       return "LM Studio";
     default:
@@ -35,7 +37,7 @@ export function agentInitializationFailureMessage(agentType?: string): string {
           ? "Grok is installed and signed in"
           : agentType === "lmstudio"
             ? "LM Studio is running and reachable"
-            : agentType === "claude-codex"
+            : agentType === "claude-codex" || agentType === "planner-runner"
               ? "Claude Code and Codex are installed and signed in"
               : `${agentName} is installed and authenticated`;
 

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -265,6 +265,7 @@ export function defaultContextWindowFor(
   // Paired threads gauge against the planner (Claude defaults to the 1M
   // tier); the runtime-reported contextWindow corrects this per turn.
   if (agentType === "claude-codex") return 1_000_000;
+  if (agentType === "planner-runner") return 1_000_000;
   if (agentType === "claude-code" && modelId) {
     if (/\[1m\]$/i.test(modelId)) {
       const stripped = modelId.replace(/\[1m\]$/i, "").replace(/-\d{8}$/, "");

--- a/src/lib/provider-boundaries.ts
+++ b/src/lib/provider-boundaries.ts
@@ -29,6 +29,8 @@ export function providerDisplayName(
       return "Grok";
     case "claude-codex":
       return "Claude + Codex";
+    case "planner-runner":
+      return "Planner + Runner";
     case "lmstudio":
       return "LM Studio";
     default: {

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -150,6 +150,7 @@ const DEFAULT_SEREN_MODELS: Record<AgentType, string> = {
   gemini: "google/gemini-2.5-pro",
   grok: "arcee-ai/trinity-large-thinking",
   "claude-codex": "arcee-ai/trinity-large-thinking",
+  "planner-runner": "arcee-ai/trinity-large-thinking",
   lmstudio: "arcee-ai/trinity-large-thinking",
 };
 
@@ -248,9 +249,11 @@ export function buildRedirectMessage(
           ? "Grok"
           : agentType === "claude-codex"
             ? "Claude + Codex"
-            : agentType === "lmstudio"
-              ? "LM Studio"
-              : "Claude Code";
+            : agentType === "planner-runner"
+              ? "Planner + Runner"
+              : agentType === "lmstudio"
+                ? "LM Studio"
+                : "Claude Code";
   const reasonText =
     reason === "prompt_too_long"
       ? `${agentName} agent's context window is full.`
@@ -305,9 +308,11 @@ export async function performAgentFallback(
           ? "Grok"
           : agentType === "claude-codex"
             ? "Claude + Codex"
-            : agentType === "lmstudio"
-              ? "LM Studio"
-              : "Claude";
+            : agentType === "planner-runner"
+              ? "Planner + Runner"
+              : agentType === "lmstudio"
+                ? "LM Studio"
+                : "Claude";
   const title = sessionTitle || `${agentName} Agent (continued)`;
 
   try {

--- a/src/services/mission-agent-catalog.ts
+++ b/src/services/mission-agent-catalog.ts
@@ -250,7 +250,7 @@ export async function loadMissionPermissionCatalog(
 
 function localAgentForTarget(
   target: MissionModelTarget,
-): Exclude<AgentType, "claude-codex" | "lmstudio"> | null {
+): Exclude<AgentType, "claude-codex" | "planner-runner" | "lmstudio"> | null {
   switch (target) {
     case "claude-code":
     case "claude-codex:planner":
@@ -268,7 +268,7 @@ function localAgentForTarget(
 }
 
 function localAgentDisplayName(
-  agentType: Exclude<AgentType, "claude-codex" | "lmstudio">,
+  agentType: Exclude<AgentType, "claude-codex" | "planner-runner" | "lmstudio">,
 ): string {
   switch (agentType) {
     case "claude-code":
@@ -285,7 +285,7 @@ function localAgentDisplayName(
 const localCatalogLoads = new Map<string, Promise<AgentModelCatalogEntry[]>>();
 
 function loadLocalCatalog(
-  agentType: Exclude<AgentType, "claude-codex" | "lmstudio">,
+  agentType: Exclude<AgentType, "claude-codex" | "planner-runner" | "lmstudio">,
   cwd: string,
 ): Promise<AgentModelCatalogEntry[]> {
   const key = `${agentType}:${cwd}`;
@@ -346,6 +346,8 @@ export function missionAgentAllowed(
     case "grok":
       return allowsGrokAgent(policy);
     case "claude-codex":
+      return allowsClaudeAgent(policy) && allowsCodexAgent(policy);
+    case "planner-runner":
       return allowsClaudeAgent(policy) && allowsCodexAgent(policy);
     case "lmstudio":
       return allowsLmStudioAgent(policy);

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -30,7 +30,18 @@ export type AgentType =
   | "gemini"
   | "grok"
   | "claude-codex"
+  | "planner-runner"
   | "lmstudio";
+
+/**
+ * Agents selectable as a Planner + Runner role (#3748): every single-agent
+ * native runtime plus the hosted Seren runtimes. The paired wrappers cannot
+ * nest inside themselves.
+ */
+export type PairedRoleAgentType =
+  | Exclude<AgentType, "claude-codex" | "planner-runner">
+  | "seren"
+  | "seren-private";
 export type UnlistenFn = () => void;
 
 /**
@@ -119,7 +130,7 @@ export function assertPrivilegedConversationProvider(
 
 export type ProviderOrigin = "desktop" | "remote";
 
-/** Roles inside a paired `claude-codex` thread (#2368). */
+/** Roles inside a paired `claude-codex` or `planner-runner` thread (#2368, #3748). */
 export type PairedRole = "planner" | "executor";
 
 export interface AgentOAuthRouting {
@@ -157,6 +168,7 @@ export function supportsConversationFork(agentType: AgentType): boolean {
     agentType === "gemini" ||
     agentType === "grok" ||
     agentType === "claude-codex" ||
+    agentType === "planner-runner" ||
     agentType === "lmstudio"
   );
 }
@@ -411,6 +423,8 @@ export interface PairedRoleStatus {
 export interface PairedStatus {
   state: PairedState;
   activeRole: PairedRole | null;
+  /** Wrapper agent type; absent on claude-codex statuses from older runtimes. */
+  agentType?: "claude-codex" | "planner-runner";
   planner: PairedRoleStatus;
   executor: PairedRoleStatus;
 }
@@ -429,8 +443,18 @@ export interface PairedTranscriptEvent {
 
 /** Per-role spawn configuration restored from the conversation row. */
 export interface PairedSpawnConfig {
-  planner?: { modelId?: string; effort?: string; serviceTier?: string };
-  executor?: { modelId?: string; effort?: string; serviceTier?: string };
+  planner?: {
+    agentType?: PairedRoleAgentType;
+    modelId?: string;
+    effort?: string;
+    serviceTier?: string;
+  };
+  executor?: {
+    agentType?: PairedRoleAgentType;
+    modelId?: string;
+    effort?: string;
+    serviceTier?: string;
+  };
 }
 
 /** Capture only explicit paired role pins that a fresh session can restore. */
@@ -439,12 +463,21 @@ export function pairedSpawnConfigFromStatus(
 ): PairedSpawnConfig | undefined {
   if (!paired) return undefined;
 
+  const persistAgents = paired.agentType === "planner-runner";
   const roleConfig = (
     role: PairedRoleStatus,
   ):
-    | { modelId?: string; effort?: string; serviceTier?: string }
+    | {
+        agentType?: PairedRoleAgentType;
+        modelId?: string;
+        effort?: string;
+        serviceTier?: string;
+      }
     | undefined => {
     const config = {
+      ...(persistAgents && role.agentType
+        ? { agentType: role.agentType as PairedRoleAgentType }
+        : {}),
       ...(role.pinnedModelId ? { modelId: role.pinnedModelId } : {}),
       ...(role.pinnedEffort ? { effort: role.pinnedEffort } : {}),
       ...(role.pinnedServiceTier
@@ -860,6 +893,22 @@ export async function listRemoteSessions(
 }
 
 /**
+ * Swap one Planner + Runner role to a different agent (#3748). The runtime
+ * terminates that role's inner session and spawns the new agent in place.
+ */
+export async function setRoleAgent(
+  sessionId: string,
+  role: PairedRole,
+  agentType: PairedRoleAgentType,
+): Promise<void> {
+  return invokeProvider("provider_set_role_agent", {
+    sessionId,
+    role,
+    agentType,
+  });
+}
+
+/**
  * Set the AI model for an agent runtime session. Paired sessions require a
  * role so only that role's inner session is touched.
  */
@@ -1088,6 +1137,18 @@ export async function ensurePairedCli(): Promise<string> {
   return invokeProvider<string>(
     "provider_ensure_agent_cli",
     { agentType: "claude-codex" },
+    { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Ensure the CLIs backing a Planner + Runner thread's default pairing are
+ * installed. A swapped role's CLI is ensured separately before the swap.
+ */
+export async function ensureGeneralPairedCli(): Promise<string> {
+  return invokeProvider<string>(
+    "provider_ensure_agent_cli",
+    { agentType: "planner-runner" },
     { timeoutMs: CLI_ENSURE_TIMEOUT_MS },
   );
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -515,6 +515,7 @@ import type {
   DiffEvent,
   DiffProposalEvent,
   PairedRole,
+  PairedRoleAgentType,
   PairedSpawnConfig,
   PairedStatus,
   PairedTranscriptEvent,
@@ -1463,7 +1464,11 @@ export interface ActiveSession {
 // ============================================================================
 
 function usesClaudeMemory(agentType: AgentType): boolean {
-  return agentType === "claude-code" || agentType === "claude-codex";
+  return (
+    agentType === "claude-code" ||
+    agentType === "claude-codex" ||
+    agentType === "planner-runner"
+  );
 }
 
 /**
@@ -1474,7 +1479,11 @@ function usesClaudeMemory(agentType: AgentType): boolean {
  * only ever holds the `claude-codex` wrapper. #3727.
  */
 function agentTypeTakesClaudeSlot(agentType: AgentType): boolean {
-  return agentType === "claude-code" || agentType === "claude-codex";
+  return (
+    agentType === "claude-code" ||
+    agentType === "claude-codex" ||
+    agentType === "planner-runner"
+  );
 }
 
 function encodeClaudeProjectDirForPath(cwd: string): string {
@@ -3391,9 +3400,11 @@ export const agentStore = {
             ? "Grok Agent"
             : resolvedAgentType === "claude-codex"
               ? "Claude + Codex"
-              : resolvedAgentType === "lmstudio"
-                ? "LM Studio Agent"
-                : "Claude Code Agent");
+              : resolvedAgentType === "planner-runner"
+                ? "Planner + Runner"
+                : resolvedAgentType === "lmstudio"
+                  ? "LM Studio Agent"
+                  : "Claude Code Agent");
 
     // Prevent concurrent spawns for the same conversation. Internal retries
     // (initRetryAttempt > 0) are allowed through because they are sequential
@@ -3570,7 +3581,9 @@ export const agentStore = {
                   ? providerService.ensureGrokCli
                   : resolvedAgentType === "claude-codex"
                     ? providerService.ensurePairedCli
-                    : null;
+                    : resolvedAgentType === "planner-runner"
+                      ? providerService.ensureGeneralPairedCli
+                      : null;
 
         if (ensureFn) {
           console.log("[AgentStore] Ensuring CLI is installed...");
@@ -3660,7 +3673,8 @@ export const agentStore = {
         // opts.paired.
         const reasoningEffort =
           resolvedAgentType === "claude-code" ||
-          resolvedAgentType === "claude-codex"
+          resolvedAgentType === "claude-codex" ||
+          resolvedAgentType === "planner-runner"
             ? settingsStore.settings.claudeReasoningEffort
             : undefined;
 
@@ -4408,7 +4422,10 @@ export const agentStore = {
       // PairedStatus the runtime's flat session info does not expose. Re-adopting
       // one would drop the paired UI, so leave paired resumes on the existing
       // terminate+respawn path (which reseeds pairedConfig from metadata). #2672
-      if (liveInfo.agentType === "claude-codex") {
+      if (
+        liveInfo.agentType === "claude-codex" ||
+        liveInfo.agentType === "planner-runner"
+      ) {
         return false;
       }
 
@@ -4673,6 +4690,7 @@ export const agentStore = {
       convo.agent_type === "gemini" ||
       convo.agent_type === "grok" ||
       convo.agent_type === "claude-codex" ||
+      convo.agent_type === "planner-runner" ||
       convo.agent_type === "lmstudio"
         ? (convo.agent_type as AgentType)
         : state.selectedAgentType;
@@ -5307,10 +5325,11 @@ export const agentStore = {
     // swap, fork, and restoreSessionSettings machinery here assumes one.
     // The planner's 1M window makes overflow rare — skip rather than risk
     // a half-restored pair (#2368).
-    if (session.info.agentType === "claude-codex") {
-      console.info(
-        "[AgentStore] Compaction skipped for paired Claude + Codex thread",
-      );
+    if (
+      session.info.agentType === "claude-codex" ||
+      session.info.agentType === "planner-runner"
+    ) {
+      console.info("[AgentStore] Compaction skipped for paired agent thread");
       return { outcome: "skipped_nothing_to_compact" };
     }
 
@@ -7126,6 +7145,40 @@ export const agentStore = {
     }
   },
 
+  /**
+   * Swap a Planner + Runner role to a different agent (#3748). Native CLIs
+   * are ensured before the runtime replaces that role's inner session; the
+   * refreshed paired status echo re-renders the pills and declaration.
+   */
+  async setPairedAgent(
+    role: PairedRole,
+    agentType: PairedRoleAgentType,
+    forSessionId?: string,
+  ) {
+    const sessionId = forSessionId ?? state.activeSessionId;
+    if (!sessionId || !state.sessions[sessionId]) return;
+    try {
+      const ensureFn =
+        agentType === "claude-code"
+          ? providerService.ensureClaudeCli
+          : agentType === "codex"
+            ? providerService.ensureCodexCli
+            : agentType === "gemini"
+              ? providerService.ensureGeminiCli
+              : agentType === "grok"
+                ? providerService.ensureGrokCli
+                : agentType === "lmstudio"
+                  ? providerService.ensureLmStudioCli
+                  : null;
+      if (ensureFn) await ensureFn();
+      await providerService.setRoleAgent(sessionId, role, agentType);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("[AgentStore] Failed to set paired role agent:", error);
+      setState("sessions", sessionId, "error", message);
+    }
+  },
+
   /** Role-scoped config (reasoning effort) for paired threads (#2368). */
   async setPairedConfigOption(
     role: PairedRole,
@@ -7840,6 +7893,7 @@ export const agentStore = {
             sess &&
             sess.role === "serving" &&
             sess.info.agentType !== "claude-codex" &&
+            sess.info.agentType !== "planner-runner" &&
             !sess.standbySessionId &&
             !sess.isCompacting &&
             !sess.predictiveCompactInFlight &&
@@ -9273,7 +9327,7 @@ export const agentStore = {
       return null;
     }
     const forkedMessages = allMessages.slice(0, forkIndex + 1).map((message) =>
-      agentType === "claude-codex" &&
+      (agentType === "claude-codex" || agentType === "planner-runner") &&
       message.id === `paired-declaration-${session.conversationId}`
         ? {
             ...message,

--- a/tests/unit/agent-cli-provisioning.test.ts
+++ b/tests/unit/agent-cli-provisioning.test.ts
@@ -43,6 +43,10 @@ describe("#3680 complete automatic CLI provisioning roster", () => {
         kind: "derived",
         dependencies: ["claude-code", "codex"],
       },
+      "planner-runner": {
+        kind: "derived",
+        dependencies: ["claude-code", "codex"],
+      },
       gemini: { kind: "verified-artifact", target: "antigravity" },
       grok: { kind: "npm", target: "grok" },
       lmstudio: { kind: "external-app", target: "lmstudio" },

--- a/tests/unit/agent-credential-lease-wiring.test.ts
+++ b/tests/unit/agent-credential-lease-wiring.test.ts
@@ -10,7 +10,7 @@ const agentStoreSource = readFileSync(
   "utf8",
 );
 
-function bodyAfter(marker: string, width = 12_000): string {
+function bodyAfter(marker: string, width = 14_000): string {
   const index = agentStoreSource.indexOf(marker);
   expect(index, `missing ${marker}`).toBeGreaterThanOrEqual(0);
   return agentStoreSource.slice(index, index + width);

--- a/tests/unit/launcher-redesign.test.ts
+++ b/tests/unit/launcher-redesign.test.ts
@@ -24,6 +24,7 @@ const runtimeAgentTypes: AgentType[] = [
   "codex",
   "claude-code",
   "claude-codex",
+  "planner-runner",
   "gemini",
   "grok",
   "lmstudio",
@@ -88,7 +89,7 @@ describe("ThreadSidebar — chip vocabulary (#1832)", () => {
     const hosted = Object.values(NATIVE_AGENT_LAUNCHER_METADATA).filter(
       (metadata) => metadata.chip.variant === "subscription",
     );
-    expect(hosted).toHaveLength(5);
+    expect(hosted).toHaveLength(6);
     expect(
       hosted.every((metadata) =>
         metadata.chip.label.startsWith("Subscription"),
@@ -363,10 +364,14 @@ describe("AgentChat — paired thread surfaces (#2368)", () => {
   });
 
   it("shows the compact paired header states", () => {
-    expect(agentChatTsx).toContain('"Claude planning"');
-    expect(agentChatTsx).toContain('"Codex editing"');
-    expect(agentChatTsx).toContain('"Claude reviewing"');
+    // Role labels come from the live paired status so a swapped pairing names
+    // its own agents; Claude/Codex remain the defaults (#3748).
+    expect(agentChatTsx).toContain("${plannerLabel} planning");
+    expect(agentChatTsx).toContain("${executorLabel} editing");
+    expect(agentChatTsx).toContain("${plannerLabel} reviewing");
     expect(agentChatTsx).toContain('"Waiting for approval"');
+    expect(agentChatTsx).toContain('?? "Claude"');
+    expect(agentChatTsx).toContain('?? "Codex"');
   });
 
   it("renders handoff events as inline transcript activity lines", () => {

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // @ts-expect-error — plain-JS runtime module without type declarations.
 import {
   createPairedRuntime,
+  GENERAL_PAIRED_AGENT_TYPE,
   PAIRED_AGENT_TYPE,
   resolvePlannerModel,
 } from "../../bin/browser-local/paired-runtime.mjs";
@@ -1483,5 +1484,145 @@ describe("resolvePlannerModel (#2827)", () => {
     expect(resolvePlannerModel(null, undefined)).toMatchObject({
       reason: "default",
     });
+  });
+});
+
+describe("planner-runner — configurable pairing (#3748)", () => {
+  let h: ReturnType<typeof createHarness>;
+  beforeEach(() => {
+    h = createHarness();
+  });
+
+  async function spawnGeneral(params: Record<string, unknown> = {}) {
+    return h.paired.spawnSession({
+      agentType: GENERAL_PAIRED_AGENT_TYPE,
+      cwd: "/tmp/project",
+      localSessionId: "paired-1",
+      ...params,
+    });
+  }
+
+  it("defaults to the Claude + Codex pairing when no roles are configured", async () => {
+    const info = await spawnGeneral();
+    expect(info.agentType).toBe(GENERAL_PAIRED_AGENT_TYPE);
+    const spawnTypes = h.inner.spawnSession.mock.calls.map(
+      (c) => c[0].agentType,
+    );
+    expect(spawnTypes).toEqual(["claude-code", "codex"]);
+  });
+
+  it("spawns the configured role agents and names them in the declaration", async () => {
+    await spawnGeneral({
+      paired: {
+        planner: { agentType: "gemini" },
+        executor: { agentType: "grok" },
+      },
+    });
+    const spawnTypes = h.inner.spawnSession.mock.calls.map(
+      (c) => c[0].agentType,
+    );
+    expect(spawnTypes).toEqual(["gemini", "grok"]);
+
+    const declarations = eventsFor(h.emitted, "provider://paired-event").filter(
+      (e) => e.payload.kind === "declaration",
+    );
+    const text = String(declarations[0].payload.text);
+    expect(text).toContain("Antigravity is planner and reviewer");
+    expect(text).toContain("Grok is runner");
+  });
+
+  it("allows the same agent in both roles", async () => {
+    await spawnGeneral({
+      paired: {
+        planner: { agentType: "codex" },
+        executor: { agentType: "codex" },
+      },
+    });
+    const spawnTypes = h.inner.spawnSession.mock.calls.map(
+      (c) => c[0].agentType,
+    );
+    expect(spawnTypes).toEqual(["codex", "codex"]);
+  });
+
+  it("keeps a non-Claude planner on its own default model — no Fable pin", async () => {
+    await spawnGeneral({
+      paired: { planner: { agentType: "gemini" } },
+    });
+    expect(h.inner.setSessionModel).not.toHaveBeenCalled();
+  });
+
+  it("still pins Fable for a Claude planner", async () => {
+    await spawnGeneral();
+    expect(h.inner.setSessionModel).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: "claude-fable-5[1m]" }),
+    );
+  });
+
+  it("records the pairing in the composite session id for resume", async () => {
+    const info = await spawnGeneral({
+      paired: {
+        planner: { agentType: "gemini" },
+        executor: { agentType: "grok" },
+      },
+    });
+    const composite = JSON.parse(String(info.agentSessionId));
+    expect(composite.agents).toEqual({ planner: "gemini", executor: "grok" });
+  });
+
+  it("respawns the recorded pairing from a resume composite over stale config", async () => {
+    const resume = JSON.stringify({
+      planner: "planner-remote-id",
+      executor: "executor-remote-id",
+      agents: { planner: "grok", executor: "lmstudio" },
+    });
+    await spawnGeneral({
+      resumeAgentSessionId: resume,
+      paired: { planner: { agentType: "gemini" } },
+    });
+    const spawnTypes = h.inner.spawnSession.mock.calls.map(
+      (c) => c[0].agentType,
+    );
+    expect(spawnTypes).toEqual(["grok", "lmstudio"]);
+  });
+
+  it("swaps one role's agent in place and refreshes the declaration", async () => {
+    await spawnGeneral();
+    const executorInner = h.inner.spawnSession.mock.calls[1][0]
+      .localSessionId as string;
+
+    await h.paired.setRoleAgent({
+      sessionId: "paired-1",
+      role: "executor",
+      agentType: "gemini",
+    });
+
+    expect(h.inner.terminateSession).toHaveBeenCalledWith({
+      sessionId: executorInner,
+    });
+    const spawnTypes = h.inner.spawnSession.mock.calls.map(
+      (c) => c[0].agentType,
+    );
+    expect(spawnTypes).toEqual(["claude-code", "codex", "gemini"]);
+
+    const declarations = eventsFor(h.emitted, "provider://paired-event").filter(
+      (e) => e.payload.kind === "declaration",
+    );
+    const latest = String(declarations.at(-1)?.payload.text);
+    expect(latest).toContain("Antigravity is runner");
+  });
+
+  it("refuses role swaps on a claude-codex thread", async () => {
+    await h.paired.spawnSession({
+      agentType: PAIRED_AGENT_TYPE,
+      cwd: "/tmp/project",
+      localSessionId: "paired-1",
+    });
+    await expect(
+      h.paired.setRoleAgent({
+        sessionId: "paired-1",
+        role: "executor",
+        agentType: "gemini",
+      }),
+    ).rejects.toThrow(/fixed/i);
   });
 });

--- a/tests/validation/scenarios/planner-runner-walkthrough.ts
+++ b/tests/validation/scenarios/planner-runner-walkthrough.ts
@@ -98,6 +98,14 @@ export default async function run(ctx: ScenarioContext): Promise<void> {
         30_000,
       ))
     ) {
+      await ctx.writeArtifact(
+        "00-signin-failure-screenshot.json",
+        await ctx.client.screenshot("body"),
+      );
+      await ctx.writeArtifact(
+        "00-signin-failure-text.json",
+        await ctx.client.dumpText("body"),
+      );
       throw new Error("Sign-in did not complete");
     }
   }

--- a/tests/validation/scenarios/planner-runner-walkthrough.ts
+++ b/tests/validation/scenarios/planner-runner-walkthrough.ts
@@ -1,0 +1,229 @@
+// ABOUTME: Signed-in live walkthrough for the Planner + Runner paired agent (#3748).
+// ABOUTME: Verifies launcher placement, role enumeration, a hosted pairing end-to-end, and claude-codex regression.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+import { submitSignIn } from "./signed-in-smoke";
+
+interface TextDump {
+  text?: string;
+}
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? ((value as TextDump).text as string)
+    : JSON.stringify(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function present(
+  client: ScenarioContext["client"],
+  selector: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    await client.waitFor(selector, timeoutMs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Approve any pending action card so the paired turn can proceed hands-free. */
+async function approveIfPrompted(
+  client: ScenarioContext["client"],
+): Promise<boolean> {
+  const approveSelectors = [
+    "button[title='Pre-approve matching actions for this task, with limits you set']",
+    "button[data-testid='action-approve']",
+  ];
+  for (const selector of approveSelectors) {
+    if (await present(client, selector, 500)) {
+      await client.click(selector);
+      return true;
+    }
+  }
+  return false;
+}
+
+async function waitForBodyText(
+  ctx: ScenarioContext,
+  needle: string,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const body = textOf(await ctx.client.dumpText("body"));
+    if (body.includes(needle)) return;
+    await approveIfPrompted(ctx.client);
+    await sleep(2_000);
+  }
+  await ctx.writeArtifact(
+    `${label}-timeout-screenshot.json`,
+    await ctx.client.screenshot("body"),
+  );
+  throw new Error(`Timed out waiting for "${needle}" during ${label}`);
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  const email = process.env.SEREN_VALIDATION_AGENT_EMAIL;
+  const password = process.env.SEREN_VALIDATION_AGENT_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "SEREN_VALIDATION_AGENT_EMAIL and SEREN_VALIDATION_AGENT_PASSWORD must be set",
+    );
+  }
+  const projectDir = process.env.SEREN_WALKTHROUGH_PROJECT_DIR;
+  if (!projectDir || !existsSync(projectDir)) {
+    throw new Error("SEREN_WALKTHROUGH_PROJECT_DIR must point at a scratch repo");
+  }
+
+  // --- Stage 0: sign in as the validation user -----------------------------
+  const alreadySignedIn = await present(
+    ctx.client,
+    "button[aria-label^='SerenBucks balance']",
+    8_000,
+  );
+  if (!alreadySignedIn) {
+    await submitSignIn(ctx.client, email, password);
+    if (
+      !(await present(
+        ctx.client,
+        "button[aria-label^='SerenBucks balance']",
+        30_000,
+      ))
+    ) {
+      throw new Error("Sign-in did not complete");
+    }
+  }
+  await ctx.client.command({ command: "setRootPath", path: projectDir });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+
+  // --- Stage 1: launcher placement — directly below Claude + Codex ---------
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-planner-runner-agent']", 10_000);
+  await ctx.writeArtifact(
+    "01-launcher-menu.json",
+    await ctx.client.screenshot("body"),
+  );
+  const menuText = textOf(await ctx.client.dumpText("body"));
+  const codexIdx = menuText.indexOf("Claude + Codex");
+  const prIdx = menuText.indexOf("Planner + Runner");
+  if (codexIdx < 0 || prIdx < 0 || prIdx < codexIdx) {
+    throw new Error(
+      `Launcher order wrong: Claude + Codex at ${codexIdx}, Planner + Runner at ${prIdx}`,
+    );
+  }
+  await ctx.writeArtifact("01-launcher-menu-text.json", { menuText });
+
+  // --- Stage 2: launch — default pairing is Claude + Codex -----------------
+  await ctx.client.click("[data-testid='new-planner-runner-agent']");
+  await ctx.client.waitFor("[data-testid='paired-thread-header']", 120_000);
+  await ctx.client.waitFor(".chat-composer-form textarea", 120_000);
+  await waitForBodyText(ctx, "Claude is planner and reviewer", 120_000, "stage2");
+  await ctx.client.waitFor(
+    "[data-testid='paired-agent-selector-planner']",
+    30_000,
+  );
+  await ctx.writeArtifact(
+    "02-default-pairing.json",
+    await ctx.client.screenshot("body"),
+  );
+
+  // --- Stage 3: completeness — the planner dropdown lists the live set -----
+  await ctx.client.click("[data-testid='paired-agent-selector-planner']");
+  await sleep(700);
+  await ctx.writeArtifact(
+    "03-planner-agent-menu.json",
+    await ctx.client.screenshot("body"),
+  );
+  const dropdownText = textOf(await ctx.client.dumpText("body"));
+  const expectedAgents = [
+    "Claude Code",
+    "Codex",
+    "Antigravity",
+    "Grok",
+    "LM Studio",
+    "Seren Agent",
+    "Seren Private Models",
+  ];
+  const missing = expectedAgents.filter((name) => !dropdownText.includes(name));
+  await ctx.writeArtifact("03-planner-agent-menu-text.json", {
+    expectedAgents,
+    missing,
+  });
+  if (missing.length > 0) {
+    throw new Error(`Planner agent menu missing: ${missing.join(", ")}`);
+  }
+
+  // --- Stage 4: hosted pairing — Seren plans, Codex runs -------------------
+  await ctx.client.click(
+    "[data-testid='paired-agent-option-planner-seren']",
+  );
+  await waitForBodyText(ctx, "Seren is planner and reviewer", 120_000, "stage4-swap");
+  await ctx.writeArtifact(
+    "04-hosted-pairing-declaration.json",
+    await ctx.client.screenshot("body"),
+  );
+
+  const marker = `pr-walkthrough-${Date.now()}`;
+  await ctx.client.fill(
+    ".chat-composer-form textarea",
+    `Create a file named hello.txt in the project root containing exactly "${marker}" and nothing else, then confirm it exists.`,
+  );
+  await ctx.client.click(".chat-composer-form button[type='submit']");
+
+  await waitForBodyText(ctx, "handed off to Codex", 420_000, "stage4-handoff");
+  await ctx.writeArtifact(
+    "05-handoff.json",
+    await ctx.client.screenshot("body"),
+  );
+  await waitForBodyText(ctx, "handed back to Seren", 600_000, "stage4-review");
+  await ctx.writeArtifact(
+    "06-review-complete.json",
+    await ctx.client.screenshot("body"),
+  );
+
+  const helloPath = path.join(projectDir, "hello.txt");
+  const helloContents = existsSync(helloPath)
+    ? readFileSync(helloPath, "utf8").trim()
+    : null;
+  await ctx.writeArtifact("07-real-artifact.json", {
+    helloPath,
+    helloContents,
+    marker,
+    matches: helloContents === marker,
+  });
+  if (helloContents !== marker) {
+    throw new Error(
+      `Runner did not produce the real artifact: ${helloPath} => ${JSON.stringify(helloContents)}`,
+    );
+  }
+
+  // --- Stage 5: regression — Claude + Codex unchanged, no agent pills ------
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-claude-codex-agent']", 10_000);
+  await ctx.client.click("[data-testid='new-claude-codex-agent']");
+  await ctx.client.waitFor("[data-testid='paired-thread-header']", 120_000);
+  await waitForBodyText(ctx, "Claude is planner and reviewer", 120_000, "stage5");
+  const regressionBody = textOf(await ctx.client.dumpText("body"));
+  const hasAgentPills = regressionBody.includes("Planner · Claude Code");
+  await ctx.writeArtifact("08-claude-codex-regression.json", {
+    declarationUnchanged: regressionBody.includes(
+      "Codex is executor for code edits, commands, and tests",
+    ),
+    agentPillsAbsent: !hasAgentPills,
+  });
+  await ctx.writeArtifact(
+    "08-claude-codex-regression-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+  if (hasAgentPills) {
+    throw new Error("claude-codex thread must not offer role-agent pills");
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Planner + Runner** (#3748): a paired coding agent identical in workflow to Claude + Codex, but with both roles user-selectable from **every agent Seren Desktop offers** — Claude Code, Codex, Antigravity, Grok, LM Studio, plus the hosted Seren Agent (SerenModels) and Seren Private Models. Listed directly below Claude + Codex in both "New" menus. No new modal: roles are swapped through flat composer pills, matching the live paired-thread design.

All five product decisions recorded on the issue are implemented: same-agent pairing allowed; each planner keeps its own default model (Fable/Opus pin only when the planner is Claude); no capacity limits or warnings; new threads open as Claude + Codex; no mixed-billing display.

## What changed

**Node provider runtime**
- `paired-runtime.mjs` — role identities resolve from spawn params; `planner-runner` wrapper type with per-agent labels in the declaration/handoff/review text; `setRoleAgent` swaps one leg in place; the composite session id records the pairing so resumes respawn the same agents. The `claude-codex` wrapper is byte-identical in behavior.
- `seren-runtime.mjs` (new) — SerenModels / Private Models as spawnable role sessions: OpenAI-compatible streaming through the credential broker's loopback publisher proxy, reusing the LM Studio runtime's local-tool, MCP, and permission machinery (its session core is now exported with a per-session chat endpoint override).
- `providers.mjs` — hosted-session dispatch across all session RPCs; `provider_set_role_agent` command; wrapper-aware capacity attribution.
- `agent-registry.mjs` — `planner-runner` definition below Claude + Codex; derived claude-code/codex provisioning for the default pairing.

**Frontend**
- New `PairedAgentSelector` pill (role-scoped) enumerating all seven agents from live availability, org policy, and sign-in state — no hardcoded roster; stable testids on every option.
- Launcher rows in ThreadSidebar (data-driven) and ThreadTabBar (below Claude + Codex); paired header/declaration labels driven by live role status; `PairedSpawnConfig` carries each role's `agentType` for restore; `setPairedAgent` store action ensures a swapped role's CLI first.

**Rust**
- `planner-runner` registered in `NATIVE_AGENT_PROVIDERS` + `DERIVED_KIND_CASE_SQL` (drift-guard green).
- `split_paired_session_ids` returns per-provider transcript-leg vectors routed by the composite's recorded role agents — same-agent pairings clean up both legs; hosted legs correctly skipped.

**Out of scope by owner decision:** Mission Control integration (not needed), mixed-billing chips (not needed). Privacy Mode: paired wrappers remain blocked wholesale on privileged threads, unchanged from Claude + Codex.

## Verification

**Automated (all green, run against this branch):**
- Full unit suite: **3,110 tests / 450 files pass**, including 9 new coordinator cases (default pairing, configured + same-agent pairings, no cross-agent model pin, resume from recorded pairing, in-place role swap, claude-codex swap refusal) and extended roster drift-guards.
- Rust: chat + provider_runtime modules **96 tests pass**, including a new transcript-leg routing test and the existing paired-deletion + derived-kind drift guards.
- Biome exit 0 at main's baseline; zero net-new tsc errors vs. main (254 = 254).
- All 60 pre-existing paired (claude-codex) tests pass unmodified in behavior.

**Live app evidence:**
- The validation app was built and launched from this branch (validation control server up, provider runtime with all modified modules booted `{"ok":true}`, CLI updater ran) — proving the full change-set loads and boots in the real app.
- A five-stage signed-in walkthrough scenario is committed at `tests/validation/scenarios/planner-runner-walkthrough.ts` (launcher placement, default pairing, live seven-agent enumeration with hard-fail on omissions, hosted Seren-plans/Codex-runs turn verified by an on-disk artifact, claude-codex regression). Two execution attempts were cut mid-run by host session restarts before completing.

**Review gate:** the repository owner explicitly approved validation and directed create-and-merge on 2026-08-08, waiving completion of the live walkthrough. The committed scenario remains runnable for post-merge verification.

Closes #3748

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
