### PR TITLE
feat(chat): add Seren Models routing preference (provider.sort) (#3747)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -652,6 +652,10 @@ pub struct Conversation {
     pub employee_id: Option<String>,
     #[serde(default)]
     pub privileged: bool,
+    /// Seren Models routing preference ("fastest" | "cheapest"). NULL keeps
+    /// the server-default Fastest routing for threads that never chose one.
+    #[serde(default)]
+    pub routing_preference: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -735,6 +739,10 @@ pub struct UnifiedConversationRow {
     // the durable SQLite value is hydrated immediately after the read.
     #[serde(default)]
     pub privileged: bool,
+    /// Seren Models routing preference ("fastest" | "cheapest"); NULL means
+    /// the thread follows the server-default Fastest routing.
+    #[serde(default)]
+    pub routing_preference: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -762,6 +770,7 @@ pub async fn create_conversation(
     selected_provider: Option<String>,
     project_root: Option<String>,
     employee_id: Option<String>,
+    routing_preference: Option<String>,
 ) -> Result<Conversation, String> {
     let created_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -780,13 +789,14 @@ pub async fn create_conversation(
         is_archived: false,
         employee_id: employee_id.clone(),
         privileged: false,
+        routing_preference: routing_preference.clone(),
     };
 
     run_db(app, move |conn| {
         conn.execute(
-            "INSERT INTO conversations (id, title, created_at, selected_model, selected_provider, project_root, is_archived, kind, employee_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 'chat', ?7)",
-            params![id, title, created_at, selected_model, selected_provider, normalized_project_root, employee_id],
+            "INSERT INTO conversations (id, title, created_at, selected_model, selected_provider, project_root, is_archived, kind, employee_id, routing_preference)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 'chat', ?7, ?8)",
+            params![id, title, created_at, selected_model, selected_provider, normalized_project_root, employee_id, routing_preference],
         )?;
         mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
@@ -848,6 +858,7 @@ pub async fn list_conversations(
                        c.employee_id, c.agent_type, c.agent_session_id,
                        c.agent_cwd, c.agent_model_id, c.agent_permission_mode,
                        c.agent_metadata, c.project_id, c.privileged,
+                       c.routing_preference,
                        psr.provider AS runtime_provider,
                        {case} AS derived_kind
                 FROM conversations c
@@ -863,7 +874,7 @@ pub async fn list_conversations(
                         ELSE agent_type END AS agent_type,
                    agent_session_id, agent_cwd, agent_model_id,
                    agent_permission_mode, agent_metadata, project_id,
-                   privileged
+                   privileged, routing_preference
             FROM derived
             WHERE is_archived = 0
               AND (?1 IS NULL OR derived_kind = ?1)
@@ -899,6 +910,7 @@ pub async fn list_conversations(
                     agent_metadata: row.get(14)?,
                     project_id: row.get(15)?,
                     privileged: row.get::<_, i32>(16)? != 0,
+                    routing_preference: row.get(17)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -920,7 +932,7 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                          THEN COALESCE(c.selected_provider, psr.provider)
                          ELSE c.selected_provider END AS selected_provider,
                     c.project_root, c.is_archived, c.employee_id,
-                    c.privileged
+                    c.privileged, c.routing_preference
              FROM conversations c
              LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
              WHERE c.id = ?1
@@ -941,6 +953,7 @@ pub async fn get_conversation(app: AppHandle, id: String) -> Result<Option<Conve
                     is_archived: row.get::<_, i32>(6)? != 0,
                     employee_id: row.get(7)?,
                     privileged: row.get::<_, i32>(8)? != 0,
+                    routing_preference: row.get(9)?,
                 })
             })
             .optional()?;
@@ -957,6 +970,7 @@ pub async fn update_conversation(
     title: Option<String>,
     selected_model: Option<String>,
     selected_provider: Option<String>,
+    routing_preference: Option<String>,
 ) -> Result<(), String> {
     let index_id = id.clone();
     let index_title = title.clone();
@@ -979,6 +993,13 @@ pub async fn update_conversation(
             conn.execute(
                 "UPDATE conversations SET selected_provider = ?1 WHERE id = ?2",
                 params![p, id],
+            )?;
+            mark_sync_upsert(conn, "conversations", &id)?;
+        }
+        if let Some(r) = routing_preference {
+            conn.execute(
+                "UPDATE conversations SET routing_preference = ?1 WHERE id = ?2",
+                params![r, id],
             )?;
             mark_sync_upsert(conn, "conversations", &id)?;
         }

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -757,7 +757,28 @@ created if missing.",
             body["reasoning"] = serde_json::json!({ "effort": effort });
         }
 
+        self.apply_provider_sort(&mut body, routing);
+
         body
+    }
+
+    /// Inject the routing preference as `provider.sort` (#3747). Only
+    /// seren-models understands the field, and seren-router rejects unknown
+    /// values with a 400, so both the publisher and the value are gated here.
+    fn apply_provider_sort(&self, body: &mut serde_json::Value, routing: &RoutingDecision) {
+        if self.publisher_slug != DEFAULT_PUBLISHER_SLUG {
+            return;
+        }
+        if let Some(ref sort) = routing.provider_sort {
+            if matches!(sort.as_str(), "price" | "throughput" | "latency") {
+                body["provider"] = serde_json::json!({ "sort": sort });
+                log::info!("[ChatModelWorker] provider.sort={sort} attached");
+            } else {
+                log::warn!(
+                    "[ChatModelWorker] Ignoring unknown provider_sort value: {sort}"
+                );
+            }
+        }
     }
 
     /// Extract text from a content value that may be a string, an array of parts,
@@ -2141,6 +2162,7 @@ impl Worker for ChatModelWorker {
                 body["tools"] = serde_json::json!(tools);
                 body["tool_choice"] = serde_json::json!("auto");
             }
+            self.apply_provider_sort(&mut body, routing);
             // Cap output tokens on tool-call rounds — tool selections are small.
             if round > 0 {
                 body["max_tokens"] = serde_json::json!(4096);
@@ -2706,6 +2728,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -2727,6 +2750,55 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[1]["content"], "previous message");
         assert_eq!(messages[2]["content"], "Hello world");
+        // No routing preference set → provider.sort must be absent so the
+        // server keeps its default Fastest policy (#3747).
+        assert!(body.get("provider").is_none());
+    }
+
+    #[test]
+    fn provider_sort_reaches_seren_models_bodies_only() {
+        let routing = |sort: Option<&str>| RoutingDecision {
+            worker_type: super::super::types::WorkerType::ChatModel,
+            model_id: "anthropic/claude-sonnet-4".to_string(),
+            delegation: super::super::types::DelegationType::InLoop,
+            reason: "General chat".to_string(),
+            selected_skills: vec![],
+            publisher_slug: None,
+            reasoning_effort: None,
+            provider_sort: sort.map(String::from),
+            project_root: None,
+        };
+
+        // seren-models worker with a valid preference → provider.sort on the body.
+        let worker = ChatModelWorker::new();
+        let body =
+            worker.build_request_body("hi", &[], &routing(Some("price")), "", &[], &[], None);
+        assert_eq!(body["provider"]["sort"], "price");
+
+        // The tool-loop body is built separately from build_request_body;
+        // apply_provider_sort is the shared injection point for both.
+        let mut loop_body = serde_json::json!({
+            "model": "anthropic/claude-sonnet-4",
+            "messages": [],
+            "stream": true
+        });
+        worker.apply_provider_sort(&mut loop_body, &routing(Some("price")));
+        assert_eq!(loop_body["provider"]["sort"], "price");
+
+        // Unknown values never reach the wire — seren-router 400s on them.
+        let mut invalid_body = serde_json::json!({ "model": "m", "stream": true });
+        worker.apply_provider_sort(&mut invalid_body, &routing(Some("balanced")));
+        assert!(invalid_body.get("provider").is_none());
+
+        // A non-seren-models publisher (private chat) must not see the field.
+        let private_worker = ChatModelWorker::with_tools(
+            Vec::new(),
+            Some("seren-private-models".to_string()),
+            EffectiveAgentPolicy::default(),
+        );
+        let mut private_body = serde_json::json!({ "model": "m", "stream": true });
+        private_worker.apply_provider_sort(&mut private_body, &routing(Some("price")));
+        assert!(private_body.get("provider").is_none());
     }
 
     #[test]
@@ -2740,6 +2812,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
         let dynamic_guidance =
@@ -2797,6 +2870,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -2840,6 +2914,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -2876,6 +2951,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -2905,6 +2981,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -3368,6 +3445,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -4084,6 +4162,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
         let tools = vec![
@@ -4117,6 +4196,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
         let tools = vec![make_tool("gateway__gmail__send_message")];
@@ -4149,6 +4229,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -4184,6 +4265,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -4216,6 +4298,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 

--- a/src-tauri/src/orchestrator/mcp_publisher_worker.rs
+++ b/src-tauri/src/orchestrator/mcp_publisher_worker.rs
@@ -382,6 +382,7 @@ mod tests {
             selected_skills: vec![],
             publisher_slug: publisher_slug.map(String::from),
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         }
     }

--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -84,6 +84,7 @@ pub fn route(
         publisher_slug,
         reasoning_effort: capabilities.reasoning_effort.clone(),
         project_root: capabilities.project_root.clone(),
+        provider_sort: capabilities.provider_sort.clone(),
     }
 }
 
@@ -564,6 +565,7 @@ mod tests {
             installed_skills: vec![],
             model_rankings: vec![],
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
             effective_agent_policy: EffectiveAgentPolicy::default(),
         }
@@ -595,6 +597,7 @@ mod tests {
             installed_skills: skills,
             model_rankings: vec![],
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
             effective_agent_policy: EffectiveAgentPolicy::default(),
         }

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -117,6 +117,11 @@ pub struct RoutingDecision {
     /// Project root for live repo context injection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_root: Option<String>,
+    /// Seren Models `provider.sort` wire value ("price" | "throughput" |
+    /// "latency") resolved from the thread's routing preference. Only
+    /// injected into seren-models request bodies.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub provider_sort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -215,6 +220,10 @@ pub struct UserCapabilities {
     /// Values: "minimal", "low", "medium", "high", "xhigh". None = provider default.
     #[serde(default)]
     pub reasoning_effort: Option<String>,
+    /// Seren Models `provider.sort` wire value resolved by the frontend from
+    /// the thread's routing preference. None = server-default Fastest routing.
+    #[serde(default)]
+    pub provider_sort: Option<String>,
     /// Project root directory path. Used to gather live repo context (git status,
     /// branch, directory structure) for injection into the system prompt.
     #[serde(default)]
@@ -493,6 +502,7 @@ mod tests {
             }],
             publisher_slug: None,
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
         };
 
@@ -616,6 +626,7 @@ mod tests {
             installed_skills: vec![],
             model_rankings: vec![],
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
             effective_agent_policy: EffectiveAgentPolicy::default(),
         };
@@ -641,6 +652,7 @@ mod tests {
             installed_skills: vec![],
             model_rankings: vec![],
             reasoning_effort: None,
+            provider_sort: None,
             project_root: None,
             effective_agent_policy: EffectiveAgentPolicy::default(),
         };

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -742,7 +742,8 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             project_id TEXT,
             project_root TEXT,
             employee_id TEXT,
-            privileged INTEGER NOT NULL DEFAULT 0
+            privileged INTEGER NOT NULL DEFAULT 0,
+            routing_preference TEXT
         )",
         [],
     )?;
@@ -1067,6 +1068,18 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     if !has_privileged {
         conn.execute(
             "ALTER TABLE conversations ADD COLUMN privileged INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+
+    // Seren Models routing preference (#3747). Nullable so pre-existing
+    // threads keep the default (Fastest) behavior without a backfill.
+    let has_routing_preference: bool = conn
+        .prepare("SELECT routing_preference FROM conversations LIMIT 1")
+        .is_ok();
+    if !has_routing_preference {
+        conn.execute(
+            "ALTER TABLE conversations ADD COLUMN routing_preference TEXT",
             [],
         )?;
     }
@@ -2199,6 +2212,57 @@ mod tests {
             agent_metadata,
             Some("{\"pendingBootstrapPromptContext\":\"seed\"}".to_string())
         );
+    }
+
+    #[test]
+    fn migration_adds_routing_preference_column() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        // Pre-#3747 schema: no routing_preference column.
+        conn.execute(
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                selected_model TEXT,
+                selected_provider TEXT,
+                is_archived INTEGER DEFAULT 0,
+                kind TEXT NOT NULL DEFAULT 'chat'
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at) VALUES ('c1', 'Old', 1000)",
+            [],
+        )
+        .unwrap();
+
+        setup_schema(&conn).unwrap();
+
+        // Legacy rows stay NULL (server-default Fastest routing); new writes persist.
+        let legacy: Option<String> = conn
+            .query_row(
+                "SELECT routing_preference FROM conversations WHERE id = 'c1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy, None);
+
+        conn.execute(
+            "UPDATE conversations SET routing_preference = 'cheapest' WHERE id = 'c1'",
+            [],
+        )
+        .unwrap();
+        let updated: Option<String> = conn
+            .query_row(
+                "SELECT routing_preference FROM conversations WHERE id = 'c1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(updated, Some("cheapest".to_string()));
     }
 
     #[test]

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -60,6 +60,7 @@ import {
   computeProviderBoundaries,
   providerDisplayName,
 } from "@/lib/provider-boundaries";
+import { providerSortForPreference } from "@/lib/providers/routing-preference";
 import type { Attachment, ProviderId } from "@/lib/providers/types";
 import {
   escapeHtmlWithSkillsAndLinks,
@@ -139,6 +140,7 @@ import { PublisherSuggestions } from "./PublisherSuggestions";
 import { ReasoningEffortSelector } from "./ReasoningEffortSelector";
 import { RerouteAnnouncement } from "./RerouteAnnouncement";
 import { RLMStepsBlock } from "./RLMStepsBlock";
+import { RoutingPreferenceSelector } from "./RoutingPreferenceSelector";
 import { SatisfactionSignal } from "./SatisfactionSignal";
 import { SkillsButton } from "./SkillsButton";
 import { SlashCommandPopup } from "./SlashCommandPopup";
@@ -1325,6 +1327,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
           );
         },
         historyBeforeRetry,
+        providerSortForPreference(conversationStore.getRoutingPreference(id)),
       );
 
       const updated = {
@@ -2306,6 +2309,9 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   <ModelSelector threadId={conversationId()} />
                   <ToolsetSelector />
                   <ReasoningEffortSelector />
+                  <Show when={activeThreadProvider() === "seren"}>
+                    <RoutingPreferenceSelector threadId={conversationId()} />
+                  </Show>
                   <SkillsButton
                     recentSkill={recentSkill()}
                     onLaunch={() => {

--- a/src/components/chat/RoutingPreferenceSelector.tsx
+++ b/src/components/chat/RoutingPreferenceSelector.tsx
@@ -1,0 +1,115 @@
+// ABOUTME: Per-thread Seren Models routing preference selector (Fastest/Cheapest).
+// ABOUTME: Persists the choice on the conversation row; requests map it to provider.sort.
+
+import type { Component } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import {
+  DEFAULT_ROUTING_PREFERENCE,
+  ROUTING_PREFERENCE_OPTIONS,
+  type RoutingPreference,
+} from "@/lib/providers/routing-preference";
+import { conversationStore } from "@/stores/conversation.store";
+
+interface RoutingPreferenceSelectorProps {
+  threadId: string | null;
+}
+
+export const RoutingPreferenceSelector: Component<
+  RoutingPreferenceSelectorProps
+> = (props) => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let containerRef: HTMLDivElement | undefined;
+
+  // Legacy threads (null) behave as Fastest — the server default.
+  const activePreference = (): RoutingPreference =>
+    conversationStore.getRoutingPreference(props.threadId) ??
+    DEFAULT_ROUTING_PREFERENCE;
+
+  const activeOption = () =>
+    ROUTING_PREFERENCE_OPTIONS.find((o) => o.id === activePreference()) ??
+    ROUTING_PREFERENCE_OPTIONS[0];
+
+  const handleSelect = (id: RoutingPreference) => {
+    setIsOpen(false);
+    if (props.threadId) {
+      void conversationStore.updateConversationRoutingPreference(
+        props.threadId,
+        id,
+      );
+    }
+  };
+
+  const handleDocumentClick = (event: MouseEvent) => {
+    if (!isOpen()) return;
+    if (
+      containerRef &&
+      event.target instanceof Node &&
+      !containerRef.contains(event.target)
+    ) {
+      setIsOpen(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("click", handleDocumentClick);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("click", handleDocumentClick);
+  });
+
+  return (
+    <div class="relative" ref={containerRef}>
+      <button
+        type="button"
+        class="flex items-center gap-2 px-3 py-1.5 bg-popover border border-muted rounded-md text-sm text-foreground cursor-pointer transition-colors hover:border-muted-foreground/40"
+        onClick={() => setIsOpen(!isOpen())}
+        title="Choose how Seren Models routes this thread's requests"
+      >
+        <span class="text-[14px]">🧭</span>
+        <span class="text-foreground max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap">
+          {activeOption().name}
+        </span>
+        <span class="text-[10px] text-muted-foreground">
+          {isOpen() ? "▲" : "▼"}
+        </span>
+      </button>
+
+      <Show when={isOpen()}>
+        <div class="absolute bottom-[calc(100%+8px)] left-0 min-w-[240px] bg-surface-2 border border-surface-3 rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.5)] z-[1000] overflow-hidden">
+          <div class="px-3 py-2 bg-surface-3 border-b border-surface-3">
+            <span class="text-xs text-muted-foreground">Routing</span>
+          </div>
+
+          <div class="max-h-[250px] overflow-y-auto py-1 bg-surface-2">
+            <For each={ROUTING_PREFERENCE_OPTIONS}>
+              {(option) => (
+                <button
+                  type="button"
+                  class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border ${activePreference() === option.id ? "bg-primary/[0.12]" : ""}`}
+                  onClick={() => handleSelect(option.id)}
+                >
+                  <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                    <span class="text-foreground font-medium">
+                      {option.name}
+                    </span>
+                    <span class="text-[11px] text-muted-foreground">
+                      {option.description}
+                    </span>
+                  </div>
+                  <Show when={activePreference() === option.id}>
+                    <span class="text-success text-sm font-semibold">
+                      &#10003;
+                    </span>
+                  </Show>
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default RoutingPreferenceSelector;

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
 import { isWindowsPlatform } from "@/lib/platform";
+import { ROUTING_PREFERENCE_OPTIONS } from "@/lib/providers/routing-preference";
 import {
   type EraseTargetReport,
   eraseAllConversationData,
@@ -613,6 +614,34 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                   placeholder="Select a model"
                 />
               </Show>
+            </div>
+
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-border">
+              <label class="flex flex-col gap-0.5 flex-1">
+                <span class="text-[0.95rem] font-medium text-foreground">
+                  Default Routing
+                </span>
+                <span class="text-[0.8rem] text-muted-foreground">
+                  How Seren Models picks a provider for new threads. Each thread
+                  can override this from the composer.
+                </span>
+              </label>
+              <select
+                value={settingsState.app.chatRoutingPreference}
+                onChange={(e) =>
+                  settingsStore.set(
+                    "chatRoutingPreference",
+                    e.currentTarget.value === "cheapest"
+                      ? "cheapest"
+                      : "fastest",
+                  )
+                }
+                class="w-[140px] px-3 py-2 bg-surface-3/80 border border-border-strong rounded-md text-foreground text-[0.9rem] focus:outline-none focus:border-accent"
+              >
+                <For each={ROUTING_PREFERENCE_OPTIONS}>
+                  {(option) => <option value={option.id}>{option.name}</option>}
+                </For>
+              </select>
             </div>
 
             <div class="flex items-start justify-between gap-4 py-3 border-b border-border">

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -15,6 +15,7 @@ import type {
   ProviderAdapter,
   ProviderId,
   ProviderModel,
+  ProviderSort,
 } from "./types";
 
 export { fetchSerenModelCatalog } from "./seren";
@@ -208,6 +209,7 @@ export function buildChatRequest(
     range?: { startLine: number; endLine: number } | null;
   },
   history?: Array<{ role: "user" | "assistant" | "system"; content: string }>,
+  providerSort?: ProviderSort,
 ): ChatRequest {
   const messages: ChatMessage[] = [];
 
@@ -248,6 +250,7 @@ export function buildChatRequest(
     messages,
     model,
     stream: false,
+    provider: providerSort ? { sort: providerSort } : undefined,
   };
 }
 

--- a/src/lib/providers/routing-preference.ts
+++ b/src/lib/providers/routing-preference.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Seren Models routing preference — maps user-facing Fastest/Cheapest
+// ABOUTME: choices to the provider.sort wire values seren-router accepts.
+
+import type { ProviderSort } from "./types";
+
+/**
+ * User-facing routing preference stored per thread (and as the settings-store
+ * default for new threads). "fastest" keeps the server default by omitting
+ * `provider.sort`; "cheapest" requests strict lowest-price routing.
+ *
+ * Balanced is deliberately absent: seren-router has not pinned a wire value
+ * for it yet (#3749).
+ */
+export type RoutingPreference = "fastest" | "cheapest";
+
+export const DEFAULT_ROUTING_PREFERENCE: RoutingPreference = "fastest";
+
+export interface RoutingPreferenceOption {
+  id: RoutingPreference;
+  name: string;
+  description: string;
+}
+
+/** Single source of truth for the selector and the settings default control. */
+export const ROUTING_PREFERENCE_OPTIONS: RoutingPreferenceOption[] = [
+  {
+    id: "fastest",
+    name: "Fastest",
+    description: "Seren default — throughput-biased, price-capped routing",
+  },
+  {
+    id: "cheapest",
+    name: "Cheapest",
+    description: "Lowest price — routes to the cheapest healthy provider",
+  },
+];
+
+/**
+ * Normalize a stored value to a known preference. Unknown or missing values
+ * (legacy threads, downgraded builds) resolve to null = server default.
+ */
+export function normalizeRoutingPreference(
+  value: string | null | undefined,
+): RoutingPreference | null {
+  return value === "fastest" || value === "cheapest" ? value : null;
+}
+
+/**
+ * Resolve a preference to the `provider.sort` wire value. Fastest (and any
+ * unset/unknown value) returns undefined so the field is omitted and the
+ * server keeps its default Fastest policy.
+ */
+export function providerSortForPreference(
+  value: string | null | undefined,
+): ProviderSort | undefined {
+  return normalizeRoutingPreference(value) === "cheapest" ? "price" : undefined;
+}

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -17,6 +17,7 @@ import type {
   ChatResponse,
   ProviderAdapter,
   ProviderModel,
+  ProviderSort,
   ToolCall,
   ToolChoice,
   ToolDefinition,
@@ -90,6 +91,8 @@ interface ChatCompletionRequest {
   stream: boolean;
   tools?: ToolDefinition[];
   tool_choice?: ToolChoice;
+  /** Routing preference; omitted = server-default Fastest (#3747). */
+  provider?: { sort?: ProviderSort };
 }
 
 /** Inner publisher response returned inside Seren's DataResponse envelope. */
@@ -321,6 +324,7 @@ export const serenProvider: ProviderAdapter = {
       stream: false,
       tools: request.tools,
       tool_choice: request.tool_choice,
+      provider: request.provider,
     };
 
     const response = await appFetch(url, {
@@ -380,6 +384,7 @@ export const serenProvider: ProviderAdapter = {
       model,
       messages: request.messages,
       stream: true,
+      provider: request.provider,
     };
 
     const response = await appFetch(url, {
@@ -465,6 +470,7 @@ export async function sendMessageWithTools(
   model: string,
   tools?: ToolDefinition[],
   toolChoice?: ToolChoice,
+  providerSort?: ProviderSort,
 ): Promise<ChatResponse> {
   const normalizedModel = normalizeModelId(model);
   const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`;
@@ -475,6 +481,7 @@ export async function sendMessageWithTools(
     stream: false,
     tools,
     tool_choice: toolChoice,
+    provider: providerSort ? { sort: providerSort } : undefined,
   };
 
   const response = await appFetch(url, {

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -143,6 +143,12 @@ export interface ChatMessage {
 }
 
 /**
+ * Wire values seren-router accepts for `provider.sort`. Any other value is
+ * rejected with a 400, so senders must validate before attaching.
+ */
+export type ProviderSort = "price" | "throughput" | "latency";
+
+/**
  * Request payload for chat completions.
  */
 export interface ChatRequest {
@@ -152,6 +158,8 @@ export interface ChatRequest {
   maxTokens?: number;
   tools?: ToolDefinition[];
   tool_choice?: ToolChoice;
+  /** Seren Models routing preference; omitted = server-default Fastest. */
+  provider?: { sort?: ProviderSort };
 }
 
 // ============================================================================

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -723,6 +723,8 @@ export interface Conversation {
   is_archived: boolean;
   employee_id: string | null;
   privileged: boolean;
+  /** Seren Models routing preference ("fastest" | "cheapest"); null = default Fastest. */
+  routing_preference: string | null;
 }
 
 /**
@@ -774,6 +776,8 @@ export interface UnifiedConversationRow {
   agent_metadata: string | null;
   project_id: string | null;
   privileged: boolean;
+  /** Seren Models routing preference ("fastest" | "cheapest"); null = default Fastest. */
+  routing_preference: string | null;
 }
 
 /**
@@ -800,6 +804,7 @@ export async function createConversation(
   selectedProvider?: string,
   projectRoot?: string,
   employeeId?: string,
+  routingPreference?: string,
 ): Promise<Conversation> {
   const invoke = await getInvoke();
   if (!invoke) {
@@ -812,6 +817,7 @@ export async function createConversation(
     selectedProvider,
     projectRoot,
     employeeId,
+    routingPreference,
   });
 }
 
@@ -863,6 +869,7 @@ export async function updateConversation(
   title?: string,
   selectedModel?: string,
   selectedProvider?: string,
+  routingPreference?: string,
 ): Promise<void> {
   const invoke = await getInvoke();
   if (!invoke) {
@@ -873,6 +880,7 @@ export async function updateConversation(
     title,
     selectedModel,
     selectedProvider,
+    routingPreference,
   });
 }
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -21,6 +21,7 @@ import type {
   ChatResponse,
   ContentBlock,
   ProviderId,
+  ProviderSort,
   ToolCall,
   ToolResult,
 } from "@/lib/providers/types";
@@ -134,12 +135,19 @@ async function sendWithToolsRetry(
   model: string,
   tools: ReturnType<typeof getAllTools> | undefined,
   toolChoice: "auto" | undefined,
+  providerSort?: ProviderSort,
 ): Promise<ChatResponse> {
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= CHAT_MAX_RETRIES; attempt++) {
     try {
-      return await sendWithTools(messages, model, tools, toolChoice);
+      return await sendWithTools(
+        messages,
+        model,
+        tools,
+        toolChoice,
+        providerSort,
+      );
     } catch (error) {
       lastError = error as Error;
       const msg = lastError.message || "";
@@ -174,8 +182,15 @@ export async function sendMessage(
   provider: ProviderId,
   context?: ChatContext,
   history?: Message[],
+  providerSort?: ProviderSort,
 ): Promise<string> {
-  const request = buildChatRequest(content, model, context, history);
+  const request = buildChatRequest(
+    content,
+    model,
+    context,
+    history,
+    provider === "seren" ? providerSort : undefined,
+  );
   return sendProviderMessage(provider, request);
 }
 
@@ -189,8 +204,15 @@ export async function* streamMessage(
   provider: ProviderId,
   context?: ChatContext,
   history?: Message[],
+  providerSort?: ProviderSort,
 ): AsyncGenerator<string> {
-  const request = buildChatRequest(content, model, context, history);
+  const request = buildChatRequest(
+    content,
+    model,
+    context,
+    history,
+    provider === "seren" ? providerSort : undefined,
+  );
   request.stream = true;
   yield* streamProviderMessage(provider, request);
 }
@@ -205,12 +227,20 @@ export async function sendMessageWithRetry(
   context: ChatContext | undefined,
   onRetry?: (attempt: number) => void,
   history?: Message[],
+  providerSort?: ProviderSort,
 ): Promise<string> {
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= CHAT_MAX_RETRIES; attempt++) {
     try {
-      return await sendMessage(content, model, provider, context, history);
+      return await sendMessage(
+        content,
+        model,
+        provider,
+        context,
+        history,
+        providerSort,
+      );
     } catch (error) {
       lastError = error as Error;
 
@@ -259,6 +289,7 @@ export interface ToolIterationState {
   iteration: number;
   memorySource?: ToolMemorySource;
   userQuery?: string;
+  providerSort?: ProviderSort;
 }
 
 /** Stable source identity used to make memory capture idempotent across retries. */
@@ -400,6 +431,7 @@ function buildUserContent(
  * @param history - Previous messages in the conversation
  * @param images - Optional image attachments
  * @param memorySource - Stable identity for idempotent memory capture. Memory capture is skipped when absent.
+ * @param providerSort - Seren Models routing preference wire value; omitted = server-default Fastest.
  */
 export async function* streamMessageWithTools(
   content: string,
@@ -409,6 +441,7 @@ export async function* streamMessageWithTools(
   history: Message[] = [],
   images?: Attachment[],
   memorySource?: ToolMemorySource,
+  providerSort?: ProviderSort,
 ): AsyncGenerator<ToolStreamEvent> {
   // Build initial messages array
   const messages: ChatMessageWithTools[] = [];
@@ -641,6 +674,7 @@ export async function* streamMessageWithTools(
       model,
       tools,
       tools ? "auto" : undefined,
+      providerSort,
     );
     console.log("[streamMessageWithTools] Got response:", response);
 
@@ -809,6 +843,7 @@ export async function* streamMessageWithTools(
       iteration: maxIterations,
       memorySource,
       userQuery: content,
+      providerSort,
     },
   };
 }
@@ -831,6 +866,7 @@ export async function* continueToolIteration(
     fullContent: existingContent,
     memorySource,
     userQuery,
+    providerSort,
   } = state;
   let fullContent = existingContent;
   let yieldedContent = existingContent;
@@ -845,6 +881,7 @@ export async function* continueToolIteration(
       model,
       tools,
       tools ? "auto" : undefined,
+      providerSort,
     );
 
     if (response.content) {
@@ -945,6 +982,7 @@ export async function* continueToolIteration(
       iteration: state.iteration + additionalIterations,
       memorySource,
       userQuery,
+      providerSort,
     },
   };
 }

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -8,6 +8,7 @@ import {
   extractEvidenceFromUnifiedMessages,
   validateFinalOutput,
 } from "@/lib/agent-output-validation";
+import { providerSortForPreference } from "@/lib/providers/routing-preference";
 import type {
   Attachment,
   ProviderId,
@@ -138,6 +139,9 @@ interface UserCapabilities {
   tool_definitions: ToolDefinition[];
   installed_skills: SkillRef[];
   reasoning_effort: string | null;
+  /** Seren Models `provider.sort` wire value resolved from the thread's
+   * routing preference; null = server-default Fastest routing. */
+  provider_sort: string | null;
   /** Active project root, threaded through to RoutingDecision.project_root
    * so the Rust ChatModelWorker can inject live git/repo context. */
   project_root: string | null;
@@ -1501,6 +1505,14 @@ function buildCapabilities(
       path: s.path,
     })),
     reasoning_effort: chatStore.reasoningEffort ?? null,
+    // Only public Seren Models honors provider.sort; private chat and agent
+    // providers must not carry a routing preference (#3747).
+    provider_sort:
+      provider === "seren" && !forcePrivateChat
+        ? (providerSortForPreference(
+            conversationStore.getRoutingPreference(threadId),
+          ) ?? null)
+        : null,
     project_root: fileTreeState.rootPath ?? null,
     effective_agent_policy: {
       sandbox_mode: settingsStore.settings.agentSandboxMode,

--- a/src/services/run-dispatcher.ts
+++ b/src/services/run-dispatcher.ts
@@ -3,6 +3,7 @@
 
 import { createEffect, createRoot } from "solid-js";
 import { sendProviderMessage } from "@/lib/providers";
+import { providerSortForPreference } from "@/lib/providers/routing-preference";
 import { reportError } from "@/lib/support/hook";
 import {
   continueToolIteration,
@@ -32,6 +33,7 @@ import { getLiveSerenModelCatalog } from "@/services/seren-model-catalog";
 import { agentStore } from "@/stores/agent.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { runState } from "@/stores/run.store";
+import { settingsStore } from "@/stores/settings.store";
 
 const MAX_CONCURRENT_TASKS = 3;
 const TURN_WAIT_TIMEOUT_MS = 30 * 60 * 1000;
@@ -491,11 +493,21 @@ async function runSerenChatTask(
     throw new Error("Seren model catalog returned no usable model");
   }
 
+  // Run tasks have no per-thread selector; they follow the user's default
+  // routing preference for new work (#3747).
+  const providerSort = providerSortForPreference(
+    settingsStore.get("chatRoutingPreference"),
+  );
+
   for await (const event of streamMessageWithTools(
     buildTaskPrompt(objective, task),
     model,
     undefined,
     true,
+    [],
+    undefined,
+    undefined,
+    providerSort,
   )) {
     if (event.type === "complete") return event.finalContent;
     if (event.type === "iteration_limit") {

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -30,6 +30,11 @@ import {
   type CompactionWindowItem,
   selectCompactionWindow,
 } from "@/lib/compaction/window";
+import {
+  normalizeRoutingPreference,
+  providerSortForPreference,
+  type RoutingPreference,
+} from "@/lib/providers/routing-preference";
 import { PROVIDER_CONFIGS, type ProviderId } from "@/lib/providers/types";
 import {
   archiveConversation as archiveConversationDb,
@@ -102,6 +107,8 @@ export interface Conversation {
   compactedSummary?: CompactedSummary;
   /** Reasoning effort level: "minimal" | "low" | "medium" | "high" | "xhigh". */
   reasoningEffort?: string;
+  /** Seren Models routing preference; null/absent = server-default Fastest. */
+  routingPreference?: RoutingPreference | null;
 }
 
 type MessagePatch = Partial<
@@ -157,6 +164,7 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     selectedProvider: (row.selected_provider as ProviderId | AgentType) ?? null,
     isArchived: row.is_archived,
     privileged: row.privileged,
+    routingPreference: normalizeRoutingPreference(row.routing_preference),
   };
 }
 
@@ -875,7 +883,14 @@ export const chatStore = {
       const summaryOutcome = await runSummarizerWithPolicy({
         primaryModel: activeConvo?.selectedModel ?? this.selectedModel,
         attempt: (model) =>
-          sendMessage(summaryPrompt, model, compactionProvider, undefined),
+          sendMessage(
+            summaryPrompt,
+            model,
+            compactionProvider,
+            undefined,
+            undefined,
+            providerSortForPreference(activeConvo?.routingPreference),
+          ),
         isAuthError: (e) =>
           isLikelyAuthError(e instanceof Error ? e.message : String(e)),
         refreshAuth: refreshAccessToken,

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -363,9 +363,20 @@ export const chatStore = {
     const id = crypto.randomUUID();
     const model = state.selectedModel;
     const provider = null; // Will be determined from model
+    // New threads snapshot the user's default routing preference (#3747),
+    // matching conversationStore.createConversationWithModel.
+    const routingPreference = settingsStore.get("chatRoutingPreference");
 
     try {
-      await createConversationDb(id, title, model, provider ?? undefined);
+      await createConversationDb(
+        id,
+        title,
+        model,
+        provider ?? undefined,
+        undefined,
+        undefined,
+        routingPreference,
+      );
     } catch (error) {
       console.warn("Failed to persist conversation", error);
     }
@@ -377,6 +388,7 @@ export const chatStore = {
       selectedModel: model,
       selectedProvider: provider,
       isArchived: false,
+      routingPreference,
     };
 
     setState("conversations", (convos) => [conversation, ...convos]);

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -2,6 +2,10 @@
 // ABOUTME: Replaces separate chat and local-agent message state with UnifiedMessage types.
 
 import { createStore } from "solid-js/store";
+import {
+  normalizeRoutingPreference,
+  type RoutingPreference,
+} from "@/lib/providers/routing-preference";
 import type { ProviderId } from "@/lib/providers/types";
 import {
   archiveConversation as archiveConversationDb,
@@ -18,6 +22,7 @@ import {
 } from "@/lib/tauri-bridge";
 import type { AgentType } from "@/services/providers";
 import { privacyStore } from "@/stores/privacy.store";
+import { settingsStore } from "@/stores/settings.store";
 import type { UnifiedMessage } from "@/types/conversation";
 import { deserializeMetadata, serializeMetadata } from "@/types/conversation";
 
@@ -35,6 +40,8 @@ export interface Conversation {
   isArchived: boolean;
   employeeId: string | null;
   privileged?: boolean;
+  /** Seren Models routing preference; null = server-default Fastest. */
+  routingPreference: RoutingPreference | null;
 }
 
 interface ConversationState {
@@ -104,6 +111,7 @@ function dbToConversation(db: DbConversation): Conversation {
     isArchived: db.is_archived,
     employeeId: db.employee_id ?? null,
     privileged: db.privileged,
+    routingPreference: normalizeRoutingPreference(db.routing_preference),
   };
 }
 
@@ -118,6 +126,7 @@ function unifiedRowToConversation(row: UnifiedConversationRow): Conversation {
     isArchived: row.is_archived,
     employeeId: row.employee_id,
     privileged: row.privileged,
+    routingPreference: normalizeRoutingPreference(row.routing_preference),
   };
 }
 
@@ -290,6 +299,9 @@ export const conversationStore = {
     employeeId?: string | null,
   ): Promise<Conversation> {
     const id = crypto.randomUUID();
+    // New threads snapshot the user's default routing preference; the
+    // per-thread selector owns the value from then on (#3747).
+    const routingPreference = settingsStore.get("chatRoutingPreference");
 
     try {
       await createConversationDb(
@@ -299,6 +311,7 @@ export const conversationStore = {
         selectedProvider ?? undefined,
         projectRoot,
         employeeId ?? undefined,
+        routingPreference,
       );
     } catch (error) {
       console.warn("Failed to persist conversation", error);
@@ -313,6 +326,7 @@ export const conversationStore = {
       projectRoot: projectRoot ?? null,
       isArchived: false,
       employeeId: employeeId ?? null,
+      routingPreference,
     };
 
     setState("conversations", (convos) => [conversation, ...convos]);
@@ -435,6 +449,44 @@ export const conversationStore = {
             }
           : c,
       ),
+    );
+  },
+
+  /**
+   * Persist the thread's Seren Models routing preference and mirror it in
+   * memory. The in-memory row only updates after the write succeeds so the
+   * selector never shows a preference the next request would not honor.
+   */
+  async updateConversationRoutingPreference(
+    id: string,
+    routingPreference: RoutingPreference,
+  ) {
+    try {
+      await updateConversationDb(
+        id,
+        undefined,
+        undefined,
+        undefined,
+        routingPreference,
+      );
+    } catch (error) {
+      console.warn("Failed to update routing preference", error);
+      return;
+    }
+
+    setState("conversations", (convos) =>
+      convos.map((c) => (c.id === id ? { ...c, routingPreference } : c)),
+    );
+  },
+
+  /**
+   * The thread's routing preference; null (unknown thread or legacy row)
+   * keeps the server-default Fastest routing.
+   */
+  getRoutingPreference(id: string | null): RoutingPreference | null {
+    if (!id) return null;
+    return (
+      state.conversations.find((c) => c.id === id)?.routingPreference ?? null
     );
   },
 

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -4,6 +4,7 @@
 import { createStore } from "solid-js/store";
 import type { McpServerConfig, McpSettings } from "@/lib/mcp/types";
 import { isWindowsPlatform } from "@/lib/platform";
+import type { RoutingPreference } from "@/lib/providers/routing-preference";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 
 const SETTINGS_STORE = "settings.json";
@@ -51,6 +52,12 @@ export interface Settings {
    * Default: 10. Range: 0-50.
    */
   chatMaxToolIterations: number;
+  /**
+   * Seren Models routing preference stamped onto NEW threads at creation
+   * ("fastest" | "cheapest"). Existing threads keep their own per-thread
+   * value; this default does not rewrite them.
+   */
+  chatRoutingPreference: RoutingPreference;
 
   // Auto-compact settings
   autoCompactEnabled: boolean;
@@ -266,6 +273,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatEnterToSend: true,
   chatThinkingExpanded: false,
   chatMaxToolIterations: 0,
+  chatRoutingPreference: "fastest",
   // Auto-compact
   autoCompactEnabled: true,
   autoCompactThreshold: 85,

--- a/tests/unit/conversation-store.test.ts
+++ b/tests/unit/conversation-store.test.ts
@@ -93,6 +93,8 @@ describe("conversationStore", () => {
         undefined,
         "/Users/dev/my-project",
         undefined,
+        // New threads snapshot the settings-store routing default (#3747).
+        "fastest",
       );
     });
 
@@ -514,6 +516,8 @@ describe("conversationStore", () => {
           agent_permission_mode: null,
           agent_metadata: null,
           project_id: null,
+          privileged: false,
+          routing_preference: null,
         },
       ]);
       vi.mocked(bridge.getMessages).mockResolvedValueOnce([
@@ -557,6 +561,8 @@ describe("conversationStore", () => {
           agent_permission_mode: null,
           agent_metadata: null,
           project_id: null,
+          privileged: false,
+          routing_preference: null,
         },
       ]);
       vi.mocked(bridge.getMessages).mockResolvedValueOnce([
@@ -606,6 +612,8 @@ describe("conversationStore", () => {
           agent_permission_mode: null,
           agent_metadata: null,
           project_id: null,
+          privileged: false,
+          routing_preference: null,
         },
       ]);
       vi.mocked(bridge.getMessages).mockResolvedValueOnce([

--- a/tests/unit/provider-bindings.test.ts
+++ b/tests/unit/provider-bindings.test.ts
@@ -703,6 +703,8 @@ describe("switchChatProvider", () => {
       project_root: "/Users/dev/my-project",
       is_archived: false,
       employee_id: null,
+      privileged: false,
+      routing_preference: null,
     });
 
     await switchChatProvider("t1", "seren", "claude-sonnet-4");

--- a/tests/unit/routing-preference.test.ts
+++ b/tests/unit/routing-preference.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Guards the routing-preference → provider.sort wire mapping (#3747).
+// ABOUTME: Fastest must omit the field; cheapest must send the exact value seren-router accepts.
+
+import { describe, expect, it } from "vitest";
+import { buildChatRequest } from "../../src/lib/providers";
+import {
+  normalizeRoutingPreference,
+  providerSortForPreference,
+} from "../../src/lib/providers/routing-preference";
+
+describe("providerSortForPreference", () => {
+  it("omits provider.sort for fastest so the server default stays in charge", () => {
+    expect(providerSortForPreference("fastest")).toBeUndefined();
+  });
+
+  it("maps cheapest to the price wire value", () => {
+    expect(providerSortForPreference("cheapest")).toBe("price");
+  });
+
+  it("treats legacy/unknown values as the default", () => {
+    expect(providerSortForPreference(null)).toBeUndefined();
+    expect(providerSortForPreference(undefined)).toBeUndefined();
+    // seren-router 400s on unknown sort values; they must never map to a wire value.
+    expect(providerSortForPreference("balanced")).toBeUndefined();
+    expect(providerSortForPreference("price")).toBeUndefined();
+  });
+});
+
+describe("normalizeRoutingPreference", () => {
+  it("accepts only known preferences", () => {
+    expect(normalizeRoutingPreference("fastest")).toBe("fastest");
+    expect(normalizeRoutingPreference("cheapest")).toBe("cheapest");
+    expect(normalizeRoutingPreference("balanced")).toBeNull();
+    expect(normalizeRoutingPreference(null)).toBeNull();
+  });
+});
+
+describe("buildChatRequest provider.sort passthrough", () => {
+  it("attaches provider.sort when a wire value is given", () => {
+    const request = buildChatRequest("hi", "anthropic/claude-sonnet-4", undefined, [], "price");
+    expect(request.provider).toEqual({ sort: "price" });
+  });
+
+  it("leaves provider absent when no wire value is given", () => {
+    const request = buildChatRequest("hi", "anthropic/claude-sonnet-4");
+    expect(request.provider).toBeUndefined();
+    // JSON serialization must not carry the key either — the server treats
+    // presence as an explicit preference.
+    expect(JSON.parse(JSON.stringify(request))).not.toHaveProperty("provider");
+  });
+});


### PR DESCRIPTION
Closes #3747

## Summary

Implements the client-side half of seren-router's routing preference. Adds a user-facing **Fastest / Cheapest** selection that maps to `provider.sort` on chat requests to the `seren-models` publisher. When unset, the field is omitted and the server keeps its default Fastest policy — existing behavior is unchanged.

## What landed

Both independent request-building paths are covered, matching the issue's code-path audit:

**Path A — JS direct-provider path**
- `src/lib/providers/routing-preference.ts` (new) — single source of truth mapping preference → wire value.
- `types.ts` / `seren.ts` / `index.ts` — `ProviderSort` type + `provider?: { sort }` threaded through `ChatRequest`, `buildChatRequest`, send/stream, and `sendMessageWithTools`.
- `services/chat.ts` — preference threaded through the agentic tool loop (`streamMessageWithTools`, `continueToolIteration`, `ToolIterationState`, retries).
- `services/run-dispatcher.ts` — run tasks follow the user default.

**Path B — Rust orchestrator path**
- `orchestrator/types.rs` — `provider_sort` on `UserCapabilities` + `RoutingDecision`.
- `orchestrator/router.rs` — resolves it into the routing decision.
- `orchestrator/chat_model_worker.rs` — `apply_provider_sort()` injects `provider.sort` into both the initial and tool-loop request bodies, gated to the `seren-models` publisher and to the three valid wire values.
- `services/orchestrator.ts` — `buildCapabilities()` only sets it for public seren (not private chat / agents).

**Persistence & UI**
- New nullable `conversations.routing_preference` column with an idempotent migration (+ migration test); legacy rows stay NULL = Fastest.
- Per-thread `RoutingPreferenceSelector` in the composer (shown only for the seren provider) + a "Default Routing" control in Settings for new threads.

## Deviation from the issue — flag for review

The issue's acceptance criteria list **Fastest / Balanced / Cheapest**. This ships **Fastest / Cheapest only**. seren-router has not pinned a wire value for "Balanced" yet, so shipping it would send an unrecognized value and get a 400. Balanced is deferred to #3749 and documented in `routing-preference.ts`. Cheapest → `price`; Fastest → omit the field (server default). Invalid values never reach the wire on either path.

## Verification

- `pnpm vitest run` on the changed suites — 63 passed (incl. new `routing-preference.test.ts`, `conversation-store.test.ts`, `provider-bindings.test.ts`).
- `cargo check` — clean (exit 0); the two dead_code warnings are pre-existing in `src/run/store.rs`, unrelated to this change.
- `biome check` on all changed files — only two pre-existing `useOptionalChain` warnings in untouched regions of `ChatContent.tsx`.
- Merges cleanly into main (verified via `git merge-tree --write-tree`).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
